### PR TITLE
Relax create wizard: only name and description required, version defaults to 0.0.0

### DIFF
--- a/openspec/changes/interactive-build-reconciliation/tasks.md
+++ b/openspec/changes/interactive-build-reconciliation/tasks.md
@@ -17,18 +17,18 @@
 
 ## 3. Create Wizard Relaxation — Research
 
-- [ ] 3.1 Explore: Review the create wizard's validation logic — what fields are currently required, how `canCreate` is gated, and where the "at least one asset" requirement is enforced
-- [ ] 3.2 Explore: Review the version field default value and where `0.1.0` is currently set — identify all places the default needs to change to `0.0.0`
-- [ ] 3.3 Propose: Approach for relaxing create requirements (name + description only, version defaults `0.0.0`, assets optional) while keeping the form unchanged
+- [x] 3.1 Explore: Review the create wizard's validation logic — what fields are currently required, how `canCreate` is gated, and where the "at least one asset" requirement is enforced
+- [x] 3.2 Explore: Review the version field default value and where `0.1.0` is currently set — identify all places the default needs to change to `0.0.0`
+- [x] 3.3 Propose: Approach for relaxing create requirements (name + description only, version defaults `0.0.0`, assets optional) while keeping the form unchanged
 
 ## 4. Create Wizard Relaxation — Implementation
 
-- [ ] 4.1 Implement: Change the create wizard so only name and description are required to complete — remove the "at least one asset" gate
-- [ ] 4.2 Implement: Change the version default from `0.1.0` to `0.0.0` in both the create wizard and any test fixtures
-- [ ] 4.3 Implement: Ensure scaffolded starter files contain no YAML front matter (verify current behavior, fix if needed)
-- [ ] 4.4 Implement: Add test for scaffolding a minimal project with only name and description (no assets)
-- [ ] 4.5 Implement: Add test for version defaulting to `0.0.0`
-- [ ] 4.6 Verify: Run `bun check` — all tests pass, types check, lint clean
+- [x] 4.1 Implement: Change the create wizard so only name and description are required to complete — remove the "at least one asset" gate
+- [x] 4.2 Implement: Change the version default from `0.1.0` to `0.0.0` in both the create wizard and any test fixtures
+- [x] 4.3 Implement: Ensure scaffolded starter files contain no YAML front matter (verify current behavior, fix if needed)
+- [x] 4.4 Implement: Add test for scaffolding a minimal project with only name and description (no assets)
+- [x] 4.5 Implement: Add test for version defaulting to `0.0.0`
+- [x] 4.6 Verify: Run `bun check` — all tests pass, types check, lint clean
 
 ## 5. Build Command Hardening — Research
 

--- a/packages/cli/src/__tests__/create-build.test.ts
+++ b/packages/cli/src/__tests__/create-build.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { writeScaffold } from '../commands/create/index.ts'
+import { DEFAULT_VERSION } from '../commands/create-scaffold.ts'
 
 let testDir: string
 
@@ -51,7 +52,7 @@ describe('writeScaffold', () => {
     const files = await writeScaffold(
       {
         name: 'my-facet',
-        version: '0.1.0',
+        version: DEFAULT_VERSION,
         description: 'A test facet',
         skills: ['code-review', 'testing-guide'],
         agents: ['reviewer'],
@@ -70,7 +71,7 @@ describe('writeScaffold', () => {
     const manifestText = await Bun.file(join(dir, 'facet.json')).text()
     const manifest = JSON.parse(manifestText)
     expect(manifest.name).toBe('my-facet')
-    expect(manifest.version).toBe('0.1.0')
+    expect(manifest.version).toBe(DEFAULT_VERSION)
     expect(manifest.description).toBe('A test facet')
     expect(manifest.skills).toBeDefined()
     expect(manifest.skills['code-review']).toBeDefined()
@@ -99,7 +100,7 @@ describe('writeScaffold', () => {
     const files = await writeScaffold(
       {
         name: 'minimal',
-        version: '0.1.0',
+        version: DEFAULT_VERSION,
         description: '',
         skills: ['minimal'],
         agents: [],
@@ -120,12 +121,58 @@ describe('writeScaffold', () => {
     expect(manifest.commands).toBeUndefined()
   })
 
+  test('scaffolds minimal project with only name and description (no assets)', async () => {
+    const dir = await createFixtureDir('scaffold-minimal')
+    const files = await writeScaffold(
+      {
+        name: 'bare-bones',
+        version: DEFAULT_VERSION,
+        description: 'A minimal facet',
+        skills: [],
+        agents: [],
+        commands: [],
+      },
+      dir,
+    )
+
+    expect(files).toContain('facet.json')
+    expect(files).toHaveLength(1)
+
+    const manifestText = await Bun.file(join(dir, 'facet.json')).text()
+    const manifest = JSON.parse(manifestText)
+    expect(manifest.name).toBe('bare-bones')
+    expect(manifest.version).toBe(DEFAULT_VERSION)
+    expect(manifest.description).toBe('A minimal facet')
+    expect(manifest.skills).toBeUndefined()
+    expect(manifest.agents).toBeUndefined()
+    expect(manifest.commands).toBeUndefined()
+  })
+
+  test('version defaults to DEFAULT_VERSION (0.0.0)', async () => {
+    const dir = await createFixtureDir('scaffold-default-version')
+    await writeScaffold(
+      {
+        name: 'default-ver',
+        version: DEFAULT_VERSION,
+        description: 'Testing default version',
+        skills: ['example'],
+        agents: [],
+        commands: [],
+      },
+      dir,
+    )
+
+    const manifestText = await Bun.file(join(dir, 'facet.json')).text()
+    const manifest = JSON.parse(manifestText)
+    expect(manifest.version).toBe('0.0.0')
+  })
+
   test('scaffolded project passes build', async () => {
     const dir = await createFixtureDir('scaffold-buildable')
     await writeScaffold(
       {
         name: 'buildable',
-        version: '0.1.0',
+        version: DEFAULT_VERSION,
         description: 'A buildable facet',
         skills: ['helper'],
         agents: ['assistant'],
@@ -140,7 +187,7 @@ describe('writeScaffold', () => {
     expect(result.stdout).toContain('Built buildable')
 
     // Verify dist/ output exists — archive + build manifest
-    const distArchive = await Bun.file(join(dir, 'dist/buildable-0.1.0.facet')).exists()
+    const distArchive = await Bun.file(join(dir, `dist/buildable-${DEFAULT_VERSION}.facet`)).exists()
     expect(distArchive).toBe(true)
 
     const distManifest = await Bun.file(join(dir, 'dist/build-manifest.json')).exists()

--- a/packages/cli/src/commands/create-scaffold.ts
+++ b/packages/cli/src/commands/create-scaffold.ts
@@ -13,6 +13,10 @@ export interface CreateOptions {
   commands: string[]
 }
 
+// --- Defaults ---
+
+export const DEFAULT_VERSION = '0.0.0'
+
 // --- Validation ---
 
 export const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/

--- a/packages/cli/src/tui/views/create/create-view.tsx
+++ b/packages/cli/src/tui/views/create/create-view.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from 'ink'
 import { useCallback, useEffect } from 'react'
 import { ASSET_LABELS, ASSET_TYPES } from '../../../commands/create/types.ts'
-import { isValidKebabCase } from '../../../commands/create-scaffold.ts'
+import { DEFAULT_VERSION, isValidKebabCase } from '../../../commands/create-scaffold.ts'
 import { AssetSection } from '../../components/asset-section.tsx'
 import { Button } from '../../components/button.tsx'
 import { EditableField } from '../../components/editable-field.tsx'
@@ -9,7 +9,7 @@ import { useFocusOrder } from '../../context/focus-order-context.ts'
 import { useFormState } from '../../context/form-state-context.ts'
 import { WizardLayout } from '../../layouts/wizard-layout.tsx'
 
-function computeFocusIds(form: ReturnType<typeof useFormState>['form'], hasAnyAsset: boolean): string[] {
+function computeFocusIds(form: ReturnType<typeof useFormState>['form']): string[] {
   const ids: string[] = ['field-name', 'field-description', 'field-version']
 
   for (const type of ASSET_TYPES) {
@@ -22,9 +22,7 @@ function computeFocusIds(form: ReturnType<typeof useFormState>['form'], hasAnyAs
     ids.push(`add-${type}`)
   }
 
-  if (hasAnyAsset) {
-    ids.push('create-btn')
-  }
+  ids.push('create-btn')
 
   return ids
 }
@@ -53,19 +51,17 @@ export function CreateView({ onSubmit }: { onSubmit: () => void }) {
   const versionReady = nameSettled && descriptionSettled
   const assetsReady = nameSettled && descriptionSettled && versionSettled
 
-  const totalAssets = form.assets.skill.items.length + form.assets.command.items.length + form.assets.agent.items.length
-  const hasAnyAsset = totalAssets > 0
-  const canCreate = assetsReady && hasAnyAsset
+  const canCreate = assetsReady
 
   // Recompute focus order
   useEffect(() => {
-    const ids = computeFocusIds(form, hasAnyAsset)
+    const ids = computeFocusIds(form)
     setFocusIds(ids)
 
     if (focusedId && !ids.includes(focusedId)) {
       focus(ids[0] ?? '')
     }
-  }, [form, hasAnyAsset, setFocusIds, focus, focusedId])
+  }, [form, setFocusIds, focus, focusedId])
 
   // Auto-focus name field on mount
   useEffect(() => {
@@ -97,9 +93,9 @@ export function CreateView({ onSubmit }: { onSubmit: () => void }) {
         field="version"
         label="Version"
         hint="SemVer N.N.N"
-        defaultValue="0.1.0"
+        defaultValue={DEFAULT_VERSION}
         dimmed={!versionReady}
-        validate={(v) => (/^\d+\.\d+\.\d+$/.test(v) ? undefined : 'Must be SemVer (e.g., 0.1.0)')}
+        validate={(v) => (/^\d+\.\d+\.\d+$/.test(v) ? undefined : `Must be SemVer (e.g., ${DEFAULT_VERSION})`)}
         onConfirm={() => focus(`add-${ASSET_TYPES[0]}`)}
       />
 
@@ -139,9 +135,7 @@ export function CreateView({ onSubmit }: { onSubmit: () => void }) {
               ? 'Enter a name to continue'
               : !descriptionConfirmed
                 ? 'Enter a description to continue'
-                : !versionConfirmed
-                  ? 'Enter a version to continue'
-                  : 'Add at least one skill, command, or agent'}
+                : 'Enter a version to continue'}
           </Text>
         </Box>
       )}


### PR DESCRIPTION
## Summary

- Removes the "at least one asset" gate from the create wizard — authors can now scaffold a project with only a name and description.
- Changes the default version from `0.1.0` to `0.0.0`, extracted into a shared `DEFAULT_VERSION` constant.
- The create button is always visible once name, description, and version are settled, regardless of whether any assets have been added.
- Removes the "Add at least one skill, command, or agent" hint text; the wizard now only prompts for incomplete identity fields.
- Adds tests for scaffolding a minimal project with no assets and for the `0.0.0` version default.
- Updates existing test fixtures to use the `DEFAULT_VERSION` constant instead of hardcoded `0.1.0`.
- Marks the corresponding OpenSpec tasks (sections 3 and 4) as complete.