### PR TITLE
Migrate skill paths to Agent Skills directory convention (skills/<name>/SKILL.md)

### DIFF
--- a/architecture/001-facet-manifest-schema.md
+++ b/architecture/001-facet-manifest-schema.md
@@ -15,6 +15,7 @@ decision-makers: julian
 | modified by change: local-authoring                | 2026-03-27 | julian          |        |
 | modified by ADR-006: manifest serialization format | 2026-03-28 | julian          |        |
 | modified by change: json-manifest-migration        | 2026-03-29 | julian          |        |
+| modified by change: interactive-build-reconciliation | 2026-03-31 | julian          |        |
 
 ## Context and Problem Statement
 
@@ -199,7 +200,9 @@ The CLI validates platform config against known platform schemas at build and pu
 | `description` | Yes      | Human-readable description of the skill.                               |
 | `platforms`   | No       | Map of platform name → platform-specific skill config.                 |
 
-The skill's prompt content lives in a file at the conventional path `skills/<name>.md`. All three descriptor types require a description — consumers need to know what an asset does to decide whether to use it. Prompt content is resolved from conventional file paths (`<type>/<name>.md`) rather than declared in the manifest.
+The skill's prompt content lives in a file at the conventional path `skills/<name>/SKILL.md`, following the [Agent Skills](https://agentskills.io/specification) directory convention. Agents and commands use the flat file convention: `agents/<name>.md` and `commands/<name>.md`. All three descriptor types require a description — consumers need to know what an asset does to decide whether to use it. Prompt content is resolved from these conventional file paths rather than declared in the manifest.
+
+> **Modification note (interactive-build-reconciliation, 2026-03-31):** Skills changed from the flat file convention `skills/<name>.md` to the Agent Skills directory convention `skills/<name>/SKILL.md`. This aligns with the cross-platform Agent Skills ecosystem. Agents and commands retain the flat file convention.
 
 **Command descriptor:**
 

--- a/openspec/changes/interactive-build-reconciliation/tasks.md
+++ b/openspec/changes/interactive-build-reconciliation/tasks.md
@@ -2,18 +2,18 @@
 
 ## 1. Skill Convention Migration — Research
 
-- [ ] 1.1 Explore: Review current skill file path resolution in the build pipeline — how `skills/<name>.md` is resolved, where the convention is hardcoded, and what tests cover it
-- [ ] 1.2 Explore: Review the create wizard's skill scaffolding — how skill starter files are generated and where the flat file path is constructed
-- [ ] 1.3 Explore: Review existing tests that assert skill file paths (`skills/<name>.md`) — enumerate all tests that will need updating for the directory convention
-- [ ] 1.4 Propose: Approach for migrating skill resolution from `skills/<name>.md` to `skills/<name>/SKILL.md` across the build pipeline, create wizard, and tests
+- [x] 1.1 Explore: Review current skill file path resolution in the build pipeline — how `skills/<name>.md` is resolved, where the convention is hardcoded, and what tests cover it
+- [x] 1.2 Explore: Review the create wizard's skill scaffolding — how skill starter files are generated and where the flat file path is constructed
+- [x] 1.3 Explore: Review existing tests that assert skill file paths (`skills/<name>.md`) — enumerate all tests that will need updating for the directory convention
+- [x] 1.4 Propose: Approach for migrating skill resolution from `skills/<name>.md` to `skills/<name>/SKILL.md` across the build pipeline, create wizard, and tests
 
 ## 2. Skill Convention Migration — Implementation
 
-- [ ] 2.1 Implement: Update prompt content resolution to resolve skills from `skills/<name>/SKILL.md` instead of `skills/<name>.md`
-- [ ] 2.2 Implement: Update the create wizard's skill scaffolding to create `skills/<name>/SKILL.md` inside a directory instead of a flat file
-- [ ] 2.3 Implement: Update all existing tests that assert skill file paths to use the new directory convention
-- [ ] 2.4 Implement: Update ADR-001 with a modification note for the skill path convention change
-- [ ] 2.5 Verify: Run `bun check` — all tests pass, types check, lint clean
+- [x] 2.1 Implement: Update prompt content resolution to resolve skills from `skills/<name>/SKILL.md` instead of `skills/<name>.md`
+- [x] 2.2 Implement: Update the create wizard's skill scaffolding to create `skills/<name>/SKILL.md` inside a directory instead of a flat file
+- [x] 2.3 Implement: Update all existing tests that assert skill file paths to use the new directory convention
+- [x] 2.4 Implement: Update ADR-001 with a modification note for the skill path convention change
+- [x] 2.5 Verify: Run `bun check` — all tests pass, types check, lint clean
 
 ## 3. Create Wizard Relaxation — Research
 

--- a/packages/cli/src/__tests__/create-build.test.ts
+++ b/packages/cli/src/__tests__/create-build.test.ts
@@ -61,8 +61,8 @@ describe('writeScaffold', () => {
     )
 
     expect(files).toContain('facet.json')
-    expect(files).toContain('skills/code-review.md')
-    expect(files).toContain('skills/testing-guide.md')
+    expect(files).toContain('skills/code-review/SKILL.md')
+    expect(files).toContain('skills/testing-guide/SKILL.md')
     expect(files).toContain('agents/reviewer.md')
     expect(files).toContain('commands/deploy.md')
 
@@ -81,10 +81,10 @@ describe('writeScaffold', () => {
     expect(manifest.commands.deploy).toBeDefined()
 
     // Verify starter files exist and have named template content
-    const skill = await Bun.file(join(dir, 'skills/code-review.md')).text()
+    const skill = await Bun.file(join(dir, 'skills/code-review/SKILL.md')).text()
     expect(skill).toContain('# Code Review')
 
-    const skill2 = await Bun.file(join(dir, 'skills/testing-guide.md')).text()
+    const skill2 = await Bun.file(join(dir, 'skills/testing-guide/SKILL.md')).text()
     expect(skill2).toContain('# Testing Guide')
 
     const agent = await Bun.file(join(dir, 'agents/reviewer.md')).text()
@@ -109,7 +109,7 @@ describe('writeScaffold', () => {
     )
 
     expect(files).toContain('facet.json')
-    expect(files).toContain('skills/minimal.md')
+    expect(files).toContain('skills/minimal/SKILL.md')
     expect(files).not.toContain('agents/')
     expect(files).not.toContain('commands/')
 
@@ -157,7 +157,7 @@ describe('writeScaffold', () => {
 describe('facet build', () => {
   test('build succeeds on valid project', async () => {
     const dir = await createFixtureDir('build-valid')
-    await Bun.write(join(dir, 'skills/review.md'), '# Review skill content')
+    await Bun.write(join(dir, 'skills/review/SKILL.md'), '# Review skill content')
     await Bun.write(
       join(dir, 'facet.json'),
       JSON.stringify({

--- a/packages/cli/src/commands/create-scaffold.ts
+++ b/packages/cli/src/commands/create-scaffold.ts
@@ -134,7 +134,7 @@ export function generateManifest(opts: CreateOptions): string {
 export function previewFiles(opts: CreateOptions): string[] {
   const files: string[] = [FACET_MANIFEST_FILE]
   for (const skill of opts.skills) {
-    files.push(`skills/${skill}.md`)
+    files.push(`skills/${skill}/SKILL.md`)
   }
   for (const agent of opts.agents) {
     files.push(`agents/${agent}.md`)
@@ -155,11 +155,11 @@ export async function writeScaffold(opts: CreateOptions, targetDir: string): Pro
   await Bun.write(manifestPath, generateManifest(opts))
   files.push(FACET_MANIFEST_FILE)
 
-  // Write skill files
+  // Write skill files (Agent Skills directory convention: skills/<name>/SKILL.md)
   for (const skill of opts.skills) {
-    await mkdir(join(targetDir, 'skills'), { recursive: true })
-    await Bun.write(join(targetDir, `skills/${skill}.md`), skillTemplate(skill))
-    files.push(`skills/${skill}.md`)
+    await mkdir(join(targetDir, 'skills', skill), { recursive: true })
+    await Bun.write(join(targetDir, `skills/${skill}/SKILL.md`), skillTemplate(skill))
+    files.push(`skills/${skill}/SKILL.md`)
   }
 
   // Write agent files

--- a/packages/core/src/__tests__/build-pipeline.test.ts
+++ b/packages/core/src/__tests__/build-pipeline.test.ts
@@ -206,7 +206,7 @@ describe('validatePlatformConfigs', () => {
 describe('runBuildPipeline', () => {
   test('successful build with valid facet', async () => {
     const dir = await createFixtureDir('valid-build')
-    await Bun.write(join(dir, 'skills/example.md'), '# Example skill')
+    await Bun.write(join(dir, 'skills/example/SKILL.md'), '# Example skill')
     await Bun.write(
       join(dir, 'facet.json'),
       JSON.stringify({
@@ -230,8 +230,8 @@ describe('runBuildPipeline', () => {
       expect(result.archiveFilename).toBe('test-facet-1.0.0.facet')
       expect(result.archiveBytes.length).toBeGreaterThan(0)
       expect(Object.keys(result.assetHashes)).toContain('facet.json')
-      expect(Object.keys(result.assetHashes)).toContain('skills/example.md')
-      expect(result.assetHashes['skills/example.md']).toMatchInlineSnapshot(
+      expect(Object.keys(result.assetHashes)).toContain('skills/example/SKILL.md')
+      expect(result.assetHashes['skills/example/SKILL.md']).toMatchInlineSnapshot(
         `"sha256:ded8057927e03783371d0d929e4a6e92da66eb9dd164377ad6845a5a1c0cb5ba"`,
       )
       expect(result.integrity).toMatch(/^sha256:[a-f0-9]{64}$/)
@@ -263,13 +263,13 @@ describe('runBuildPipeline', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) {
       expect(result.errors[0]?.path).toBe('skills.example')
-      expect(result.errors[0]?.message).toContain('skills/example.md')
+      expect(result.errors[0]?.message).toContain('skills/example/SKILL.md')
     }
   })
 
   test('build succeeds with cross-type name sharing', async () => {
     const dir = await createFixtureDir('cross-type')
-    await Bun.write(join(dir, 'skills/review.md'), '# Review skill')
+    await Bun.write(join(dir, 'skills/review/SKILL.md'), '# Review skill')
     await Bun.write(join(dir, 'commands/review.md'), '# Review command')
     await Bun.write(
       join(dir, 'facet.json'),
@@ -291,8 +291,8 @@ describe('runBuildPipeline', () => {
 
   test('build with all asset types includes all hashes', async () => {
     const dir = await createFixtureDir('all-types')
-    await Bun.write(join(dir, 'skills/alpha.md'), '# Alpha skill')
-    await Bun.write(join(dir, 'skills/beta.md'), '# Beta skill')
+    await Bun.write(join(dir, 'skills/alpha/SKILL.md'), '# Alpha skill')
+    await Bun.write(join(dir, 'skills/beta/SKILL.md'), '# Beta skill')
     await Bun.write(join(dir, 'agents/helper.md'), '# Helper agent')
     await Bun.write(join(dir, 'commands/deploy.md'), '# Deploy command')
     await Bun.write(
@@ -322,15 +322,15 @@ describe('runBuildPipeline', () => {
         'agents/helper.md',
         'commands/deploy.md',
         'facet.json',
-        'skills/alpha.md',
-        'skills/beta.md',
+        'skills/alpha/SKILL.md',
+        'skills/beta/SKILL.md',
       ])
     }
   })
 
   test('build fails on malformed compact facets entry', async () => {
     const dir = await createFixtureDir('bad-facets')
-    await Bun.write(join(dir, 'skills/x.md'), '# Skill')
+    await Bun.write(join(dir, 'skills/x/SKILL.md'), '# Skill')
     await Bun.write(
       join(dir, 'facet.json'),
       JSON.stringify({
@@ -356,7 +356,7 @@ describe('runBuildPipeline', () => {
 describe('writeBuildOutput', () => {
   test('writes archive and build manifest to dist/', async () => {
     const dir = await createFixtureDir('write-output')
-    await Bun.write(join(dir, 'skills/example.md'), '# Resolved content')
+    await Bun.write(join(dir, 'skills/example/SKILL.md'), '# Resolved content')
     await Bun.write(
       join(dir, 'facet.json'),
       JSON.stringify({
@@ -385,7 +385,7 @@ describe('writeBuildOutput', () => {
     expect(manifest.archive).toBe('test-facet-1.0.0.facet')
     expect(manifest.integrity).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(manifest.assets['facet.json']).toMatch(/^sha256:[a-f0-9]{64}$/)
-    expect(manifest.assets['skills/example.md']).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(manifest.assets['skills/example/SKILL.md']).toMatch(/^sha256:[a-f0-9]{64}$/)
 
     // No loose files
     const looseManifest = await Bun.file(join(dir, 'dist/facet.json')).exists()
@@ -394,7 +394,7 @@ describe('writeBuildOutput', () => {
 
   test('cleans previous dist/ before writing', async () => {
     const dir = await createFixtureDir('clean-dist')
-    await Bun.write(join(dir, 'skills/x.md'), '# Skill')
+    await Bun.write(join(dir, 'skills/x/SKILL.md'), '# Skill')
     await Bun.write(
       join(dir, 'facet.json'),
       JSON.stringify({

--- a/packages/core/src/__tests__/content-hash.test.ts
+++ b/packages/core/src/__tests__/content-hash.test.ts
@@ -63,7 +63,7 @@ describe('collectArchiveEntries', () => {
 
     expect(entries).toHaveLength(4)
     expect(entries.map((e) => e.path)).toContain('facet.json')
-    expect(entries.map((e) => e.path)).toContain('skills/review.md')
+    expect(entries.map((e) => e.path)).toContain('skills/review/SKILL.md')
     expect(entries.map((e) => e.path)).toContain('agents/helper.md')
     expect(entries.map((e) => e.path)).toContain('commands/deploy.md')
   })
@@ -84,7 +84,7 @@ describe('collectArchiveEntries', () => {
     const entries = collectArchiveEntries(resolved, 'manifest content')
     const paths = entries.map((e) => e.path)
 
-    expect(paths).toEqual(['agents/b-agent.md', 'facet.json', 'skills/a-skill.md', 'skills/z-skill.md'])
+    expect(paths).toEqual(['agents/b-agent.md', 'facet.json', 'skills/a-skill/SKILL.md', 'skills/z-skill/SKILL.md'])
   })
 
   test('handles manifest with no optional asset types', () => {
@@ -105,7 +105,7 @@ describe('computeAssetHashes', () => {
   test('returns correct hash for each entry', () => {
     const entries = [
       { path: 'facet.json', content: '{"name":"test"}' },
-      { path: 'skills/review.md', content: '# Review' },
+      { path: 'skills/review/SKILL.md', content: '# Review' },
     ]
 
     const hashes = computeAssetHashes(entries)
@@ -114,7 +114,7 @@ describe('computeAssetHashes', () => {
     expect(hashes['facet.json']).toMatchInlineSnapshot(
       `"sha256:7d9fd2051fc32b32feab10946fab6bb91426ab7e39aa5439289ed892864aa91d"`,
     )
-    expect(hashes['skills/review.md']).toMatchInlineSnapshot(
+    expect(hashes['skills/review/SKILL.md']).toMatchInlineSnapshot(
       `"sha256:f1a9d9d60fba2e67d82d788760d147d95461a58456411e205bf33a6dbdc3497f"`,
     )
   })
@@ -134,7 +134,7 @@ describe('assembleTar', () => {
   test('produces a valid tar archive', () => {
     const entries = [
       { path: 'facet.json', content: '{"name":"test","version":"1.0.0"}' },
-      { path: 'skills/review.md', content: '# Review skill' },
+      { path: 'skills/review/SKILL.md', content: '# Review skill' },
     ]
 
     const tar = assembleTar(entries)
@@ -147,7 +147,7 @@ describe('assembleTar', () => {
 
     const names = parsed.map((f) => f.name)
     expect(names).toContain('facet.json')
-    expect(names).toContain('skills/review.md')
+    expect(names).toContain('skills/review/SKILL.md')
   })
 
   test('tar contains correct file contents', () => {
@@ -205,7 +205,7 @@ describe('compressArchive', () => {
   test('compressed archive can be decompressed to recover original tar', async () => {
     const entries = [
       { path: 'facet.json', content: '{"name":"test","version":"1.0.0"}' },
-      { path: 'skills/review.md', content: '# Review skill' },
+      { path: 'skills/review/SKILL.md', content: '# Review skill' },
     ]
 
     const tar = assembleTar(entries)
@@ -220,7 +220,7 @@ describe('compressArchive', () => {
 
     const names = parsed.map((f) => f.name)
     expect(names).toContain('facet.json')
-    expect(names).toContain('skills/review.md')
-    expect(parsed.find((f) => f.name === 'skills/review.md')?.text).toBe('# Review skill')
+    expect(names).toContain('skills/review/SKILL.md')
+    expect(parsed.find((f) => f.name === 'skills/review/SKILL.md')?.text).toBe('# Review skill')
   })
 })

--- a/packages/core/src/__tests__/facet-loader.test.ts
+++ b/packages/core/src/__tests__/facet-loader.test.ts
@@ -174,7 +174,7 @@ describe('loadManifest', () => {
 describe('resolvePrompts', () => {
   test('prompt content is resolved from conventional file paths', async () => {
     const dir = await createFixtureDir('resolve-convention')
-    await writeFixture(dir, 'skills/review.md', '# Code Review\nReview all code.')
+    await writeFixture(dir, 'skills/review/SKILL.md', '# Code Review\nReview all code.')
     await writeFixture(dir, 'agents/reviewer.md', '# Reviewer\nReview this code.')
     await writeFixture(dir, 'commands/deploy.md', '# Deploy\nDeploy the code.')
 
@@ -242,7 +242,7 @@ describe('resolvePrompts', () => {
 
   test('manifest without agents or commands resolves successfully', async () => {
     const dir = await createFixtureDir('resolve-skills-only')
-    await writeFixture(dir, 'skills/x.md', '# Skill X\nDo x.')
+    await writeFixture(dir, 'skills/x/SKILL.md', '# Skill X\nDo x.')
 
     const manifest = {
       name: 'test',

--- a/packages/core/src/build/content-hash.ts
+++ b/packages/core/src/build/content-hash.ts
@@ -27,7 +27,7 @@ export function collectArchiveEntries(resolved: ResolvedFacetManifest, manifestC
 
   if (resolved.skills) {
     for (const [name, skill] of Object.entries(resolved.skills)) {
-      entries.push({ path: `skills/${name}.md`, content: skill.prompt })
+      entries.push({ path: `skills/${name}/SKILL.md`, content: skill.prompt })
     }
   }
 

--- a/packages/core/src/loaders/facet.ts
+++ b/packages/core/src/loaders/facet.ts
@@ -45,7 +45,8 @@ export async function loadManifest(dir: string): Promise<Result<FacetManifest>> 
 
 /**
  * A manifest with all prompts resolved to their string content.
- * File paths are derived from convention: `<type>/<name>.md`.
+ * File paths are derived from convention: skills use `skills/<name>/SKILL.md`,
+ * agents use `agents/<name>.md`, commands use `commands/<name>.md`.
  */
 export interface ResolvedFacetManifest {
   name: string
@@ -83,8 +84,9 @@ export interface ResolvedFacetManifest {
  * Resolves prompt content for all skills, agents, and commands by reading
  * files at conventional paths relative to the facet root directory.
  *
- * The convention is `<type>/<name>.md` — for example, a skill named
- * "code-review" resolves to `skills/code-review.md`.
+ * Skills use the Agent Skills directory convention: a skill named "code-review"
+ * resolves to `skills/code-review/SKILL.md`. Agents and commands use the flat
+ * file convention: `agents/<name>.md` and `commands/<name>.md`.
  *
  * This also serves as file existence verification for all three asset types —
  * if an expected file doesn't exist, resolution fails with an error identifying
@@ -96,7 +98,7 @@ export interface ResolvedFacetManifest {
 export async function resolvePrompts(manifest: FacetManifest, rootDir: string): Promise<Result<ResolvedFacetManifest>> {
   const errors: ValidationError[] = []
 
-  // Resolve skill prompts from skills/<name>.md
+  // Resolve skill prompts from skills/<name>/SKILL.md
   let resolvedSkills: ResolvedFacetManifest['skills'] | undefined
   if (manifest.skills) {
     resolvedSkills = {}
@@ -158,11 +160,13 @@ export async function resolvePrompts(manifest: FacetManifest, rootDir: string): 
 }
 
 /**
- * Resolves prompt content for a single asset by reading <type>/<name>.md.
+ * Resolves prompt content for a single asset by reading the file at its
+ * conventional path. Skills use `skills/<name>/SKILL.md` (Agent Skills
+ * directory convention). Agents and commands use `<type>/<name>.md`.
  * Returns the file content as a string, or a ValidationError if the file doesn't exist.
  */
 async function resolveAssetPrompt(assetType: string, name: string, rootDir: string): Promise<string | ValidationError> {
-  const relativePath = `${assetType}/${name}.md`
+  const relativePath = assetType === 'skills' ? `${assetType}/${name}/SKILL.md` : `${assetType}/${name}.md`
   const filePath = join(rootDir, relativePath)
   const file = Bun.file(filePath)
   const exists = await file.exists()

--- a/packages/core/src/schemas/facet-manifest.ts
+++ b/packages/core/src/schemas/facet-manifest.ts
@@ -2,7 +2,7 @@ import { type } from 'arktype'
 
 // --- Sub-schemas ---
 
-/** Skill descriptor — description is required, prompt resolved from skills/<name>.md */
+/** Skill descriptor — description is required, prompt resolved from skills/<name>/SKILL.md */
 const SkillDescriptor = type({
   description: 'string',
   'platforms?': type.Record('string', 'unknown'),


### PR DESCRIPTION
## Summary

- Migrates skill file resolution from flat `skills/<name>.md` to the [Agent Skills](https://agentskills.io/specification) directory convention `skills/<name>/SKILL.md`. Agents and commands retain the flat file convention.
- Updates the facet manifest schema, loader, content hash assembly, CLI scaffolding, and all associated tests to use the new skill path pattern.
- Adds a modification note to ADR-001 documenting the convention change.
- Includes OpenSpec change artifacts (proposal, design, delta specs, tasks) for the `interactive-build-reconciliation` change, which introduces `facet edit` and the broader authoring model this migration is part of.
- Adjusts OpenSpec proposal word limit rules from a hard 500-word cap to a 300-1000 word guideline.