### PR TITLE
Harden build pipeline: front matter detection, empty file validation, and edit suggestions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/brand": {
       "name": "@agent-facets/brand",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/bun": "1.3.10",
       },
@@ -27,7 +27,7 @@
     },
     "packages/cli": {
       "name": "agent-facets",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "facet": "./dist/facet",
       },
@@ -53,11 +53,12 @@
     },
     "packages/core": {
       "name": "@agent-facets/core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "arktype": "2.1.29",
         "comment-json": "^4.2.5",
         "nanotar": "0.3.0",
+        "yaml": "2.8.3",
       },
       "devDependencies": {
         "@types/bun": "1.3.10",
@@ -1880,7 +1881,7 @@
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yargs": ["yargs@17.7.1", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw=="],
 
@@ -1905,6 +1906,8 @@
     "@asyncapi/parser/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "@changesets/parse/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@fission-ai/openspec/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -1949,6 +1952,8 @@
     "@mintlify/mdx/react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
     "@mintlify/openapi-parser/ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "@mintlify/openapi-parser/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "@mintlify/prebuild/chalk": ["chalk@5.3.0", "", {}, "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="],
 
@@ -2106,6 +2111,8 @@
 
     "postcss-load-config/lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
+    "postcss-load-config/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
     "public-ip/got": ["got@12.6.1", "", { "dependencies": { "@sindresorhus/is": "^5.2.0", "@szmarczak/http-timer": "^5.0.1", "cacheable-lookup": "^7.0.0", "cacheable-request": "^10.2.8", "decompress-response": "^6.0.0", "form-data-encoder": "^2.1.2", "get-stream": "^6.0.1", "http2-wrapper": "^2.1.10", "lowercase-keys": "^3.0.0", "p-cancelable": "^3.0.0", "responselike": "^3.0.0" } }, "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -2143,6 +2150,8 @@
     "unist-util-remove/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "vfile-matter/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/openspec/changes/interactive-build-reconciliation/tasks.md
+++ b/openspec/changes/interactive-build-reconciliation/tasks.md
@@ -32,18 +32,18 @@
 
 ## 5. Build Command Hardening — Research
 
-- [ ] 5.1 Explore: Review the current build pipeline validation steps — what checks exist today, where new checks for front matter detection and empty file validation would be inserted
-- [ ] 5.2 Explore: Review the build command's error output and TUI — how errors are currently displayed, where the "suggest facet edit" message would be added
-- [ ] 5.3 Propose: Approach for adding front matter detection, empty file validation, and "suggest edit" messaging to the build pipeline
+- [x] 5.1 Explore: Review the current build pipeline validation steps — what checks exist today, where new checks for front matter detection and empty file validation would be inserted
+- [x] 5.2 Explore: Review the build command's error output and TUI — how errors are currently displayed, where the "suggest facet edit" message would be added
+- [x] 5.3 Propose: Approach for adding front matter detection, empty file validation, and "suggest edit" messaging to the build pipeline
 
 ## 6. Build Command Hardening — Implementation
 
-- [ ] 6.1 Implement: Add front matter detection to the build pipeline — fail with an error identifying the file if any content file contains YAML front matter
-- [ ] 6.2 Implement: Add empty file validation to the build pipeline — fail with an error if any content file is empty (zero bytes or whitespace only)
-- [ ] 6.3 Implement: Add "run `facet edit` to fix" suggestion to all build failure messages
-- [ ] 6.4 Implement: Add tests for build failing on files with front matter
-- [ ] 6.5 Implement: Add tests for build failing on empty content files
-- [ ] 6.6 Verify: Run `bun check` — all tests pass, types check, lint clean
+- [x] 6.1 Implement: Add front matter detection to the build pipeline — fail with an error identifying the file if any content file contains YAML front matter
+- [x] 6.2 Implement: Add empty file validation to the build pipeline — fail with an error if any content file is empty (zero bytes or whitespace only)
+- [x] 6.3 Implement: Add "run `facet edit` to fix" suggestion to all build failure messages
+- [x] 6.4 Implement: Add tests for build failing on files with front matter
+- [x] 6.5 Implement: Add tests for build failing on empty content files
+- [x] 6.6 Verify: Run `bun check` — all tests pass, types check, lint clean
 
 ## 7. Core Edit Logic — Research
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -38,7 +38,9 @@ export const buildCommand: Command = {
       process.stdout.write(`✓ Built ${buildName} v${buildVersion} → dist/ (${artifactCount} assets, ${shortHash})\n`)
       return 0
     } catch {
-      process.stdout.write(`✗ Build failed — ${errorCount} error${errorCount !== 1 ? 's' : ''}\n`)
+      process.stdout.write(
+        `✗ Build failed — ${errorCount} error${errorCount !== 1 ? 's' : ''}. Run \`facet edit\` to fix.\n`,
+      )
       return 1
     }
   },

--- a/packages/cli/src/tui/components/stage-row.tsx
+++ b/packages/cli/src/tui/components/stage-row.tsx
@@ -9,6 +9,7 @@ export interface Stage {
   label: string
   status: StageStatus
   detail?: string
+  errors?: string[]
 }
 
 const ICONS: Record<StageStatus, ReactNode> = {
@@ -24,10 +25,21 @@ const ICONS: Record<StageStatus, ReactNode> = {
 
 export function StageRow({ stage }: { stage: Stage }) {
   return (
-    <Box gap={1}>
-      {ICONS[stage.status]}
-      <Text dimColor={stage.status === 'pending'}>{stage.label}</Text>
-      {stage.detail && <Text color={THEME.hint}> — {stage.detail}</Text>}
+    <Box flexDirection="column">
+      <Box gap={1}>
+        {ICONS[stage.status]}
+        <Text dimColor={stage.status === 'pending'}>{stage.label}</Text>
+        {stage.detail && <Text color={THEME.hint}> — {stage.detail}</Text>}
+      </Box>
+      {stage.errors && stage.errors.length > 0 && (
+        <Box flexDirection="column" marginLeft={3}>
+          {stage.errors.map((e) => (
+            <Text key={e} color={THEME.warning}>
+              {e}
+            </Text>
+          ))}
+        </Box>
+      )}
     </Box>
   )
 }

--- a/packages/cli/src/tui/views/build/build-view.tsx
+++ b/packages/cli/src/tui/views/build/build-view.tsx
@@ -1,6 +1,12 @@
-import { type BuildProgress, runBuildPipeline, writeBuildOutput } from '@agent-facets/core'
+import {
+  BUILD_STAGES,
+  type BuildProgress,
+  type BuildStage,
+  runBuildPipeline,
+  writeBuildOutput,
+} from '@agent-facets/core'
 import { Box, Text, useApp } from 'ink'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Stage } from '../../components/stage-row.tsx'
 import { StageRow } from '../../components/stage-row.tsx'
 import { THEME } from '../../theme.ts'
@@ -24,54 +30,61 @@ export function BuildView({
   onFailure?: (errorCount: number) => void
 }) {
   const { exit } = useApp()
-  const [stages, setStages] = useState<Stage[]>([
-    { label: 'Validating manifest', status: 'pending' },
-    { label: 'Assembling archive', status: 'pending' },
-    { label: 'Writing output', status: 'pending' },
-  ])
+  const [stages, setStages] = useState<Stage[]>(BUILD_STAGES.map((label) => ({ label, status: 'pending' as const })))
   const [result, setResult] = useState<BuildViewResult | null>(null)
-  const [errors, setErrors] = useState<string[]>([])
   const [warnings, setWarnings] = useState<string[]>([])
 
-  const updateStage = useCallback((index: number, update: Partial<Stage>) => {
-    setStages((prev) => prev.map((s, i) => (i === index ? { ...s, ...update } : s)))
-  }, [])
+  // Deferred exit: set this to an Error to exit after the next render cycle,
+  // ensuring error/stage state updates are painted before Ink unmounts.
+  const [pendingExit, setPendingExit] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (pendingExit) {
+      exit(pendingExit)
+    }
+  }, [pendingExit, exit])
+
+  // Build a stable lookup from stage label to index
+  const stageIndexMap = useMemo(() => Object.fromEntries(BUILD_STAGES.map((label, i) => [label, i])), [])
+
+  const updateStage = useCallback(
+    (label: BuildStage, update: Partial<Stage>) => {
+      const index = stageIndexMap[label]
+      if (index !== undefined) {
+        setStages((prev) => prev.map((s, i) => (i === index ? { ...s, ...update } : s)))
+      }
+    },
+    [stageIndexMap],
+  )
 
   useEffect(() => {
     async function run() {
-      // Stages 1 & 2: Validate and assemble archive (pipeline handles both, emits progress)
-      const stageIndexMap: Record<string, number> = {
-        'Validating manifest': 0,
-        'Assembling archive': 1,
-      }
-
       const pipelineResult = await runBuildPipeline(rootDir, (progress: BuildProgress) => {
-        const index = stageIndexMap[progress.stage]
-        if (index !== undefined) {
-          updateStage(index, {
-            status: progress.status === 'running' ? 'running' : progress.status === 'done' ? 'done' : 'failed',
-          })
-        }
+        updateStage(progress.stage, {
+          status: progress.status === 'running' ? 'running' : progress.status === 'done' ? 'done' : 'failed',
+        })
       })
 
       setWarnings(pipelineResult.warnings)
 
       if (!pipelineResult.ok) {
-        setErrors(pipelineResult.errors.map((e) => `${e.path ? `${e.path}: ` : ''}${e.message}`))
+        const formatted = pipelineResult.errors.map((e) => e.message)
+        // Find the stage that failed and attach errors to it
+        setStages((prev) => prev.map((s) => (s.status === 'failed' ? { ...s, errors: formatted } : s)))
         onFailure?.(pipelineResult.errors.length)
-        exit(new Error('Build failed'))
+        // Defer exit so React renders the errors and failed stage status first
+        setPendingExit(new Error('Build failed'))
         return
       }
 
-      // Stage 3: Write output
-      updateStage(2, { status: 'running' })
+      // Writing output stage — handled here, not by the pipeline
+      updateStage('Writing output', { status: 'running' })
       try {
         await writeBuildOutput(pipelineResult, rootDir)
 
-        // Derive file list from asset hashes (these are the files inside the archive)
         const files = Object.keys(pipelineResult.assetHashes).sort()
 
-        updateStage(2, { status: 'done' })
+        updateStage('Writing output', { status: 'done' })
         setResult({
           name: pipelineResult.data.name,
           version: pipelineResult.data.version,
@@ -83,8 +96,8 @@ export function BuildView({
         onSuccess?.(pipelineResult.data.name, pipelineResult.data.version, files.length, pipelineResult.integrity)
         exit()
       } catch (err) {
-        updateStage(2, { status: 'failed', detail: String(err) })
-        exit(err instanceof Error ? err : new Error(String(err)))
+        updateStage('Writing output', { status: 'failed', detail: String(err) })
+        setPendingExit(err instanceof Error ? err : new Error(String(err)))
       }
     }
 
@@ -109,20 +122,6 @@ export function BuildView({
             <Text key={w} color={THEME.warning}>
               {' '}
               ⚠ {w}
-            </Text>
-          ))}
-        </Box>
-      )}
-
-      {errors.length > 0 && (
-        <Box flexDirection="column">
-          <Text bold color={THEME.warning}>
-            Errors:
-          </Text>
-          {errors.map((e) => (
-            <Text key={e} color={THEME.warning}>
-              {' '}
-              {e}
             </Text>
           ))}
         </Box>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "arktype": "2.1.29",
     "comment-json": "^4.2.5",
-    "nanotar": "0.3.0"
+    "nanotar": "0.3.0",
+    "yaml": "2.8.3"
   },
   "devDependencies": {
     "@types/bun": "1.3.10"

--- a/packages/core/src/__tests__/build-pipeline.test.ts
+++ b/packages/core/src/__tests__/build-pipeline.test.ts
@@ -351,6 +351,83 @@ describe('runBuildPipeline', () => {
   })
 })
 
+// --- Content validation ---
+
+describe('content validation', () => {
+  test('build fails on file with YAML front matter', async () => {
+    const dir = await createFixtureDir('front-matter')
+    await Bun.write(
+      join(dir, 'skills/review/SKILL.md'),
+      '---\nname: Review\ndescription: A review skill\n---\n# Review\nReview all code.',
+    )
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name: 'test-facet',
+        version: '1.0.0',
+        skills: {
+          review: { description: 'A review skill' },
+        },
+      }),
+    )
+
+    const result = await runBuildPipeline(dir)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]?.path).toBe('skills.review')
+      expect(result.errors[0]?.message).toContain('front matter')
+      expect(result.errors[0]?.message).toContain('skills/review/SKILL.md')
+    }
+  })
+
+  test('build fails on empty content file', async () => {
+    const dir = await createFixtureDir('empty-file')
+    await Bun.write(join(dir, 'skills/empty/SKILL.md'), '')
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name: 'test-facet',
+        version: '1.0.0',
+        skills: {
+          empty: { description: 'An empty skill' },
+        },
+      }),
+    )
+
+    const result = await runBuildPipeline(dir)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]?.path).toBe('skills.empty')
+      expect(result.errors[0]?.message).toContain('empty')
+    }
+  })
+
+  test('build fails on whitespace-only content file', async () => {
+    const dir = await createFixtureDir('whitespace-file')
+    await Bun.write(join(dir, 'agents/blank.md'), '   \n\n  \n')
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name: 'test-facet',
+        version: '1.0.0',
+        agents: {
+          blank: { description: 'A blank agent' },
+        },
+      }),
+    )
+
+    const result = await runBuildPipeline(dir)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]?.path).toBe('agents.blank')
+      expect(result.errors[0]?.message).toContain('empty')
+    }
+  })
+})
+
 // --- Build output generation ---
 
 describe('writeBuildOutput', () => {

--- a/packages/core/src/__tests__/facet-manifest.test.ts
+++ b/packages/core/src/__tests__/facet-manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { type } from 'arktype'
-import { checkFacetManifestConstraints, type FacetManifest, FacetManifestSchema } from '../schemas/facet-manifest.ts'
+import { type FacetManifest, FacetManifestSchema } from '../schemas/facet-manifest.ts'
 
 // --- Valid manifests ---
 
@@ -88,9 +88,6 @@ describe('FacetManifestSchema — valid manifests', () => {
     }
     const result = FacetManifestSchema(input)
     expect(result).not.toBeInstanceOf(type.errors)
-    const data = result as FacetManifest
-    const errors = checkFacetManifestConstraints(data)
-    expect(errors).toHaveLength(0)
   })
 })
 
@@ -137,38 +134,29 @@ describe('FacetManifestSchema — invalid manifests', () => {
     const errors = result as InstanceType<typeof type.errors>
     expect(errors.some((e) => e.path.includes('bad'))).toBe(true)
   })
-})
 
-// --- Business-rule constraints ---
-
-describe('checkFacetManifestConstraints', () => {
-  test('no text assets → error', () => {
+  test('no text assets → schema error', () => {
     const input = {
       name: 'empty',
       version: '1.0.0',
       servers: { jira: '1.0.0' },
     }
     const result = FacetManifestSchema(input)
-    expect(result).not.toBeInstanceOf(type.errors)
-    const errors = checkFacetManifestConstraints(result as FacetManifest)
-    expect(errors).toHaveLength(1)
-    const firstError = errors[0]
-    expect(firstError).toBeDefined()
-    expect(firstError?.message).toContain('at least one text asset')
+    expect(result).toBeInstanceOf(type.errors)
+    const errors = result as InstanceType<typeof type.errors>
+    expect(errors.some((e) => e.message.includes('at least one text asset'))).toBe(true)
   })
 
-  test('selective facets entry with no asset selection → error', () => {
+  test('selective facets entry with no asset selection → schema error', () => {
     const input = {
       name: 'bad-selective',
       version: '1.0.0',
       facets: [{ name: 'other', version: '1.0.0' }],
     }
     const result = FacetManifestSchema(input)
-    expect(result).not.toBeInstanceOf(type.errors)
-    const errors = checkFacetManifestConstraints(result as FacetManifest)
-    const selectiveError = errors.find((e) => e.message.includes('at least one asset type'))
-    expect(selectiveError).toBeDefined()
-    expect(selectiveError?.path).toBe('facets[0]')
+    expect(result).toBeInstanceOf(type.errors)
+    const errors = result as InstanceType<typeof type.errors>
+    expect(errors.some((e) => e.message.includes('at least one asset type'))).toBe(true)
   })
 })
 

--- a/packages/core/src/build/pipeline.ts
+++ b/packages/core/src/build/pipeline.ts
@@ -9,11 +9,12 @@ import {
   computeContentHash,
 } from './content-hash.ts'
 import { detectNamingCollisions } from './detect-collisions.ts'
+import { validateContentFiles } from './validate-content.ts'
 import { validateCompactFacets } from './validate-facets.ts'
 import { validatePlatformConfigs } from './validate-platforms.ts'
 
 export interface BuildProgress {
-  stage: string
+  stage: BuildStage
   status: 'running' | 'done' | 'failed'
 }
 
@@ -33,19 +34,33 @@ export interface BuildFailure {
   warnings: string[]
 }
 
+/** Stage names emitted by the build pipeline via the onProgress callback. */
+export const BUILD_STAGES = [
+  'Parsing manifest',
+  'Resolving prompts',
+  'Validating assets',
+  'Checking collisions',
+  'Validating platforms',
+  'Assembling archive',
+  'Writing output',
+] as const
+
+export type BuildStage = (typeof BUILD_STAGES)[number]
+
 /**
  * Runs the full build pipeline:
- * 1. Load manifest — read the facet manifest, parse JSON, validate schema, check constraints
- * 2. Resolve prompts — read prompt files at conventional paths for skills, agents, commands (also verifies files exist)
- * 3. Validate compact facets format — check name@version pattern
- * 4. Detect naming collisions — fail if same name used within an asset type
- * 5. Validate platform config — check known platform schemas, warn on unknown
- * 6. Assemble archive — collect entries, compute per-asset hashes, build deterministic tar, compute integrity hash, compress for delivery
+ * 1. Parse manifest — read facet.json, parse JSON, validate schema, check constraints
+ * 2. Resolve prompts — read prompt files at conventional paths (also verifies files exist)
+ * 3. Validate content — no front matter, no empty files
+ * 4. Check collisions — fail if same name used within an asset type
+ * 5. Validate platforms — check known platform schemas, warn on unknown
+ * 6. Assemble archive — collect entries, compute hashes, build tar, compress
  *
  * Returns the resolved manifest and archive data on success, or collected errors on failure.
  * Warnings are returned in both cases.
  *
  * An optional `onProgress` callback receives stage updates for UI display.
+ * The 'Writing output' stage is emitted by name but handled by the caller (BuildView).
  */
 export async function runBuildPipeline(
   rootDir: string,
@@ -53,46 +68,64 @@ export async function runBuildPipeline(
 ): Promise<BuildResult | BuildFailure> {
   const warnings: string[] = []
 
-  // Stage 1: Load manifest
-  onProgress?.({ stage: 'Validating manifest', status: 'running' })
+  // Stage 1: Parse manifest
+  onProgress?.({ stage: 'Parsing manifest', status: 'running' })
 
   const loadResult = await loadManifest(rootDir)
   if (!loadResult.ok) {
-    onProgress?.({ stage: 'Validating manifest', status: 'failed' })
+    onProgress?.({ stage: 'Parsing manifest', status: 'failed' })
     return { ok: false, errors: loadResult.errors, warnings }
   }
   const manifest = loadResult.data
 
+  onProgress?.({ stage: 'Parsing manifest', status: 'done' })
+
   // Stage 2: Resolve prompts (also serves as file existence verification)
+  onProgress?.({ stage: 'Resolving prompts', status: 'running' })
+
   const resolveResult = await resolvePrompts(manifest, rootDir)
   if (!resolveResult.ok) {
-    onProgress?.({ stage: 'Validating manifest', status: 'failed' })
+    onProgress?.({ stage: 'Resolving prompts', status: 'failed' })
     return { ok: false, errors: resolveResult.errors, warnings }
   }
 
-  // Stage 3: Validate compact facets format
-  const facetsErrors = validateCompactFacets(manifest)
-  if (facetsErrors.length > 0) {
-    onProgress?.({ stage: 'Validating manifest', status: 'failed' })
-    return { ok: false, errors: facetsErrors, warnings }
+  onProgress?.({ stage: 'Resolving prompts', status: 'done' })
+
+  // Stage 3: Validate assets (no front matter, no empty files)
+  onProgress?.({ stage: 'Validating assets', status: 'running' })
+
+  const contentErrors = validateContentFiles(resolveResult.data)
+  if (contentErrors.length > 0) {
+    onProgress?.({ stage: 'Validating assets', status: 'failed' })
+    return { ok: false, errors: contentErrors, warnings }
   }
 
-  // Stage 4: Detect naming collisions
+  onProgress?.({ stage: 'Validating assets', status: 'done' })
+
+  // Stage 4: Check naming collisions
+  onProgress?.({ stage: 'Checking collisions', status: 'running' })
+
   const collisionErrors = detectNamingCollisions(manifest)
-  if (collisionErrors.length > 0) {
-    onProgress?.({ stage: 'Validating manifest', status: 'failed' })
-    return { ok: false, errors: collisionErrors, warnings }
+  const facetsErrors = validateCompactFacets(manifest)
+  const checkErrors = [...collisionErrors, ...facetsErrors]
+  if (checkErrors.length > 0) {
+    onProgress?.({ stage: 'Checking collisions', status: 'failed' })
+    return { ok: false, errors: checkErrors, warnings }
   }
+
+  onProgress?.({ stage: 'Checking collisions', status: 'done' })
 
   // Stage 5: Validate platform config
+  onProgress?.({ stage: 'Validating platforms', status: 'running' })
+
   const platformResult = validatePlatformConfigs(manifest)
   if (platformResult.errors.length > 0) {
-    onProgress?.({ stage: 'Validating manifest', status: 'failed' })
+    onProgress?.({ stage: 'Validating platforms', status: 'failed' })
     return { ok: false, errors: platformResult.errors, warnings: [...warnings, ...platformResult.warnings] }
   }
   warnings.push(...platformResult.warnings)
 
-  onProgress?.({ stage: 'Validating manifest', status: 'done' })
+  onProgress?.({ stage: 'Validating platforms', status: 'done' })
 
   // Stage 6: Assemble archive, compute content hashes, and compress for delivery
   onProgress?.({ stage: 'Assembling archive', status: 'running' })

--- a/packages/core/src/build/validate-content.ts
+++ b/packages/core/src/build/validate-content.ts
@@ -1,0 +1,50 @@
+import { hasFrontMatter } from '../front-matter.ts'
+import type { ResolvedFacetManifest } from '../loaders/facet.ts'
+import type { ValidationError } from '../types.ts'
+
+/**
+ * Validates resolved prompt content for all assets:
+ * - No YAML front matter (manifest is the single source of truth for metadata)
+ * - No empty files (zero bytes or whitespace only)
+ *
+ * Returns an array of validation errors, one per offending file.
+ */
+export function validateContentFiles(resolved: ResolvedFacetManifest): ValidationError[] {
+  const errors: ValidationError[] = []
+
+  const assetTypes = [
+    { type: 'skills', assets: resolved.skills },
+    { type: 'agents', assets: resolved.agents },
+    { type: 'commands', assets: resolved.commands },
+  ] as const
+
+  for (const { type, assets } of assetTypes) {
+    if (!assets) continue
+    for (const [name, asset] of Object.entries(assets)) {
+      const relativePath = type === 'skills' ? `skills/${name}/SKILL.md` : `${type}/${name}.md`
+
+      // Check for empty content
+      if (asset.prompt.trim().length === 0) {
+        errors.push({
+          path: `${type}.${name}`,
+          message: `File is empty: ${relativePath}. Content files must contain prompt content.`,
+          expected: 'non-empty content',
+          actual: 'empty or whitespace only',
+        })
+        continue // Skip front matter check on empty files
+      }
+
+      // Check for YAML front matter
+      if (hasFrontMatter(asset.prompt)) {
+        errors.push({
+          path: `${type}.${name}`,
+          message: `File contains YAML front matter: ${relativePath}. The manifest is the source of truth for metadata — use \`facet edit\` to reconcile.`,
+          expected: 'no front matter',
+          actual: 'front matter detected',
+        })
+      }
+    }
+  }
+
+  return errors
+}

--- a/packages/core/src/front-matter.ts
+++ b/packages/core/src/front-matter.ts
@@ -1,0 +1,58 @@
+import { parse as parseYaml } from 'yaml'
+
+/**
+ * Matches YAML front matter: opening `---`, YAML content, closing `---`.
+ * Anchored to start of string. Handles optional trailing content.
+ */
+const FRONT_MATTER_RE = /^---\n([\s\S]*?)\n---(?:\n([\s\S]*))?$/
+
+/** Matches empty front matter: `---\n---` with optional trailing content. */
+const EMPTY_FRONT_MATTER_RE = /^---\n---(?:\n([\s\S]*))?$/
+
+/** Normalize BOM and line endings to LF. */
+function normalize(raw: string): string {
+  return raw
+    .replace(/^\uFEFF/, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+}
+
+/** Returns true if the string contains YAML front matter. */
+export function hasFrontMatter(raw: string): boolean {
+  const input = normalize(raw)
+  return FRONT_MATTER_RE.test(input) || EMPTY_FRONT_MATTER_RE.test(input)
+}
+
+export interface FrontMatterResult<T = Record<string, unknown>> {
+  /** Parsed YAML attributes. Empty object if no front matter or parse failure. */
+  data: T
+  /** Markdown body with front matter stripped. Original content if no front matter. */
+  content: string
+}
+
+/**
+ * Extracts YAML front matter attributes and clean body from a string.
+ * Returns the original content unchanged if no front matter is found.
+ * Treats YAML parse failures as "no front matter" (returns empty data + original content).
+ */
+export function extractFrontMatter<T = Record<string, unknown>>(raw: string): FrontMatterResult<T> {
+  const input = normalize(raw)
+
+  const emptyMatch = input.match(EMPTY_FRONT_MATTER_RE)
+  if (emptyMatch) {
+    return { data: {} as T, content: emptyMatch[1] ?? '' }
+  }
+
+  const match = input.match(FRONT_MATTER_RE)
+  if (!match) {
+    return { data: {} as T, content: raw }
+  }
+
+  try {
+    const yaml = match[1] ?? ''
+    return { data: (parseYaml(yaml) ?? {}) as T, content: match[2] ?? '' }
+  } catch {
+    // Malformed YAML — treat as no front matter
+    return { data: {} as T, content: raw }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,4 @@
 // types
-
 export type { ArchiveEntry } from './build/content-hash.ts'
 export {
   assembleTar,
@@ -9,13 +8,16 @@ export {
   computeContentHash,
 } from './build/content-hash.ts'
 export { detectNamingCollisions } from './build/detect-collisions.ts'
-export type { BuildFailure, BuildProgress, BuildResult } from './build/pipeline.ts'
+export type { BuildFailure, BuildProgress, BuildResult, BuildStage } from './build/pipeline.ts'
 // build pipeline
-export { runBuildPipeline } from './build/pipeline.ts'
+export { BUILD_STAGES, runBuildPipeline } from './build/pipeline.ts'
 export { validateCompactFacets } from './build/validate-facets.ts'
 export type { PlatformValidationResult } from './build/validate-platforms.ts'
 export { validatePlatformConfigs } from './build/validate-platforms.ts'
 export { writeBuildOutput } from './build/write-output.ts'
+// front matter
+export type { FrontMatterResult } from './front-matter.ts'
+export { extractFrontMatter, hasFrontMatter } from './front-matter.ts'
 export type { ResolvedFacetManifest } from './loaders/facet.ts'
 // loaders
 export { FACET_MANIFEST_FILE, loadManifest, resolvePrompts } from './loaders/facet.ts'
@@ -24,10 +26,7 @@ export type { BuildManifest } from './schemas/build-manifest.ts'
 export { BuildManifestSchema } from './schemas/build-manifest.ts'
 export type { FacetManifest } from './schemas/facet-manifest.ts'
 // schemas
-export {
-  checkFacetManifestConstraints,
-  FacetManifestSchema,
-} from './schemas/facet-manifest.ts'
+export { FacetManifestSchema } from './schemas/facet-manifest.ts'
 export type { Lockfile } from './schemas/lockfile.ts'
 export { LockfileSchema } from './schemas/lockfile.ts'
 export type { ServerManifest } from './schemas/server-manifest.ts'

--- a/packages/core/src/loaders/facet.ts
+++ b/packages/core/src/loaders/facet.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { type } from 'arktype'
-import { checkFacetManifestConstraints, type FacetManifest, FacetManifestSchema } from '../schemas/facet-manifest.ts'
+import { type FacetManifest, FacetManifestSchema } from '../schemas/facet-manifest.ts'
 import type { Result, ValidationError } from '../types.ts'
 import { mapArkErrors, parseJson, readFile } from './validate.ts'
 
@@ -32,12 +32,6 @@ export async function loadManifest(dir: string): Promise<Result<FacetManifest>> 
   const validated = FacetManifestSchema(jsonResult.data)
   if (validated instanceof type.errors) {
     return { ok: false, errors: mapArkErrors(validated) }
-  }
-
-  // Phase 3: Business-rule constraints
-  const constraintErrors = checkFacetManifestConstraints(validated)
-  if (constraintErrors.length > 0) {
-    return { ok: false, errors: constraintErrors }
   }
 
   return { ok: true, data: validated }

--- a/packages/core/src/loaders/validate.ts
+++ b/packages/core/src/loaders/validate.ts
@@ -8,9 +8,11 @@ import type { ValidationError } from '../types.ts'
 export function mapArkErrors(errors: InstanceType<typeof type.errors>): ValidationError[] {
   return errors.map((err) => ({
     path: err.path.join('.'),
-    message: err.message,
+    // For predicate errors (.narrow()), err.message includes the full data object.
+    // Use err.expected directly — it's our clean sentence from ctx.mustBe().
+    message: err.code === 'predicate' ? (err.expected ?? err.message) : err.message,
     expected: err.expected ?? 'unknown',
-    actual: err.actual ?? 'unknown',
+    actual: err.code === 'predicate' ? 'constraint not met' : (err.actual ?? 'unknown'),
   }))
 }
 

--- a/packages/core/src/schemas/facet-manifest.ts
+++ b/packages/core/src/schemas/facet-manifest.ts
@@ -37,9 +37,11 @@ const ServerReference = type('string').or({ image: 'string' })
 // --- Main schema ---
 
 /**
- * The structural schema for the facet manifest — validates shape only.
- * Custom constraints (at least one text asset, selective entry must select at least one type)
- * are checked post-validation by checkFacetManifestConstraints().
+ * The facet manifest schema — validates structure and business constraints.
+ *
+ * Structural validation covers field types and shapes. Narrow constraints enforce:
+ * 1. At least one text asset (skills, agents, commands, or facets) must be present
+ * 2. Selective facets entries must include at least one asset type selection
  */
 export const FacetManifestSchema = type({
   name: 'string',
@@ -51,63 +53,35 @@ export const FacetManifestSchema = type({
   'commands?': type.Record('string', CommandDescriptor),
   'facets?': FacetsEntry.array(),
   'servers?': type.Record('string', ServerReference),
-})
-
-/** Inferred TypeScript type for a validated facet manifest */
-export type FacetManifest = typeof FacetManifestSchema.infer
-
-// --- Custom validation ---
-
-export interface FacetManifestError {
-  path: string
-  message: string
-  expected: string
-  actual: string
-}
-
-/**
- * Checks business-rule constraints that ArkType's structural validation cannot express:
- * 1. At least one text asset must be present (skills, agents, commands, or facets)
- * 2. Selective facets entries must include at least one asset type
- */
-export function checkFacetManifestConstraints(manifest: FacetManifest): FacetManifestError[] {
-  const errors: FacetManifestError[] = []
-
+}).narrow((data, ctx) => {
   // Constraint 1: at least one text asset
-  const hasSkills = manifest.skills && Object.keys(manifest.skills).length > 0
-  const hasAgents = manifest.agents && Object.keys(manifest.agents).length > 0
-  const hasCommands = manifest.commands && Object.keys(manifest.commands).length > 0
-  const hasFacets = manifest.facets && manifest.facets.length > 0
+  const hasSkills = data.skills && Object.keys(data.skills).length > 0
+  const hasAgents = data.agents && Object.keys(data.agents).length > 0
+  const hasCommands = data.commands && Object.keys(data.commands).length > 0
+  const hasFacets = data.facets && data.facets.length > 0
 
   if (!hasSkills && !hasAgents && !hasCommands && !hasFacets) {
-    errors.push({
-      path: '',
-      message: 'Manifest must include at least one text asset (skills, agents, commands, or facets)',
-      expected: 'at least one of: skills, agents, commands, facets',
-      actual: 'none present',
-    })
+    ctx.mustBe('Manifest must include at least one text asset (skills, agents, commands, or facets)')
   }
 
   // Constraint 2: selective facets entries must select at least one asset type
-  if (manifest.facets) {
-    for (let i = 0; i < manifest.facets.length; i++) {
-      const entry = manifest.facets[i]
+  if (data.facets) {
+    for (let i = 0; i < data.facets.length; i++) {
+      const entry = data.facets[i]
       if (typeof entry === 'object') {
         const hasSelectedSkills = entry.skills && entry.skills.length > 0
         const hasSelectedAgents = entry.agents && entry.agents.length > 0
         const hasSelectedCommands = entry.commands && entry.commands.length > 0
 
         if (!hasSelectedSkills && !hasSelectedAgents && !hasSelectedCommands) {
-          errors.push({
-            path: `facets[${i}]`,
-            message: 'Selective facets entry must include at least one asset type (skills, agents, or commands)',
-            expected: 'at least one of: skills, agents, commands',
-            actual: 'none selected',
-          })
+          ctx.mustBe('Selective facets entry must include at least one asset type (skills, agents, or commands)')
         }
       }
     }
   }
 
-  return errors
-}
+  return true
+})
+
+/** Inferred TypeScript type for a validated facet manifest */
+export type FacetManifest = typeof FacetManifestSchema.infer


### PR DESCRIPTION
## Summary

- Adds front matter detection to the build pipeline — build now fails with a clear error if any content file contains YAML front matter, enforcing the manifest as the single source of truth for metadata.
- Adds empty file validation — build fails if any content file is empty or whitespace-only.
- All build failure messages now suggest running `facet edit` to fix issues, both in the TUI and the CLI summary output.
- Introduces a `front-matter.ts` module in `@agent-facets/core` with `hasFrontMatter()` and `extractFrontMatter()` utilities (the latter is exported for use by the upcoming `facet edit` command).
- Refactors the build TUI to render validation errors inline beneath the failed stage row instead of in a separate block, and defers Ink exit so error state is painted before unmount.
- Adds `yaml` as a dependency of `@agent-facets/core` for robust YAML front matter parsing.
- Marks OpenSpec tasks for sections 5 (Build Command Hardening — Research) and 6 (Build Command Hardening — Implementation) as complete.

## Example Validation Failure

```zsh
➜  tmp git:(julian/build-command-hardening) ✗ facet build

 Building facet...

 ✕ Parsing manifest
    skills.test.description must be a string (was missing)
 ○ Resolving prompts
 ○ Validating assets
 ○ Checking collisions
 ○ Validating platforms
 ○ Assembling archive
 ○ Writing output

✗ Build failed — 1 error. Run `facet edit` to fix.
```