### PR TITLE
Run checks before release and add Slack CI notifications

### DIFF
--- a/.changeset/public-llamas-run.md
+++ b/.changeset/public-llamas-run.md
@@ -1,0 +1,7 @@
+---
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/core": patch
+---
+
+Ensure CI runs tests before release and notify Slack when failures occur.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,17 @@
 commands:
+    notify-failure:
+        steps:
+            - slack/notify:
+                branch_pattern: main
+                channel: C0AQVA6UB38, C0AQFU5S4PR
+                event: fail
+                template: basic_fail_1
+    notify-success:
+        steps:
+            - slack/notify:
+                channel: C0AQVA6UB38
+                event: pass
+                template: basic_success_1
     setup-mise:
         steps:
             - checkout
@@ -53,17 +66,26 @@ jobs:
             - run:
                 command: bun scripts/ci-release.ts
                 name: Release
+orbs:
+    slack: circleci/slack@6
 version: 2.1
 workflows:
     ci:
         jobs:
             - check:
-                filters:
-                    branches:
-                        ignore: main
+                context: slack-secrets
+                post-steps:
+                    - notify-failure
             - release:
-                context: release
+                context:
+                    - release
+                    - slack-secrets
                 filters:
                     branches:
                         only: main
+                post-steps:
+                    - notify-failure
+                    - notify-success
+                requires:
+                    - check
 

--- a/.circleci/src/@config.yml
+++ b/.circleci/src/@config.yml
@@ -1,1 +1,4 @@
 version: 2.1
+
+orbs:
+  slack: circleci/slack@6

--- a/.circleci/src/commands/notify-failure.yml
+++ b/.circleci/src/commands/notify-failure.yml
@@ -1,0 +1,6 @@
+steps:
+  - slack/notify:
+      event: fail
+      template: basic_fail_1
+      channel: C0AQVA6UB38, C0AQFU5S4PR
+      branch_pattern: main

--- a/.circleci/src/commands/notify-success.yml
+++ b/.circleci/src/commands/notify-success.yml
@@ -1,0 +1,5 @@
+steps:
+  - slack/notify:
+      event: pass
+      template: basic_success_1
+      channel: C0AQVA6UB38

--- a/.circleci/src/workflows/ci.yml
+++ b/.circleci/src/workflows/ci.yml
@@ -1,10 +1,17 @@
 jobs:
   - check:
-      filters:
-        branches:
-          ignore: main
+      context: slack-secrets
+      post-steps:
+        - notify-failure
   - release:
-      context: release
+      requires:
+        - check
+      context:
+        - release
+        - slack-secrets
       filters:
         branches:
           only: main
+      post-steps:
+        - notify-failure
+        - notify-success

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@fission-ai/openspec": "1.2.0",
         "@octokit/auth-app": "8.2.0",
         "@types/bun": "1.3.11",
+        "dedent": "1.7.2",
         "mint": "4.2.392",
         "turbo": "2.8.17",
         "typescript": "6.0.2",
@@ -19,7 +20,7 @@
     },
     "packages/brand": {
       "name": "@agent-facets/brand",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/bun": "1.3.10",
       },
@@ -29,7 +30,7 @@
     },
     "packages/cli": {
       "name": "agent-facets",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "facet": "./dist/facet",
       },
@@ -56,7 +57,7 @@
     },
     "packages/core": {
       "name": "@agent-facets/core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "arktype": "2.1.29",
         "comment-json": "^4.2.5",
@@ -705,6 +706,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
     "defer-to-connect": ["defer-to-connect@2.0.1", "", {}, "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@fission-ai/openspec": "1.2.0",
     "@octokit/auth-app": "8.2.0",
     "@types/bun": "1.3.11",
+    "dedent": "1.7.2",
     "mint": "4.2.392",
     "turbo": "2.8.17",
     "typescript": "6.0.2"

--- a/packages/cli/src/__tests__/edit-integration.test.ts
+++ b/packages/cli/src/__tests__/edit-integration.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runBuildPipeline } from '@agent-facets/core'
+import dedent from 'dedent'
 import { applyOperations, buildEditContext } from '../commands/edit/index.ts'
 import type { EditOperation } from '../tui/views/edit/edit-types.ts'
 
@@ -70,7 +71,15 @@ describe('edit integration', () => {
       skills: { review: { description: 'Review' } },
     })
     await mkdir(join(dir, 'skills/review'), { recursive: true })
-    await Bun.write(join(dir, 'skills/review/SKILL.md'), '---\nname: Review\n---\n# Review skill')
+    await Bun.write(
+      join(dir, 'skills/review/SKILL.md'),
+      dedent`
+        ---
+        name: Review
+        ---
+        # Review skill
+      `,
+    )
 
     const result = await buildEditContext(dir)
     expect(result.ok).toBe(true)
@@ -104,7 +113,14 @@ describe('edit integration', () => {
     await mkdir(join(dir, 'skills/review'), { recursive: true })
     await Bun.write(
       join(dir, 'skills/review/SKILL.md'),
-      '---\nname: Review\ndescription: A review skill\n---\n# Review\nReview all code.',
+      dedent`
+        ---
+        name: Review
+        description: A review skill
+        ---
+        # Review
+        Review all code.
+      `,
     )
 
     const manifest = {

--- a/packages/core/src/__tests__/build-pipeline.test.ts
+++ b/packages/core/src/__tests__/build-pipeline.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import dedent from 'dedent'
 import { detectNamingCollisions } from '../build/detect-collisions.ts'
 import { runBuildPipeline } from '../build/pipeline.ts'
 import { validateCompactFacets } from '../build/validate-facets.ts'
@@ -358,7 +359,14 @@ describe('content validation', () => {
     const dir = await createFixtureDir('front-matter')
     await Bun.write(
       join(dir, 'skills/review/SKILL.md'),
-      '---\nname: Review\ndescription: A review skill\n---\n# Review\nReview all code.',
+      dedent`
+        ---
+        name: Review
+        description: A review skill
+        ---
+        # Review
+        Review all code.
+      `,
     )
     await Bun.write(
       join(dir, 'facet.json'),

--- a/packages/core/src/__tests__/facet-loader.test.ts
+++ b/packages/core/src/__tests__/facet-loader.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import dedent from 'dedent'
 import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
 
 let testDir: string
@@ -174,9 +175,30 @@ describe('loadManifest', () => {
 describe('resolvePrompts', () => {
   test('prompt content is resolved from conventional file paths', async () => {
     const dir = await createFixtureDir('resolve-convention')
-    await writeFixture(dir, 'skills/review/SKILL.md', '# Code Review\nReview all code.')
-    await writeFixture(dir, 'agents/reviewer.md', '# Reviewer\nReview this code.')
-    await writeFixture(dir, 'commands/deploy.md', '# Deploy\nDeploy the code.')
+    await writeFixture(
+      dir,
+      'skills/review/SKILL.md',
+      dedent`
+        # Code Review
+        Review all code.
+      `,
+    )
+    await writeFixture(
+      dir,
+      'agents/reviewer.md',
+      dedent`
+        # Reviewer
+        Review this code.
+      `,
+    )
+    await writeFixture(
+      dir,
+      'commands/deploy.md',
+      dedent`
+        # Deploy
+        Deploy the code.
+      `,
+    )
 
     const manifest = {
       name: 'test',
@@ -195,15 +217,31 @@ describe('resolvePrompts', () => {
     const result = await resolvePrompts(manifest, dir)
     expect(result.ok).toBe(true)
     if (result.ok) {
-      expect(result.data.skills?.review?.prompt).toBe('# Code Review\nReview all code.')
-      expect(result.data.agents?.reviewer?.prompt).toBe('# Reviewer\nReview this code.')
-      expect(result.data.commands?.deploy?.prompt).toBe('# Deploy\nDeploy the code.')
+      expect(result.data.skills?.review?.prompt).toBe(dedent`
+        # Code Review
+        Review all code.
+      `)
+      expect(result.data.agents?.reviewer?.prompt).toBe(dedent`
+        # Reviewer
+        Review this code.
+      `)
+      expect(result.data.commands?.deploy?.prompt).toBe(dedent`
+        # Deploy
+        Deploy the code.
+      `)
     }
   })
 
   test('file-based prompt is resolved from agents/<name>.md', async () => {
     const dir = await createFixtureDir('resolve-file')
-    await writeFixture(dir, 'agents/reviewer.md', '# Review\nCheck all code.')
+    await writeFixture(
+      dir,
+      'agents/reviewer.md',
+      dedent`
+        # Review
+        Check all code.
+      `,
+    )
 
     const manifest = {
       name: 'test',
@@ -216,7 +254,10 @@ describe('resolvePrompts', () => {
     const result = await resolvePrompts(manifest, dir)
     expect(result.ok).toBe(true)
     if (result.ok) {
-      expect(result.data.agents?.reviewer?.prompt).toBe('# Review\nCheck all code.')
+      expect(result.data.agents?.reviewer?.prompt).toBe(dedent`
+        # Review
+        Check all code.
+      `)
     }
   })
 
@@ -242,7 +283,14 @@ describe('resolvePrompts', () => {
 
   test('manifest without agents or commands resolves successfully', async () => {
     const dir = await createFixtureDir('resolve-skills-only')
-    await writeFixture(dir, 'skills/x/SKILL.md', '# Skill X\nDo x.')
+    await writeFixture(
+      dir,
+      'skills/x/SKILL.md',
+      dedent`
+        # Skill X
+        Do x.
+      `,
+    )
 
     const manifest = {
       name: 'test',
@@ -258,7 +306,10 @@ describe('resolvePrompts', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.data.name).toBe('test')
-      expect(result.data.skills?.x?.prompt).toBe('# Skill X\nDo x.')
+      expect(result.data.skills?.x?.prompt).toBe(dedent`
+        # Skill X
+        Do x.
+      `)
     }
   })
 })

--- a/scripts/ci-release.test.ts
+++ b/scripts/ci-release.test.ts
@@ -51,6 +51,7 @@ describe('ci-release', () => {
       spyOn(io, 'gitCommit').mockResolvedValue(shellResult())
       spyOn(io, 'gitPush').mockResolvedValue(shellResult())
       spyOn(io, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
+      spyOn(io, 'writeFile').mockResolvedValue(0)
     }
 
     test('creates a new PR with rich body when changesets are pending', async () => {

--- a/scripts/ci-release.ts
+++ b/scripts/ci-release.ts
@@ -16,7 +16,9 @@ import {
   filterPendingChangesets,
   hasUnpublishedVersions,
   parsePublishedPackages,
+  replaceChangelogEntry,
   shouldPublish,
+  transformChangelogContent,
 } from './lib/changesets'
 import { io } from './lib/ci-io'
 
@@ -49,7 +51,15 @@ export async function versionAndCreatePR(): Promise<number> {
   // Detect which packages changed and build rich PR body
   const packagesAfter = await io.loadWorkspacePackages()
   const changedPackages = packagesAfter.filter((p) => versionsBefore.get(p.name) !== p.version)
-  const prBody = await buildVersionPrBody(changedPackages, io.readFile)
+  const { body: prBody, entries } = await buildVersionPrBody(changedPackages, io.readFile)
+
+  // Rewrite CHANGELOG.md files with transformed content
+  for (const entry of entries) {
+    const changelogPath = `${entry.dir}/CHANGELOG.md`
+    const original = await io.readFile(changelogPath)
+    const rewritten = replaceChangelogEntry(original, entry.version, entry.content)
+    await io.writeFile(changelogPath, rewritten)
+  }
 
   // Configure git identity
   await io.gitConfig('user.name', 'circleci[bot]')
@@ -109,7 +119,7 @@ export async function publish(): Promise<number> {
 
       const changelog = await io.readFile(`${workspacePkg.dir}/CHANGELOG.md`)
       const entry = getChangelogEntry(changelog, pkg.version)
-      await io.ghReleaseCreate(tag, tag, entry.content)
+      await io.ghReleaseCreate(tag, tag, transformChangelogContent(entry.content))
       io.log(`Created GitHub Release: ${tag}`)
     } catch (err) {
       io.error(`Failed to create release for ${tag}: ${(err as Error).message}`)

--- a/scripts/lib/changesets.test.ts
+++ b/scripts/lib/changesets.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from 'bun:test'
+import dedent from 'dedent'
 import {
   buildVersionPrBody,
   filterPendingChangesets,
   hasUnpublishedVersions,
   parsePublishedPackages,
+  replaceChangelogEntry,
   shouldPublish,
+  transformChangelogContent,
   type WorkspacePackage,
 } from './changesets'
 
@@ -97,6 +100,589 @@ describe('hasUnpublishedVersions', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// transformChangelogContent
+// ---------------------------------------------------------------------------
+
+describe('transformChangelogContent', () => {
+  /** Builds a remark-style attributed line (3-space indent, loose list) as @changesets/changelog-github generates */
+  const remark = (hash: string, user: string, desc: string) =>
+    `-   [\`${hash}\`](https://github.com/agent-facets/facets/commit/${hash}) Thanks [@${user}](https://github.com/${user})! - ${desc}`
+
+  describe('attribution regex', () => {
+    test('7-character commit hash', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('098fd08', 'eXamadeus', 'Fix a bug')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - 098fd08 Thanks @eXamadeus! - Fix a bug
+      `}\n`,
+      )
+    })
+
+    test('8-character commit hash', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('abcdef01', 'user', 'Longer hash')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - abcdef01 Thanks @user! - Longer hash
+      `}\n`,
+      )
+    })
+
+    test('full 40-character commit hash', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('a'.repeat(40), 'user', 'Full hash')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa Thanks @user! - Full hash
+      `}\n`,
+      )
+    })
+
+    test('username with mixed case, numbers, and hyphens', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('abc1234', 'eXamadeus', 'Mixed case')}
+
+          ${remark('def5678', 'my-user-name', 'Hyphenated')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - abc1234 Thanks @eXamadeus! - Mixed case
+        - def5678 Thanks @my-user-name! - Hyphenated
+      `}\n`,
+      )
+    })
+
+    test('description with special characters', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('abc1234', 'user', 'Fix `foo()` in @scope/bar')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - abc1234 Thanks @user! - Fix \`foo()\` in @scope/bar
+      `}\n`,
+      )
+    })
+
+    test('bare commit hash entry (no Thanks attribution)', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          -   bb87748: Just a bare commit hash entry
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - bb87748: Just a bare commit hash entry
+      `}\n`,
+      )
+    })
+
+    test('Updated dependencies line', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          -   Updated dependencies [abc1234]
+              -   @agent-facets/core@0.2.0
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        #### Updated Dependencies
+        - abc1234 @agent-facets/core@0.2.0
+      `}\n`,
+      )
+    })
+  })
+
+  describe('spacing normalization', () => {
+    test('removes blank lines between loose list items', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'Change A')}
+
+          ${remark('bbb2222', 'bob', 'Change B')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - aaa1111 Thanks @alice! - Change A
+        - bbb2222 Thanks @bob! - Change B
+      `}\n`,
+      )
+    })
+
+    test('normalizes remark 3-space indent back to 1 space', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          -   bb87748: Bare entry
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - bb87748: Bare entry
+      `}\n`,
+      )
+    })
+  })
+
+  describe('user grouping', () => {
+    test('groups multiple changes from the same user under a heading', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'eXamadeus', 'Change A')}
+
+          ${remark('bbb2222', 'eXamadeus', 'Change B')}
+
+          ${remark('ccc3333', 'eXamadeus', 'Change C')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        **@eXamadeus** — Thanks! (3 changes)
+        - aaa1111 Change A
+        - bbb2222 Change B
+        - ccc3333 Change C
+      `}\n`,
+      )
+    })
+
+    test('sorts groups by volume descending', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'A1')}
+
+          ${remark('bbb2222', 'bob', 'B1')}
+
+          ${remark('ccc3333', 'bob', 'B2')}
+
+          ${remark('ddd4444', 'bob', 'B3')}
+
+          ${remark('eee5555', 'alice', 'A2')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        **@bob** — Thanks! (3 changes)
+        - bbb2222 B1
+        - ccc3333 B2
+        - ddd4444 B3
+
+        **@alice** — Thanks! (2 changes)
+        - aaa1111 A1
+        - eee5555 A2
+      `}\n`,
+      )
+    })
+
+    test('preserves first-seen order for ties', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'A1')}
+
+          ${remark('bbb2222', 'alice', 'A2')}
+
+          ${remark('ccc3333', 'bob', 'B1')}
+
+          ${remark('ddd4444', 'bob', 'B2')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        **@alice** — Thanks! (2 changes)
+        - aaa1111 A1
+        - bbb2222 A2
+
+        **@bob** — Thanks! (2 changes)
+        - ccc3333 B1
+        - ddd4444 B2
+      `}\n`,
+      )
+    })
+
+    test('single-change users keep original format (no grouping)', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'Solo change')}
+        `),
+      ).toBe(
+        `${dedent`
+          ### Patch Changes
+  
+          - aaa1111 Thanks @alice! - Solo change
+        `}\n`,
+      )
+    })
+
+    test('groups + singles shows Individual Contributions heading', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'eXamadeus', 'Change A')}
+
+          ${remark('bbb2222', 'eXamadeus', 'Change B')}
+
+          ${remark('ccc3333', 'contributor', 'Solo fix')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        **@eXamadeus** — Thanks! (2 changes)
+        - aaa1111 Change A
+        - bbb2222 Change B
+
+        #### Individual Contributions
+        - ccc3333 Thanks @contributor! - Solo fix
+      `}\n`,
+      )
+    })
+
+    test('all multi-change users: no Individual Contributions heading', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'A1')}
+
+          ${remark('bbb2222', 'alice', 'A2')}
+
+          ${remark('ccc3333', 'bob', 'B1')}
+
+          ${remark('ddd4444', 'bob', 'B2')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        **@alice** — Thanks! (2 changes)
+        - aaa1111 A1
+        - bbb2222 A2
+
+        **@bob** — Thanks! (2 changes)
+        - ccc3333 B1
+        - ddd4444 B2
+      `}\n`,
+      )
+    })
+
+    test('all single-change users: no heading, no grouping', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'Solo A')}
+
+          ${remark('bbb2222', 'bob', 'Solo B')}
+
+          ${remark('ccc3333', 'charlie', 'Solo C')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - aaa1111 Thanks @alice! - Solo A
+        - bbb2222 Thanks @bob! - Solo B
+        - ccc3333 Thanks @charlie! - Solo C
+      `}\n`,
+      )
+    })
+  })
+
+  describe('Updated Dependencies', () => {
+    test('multiple deps with commit hashes', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          -   Updated dependencies [bb87748]
+          -   Updated dependencies [95e2f38]
+              -   @agent-facets/brand@0.1.1
+              -   @agent-facets/core@0.1.2
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        #### Updated Dependencies
+        - 95e2f38 @agent-facets/brand@0.1.1
+        - 95e2f38 @agent-facets/core@0.1.2
+      `}\n`,
+      )
+    })
+
+    test('deps after attributed changes', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'alice', 'Fix thing')}
+
+          -   Updated dependencies [bb87748]
+              -   @agent-facets/core@0.1.2
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        - aaa1111 Thanks @alice! - Fix thing
+
+        #### Updated Dependencies
+        - bb87748 @agent-facets/core@0.1.2
+      `}\n`,
+      )
+    })
+  })
+
+  describe('mixed content', () => {
+    test('attributed + unattributed + dependencies', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Patch Changes
+
+          ${remark('aaa1111', 'eXamadeus', 'Change A')}
+
+          ${remark('bbb2222', 'eXamadeus', 'Change B')}
+
+          -   cc87748: Bare commit entry
+
+          ${remark('ddd4444', 'contributor', 'Solo fix')}
+
+          -   Updated dependencies [ee12345]
+              -   @agent-facets/core@0.2.0
+        `),
+      ).toBe(
+        `${dedent`
+        ### Patch Changes
+
+        **@eXamadeus** — Thanks! (2 changes)
+        - aaa1111 Change A
+        - bbb2222 Change B
+
+        #### Individual Contributions
+        - ddd4444 Thanks @contributor! - Solo fix
+        - cc87748: Bare commit entry
+
+        #### Updated Dependencies
+        - ee12345 @agent-facets/core@0.2.0
+      `}\n`,
+      )
+    })
+
+    test('multiple ### sections (Minor + Patch)', () => {
+      expect(
+        transformChangelogContent(dedent`
+          ### Minor Changes
+
+          ${remark('aaa1111', 'alice', 'New feature')}
+
+          ### Patch Changes
+
+          ${remark('bbb2222', 'bob', 'Bug fix')}
+        `),
+      ).toBe(
+        `${dedent`
+        ### Minor Changes
+
+        - aaa1111 Thanks @alice! - New feature
+
+        ### Patch Changes
+
+        - bbb2222 Thanks @bob! - Bug fix
+      `}\n`,
+      )
+    })
+
+    test('empty content', () => {
+      expect(transformChangelogContent('')).toBe('\n')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// replaceChangelogEntry
+// ---------------------------------------------------------------------------
+
+describe('replaceChangelogEntry', () => {
+  test('replaces the latest version entry', () => {
+    expect(
+      replaceChangelogEntry(
+        dedent`
+          # @agent-facets/core
+
+          ## 0.2.0
+
+          ### Patch Changes
+
+          - Old content here
+
+          ## 0.1.0
+
+          ### Minor Changes
+
+          - Initial release
+        `,
+        '0.2.0',
+        `${dedent`
+          ### Patch Changes
+
+          - New clean content
+        `}\n`,
+      ),
+    ).toBe(dedent`
+      # @agent-facets/core
+
+      ## 0.2.0
+
+      ### Patch Changes
+
+      - New clean content
+
+      ## 0.1.0
+
+      ### Minor Changes
+
+      - Initial release
+    `)
+  })
+
+  test('entry at end of file (no subsequent version)', () => {
+    expect(
+      replaceChangelogEntry(
+        dedent`
+          # pkg
+
+          ## 1.0.0
+
+          ### Patch Changes
+
+          - Old stuff
+        `,
+        '1.0.0',
+        `${dedent`
+          ### Patch Changes
+
+          - New stuff
+        `}\n`,
+      ),
+    ).toBe(
+      `${dedent`
+      # pkg
+
+      ## 1.0.0
+
+      ### Patch Changes
+
+      - New stuff
+    `}\n`,
+    )
+  })
+
+  test('returns unchanged when version not found', () => {
+    const changelog = dedent`
+      # pkg
+
+      ## 1.0.0
+
+      - stuff
+    `
+    expect(replaceChangelogEntry(changelog, '9.9.9', 'new content')).toBe(changelog)
+  })
+
+  test('preserves surrounding versions', () => {
+    expect(
+      replaceChangelogEntry(
+        dedent`
+          # my-package
+
+          ## 0.3.0
+
+          - v0.3 stuff
+
+          ## 0.2.0
+
+          - v0.2 stuff
+
+          ## 0.1.0
+
+          - v0.1 stuff
+        `,
+        '0.2.0',
+        '- replaced v0.2\n',
+      ),
+    ).toBe(dedent`
+      # my-package
+
+      ## 0.3.0
+
+      - v0.3 stuff
+
+      ## 0.2.0
+
+      - replaced v0.2
+
+      ## 0.1.0
+
+      - v0.1 stuff
+    `)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildVersionPrBody
+// ---------------------------------------------------------------------------
+
 describe('buildVersionPrBody', () => {
   const sampleChangelog = `# @agent-facets/core
 
@@ -126,7 +712,7 @@ describe('buildVersionPrBody', () => {
   }
 
   test('generates PR body with release sections', async () => {
-    const body = await buildVersionPrBody(
+    const { body } = await buildVersionPrBody(
       [{ name: '@agent-facets/core', version: '0.2.0', dir: 'packages/core' }],
       mockReadFile({ 'packages/core/CHANGELOG.md': sampleChangelog }),
     )
@@ -140,7 +726,7 @@ describe('buildVersionPrBody', () => {
   })
 
   test('includes header message', async () => {
-    const body = await buildVersionPrBody(
+    const { body } = await buildVersionPrBody(
       [{ name: '@agent-facets/core', version: '0.2.0', dir: 'packages/core' }],
       mockReadFile({ 'packages/core/CHANGELOG.md': sampleChangelog }),
     )
@@ -158,7 +744,7 @@ describe('buildVersionPrBody', () => {
 
 - New CLI command
 `
-    const body = await buildVersionPrBody(
+    const { body } = await buildVersionPrBody(
       [
         { name: '@agent-facets/core', version: '0.2.0', dir: 'packages/core' },
         { name: 'agent-facets', version: '0.3.0', dir: 'packages/cli' },
@@ -181,9 +767,17 @@ describe('buildVersionPrBody', () => {
 
   test('orders packages: agent-facets > core > brand', async () => {
     const makeChangelog = (name: string, version: string) =>
-      `# ${name}\n\n## ${version}\n\n### Patch Changes\n\n- Updated ${name}\n`
+      `${dedent`
+        # ${name}
 
-    const body = await buildVersionPrBody(
+        ## ${version}
+
+        ### Patch Changes
+
+        - Updated ${name}
+      `}\n`
+
+    const { body } = await buildVersionPrBody(
       [
         { name: '@agent-facets/brand', version: '0.2.0', dir: 'packages/brand' },
         { name: '@agent-facets/core', version: '0.3.0', dir: 'packages/core' },
@@ -206,9 +800,17 @@ describe('buildVersionPrBody', () => {
 
   test('truncates when body exceeds 60K characters', async () => {
     const longContent = 'x'.repeat(70_000)
-    const hugeChangelog = `# pkg\n\n## 1.0.0\n\n### Patch Changes\n\n- ${longContent}\n`
+    const hugeChangelog = `${dedent`
+        # pkg
 
-    const body = await buildVersionPrBody(
+        ## 1.0.0
+
+        ### Patch Changes
+
+        - ${longContent}
+      `}\n`
+
+    const { body } = await buildVersionPrBody(
       [{ name: 'huge-pkg', version: '1.0.0', dir: 'packages/huge' }],
       mockReadFile({ 'packages/huge/CHANGELOG.md': hugeChangelog }),
     )
@@ -216,7 +818,48 @@ describe('buildVersionPrBody', () => {
     expect(body.length).toBeLessThanOrEqual(60_000)
     expect(body).toContain('omitted from this message')
   })
+
+  test('returns per-package entries for CHANGELOG rewrite', async () => {
+    const { entries } = await buildVersionPrBody(
+      [{ name: '@agent-facets/core', version: '0.2.0', dir: 'packages/core' }],
+      mockReadFile({ 'packages/core/CHANGELOG.md': sampleChangelog }),
+    )
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toEqual(
+      expect.objectContaining({
+        dir: 'packages/core',
+        version: '0.2.0',
+      }),
+    )
+    expect(entries[0]?.content).toContain('Added a cool new feature')
+  })
+
+  test('applies transform to entry content (removes remark spacing)', async () => {
+    // Changelog with remark-style loose list items
+    const remarkChangelog = `# pkg
+
+## 1.0.0
+
+### Patch Changes
+
+-   First change
+
+-   Second change
+`
+    const { body } = await buildVersionPrBody(
+      [{ name: 'test-pkg', version: '1.0.0', dir: 'packages/test' }],
+      mockReadFile({ 'packages/test/CHANGELOG.md': remarkChangelog }),
+    )
+
+    // Should have tight spacing, not loose
+    expect(body).toContain('- First change\n- Second change')
+  })
 })
+
+// ---------------------------------------------------------------------------
+// parsePublishedPackages
+// ---------------------------------------------------------------------------
 
 describe('parsePublishedPackages', () => {
   test('parses scoped package tags', () => {

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -58,25 +58,45 @@ const PACKAGE_ORDER: Record<string, number> = {
   '@agent-facets/brand': 2,
 }
 
+/** A per-package transformed entry for CHANGELOG rewrite */
+export interface TransformedEntry {
+  dir: string
+  version: string
+  content: string
+}
+
+/** Return value of buildVersionPrBody — PR body + per-package entries for CHANGELOG rewrite */
+export interface VersionPrResult {
+  body: string
+  entries: TransformedEntry[]
+}
+
 /**
  * Build a rich PR body for the Version Packages PR.
  *
  * Reads each changed package's CHANGELOG.md, extracts the entry for its
- * new version using the changesets library parser, and composes a body
+ * new version using the changesets library parser, transforms the content
+ * (groups changes by contributor, cleans spacing), and composes a body
  * with a `# Releases` section and per-package subsections.
+ *
+ * Also returns per-package transformed entries so callers can rewrite
+ * CHANGELOG.md files on disk with the same clean format.
  */
 export async function buildVersionPrBody(
   changedPackages: { name: string; version: string; dir: string }[],
   readFile: (path: string) => Promise<string>,
-): Promise<string> {
+): Promise<VersionPrResult> {
   const packageInfos = await Promise.all(
     changedPackages.map(async (pkg) => {
       const changelog = await readFile(`${pkg.dir}/CHANGELOG.md`)
       const entry = getChangelogEntry(changelog, pkg.version)
+      const transformed = transformChangelogContent(entry.content)
       return {
         name: pkg.name,
+        dir: pkg.dir,
+        version: pkg.version,
         header: `## ${pkg.name}@${pkg.version}`,
-        content: entry.content,
+        content: transformed,
         highestLevel: entry.highestLevel,
       }
     }),
@@ -117,7 +137,294 @@ export async function buildVersionPrBody(
     ].join('\n')
   }
 
-  return body
+  const entries = sorted.map((info) => ({ dir: info.dir, version: info.version, content: info.content }))
+
+  return { body, entries }
+}
+
+// ---------------------------------------------------------------------------
+// Changelog content transformation
+// ---------------------------------------------------------------------------
+/** Matches a changelog line with GitHub attribution from @changesets/changelog-github */
+const ATTRIBUTED_LINE_RE = /^-\s+\[`([a-f0-9]+)`\]\(([^)]+)\)\s+Thanks\s+\[@([^\]]+)\]\(([^)]+)\)\s*!\s*-\s*(.+)$/
+
+/** Matches "Updated dependencies [hash]" lines */
+const UPDATED_DEPS_RE = /^-\s+Updated dependencies/
+
+interface AttributedChange {
+  hash: string
+  username: string
+  userUrl: string
+  description: string
+}
+
+interface UserGroup {
+  username: string
+  userUrl: string
+  changes: AttributedChange[]
+  firstSeen: number
+}
+
+/**
+ * Transform a changelog entry's content: group changes by contributor,
+ * sort by volume, clean up spacing, and separate dependency updates.
+ *
+ * Input is the raw content from `getChangelogEntry().content` which has been
+ * through remarkStringify (extra indentation, loose list spacing).
+ */
+export function transformChangelogContent(content: string): string {
+  // Split into sections by ### headings (e.g., ### Patch Changes, ### Minor Changes)
+  const sections = splitSections(content)
+  const transformed = sections.map(transformSection)
+  return transformed.join('\n')
+}
+
+interface Section {
+  heading: string
+  lines: string[]
+}
+
+function splitSections(content: string): Section[] {
+  const sections: Section[] = []
+  let currentHeading = ''
+  let currentLines: string[] = []
+
+  for (const line of content.split('\n')) {
+    if (line.startsWith('### ')) {
+      if (currentHeading || currentLines.length > 0) {
+        sections.push({ heading: currentHeading, lines: currentLines })
+      }
+      currentHeading = line
+      currentLines = []
+    } else {
+      currentLines.push(line)
+    }
+  }
+
+  if (currentHeading || currentLines.length > 0) {
+    sections.push({ heading: currentHeading, lines: currentLines })
+  }
+
+  return sections
+}
+
+function transformSection(section: Section): string {
+  // Parse list items from the section lines.
+  // Items can be multi-line (continuation lines are indented).
+  const items = parseListItems(section.lines)
+
+  const attributed: AttributedChange[] = []
+  const singleLineUnattributed: string[] = []
+  const depItems: string[] = []
+
+  for (const item of items) {
+    // Normalize remark's `-   ` (3 spaces) back to `- ` (1 space)
+    const normalized = item.replace(/^-\s{2,}/, '- ')
+
+    const match = normalized.match(ATTRIBUTED_LINE_RE)
+    if (match?.[1] && match[3] && match[4] && match[5]) {
+      attributed.push({
+        hash: match[1],
+        username: match[3],
+        userUrl: match[4],
+        description: match[5],
+      })
+    } else if (UPDATED_DEPS_RE.test(normalized)) {
+      depItems.push(normalized)
+    } else if (normalized.trim()) {
+      singleLineUnattributed.push(normalized)
+    }
+  }
+
+  // Group attributed changes by user
+  const groupMap = new Map<string, UserGroup>()
+  for (const [i, change] of attributed.entries()) {
+    const existing = groupMap.get(change.username)
+    if (existing) {
+      existing.changes.push(change)
+    } else {
+      groupMap.set(change.username, {
+        username: change.username,
+        userUrl: change.userUrl,
+        changes: [change],
+        firstSeen: i,
+      })
+    }
+  }
+
+  const groups = [...groupMap.values()]
+  // Sort: most changes first, ties preserve first-seen order
+  groups.sort((a, b) => b.changes.length - a.changes.length || a.firstSeen - b.firstSeen)
+
+  // Separate multi-change groups from single-change users
+  const multiGroups = groups.filter((g) => g.changes.length > 1)
+  const singleGroups = groups.filter((g) => g.changes.length === 1)
+
+  const output: string[] = []
+
+  // Add section heading
+  if (section.heading) {
+    output.push(section.heading)
+    output.push('')
+  }
+
+  // Multi-change groups
+  for (const group of multiGroups) {
+    output.push(`**@${group.username}** — Thanks! (${group.changes.length} changes)`)
+    for (const change of group.changes) {
+      output.push(`- ${change.hash} ${change.description}`)
+    }
+    output.push('')
+  }
+
+  // Individual contributions (single-change users + unattributed)
+  const hasMultiGroups = multiGroups.length > 0
+  const individualItems = [
+    ...singleGroups.map((g) => {
+      const c = g.changes[0] as AttributedChange
+      return `- ${c.hash} Thanks @${c.username}! - ${c.description}`
+    }),
+    ...singleLineUnattributed,
+  ]
+
+  if (individualItems.length > 0 && hasMultiGroups) {
+    output.push('#### Individual Contributions')
+    for (const item of individualItems) {
+      output.push(item)
+    }
+    output.push('')
+  } else if (individualItems.length > 0) {
+    // No multi-groups, just list them directly
+    for (const item of individualItems) {
+      output.push(item)
+    }
+    output.push('')
+  }
+
+  // Updated dependencies
+  if (depItems.length > 0) {
+    output.push('#### Updated Dependencies')
+    // Collect dep items — collapse "Updated dependencies [hash]" lines
+    // and extract the actual dependency bumps from continuation lines
+    const depBumps = extractDependencyBumps(depItems)
+    for (const bump of depBumps) {
+      output.push(bump)
+    }
+    output.push('')
+  }
+
+  // Remove trailing blank lines
+  while (output.length > 0 && output[output.length - 1] === '') {
+    output.pop()
+  }
+
+  return `${output.join('\n')}\n`
+}
+
+/**
+ * Parse raw section lines into individual list items.
+ * A list item starts with `-` at column 0; continuation lines are indented.
+ */
+function parseListItems(lines: string[]): string[] {
+  const items: string[] = []
+  let current = ''
+
+  for (const line of lines) {
+    const trimmed = line.trimStart()
+    if (trimmed.startsWith('- ') && !line.startsWith(' ') && !line.startsWith('\t')) {
+      if (current) items.push(current)
+      current = trimmed
+    } else if (current && trimmed) {
+      // Continuation line — append but for our purposes we flatten
+      // Multi-line items like "Updated dependencies" have indented sub-items
+      current += `\n${line}`
+    } else if (!trimmed && current) {
+      // Blank line between loose list items — don't break the item,
+      // just skip (we'll handle spacing in output)
+    }
+  }
+
+  if (current) items.push(current)
+  return items
+}
+
+/**
+ * Extract dependency bump lines from "Updated dependencies" items.
+ * Input items look like:
+ *   "- Updated dependencies [hash]\n  - @pkg@version"
+ * or sometimes multiple "Updated dependencies" lines followed by indented deps.
+ * We extract just the `- @pkg@version` lines with the hash prefixed.
+ */
+function extractDependencyBumps(items: string[]): string[] {
+  const bumps: string[] = []
+
+  for (const item of items) {
+    const lines = item.split('\n')
+    // First line: "- Updated dependencies [hash]"
+    const firstLine = lines[0] ?? ''
+    const headerMatch = firstLine.match(/Updated dependencies\s*\[([a-f0-9]+)\]/)
+    const hash = headerMatch?.[1]
+
+    // Sub-lines: indented dependency entries like "  - @agent-facets/core@0.1.2"
+    for (let i = 1; i < lines.length; i++) {
+      const depLine = lines[i] ?? ''
+      const depMatch = depLine.match(/^\s+-\s+(.+)/)
+      if (depMatch?.[1]) {
+        bumps.push(hash ? `- ${hash} ${depMatch[1]}` : `- ${depMatch[1]}`)
+      }
+    }
+
+    // If no sub-lines, the deps might be in the next item
+    // (loose list from remark splits them). Just record the header hash.
+    if (lines.length === 1 && hash) {
+      // Will be paired with a subsequent dep item — skip for now
+    }
+  }
+
+  return bumps
+}
+
+// ---------------------------------------------------------------------------
+// CHANGELOG rewrite
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace a specific version's entry in a full CHANGELOG.md string
+ * with new transformed content.
+ *
+ * Finds `## <version>` and replaces everything up to the next `## ` heading
+ * (or end of file) with the new content.
+ */
+export function replaceChangelogEntry(changelog: string, version: string, newContent: string): string {
+  const lines = changelog.split('\n')
+  const versionHeading = `## ${version}`
+
+  let startIdx = -1
+  let endIdx = lines.length
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    if (startIdx === -1) {
+      // Look for the version heading
+      if (line.trim() === versionHeading) {
+        startIdx = i
+      }
+    } else {
+      // Found the start — look for the next ## heading
+      if (line.startsWith('## ') && i > startIdx) {
+        endIdx = i
+        break
+      }
+    }
+  }
+
+  if (startIdx === -1) return changelog // version not found, return unchanged
+
+  const before = lines.slice(0, startIdx + 1) // includes the ## version line
+  const after = lines.slice(endIdx)
+  const trimmedContent = newContent.replace(/\n+$/, '')
+
+  return [...before, '', trimmedContent, '', ...after].join('\n')
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/ci-io.ts
+++ b/scripts/lib/ci-io.ts
@@ -62,6 +62,7 @@ export const io = {
 
   // Filesystem
   readFile: (path: string) => Bun.file(path).text(),
+  writeFile: (path: string, content: string) => Bun.write(path, content),
 
   scanDir: async (dir: string): Promise<string[]> => {
     const entries: string[] = []


### PR DESCRIPTION
## Summary

Two CI pipeline improvements:

1. **Gate releases on checks** — The `release` job now `requires: [check]`, ensuring tests, lint, and type checks pass before any release runs. Previously, `check` was skipped entirely on `main` (`ignore: main`), so releases ran without validation.

2. **Add Slack notifications** — Integrate `circleci/slack@6` orb to notify on build outcomes:

| Event | `#auto_cli_deploys` | `#on_call` |
| --- | --- | --- |
| `check` fails on `main` | Yes | Yes |
| `release` succeeds | Yes | — |
| `release` fails | Yes | Yes |

Notifications are implemented as reusable commands (`notify-failure`, `notify-success`) attached via `post-steps`. Feature branch check failures are silently skipped via `branch_pattern: main`.

## Changes

- `.circleci/src/@config.yml` — Add `circleci/slack@6` orb
- `.circleci/src/commands/notify-failure.yml` — New: failure notification to both channels, gated to `main`
- `.circleci/src/commands/notify-success.yml` — New: success notification to `#auto_cli_deploys`
- `.circleci/src/workflows/ci.yml` — Add `requires: [check]` to release, add `post-steps` and `slack-secrets` context to both jobs
- `.circleci/config.yml` — Regenerated via `circleci config pack`

## Prerequisites

- [x] CircleCI context `slack-secrets` with `SLACK_ACCESS_TOKEN`
- [ ] Slack bot added to `#auto_cli_deploys` and `#on_call`