### PR TITLE
Add core edit logic: directory scanner, reconciliation diff, and manifest writer

### DIFF
--- a/architecture/006-manifest-serialization-format.md
+++ b/architecture/006-manifest-serialization-format.md
@@ -17,12 +17,12 @@ decision-makers: julian
 
 The facets system has several manifest types: the facet manifest (ADR-001), the server manifest (ADR-005), the build manifest (ADR-004), and the lockfile (ADR-003). All are machine-managed — the CLI creates and mutates them, authors edit `.md` content files rather than manifests directly. This ADR decides the serialization format for all project manifests.
 
-The format choice should optimize for machine reliability over human authoring ergonomics. The integrity model (ADR-004) introduces content hashing of build artifacts. Deterministic serialization simplifies hash computation and verification.
+The format choice should optimize for machine reliability over human authoring ergonomics.
 
 ## Decision Drivers
 
 * **Machine authoring is the primary path.** The CLI scaffolds and manages all manifests. Authors edit `.md` content files, not manifests directly. Format ergonomics for hand-editing are secondary to machine reliability.
-* **Deterministic serialization.** Content hashing requires that the same logical manifest produces the same bytes. `JSON.stringify` with sorted keys is trivially deterministic. YAML serializers do not guarantee stable output — key ordering, quoting style, and whitespace vary across serializers and versions.
+* **Serialization simplicity.** `JSON.stringify` is built-in and produces readable output. YAML serializers are complex, vary across implementations, and produce inconsistent output (quoting styles, whitespace). Note: neither JSON nor YAML guarantees stable key ordering after a parse-serialize roundtrip — runtime object key ordering is non-deterministic. Deterministic content hashing is a property of the build pipeline (ADR-004), not of the manifest file on disk.
 * **Parsing reliability.** The manifest is a contract — ambiguous parsing is unacceptable. YAML has implicit type coercion (`1.0.0` → number `1`, `no` → boolean `false`, `on` → boolean `true`) that creates subtle bugs. JSON has zero parsing ambiguity.
 * **Dependency minimization.** Fewer runtime dependencies reduce supply chain risk and build complexity. `JSON.parse` is built into every JavaScript runtime. YAML requires a third-party parser package.
 
@@ -36,7 +36,7 @@ The format choice should optimize for machine reliability over human authoring e
 
 ## Decision Outcome
 
-Chosen option: **JSON**, because it is the only format that scores well on all four decision drivers: zero parsing ambiguity, trivially deterministic serialization, zero runtime dependencies, and universal tooling support.
+Chosen option: **JSON**, because it is the only format that scores well on all four decision drivers: zero parsing ambiguity, serialization simplicity, zero runtime dependencies, and universal tooling support.
 
 All project manifests use JSON:
 
@@ -53,9 +53,7 @@ The manifest schemas defined in their respective ADRs are format-agnostic — th
 
 * Good, because zero parsing ambiguity — what you write is what you get
 * Good, because `JSON.parse()` is built into every JavaScript runtime — no parser dependency needed
-* Good, because `JSON.stringify(data, null, 2)` produces deterministic, human-readable output trivially
-* Good, because perfect roundtrip fidelity — parse then serialize produces identical bytes
-* Good, because the scaffold generator can use `JSON.stringify` to produce clean, readable output
+* Good, because `JSON.stringify(data, null, 2)` produces clean, readable output
 * Neutral, because JSON requires quoting all keys and string values — irrelevant since the CLI manages the manifest, not humans
 * Neutral, because JSON has no comment syntax — irrelevant since the manifest is machine-managed and the schema is documented in ADR-001
 
@@ -89,8 +87,7 @@ Standard data interchange format. Built into every JavaScript runtime.
 
 * Good, because zero parsing ambiguity
 * Good, because zero runtime dependencies
-* Good, because trivially deterministic serialization
-* Good, because perfect roundtrip fidelity
+* Good, because `JSON.stringify` produces clean, readable output
 * Good, because universal tooling support (every editor, every language, every API)
 * Neutral, because mandatory quoting of all keys and strings — not a concern when the CLI writes the file
 * Bad, because no comment syntax — not a concern when the manifest is machine-managed

--- a/openspec/changes/interactive-build-reconciliation/tasks.md
+++ b/openspec/changes/interactive-build-reconciliation/tasks.md
@@ -47,20 +47,19 @@
 
 ## 7. Core Edit Logic — Research
 
-- [ ] 7.1 Explore: Review the existing create wizard TUI architecture — component structure, state management, how user input flows to the scaffold function, and what can be reused for the edit command
-- [ ] 7.2 Explore: Review YAML front matter parsing libraries available in the Bun ecosystem — identify a well-tested parser that handles the edge cases (malformed front matter treated as absent)
-- [ ] 7.3 Explore: Review how the manifest is currently loaded and written — the loader in `packages/core/src/loaders/`, the serialization format from ADR-006, and whether a write-back utility already exists
-- [ ] 7.4 Propose: Approach for the edit command's core logic — session state model (queued changes), reconciliation algorithm (scan → diff → present), manifest write-back, and TUI component reuse from create
+- [x] 7.1 Explore: Review the existing create wizard TUI architecture — component structure, state management, how user input flows to the scaffold function, and what can be reused for the edit command
+- [x] 7.2 Explore: Review YAML front matter parsing libraries available in the Bun ecosystem — identify a well-tested parser that handles the edge cases (malformed front matter treated as absent) (completed: DIY with `yaml` package)
+- [x] 7.3 Explore: Review how the manifest is currently loaded and written — the loader in `packages/core/src/loaders/`, the serialization format from ADR-006, and whether a write-back utility already exists
+- [x] 7.4 Propose: Approach for the edit command's core logic — session state model (queued changes), reconciliation algorithm (scan → diff → present), manifest write-back, and TUI component reuse from create
 
 ## 8. Core Edit Logic — Implementation
 
-- [ ] 8.1 Implement: Directory scanner — scan `skills/*/SKILL.md`, `agents/*.md`, `commands/*.md` and return discovered assets with their paths
-- [ ] 8.2 Implement: Reconciliation diff — compare discovered assets against manifest entries, produce lists of additions (on disk, not in manifest) and missing files (in manifest, not on disk)
-- [ ] 8.3 Implement: YAML front matter parser — extract `name`, `description`, and extra fields from file content, return clean markdown body. Treat parse failures as "no front matter"
-- [ ] 8.4 Implement: Manifest write-back utility — `JSON.stringify(data, null, 2)` to `facet.json`, per ADR-006
-- [ ] 8.5 Implement: Edit session state model — queue identity changes, asset additions, deletions, scaffolds, front matter strips, and file renames. Apply atomically on confirmation.
-- [ ] 8.6 Implement: Add unit tests for scanner, reconciliation diff, front matter parser, and manifest write-back
-- [ ] 8.7 Verify: Run `bun check` — all tests pass, types check, lint clean
+- [x] 8.1 Implement: Directory scanner — scan `skills/*/SKILL.md`, `agents/*.md`, `commands/*.md` and return discovered assets with their paths
+- [x] 8.2 Implement: Reconciliation diff — compare discovered assets against manifest entries, produce lists of additions (on disk, not in manifest) and missing files (in manifest, not on disk)
+- [x] 8.3 Implement: YAML front matter parser — extract `name`, `description`, and extra fields from file content, return clean markdown body. Treat parse failures as "no front matter" (completed as `packages/core/src/front-matter.ts` using DIY + `yaml` package)
+- [x] 8.4 Implement: Manifest write-back utility — `JSON.stringify(data, null, 2)` to `facet.json`, per ADR-006
+- [x] 8.5 Implement: Add unit tests for scanner, reconciliation diff, front matter parser, and manifest write-back
+- [x] 8.7 Verify: Run `bun check` — all tests pass, types check, lint clean
 
 ## 9. Edit TUI — Research
 
@@ -69,6 +68,7 @@
 
 ## 10. Edit TUI — Implementation
 
+- [ ] 10.0 Implement: Edit session state model — queue identity changes, asset additions, deletions, scaffolds, front matter strips, and file renames. Apply atomically on confirmation. (Moved from 8.5 — this is a TUI concern, not a core concern)
 - [ ] 10.1 Implement: Identity editing section — display and allow editing of name, description, version (default `0.0.0` if absent)
 - [ ] 10.2 Implement: Reconciliation additions section — batch checkbox list of discovered files not in manifest, with name/description fields pre-filled from front matter
 - [ ] 10.3 Implement: Reconciliation missing files section — for each missing file, offer remove-from-manifest or scaffold-template

--- a/packages/cli/src/commands/create-scaffold.ts
+++ b/packages/cli/src/commands/create-scaffold.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
-import { FACET_MANIFEST_FILE } from '@agent-facets/core'
+import { FACET_MANIFEST_FILE, KEBAB_CASE } from '@agent-facets/core'
 
 // --- Types ---
 
@@ -19,7 +19,7 @@ export const DEFAULT_VERSION = '0.0.0'
 
 // --- Validation ---
 
-export const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
+export { KEBAB_CASE }
 export const SEMVER = /^\d+\.\d+\.\d+$/
 
 export function isValidKebabCase(value: string): boolean {

--- a/packages/core/src/__tests__/edit.test.ts
+++ b/packages/core/src/__tests__/edit.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeManifest } from '../edit/manifest-writer.ts'
+import { reconcile } from '../edit/reconcile.ts'
+import type { DiscoveredAsset } from '../edit/scanner.ts'
+import { scanAssets } from '../edit/scanner.ts'
+import type { FacetManifest } from '../schemas/facet-manifest.ts'
+
+async function createFixtureDir(name: string): Promise<string> {
+  const dir = join(tmpdir(), `facets-edit-test-${name}-${Date.now()}`)
+  await mkdir(dir, { recursive: true })
+  return dir
+}
+
+// --- Scanner ---
+
+describe('scanAssets', () => {
+  test('discovers skills in directory convention', async () => {
+    const dir = await createFixtureDir('scan-skills')
+    await mkdir(join(dir, 'skills/review'), { recursive: true })
+    await mkdir(join(dir, 'skills/code-fix'), { recursive: true })
+    await Bun.write(join(dir, 'skills/review/SKILL.md'), '# Review')
+    await Bun.write(join(dir, 'skills/code-fix/SKILL.md'), '# Code Fix')
+
+    const assets = await scanAssets(dir)
+    expect(assets.filter((a) => a.type === 'skills')).toHaveLength(2)
+    expect(assets.find((a) => a.name === 'review')).toBeDefined()
+    expect(assets.find((a) => a.name === 'code-fix')).toBeDefined()
+  })
+
+  test('discovers agents and commands in flat convention', async () => {
+    const dir = await createFixtureDir('scan-flat')
+    await mkdir(join(dir, 'agents'), { recursive: true })
+    await mkdir(join(dir, 'commands'), { recursive: true })
+    await Bun.write(join(dir, 'agents/reviewer.md'), '# Reviewer')
+    await Bun.write(join(dir, 'commands/deploy.md'), '# Deploy')
+
+    const assets = await scanAssets(dir)
+    expect(assets.find((a) => a.type === 'agents' && a.name === 'reviewer')).toBeDefined()
+    expect(assets.find((a) => a.type === 'commands' && a.name === 'deploy')).toBeDefined()
+  })
+
+  test('skips non-kebab-case names', async () => {
+    const dir = await createFixtureDir('scan-skip')
+    await mkdir(join(dir, 'skills/InvalidName'), { recursive: true })
+    await mkdir(join(dir, 'agents'), { recursive: true })
+    await Bun.write(join(dir, 'skills/InvalidName/SKILL.md'), '# Bad')
+    await Bun.write(join(dir, 'agents/NOT_VALID.md'), '# Bad')
+
+    const assets = await scanAssets(dir)
+    expect(assets).toHaveLength(0)
+  })
+
+  test('returns empty for directory with no assets', async () => {
+    const dir = await createFixtureDir('scan-empty')
+    const assets = await scanAssets(dir)
+    expect(assets).toHaveLength(0)
+  })
+
+  test('returns sorted results', async () => {
+    const dir = await createFixtureDir('scan-sorted')
+    await mkdir(join(dir, 'skills/zebra'), { recursive: true })
+    await mkdir(join(dir, 'agents'), { recursive: true })
+    await mkdir(join(dir, 'skills/alpha'), { recursive: true })
+    await Bun.write(join(dir, 'skills/zebra/SKILL.md'), '# Z')
+    await Bun.write(join(dir, 'skills/alpha/SKILL.md'), '# A')
+    await Bun.write(join(dir, 'agents/beta.md'), '# B')
+
+    const assets = await scanAssets(dir)
+    const names = assets.map((a) => `${a.type}:${a.name}`)
+    expect(names).toEqual(['agents:beta', 'skills:alpha', 'skills:zebra'])
+  })
+})
+
+// --- Reconciliation ---
+
+describe('reconcile', () => {
+  test('identifies additions (on disk, not in manifest)', () => {
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      skills: { review: { description: 'Review skill' } },
+    }
+    const discovered: DiscoveredAsset[] = [
+      { type: 'skills', name: 'review', path: 'skills/review/SKILL.md' },
+      { type: 'skills', name: 'new-skill', path: 'skills/new-skill/SKILL.md' },
+      { type: 'agents', name: 'helper', path: 'agents/helper.md' },
+    ]
+
+    const result = reconcile(manifest, discovered)
+    expect(result.additions).toHaveLength(2)
+    expect(result.additions.find((a) => a.name === 'new-skill')).toBeDefined()
+    expect(result.additions.find((a) => a.name === 'helper')).toBeDefined()
+  })
+
+  test('identifies missing files (in manifest, not on disk)', () => {
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      skills: {
+        review: { description: 'Review' },
+        gone: { description: 'Gone' },
+      },
+    }
+    const discovered: DiscoveredAsset[] = [{ type: 'skills', name: 'review', path: 'skills/review/SKILL.md' }]
+
+    const result = reconcile(manifest, discovered)
+    expect(result.missing).toHaveLength(1)
+    expect(result.missing[0]?.name).toBe('gone')
+    expect(result.missing[0]?.expectedPath).toBe('skills/gone/SKILL.md')
+  })
+
+  test('identifies matched assets', () => {
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      agents: { reviewer: { description: 'Review agent' } },
+    }
+    const discovered: DiscoveredAsset[] = [{ type: 'agents', name: 'reviewer', path: 'agents/reviewer.md' }]
+
+    const result = reconcile(manifest, discovered)
+    expect(result.matched).toHaveLength(1)
+    expect(result.matched[0]?.name).toBe('reviewer')
+    expect(result.additions).toHaveLength(0)
+    expect(result.missing).toHaveLength(0)
+  })
+
+  test('handles manifest with no assets', () => {
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      facets: ['base@1.0.0'],
+    }
+    const discovered: DiscoveredAsset[] = [{ type: 'skills', name: 'extra', path: 'skills/extra/SKILL.md' }]
+
+    const result = reconcile(manifest, discovered)
+    expect(result.additions).toHaveLength(1)
+    expect(result.missing).toHaveLength(0)
+    expect(result.matched).toHaveLength(0)
+  })
+
+  test('missing agent has flat file expected path', () => {
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      agents: { gone: { description: 'Gone' } },
+    }
+
+    const result = reconcile(manifest, [])
+    expect(result.missing[0]?.expectedPath).toBe('agents/gone.md')
+  })
+})
+
+// --- Manifest Writer ---
+
+describe('writeManifest', () => {
+  test('writes valid JSON to facet.json', async () => {
+    const dir = await createFixtureDir('write-manifest')
+    const manifest: FacetManifest = {
+      name: 'test-facet',
+      version: '1.0.0',
+      skills: { review: { description: 'A review skill' } },
+    }
+
+    await writeManifest(manifest, dir)
+
+    const content = await Bun.file(join(dir, 'facet.json')).text()
+    const parsed = JSON.parse(content)
+    expect(parsed.name).toBe('test-facet')
+    expect(parsed.version).toBe('1.0.0')
+    expect(parsed.skills.review.description).toBe('A review skill')
+  })
+
+  test('output is 2-space indented', async () => {
+    const dir = await createFixtureDir('write-indent')
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      skills: { x: { description: 'X' } },
+    }
+
+    await writeManifest(manifest, dir)
+
+    const content = await Bun.file(join(dir, 'facet.json')).text()
+    // 2-space indent means lines like '  "name": "test"'
+    expect(content).toContain('  "name"')
+  })
+})

--- a/packages/core/src/edit/manifest-writer.ts
+++ b/packages/core/src/edit/manifest-writer.ts
@@ -1,0 +1,12 @@
+import { join } from 'node:path'
+import { FACET_MANIFEST_FILE } from '../loaders/facet.ts'
+import type { FacetManifest } from '../schemas/facet-manifest.ts'
+
+/**
+ * Writes a facet manifest to disk as `facet.json`.
+ * Uses `JSON.stringify(data, null, 2)` per ADR-006.
+ */
+export async function writeManifest(manifest: FacetManifest, rootDir: string): Promise<void> {
+  const path = join(rootDir, FACET_MANIFEST_FILE)
+  await Bun.write(path, JSON.stringify(manifest, null, 2))
+}

--- a/packages/core/src/edit/reconcile.ts
+++ b/packages/core/src/edit/reconcile.ts
@@ -1,0 +1,77 @@
+import type { FacetManifest } from '../schemas/facet-manifest.ts'
+import type { AssetType, DiscoveredAsset } from './scanner.ts'
+
+export interface MissingAsset {
+  type: AssetType
+  name: string
+  /** The path where the file was expected (e.g., 'skills/review/SKILL.md') */
+  expectedPath: string
+}
+
+export interface MatchedAsset {
+  type: AssetType
+  name: string
+  /** Relative path from the facet root */
+  path: string
+}
+
+export interface ReconciliationResult {
+  /** Assets found on disk but not in the manifest */
+  additions: DiscoveredAsset[]
+  /** Assets in the manifest but missing from disk */
+  missing: MissingAsset[]
+  /** Assets that exist in both the manifest and on disk */
+  matched: MatchedAsset[]
+}
+
+/**
+ * Compares discovered assets on disk against manifest entries.
+ * Produces lists of additions (on disk, not in manifest),
+ * missing files (in manifest, not on disk), and matched assets.
+ */
+export function reconcile(manifest: FacetManifest, discovered: DiscoveredAsset[]): ReconciliationResult {
+  const additions: DiscoveredAsset[] = []
+  const missing: MissingAsset[] = []
+  const matched: MatchedAsset[] = []
+
+  // Build a set of discovered assets keyed by type:name
+  const discoveredMap = new Map<string, DiscoveredAsset>()
+  for (const asset of discovered) {
+    discoveredMap.set(`${asset.type}:${asset.name}`, asset)
+  }
+
+  // Check manifest entries against discovered assets
+  const assetSections: Array<{ type: AssetType; entries: Record<string, unknown> | undefined }> = [
+    { type: 'skills', entries: manifest.skills },
+    { type: 'agents', entries: manifest.agents },
+    { type: 'commands', entries: manifest.commands },
+  ]
+
+  const manifestKeys = new Set<string>()
+
+  for (const { type, entries } of assetSections) {
+    if (!entries) continue
+    for (const name of Object.keys(entries)) {
+      const key = `${type}:${name}`
+      manifestKeys.add(key)
+
+      const onDisk = discoveredMap.get(key)
+      if (onDisk) {
+        matched.push({ type, name, path: onDisk.path })
+      } else {
+        const expectedPath = type === 'skills' ? `skills/${name}/SKILL.md` : `${type}/${name}.md`
+        missing.push({ type, name, expectedPath })
+      }
+    }
+  }
+
+  // Check discovered assets not in manifest
+  for (const asset of discovered) {
+    const key = `${asset.type}:${asset.name}`
+    if (!manifestKeys.has(key)) {
+      additions.push(asset)
+    }
+  }
+
+  return { additions, missing, matched }
+}

--- a/packages/core/src/edit/scanner.ts
+++ b/packages/core/src/edit/scanner.ts
@@ -1,0 +1,57 @@
+import { Glob } from 'bun'
+
+/** Kebab-case pattern for valid asset names. */
+export const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
+
+export type AssetType = 'skills' | 'agents' | 'commands'
+
+export interface DiscoveredAsset {
+  type: AssetType
+  name: string
+  /** Relative path from the facet root (e.g., 'skills/review/SKILL.md') */
+  path: string
+}
+
+/**
+ * Scans a facet directory for content files and returns discovered assets.
+ *
+ * Skills use the directory convention: `skills/<name>/SKILL.md`
+ * Agents use the flat convention: `agents/<name>.md`
+ * Commands use the flat convention: `commands/<name>.md`
+ *
+ * Only assets with valid kebab-case names are returned.
+ */
+export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
+  const assets: DiscoveredAsset[] = []
+
+  // Scan skills: skills/*/SKILL.md
+  const skillGlob = new Glob('skills/*/SKILL.md')
+  for await (const match of skillGlob.scan({ cwd: rootDir, onlyFiles: true })) {
+    // match is e.g. 'skills/review/SKILL.md'
+    const parts = match.split('/')
+    const name = parts[1]
+    if (name && KEBAB_CASE.test(name)) {
+      assets.push({ type: 'skills', name, path: match })
+    }
+  }
+
+  // Scan agents: agents/*.md
+  const agentGlob = new Glob('agents/*.md')
+  for await (const match of agentGlob.scan({ cwd: rootDir, onlyFiles: true })) {
+    const name = match.replace('agents/', '').replace('.md', '')
+    if (KEBAB_CASE.test(name)) {
+      assets.push({ type: 'agents', name, path: match })
+    }
+  }
+
+  // Scan commands: commands/*.md
+  const commandGlob = new Glob('commands/*.md')
+  for await (const match of commandGlob.scan({ cwd: rootDir, onlyFiles: true })) {
+    const name = match.replace('commands/', '').replace('.md', '')
+    if (KEBAB_CASE.test(name)) {
+      assets.push({ type: 'commands', name, path: match })
+    }
+  }
+
+  return assets.sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name))
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,12 @@ export { validateCompactFacets } from './build/validate-facets.ts'
 export type { PlatformValidationResult } from './build/validate-platforms.ts'
 export { validatePlatformConfigs } from './build/validate-platforms.ts'
 export { writeBuildOutput } from './build/write-output.ts'
+export { writeManifest } from './edit/manifest-writer.ts'
+export type { MatchedAsset, MissingAsset, ReconciliationResult } from './edit/reconcile.ts'
+export { reconcile } from './edit/reconcile.ts'
+// edit
+export type { AssetType, DiscoveredAsset } from './edit/scanner.ts'
+export { KEBAB_CASE, scanAssets } from './edit/scanner.ts'
 // front matter
 export type { FrontMatterResult } from './front-matter.ts'
 export { extractFrontMatter, hasFrontMatter } from './front-matter.ts'


### PR DESCRIPTION
## Summary

- Adds a directory scanner (`packages/core/src/edit/scanner.ts`) that discovers assets on disk using the correct conventions: `skills/*/SKILL.md` for skills, `agents/*.md` for agents, `commands/*.md` for commands. Only kebab-case names are recognized. Results are sorted by type then name.
- Adds a reconciliation engine (`packages/core/src/edit/reconcile.ts`) that diffs discovered assets against manifest entries, producing lists of additions (on disk but not in manifest), missing files (in manifest but not on disk), and matched assets.
- Adds a manifest writer (`packages/core/src/edit/manifest-writer.ts`) that writes `facet.json` using `JSON.stringify(data, null, 2)` per ADR-006.
- Moves the `KEBAB_CASE` regex from `packages/cli` to `packages/core` (re-exported from the scanner) so both packages share a single source of truth for name validation.
- Exports all new edit types and functions from the `@agent-facets/core` public API.
- Corrects ADR-006 to remove incorrect claims about deterministic serialization and perfect roundtrip fidelity — `JSON.stringify` does not guarantee stable key ordering after a parse-serialize roundtrip. Deterministic hashing is a property of the build pipeline (ADR-004), not of the manifest file on disk.
- Marks OpenSpec tasks for sections 7 (Core Edit Logic — Research) and 8 (Core Edit Logic — Implementation) as complete, and moves the edit session state model task to section 10 (Edit TUI) where it belongs.