### PR TITLE
Use release branch pattern for safe releases

### DIFF
--- a/.changeset/two-cases-divide.md
+++ b/.changeset/two-cases-divide.md
@@ -1,0 +1,7 @@
+---
+"@agent-facets/brand": minor
+"agent-facets": minor
+"@agent-facets/core": minor
+---
+
+Ensure proper release isolation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ commands:
     notify-failure:
         steps:
             - slack/notify:
-                branch_pattern: main
+                branch_pattern: main,release
                 channel: C0AQVA6UB38, C0AQFU5S4PR
                 event: fail
                 template: basic_fail_1
@@ -82,7 +82,9 @@ workflows:
                     - slack-secrets
                 filters:
                     branches:
-                        only: main
+                        only:
+                            - main
+                            - release
                 post-steps:
                     - notify-failure
                     - notify-success

--- a/.circleci/src/commands/notify-failure.yml
+++ b/.circleci/src/commands/notify-failure.yml
@@ -3,4 +3,4 @@ steps:
       event: fail
       template: basic_fail_1
       channel: C0AQVA6UB38, C0AQFU5S4PR
-      branch_pattern: main
+      branch_pattern: main,release

--- a/.circleci/src/workflows/ci.yml
+++ b/.circleci/src/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
         - slack-secrets
       filters:
         branches:
-          only: main
+          only:
+            - main
+            - release
       post-steps:
         - notify-failure
         - notify-success

--- a/scripts/ci-release.test.ts
+++ b/scripts/ci-release.test.ts
@@ -13,6 +13,11 @@ function setup() {
   spyOn(io, 'error').mockImplementation(() => {})
 }
 
+/** Set the branch for branch-aware routing in main() */
+function setBranch(branch: string) {
+  process.env.CIRCLE_BRANCH = branch
+}
+
 const SAMPLE_CHANGELOG = `# @agent-facets/core
 
 ## 0.2.0
@@ -29,12 +34,19 @@ const SAMPLE_CHANGELOG = `# @agent-facets/core
 `
 
 describe('ci-release', () => {
+  const originalCircleBranch = process.env.CIRCLE_BRANCH
+
   beforeEach(() => {
     setup()
   })
 
   afterEach(() => {
     mock.restore()
+    if (originalCircleBranch === undefined) {
+      delete process.env.CIRCLE_BRANCH
+    } else {
+      process.env.CIRCLE_BRANCH = originalCircleBranch
+    }
   })
 
   describe('versionAndCreatePR', () => {
@@ -55,6 +67,7 @@ describe('ci-release', () => {
     }
 
     test('creates a new PR with rich body when changesets are pending', async () => {
+      setBranch('main')
       spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md', 'README.md'])
       setupVersionPath()
 
@@ -81,6 +94,7 @@ describe('ci-release', () => {
     })
 
     test('updates existing PR body instead of creating a new one', async () => {
+      setBranch('main')
       spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       setupVersionPath()
 
@@ -106,6 +120,7 @@ describe('ci-release', () => {
     })
 
     test('exits early when changeset version produces no diff', async () => {
+      setBranch('main')
       spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       spyOn(io, 'mintGitHubToken').mockResolvedValue('fake-gh-token')
       spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
@@ -128,6 +143,7 @@ describe('ci-release', () => {
     })
 
     test('sets both GH_TOKEN and GITHUB_TOKEN', async () => {
+      setBranch('main')
       spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       setupVersionPath()
 
@@ -147,9 +163,9 @@ describe('ci-release', () => {
   })
 
   describe('publish', () => {
-    /** Common mocks to reach the publish path: no pending changesets + unpublished versions */
+    /** Common mocks to reach the publish path: on release branch + unpublished versions */
     function setupPublishPath() {
-      spyOn(io, 'scanDir').mockResolvedValue(['README.md'])
+      setBranch('release')
       spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core', private: false },
       ])
@@ -158,8 +174,17 @@ describe('ci-release', () => {
       spyOn(io, 'turboBuild').mockResolvedValue(shellResult())
     }
 
+    /** Mock the sync-back-to-main flow (success path) */
+    function setupSyncBack() {
+      spyOn(io, 'gitFetch').mockResolvedValue(shellResult())
+      spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
+      spyOn(io, 'gitMerge').mockResolvedValue(shellResult())
+      spyOn(io, 'gitPush').mockResolvedValue(shellResult())
+    }
+
     test('mints OIDC token and publishes', async () => {
       setupPublishPath()
+      setupSyncBack()
 
       const mintSpy = spyOn(io, 'mintOidcToken').mockResolvedValue('fake-oidc-token\n')
       const publishSpy = spyOn(io, 'changesetPublish').mockResolvedValue('')
@@ -176,6 +201,7 @@ describe('ci-release', () => {
 
     test('pushes tags after publishing', async () => {
       setupPublishPath()
+      setupSyncBack()
 
       spyOn(io, 'mintOidcToken').mockResolvedValue('token\n')
       spyOn(io, 'changesetPublish').mockResolvedValue('')
@@ -185,11 +211,12 @@ describe('ci-release', () => {
       const code = await main()
 
       expect(code).toBe(0)
-      expect(pushTagsSpy).toHaveBeenCalledWith('origin', 'main')
+      expect(pushTagsSpy).toHaveBeenCalledWith('origin', 'release')
     })
 
     test('creates GitHub Releases for published packages', async () => {
       setupPublishPath()
+      setupSyncBack()
 
       spyOn(io, 'mintOidcToken').mockResolvedValue('token\n')
       spyOn(io, 'changesetPublish').mockResolvedValue('New tag:  @agent-facets/core@1.1.0\n')
@@ -211,6 +238,7 @@ describe('ci-release', () => {
 
     test('mints GitHub token in publish path for releases', async () => {
       setupPublishPath()
+      setupSyncBack()
 
       const ghTokenSpy = spyOn(io, 'mintGitHubToken').mockResolvedValue('release-token')
       spyOn(io, 'mintOidcToken').mockResolvedValue('token\n')
@@ -227,6 +255,7 @@ describe('ci-release', () => {
 
     test('continues publishing even if release creation fails', async () => {
       setupPublishPath()
+      setupSyncBack()
 
       spyOn(io, 'mintOidcToken').mockResolvedValue('token\n')
       spyOn(io, 'changesetPublish').mockResolvedValue('New tag:  @agent-facets/core@1.1.0\n')
@@ -242,8 +271,168 @@ describe('ci-release', () => {
     })
   })
 
+  describe('branch gating', () => {
+    test('on main with no pending changesets, exits 0 without publishing', async () => {
+      setBranch('main')
+      spyOn(io, 'scanDir').mockResolvedValue(['README.md'])
+      const npmSpy = spyOn(io, 'npmViewVersion')
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+      expect(npmSpy).not.toHaveBeenCalled()
+    })
+
+    test('on release with all versions published, exits 0', async () => {
+      setBranch('release')
+      spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core', private: false },
+      ])
+      spyOn(io, 'npmViewVersion').mockResolvedValue('1.0.0')
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+    })
+
+    test('on a feature branch, exits 0 with no-op', async () => {
+      setBranch('feature/cool-stuff')
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+    })
+
+    test('with no CIRCLE_BRANCH set, exits 0 with no-op', async () => {
+      delete process.env.CIRCLE_BRANCH
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+    })
+  })
+
+  describe('sync-back to main', () => {
+    function setupPublishForSyncTest() {
+      setBranch('release')
+      spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core', private: false },
+      ])
+      spyOn(io, 'npmViewVersion').mockResolvedValue('1.0.0')
+      spyOn(io, 'mintGitHubToken').mockResolvedValue('fake-gh-token')
+      spyOn(io, 'turboBuild').mockResolvedValue(shellResult())
+      spyOn(io, 'mintOidcToken').mockResolvedValue('token\n')
+      spyOn(io, 'changesetPublish').mockResolvedValue('')
+      spyOn(io, 'gitPushTags').mockResolvedValue(shellResult())
+    }
+
+    test('merges release into main and pushes after publishing', async () => {
+      setupPublishForSyncTest()
+
+      const fetchSpy = spyOn(io, 'gitFetch').mockResolvedValue(shellResult())
+      const checkoutSpy = spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
+      const mergeSpy = spyOn(io, 'gitMerge').mockResolvedValue(shellResult())
+      const pushSpy = spyOn(io, 'gitPush').mockResolvedValue(shellResult())
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+      expect(fetchSpy).toHaveBeenCalledWith('origin', 'main')
+      expect(checkoutSpy).toHaveBeenCalledWith('main')
+      expect(mergeSpy).toHaveBeenCalledWith('release')
+      expect(pushSpy).toHaveBeenCalledWith('origin', 'main', false)
+    })
+
+    test('creates fallback PR and notifies Slack when merge fails', async () => {
+      setupPublishForSyncTest()
+
+      spyOn(io, 'gitFetch').mockResolvedValue(shellResult())
+      spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
+      spyOn(io, 'gitMerge').mockRejectedValue(new Error('merge conflict'))
+      spyOn(io, 'gitPush').mockResolvedValue(shellResult())
+
+      const prListSpy = spyOn(io, 'ghPrListWithBase').mockResolvedValue('')
+      const prCreateSpy = spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
+      const prUrlSpy = spyOn(io, 'ghPrUrl').mockResolvedValue('https://github.com/agent-facets/facets/pull/99\n')
+      const slackSpy = spyOn(io, 'slackNotify').mockResolvedValue(undefined)
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+      expect(prListSpy).toHaveBeenCalledWith('release', 'main')
+      expect(prCreateSpy).toHaveBeenCalledTimes(1)
+      expect(prUrlSpy).toHaveBeenCalledWith('release', 'main')
+      expect(slackSpy).toHaveBeenCalledTimes(1)
+      expect(slackSpy.mock.calls[0]?.[1]).toContain('sync-back to main failed')
+      expect(slackSpy.mock.calls[0]?.[1]).toContain('https://github.com/agent-facets/facets/pull/99')
+    })
+
+    test('skips creating fallback PR if one already exists', async () => {
+      setupPublishForSyncTest()
+
+      spyOn(io, 'gitFetch').mockResolvedValue(shellResult())
+      spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
+      spyOn(io, 'gitMerge').mockRejectedValue(new Error('merge conflict'))
+      spyOn(io, 'gitPush').mockResolvedValue(shellResult())
+
+      spyOn(io, 'ghPrListWithBase').mockResolvedValue('42')
+      const prCreateSpy = spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
+      spyOn(io, 'ghPrUrl').mockResolvedValue('https://github.com/agent-facets/facets/pull/42\n')
+      spyOn(io, 'slackNotify').mockResolvedValue(undefined)
+
+      const { main } = await import('./ci-release')
+      const code = await main()
+
+      expect(code).toBe(0)
+      expect(prCreateSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('version PR targets release branch', () => {
+    function setupVersionPath() {
+      spyOn(io, 'mintGitHubToken').mockResolvedValue('fake-gh-token')
+      spyOn(io, 'changesetVersion').mockResolvedValue(shellResult())
+      spyOn(io, 'bunInstall').mockResolvedValue(shellResult())
+      spyOn(io, 'gitDiff').mockResolvedValue(shellResult('', 1))
+      spyOn(io, 'gitDiffCached').mockResolvedValue(shellResult('', 0))
+      spyOn(io, 'gitConfig').mockResolvedValue(shellResult())
+      spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
+      spyOn(io, 'gitAdd').mockResolvedValue(shellResult())
+      spyOn(io, 'gitCommit').mockResolvedValue(shellResult())
+      spyOn(io, 'gitPush').mockResolvedValue(shellResult())
+      spyOn(io, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
+      spyOn(io, 'writeFile').mockResolvedValue(0)
+    }
+
+    test('creates PR targeting release branch, not main', async () => {
+      setBranch('main')
+      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
+      setupVersionPath()
+
+      spyOn(io, 'loadWorkspacePackages')
+        .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '0.1.0', dir: 'packages/core' }])
+        .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '0.2.0', dir: 'packages/core' }])
+
+      spyOn(io, 'ghPrList').mockResolvedValue('')
+      const prCreateSpy = spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
+
+      const { main } = await import('./ci-release')
+      await main()
+
+      // First arg to ghPrCreate is the base branch
+      expect(prCreateSpy.mock.calls[0]?.[0]).toBe('release')
+    })
+  })
+
   describe('error handling', () => {
     test('returns 1 when changeset version fails', async () => {
+      setBranch('main')
       spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       spyOn(io, 'mintGitHubToken').mockResolvedValue('fake-gh-token')
       spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
@@ -258,7 +447,7 @@ describe('ci-release', () => {
     })
 
     test('returns 1 when OIDC token minting fails', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue([])
+      setBranch('release')
       spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core', private: false },
       ])

--- a/scripts/ci-release.ts
+++ b/scripts/ci-release.ts
@@ -1,10 +1,15 @@
 /**
- * CI release script — replicates changesets/action@v1 behavior.
+ * CI release script — branch-aware release pipeline.
  *
- * Three paths:
- * 1. Pending changesets → run `changeset version`, create/update a "Version Packages" PR
- * 2. No pending changesets, all versions published → nothing to do, exit 0
- * 3. No pending changesets, unpublished versions → build, mint OIDC token, publish, push tags
+ * On `main` branch:
+ *   Pending changesets → run `changeset version`, create/update a "Version Packages" PR targeting `release`
+ *   No pending changesets → nothing to do, exit 0
+ *
+ * On `release` branch:
+ *   Unpublished versions → build, mint OIDC token, publish, push tags, sync back to main
+ *   All versions published → nothing to do, exit 0
+ *
+ * On any other branch: exit 0 (no-op)
  *
  * Uses the IO adapter (lib/ci-io.ts) for all side effects so the
  * orchestration logic is fully testable.
@@ -24,6 +29,7 @@ import { io } from './lib/ci-io'
 
 const RELEASE_BRANCH = 'changeset-release/main'
 const PR_TITLE = 'Version Packages'
+const SLACK_CHANNELS = 'C0AQVA6UB38,C0AQFU5S4PR'
 
 export async function versionAndCreatePR(): Promise<number> {
   io.log('Pending changesets found. Creating version PR...')
@@ -77,7 +83,7 @@ export async function versionAndCreatePR(): Promise<number> {
     await io.ghPrUpdate(prNumber, PR_TITLE, prBody)
     io.log(`Updated existing PR #${prNumber}`)
   } else {
-    await io.ghPrCreate('main', RELEASE_BRANCH, PR_TITLE, prBody)
+    await io.ghPrCreate('release', RELEASE_BRANCH, PR_TITLE, prBody)
     io.log('Created new Version Packages PR.')
   }
 
@@ -100,7 +106,7 @@ export async function publish(): Promise<number> {
 
   // Publish to npm and capture stdout for parsing released packages
   const publishOutput = await io.changesetPublish()
-  await io.gitPushTags('origin', 'main')
+  await io.gitPushTags('origin', 'release')
 
   // Create GitHub Releases for each published package
   const packages = await io.loadWorkspacePackages()
@@ -126,31 +132,72 @@ export async function publish(): Promise<number> {
     }
   }
 
+  // Sync release branch back to main
+  io.log('Syncing release branch back to main...')
+  try {
+    await io.gitFetch('origin', 'main')
+    await io.gitCheckout('main')
+    await io.gitMerge('release')
+    await io.gitPush('origin', 'main', false)
+    io.log('Successfully synced release to main.')
+  } catch {
+    io.log('Merge to main failed. Creating fallback PR...')
+    try {
+      const existingPr = (await io.ghPrListWithBase('release', 'main')).trim()
+      if (!existingPr) {
+        await io.ghPrCreate(
+          'main',
+          'release',
+          'Sync Release to Main',
+          'Automatic sync-back from release branch after publishing. Please resolve any conflicts and merge.',
+        )
+      }
+      const prUrl = (await io.ghPrUrl('release', 'main')).trim()
+      await io.slackNotify(
+        SLACK_CHANNELS,
+        `⚠️ Release published successfully, but sync-back to main failed. PR created: ${prUrl}`,
+      )
+    } catch (notifyErr) {
+      io.error(`Failed to create fallback PR or notify Slack: ${(notifyErr as Error).message}`)
+    }
+  }
+
   io.log('Published successfully.')
   return 0
 }
 
 export async function main(): Promise<number> {
-  const files = await io.scanDir('.changeset')
-  const pending = filterPendingChangesets(files)
+  const currentBranch = process.env.CIRCLE_BRANCH ?? ''
 
-  // Path 1: Pending changesets → version + PR
-  if (!shouldPublish(pending)) {
-    io.log(`Found ${pending.length} pending changeset(s).`)
-    return versionAndCreatePR()
-  }
+  // On main: only handle versioning (create PR targeting release)
+  if (currentBranch === 'main') {
+    const files = await io.scanDir('.changeset')
+    const pending = filterPendingChangesets(files)
 
-  // Path 2 or 3: Check npm for unpublished versions
-  const packages = await io.loadWorkspacePackages()
-  const unpublished = await hasUnpublishedVersions(packages, io.npmViewVersion)
+    if (!shouldPublish(pending)) {
+      io.log(`Found ${pending.length} pending changeset(s).`)
+      return versionAndCreatePR()
+    }
 
-  if (!unpublished) {
-    io.log('All package versions already published. Nothing to do.')
+    io.log('No pending changesets on main. Nothing to do.')
     return 0
   }
 
-  // Path 3: Unpublished versions → build + publish
-  return publish()
+  // On release: only handle publishing
+  if (currentBranch === 'release') {
+    const packages = await io.loadWorkspacePackages()
+    const unpublished = await hasUnpublishedVersions(packages, io.npmViewVersion)
+
+    if (!unpublished) {
+      io.log('All package versions already published. Nothing to do.')
+      return 0
+    }
+
+    return publish()
+  }
+
+  io.log(`Branch "${currentBranch}" is not main or release. Nothing to do.`)
+  return 0
 }
 
 if (import.meta.main) {

--- a/scripts/lib/ci-io.ts
+++ b/scripts/lib/ci-io.ts
@@ -31,9 +31,15 @@ export const io = {
   gitPush: (remote: string, ref: string, force = false) =>
     force ? $`git push ${remote} ${ref} --force` : $`git push ${remote} ${ref}`,
   gitPushTags: (remote: string, ref: string) => $`git push --follow-tags ${remote} ${ref}`,
+  gitFetch: (remote: string, branch: string) => $`git fetch ${remote} ${branch}`,
+  gitMerge: (branch: string) => $`git merge ${branch} --no-edit`,
 
   // GitHub CLI
   ghPrList: (head: string) => $`gh pr list --head ${head} --state open --json number --jq .[0].number`.text(),
+  ghPrListWithBase: (head: string, base: string) =>
+    $`gh pr list --head ${head} --base ${base} --state open --json number --jq .[0].number`.text(),
+  ghPrUrl: (head: string, base: string) =>
+    $`gh pr list --head ${head} --base ${base} --state open --json url --jq .[0].url`.text(),
   ghPrCreate: (base: string, head: string, title: string, body: string) =>
     $`gh pr create --base ${base} --head ${head} --title ${title} --body ${body}`,
   ghPrUpdate: (prNumber: string, title: string, body: string) =>
@@ -55,6 +61,22 @@ export const io = {
 
   // Dependencies
   bunInstall: () => $`bun install`,
+
+  // Slack
+  slackNotify: async (channels: string, text: string): Promise<void> => {
+    const token = process.env.SLACK_ACCESS_TOKEN ?? process.env.SLACK_BOT_TOKEN ?? ''
+    if (!token) {
+      console.error('No Slack token found (SLACK_ACCESS_TOKEN or SLACK_BOT_TOKEN). Skipping notification.')
+      return
+    }
+    for (const channel of channels.split(',').map((c) => c.trim())) {
+      await fetch('https://slack.com/api/chat.postMessage', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel, text }),
+      })
+    }
+  },
 
   // Console
   log: (...args: unknown[]) => console.log(...args),


### PR DESCRIPTION
## Problem

The release pipeline had a race condition: development work merged to `main` between the creation of a "Version Packages" PR and its merge would be inadvertently included in the release. Since publishing happened from `main`, any code landing there — regardless of intent — got shipped to npm.

## Solution

Introduce a `release` branch that isolates published code from active development.

### New flow

1. **On `main`**: CI detects pending changesets → runs `changeset version` → opens a "Version Packages" PR targeting `release` (not `main`)
2. **On `release`**: PR merge triggers CI → builds, publishes to npm, creates GitHub Releases, pushes tags
3. **Sync-back**: After publishing, `release` is merged back into `main` automatically (with a fallback PR + Slack alert if the merge fails)

### What changed

- **`ci-release.ts`** — Branch-aware routing via `CIRCLE_BRANCH`. Version path runs only on `main`, publish path only on `release`. Sync-back logic after publishing with fallback PR + Slack notification on failure.
- **`ci-io.ts`** — New IO methods: `gitFetch`, `gitMerge`, `ghPrListWithBase`, `ghPrUrl`, `slackNotify`
- **CircleCI config** — Release job now runs on both `main` and `release` branches. Slack failure notifications cover `release` branch.
- **Tests** — 8 new tests covering branch gating, sync-back merge, fallback PR creation, and Slack notification. Existing tests updated for new branch targets.

### Manual configuration (already done)

- `release` branch created from `main` and pushed to `origin`
- `the-faceter` GitHub App added to `main` branch protection bypass list (push + PR bypass) so the sync-back can push directly
- `SLACK_ACCESS_TOKEN` confirmed available in the `slack-secrets` CircleCI context