### PR TITLE
Build platform binaries for matrix of potential platforms

### DIFF
--- a/.changeset/silly-llamas-mix.md
+++ b/.changeset/silly-llamas-mix.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": minor
+---
+
+Support 12 platform binaries (linux, windows, mac and common variants)

--- a/.changeset/spotty-dogs-pump.md
+++ b/.changeset/spotty-dogs-pump.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": patch
+---
+
+Support dev platform "dev" mode via `bun dev` removing the complex build -> link flow

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 docs/.mintlify/
 node_modules/
 
+# postinstall cached binary (hard-link created by packages/cli/scripts/postinstall.mjs)
+packages/cli/bin/.facet
+
 
 # prepack/postpack backup (safety net if postpack is interrupted)
 .package.json.bak

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -2,6 +2,7 @@ plans/
 node_modules
 package.json
 bun.lock
+package-lock.json
 
 opencode.json
 opencode.jsonc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ bun install    # installs deps + sets up git hooks
 
 | Command          | Description                                                       |
 | ---------------- | ----------------------------------------------------------------- |
+| `bun dev`        | Run the CLI from source (e.g. `bun dev build ./my-facet`)         |
 | `bun check`      | Lint + typecheck + build + test (run this before submitting a PR) |
 | `bun run lint`   | Biome lint only                                                   |
 | `bun run format` | Biome auto-fix and format                                         |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ mise install
 # Install dependencies + set up git hooks
 bun install
 
+# Run the CLI locally (runs source directly, no compilation needed)
+bun dev --version
+bun dev build ./my-facet
+
 # Run lint, typecheck, build, and tests
 bun check
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/brand": {
       "name": "@agent-facets/brand",
-      "version": "0.1.2",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/bun": "1.3.10",
       },
@@ -30,9 +30,9 @@
     },
     "packages/cli": {
       "name": "agent-facets",
-      "version": "0.1.4",
+      "version": "0.2.2",
       "bin": {
-        "facet": "./dist/facet",
+        "facet": "./bin/facet",
       },
       "dependencies": {
         "@bomb.sh/args": "0.3.1",
@@ -57,7 +57,7 @@
     },
     "packages/core": {
       "name": "@agent-facets/core",
-      "version": "0.1.3",
+      "version": "0.2.1",
       "dependencies": {
         "arktype": "2.1.29",
         "comment-json": "^4.2.5",

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -247,3 +247,18 @@ The `create` command SHALL detect when a `facet.json` already exists in the targ
 
 - **WHEN** a user runs `create` in a directory that does not contain `facet.json`
 - **THEN** the system SHALL proceed with the create wizard without prompting
+
+### Requirement: CLI entry point delegates to a platform-specific binary
+
+The system SHALL use a launcher script as its npm `bin` entry point. The launcher script SHALL delegate execution to a platform-specific compiled binary. All existing CLI behavior (commands, flags, help, version, exit codes) SHALL be preserved regardless of which binary is executed.
+
+#### Scenario: Launcher delegates to compiled binary
+
+- **WHEN** a user invokes the CLI via the npm `bin` entry point (e.g., `npx facet build`)
+- **THEN** the launcher SHALL resolve and execute the platform-appropriate compiled binary
+- **AND** the CLI SHALL behave identically to a directly-invoked compiled binary
+
+#### Scenario: All commands work through the launcher
+
+- **WHEN** a user runs any registered command through the launcher
+- **THEN** the command SHALL produce the same output, exit code, and behavior as direct execution

--- a/openspec/specs/distribution/spec.md
+++ b/openspec/specs/distribution/spec.md
@@ -1,0 +1,105 @@
+## Purpose
+
+Defines how the CLI binary is packaged, resolved, and launched across platforms. Users SHALL be able to install the CLI via any JavaScript package manager and run it on any supported platform without manual configuration.
+
+## Requirements
+
+### Requirement: Users can run the CLI on any supported platform
+
+The system SHALL provide pre-compiled binaries for all supported platform, architecture, and ABI combinations. A user who installs the CLI via a JavaScript package manager SHALL receive a working binary for their platform without additional steps.
+
+#### Scenario: Install on macOS Apple Silicon
+
+- **WHEN** a user runs `npm install agent-facets` on macOS with an arm64 processor
+- **THEN** the system SHALL install a macOS arm64 binary
+- **AND** running `facet --version` SHALL print the version and exit with code 0
+
+#### Scenario: Install on Linux x86-64
+
+- **WHEN** a user runs `npm install agent-facets` on Linux with an x64 processor
+- **THEN** the system SHALL install a Linux x64 binary
+- **AND** running `facet --version` SHALL print the version and exit with code 0
+
+#### Scenario: Install on unsupported platform
+
+- **WHEN** a user runs `npm install agent-facets` on a platform for which no binary exists
+- **THEN** the system SHALL print an error message identifying the unsupported platform and architecture
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: The launcher resolves the correct binary for the current platform
+
+The system SHALL provide a launcher script that detects the user's platform, architecture, and CPU capabilities, then executes the matching compiled binary. The launcher SHALL follow a defined resolution order to locate the binary.
+
+#### Scenario: Binary resolved from cached hard-link
+
+- **WHEN** a user runs `facet` and a cached binary exists at the expected location
+- **THEN** the system SHALL execute the cached binary directly
+
+#### Scenario: Binary resolved from platform package
+
+- **WHEN** a user runs `facet` and no cached binary exists
+- **THEN** the system SHALL detect the current platform, architecture, and CPU capabilities
+- **AND** the system SHALL locate the matching per-platform binary package in `node_modules`
+- **AND** the system SHALL execute the binary from that package
+
+#### Scenario: Binary path override via environment variable
+
+- **WHEN** the `FACET_BIN_PATH` environment variable is set
+- **THEN** the system SHALL execute the binary at the specified path
+- **AND** the system SHALL skip all other resolution steps
+
+#### Scenario: No matching binary found
+
+- **WHEN** a user runs `facet` and no matching binary can be found
+- **THEN** the system SHALL print an error identifying the platform and architecture
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: Install-time optimization selects the best binary variant
+
+The system SHALL detect platform capabilities at install time and cache the optimal binary variant. This ensures variant selection happens once during installation rather than on every invocation.
+
+#### Scenario: AVX2-capable CPU receives the optimized binary
+
+- **WHEN** the CLI is installed on a system with AVX2 support
+- **THEN** the postinstall step SHALL detect AVX2 support
+- **AND** the postinstall step SHALL cache the standard (AVX2-enabled) binary variant
+
+#### Scenario: Non-AVX2 CPU receives the baseline binary
+
+- **WHEN** the CLI is installed on a system without AVX2 support
+- **THEN** the postinstall step SHALL detect the absence of AVX2
+- **AND** the postinstall step SHALL cache the baseline (no-AVX2) binary variant
+
+#### Scenario: musl libc system receives the musl binary
+
+- **WHEN** the CLI is installed on a Linux system using musl libc (e.g., Alpine)
+- **THEN** the postinstall step SHALL detect musl
+- **AND** the postinstall step SHALL cache the musl binary variant
+
+#### Scenario: Postinstall failure does not prevent CLI usage
+
+- **WHEN** the postinstall step fails (e.g., hard-link error, detection failure)
+- **THEN** the launcher SHALL still resolve the correct binary via its fallback resolution logic
+- **AND** the system SHALL NOT fail to start
+
+### Requirement: The build pipeline produces binaries for all supported targets
+
+The system SHALL provide a build script that cross-compiles the CLI entry point into standalone binaries for every supported target. Each binary SHALL be a self-contained executable that requires no external runtime.
+
+#### Scenario: Full cross-compilation build
+
+- **WHEN** a developer runs the build script without flags
+- **THEN** the system SHALL produce compiled binaries for all 12 supported targets
+- **AND** each binary SHALL be a standalone executable
+
+#### Scenario: Single-platform build for local development
+
+- **WHEN** a developer runs the build script with `--single`
+- **THEN** the system SHALL produce a compiled binary only for the current platform
+- **AND** the build SHALL complete substantially faster than a full build
+
+#### Scenario: Smoke test on native binary
+
+- **WHEN** the build script produces a binary for the current platform
+- **THEN** the build script SHALL execute `--version` against the binary to verify it runs
+- **AND** the build SHALL fail if the smoke test fails

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "scripts": {
-    "dev": "bun turbo build && bun run link",
+    "dev": "bun --cwd packages/cli src/index.ts",
     "types": "tsc --noEmit",
     "check": "bun turbo check",
     "test:scripts": "bun test scripts/",
@@ -20,13 +20,11 @@
     "release": "bun run check && changeset publish",
     "ci:pack": "circleci config pack .circleci/src > .circleci/config.yml && circleci config pack .circleci/release-src > .circleci/release.yml",
     "ci:check-pack": "diff <(circleci config pack .circleci/src) .circleci/config.yml && diff <(circleci config pack .circleci/release-src) .circleci/release.yml || (echo 'CircleCI configs are out of date. Run: bun run ci:pack' && exit 1)",
-    "link": "bun link --cwd packages/cli",
-    "unlink": "bun unlink --cwd packages/cli",
     "docs": "bun --cwd docs mint dev",
     "docs:validate": "bun --cwd docs mint validate",
     "docs:broken-links": "bun --cwd docs mint broken-links",
     "postinstall": "mise exec -- lefthook install",
-    "clean": "rm -rf .turbo node_modules packages/*/node_modules packages/*/.turbo packages/*/dist test-results/*.xml tmp docs/.mintlify"
+    "clean": "rm -rf .turbo node_modules packages/*/node_modules packages/*/.turbo packages/*/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/packages/cli/bin/facet
+++ b/packages/cli/bin/facet
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+const childProcess = require("child_process")
+const fs = require("fs")
+const path = require("path")
+const os = require("os")
+
+function run(target) {
+  const result = childProcess.spawnSync(target, process.argv.slice(2), {
+    stdio: "inherit",
+  })
+  if (result.error) {
+    console.error(result.error.message)
+    process.exit(1)
+  }
+  const code = typeof result.status === "number" ? result.status : 0
+  process.exit(code)
+}
+
+// Resolution #1: Environment variable override
+const envPath = process.env.FACET_BIN_PATH
+if (envPath) {
+  run(envPath)
+}
+
+// Resolution #2: Cached hard-link from postinstall
+const scriptPath = fs.realpathSync(__filename)
+const scriptDir = path.dirname(scriptPath)
+
+const cached = path.join(scriptDir, ".facet")
+if (fs.existsSync(cached)) {
+  run(cached)
+}
+
+// Resolution #3: Platform package lookup
+const platformMap = {
+  darwin: "darwin",
+  linux: "linux",
+  win32: "windows",
+}
+const archMap = {
+  x64: "x64",
+  arm64: "arm64",
+  arm: "arm",
+}
+
+let platform = platformMap[os.platform()]
+if (!platform) {
+  platform = os.platform()
+}
+let arch = archMap[os.arch()]
+if (!arch) {
+  arch = os.arch()
+}
+const base = "agent-facets-" + platform + "-" + arch
+const binary = platform === "windows" ? "facet.exe" : "facet"
+
+function supportsAvx2() {
+  if (arch !== "x64") return false
+
+  if (platform === "linux") {
+    try {
+      return /(^|\s)avx2(\s|$)/i.test(fs.readFileSync("/proc/cpuinfo", "utf8"))
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === "darwin") {
+    try {
+      const result = childProcess.spawnSync("sysctl", ["-n", "hw.optional.avx2_0"], {
+        encoding: "utf8",
+        timeout: 1500,
+      })
+      if (result.status !== 0) return false
+      return (result.stdout || "").trim() === "1"
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === "windows") {
+    const cmd =
+      '(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 -PassThru)::IsProcessorFeaturePresent(40)'
+
+    for (const exe of ["powershell.exe", "pwsh.exe", "pwsh", "powershell"]) {
+      try {
+        const result = childProcess.spawnSync(exe, ["-NoProfile", "-NonInteractive", "-Command", cmd], {
+          encoding: "utf8",
+          timeout: 3000,
+          windowsHide: true,
+        })
+        if (result.status !== 0) continue
+        const out = (result.stdout || "").trim().toLowerCase()
+        if (out === "true" || out === "1") return true
+        if (out === "false" || out === "0") return false
+      } catch {
+        continue
+      }
+    }
+
+    return false
+  }
+
+  return false
+}
+
+const names = (() => {
+  const avx2 = supportsAvx2()
+  const baseline = arch === "x64" && !avx2
+
+  if (platform === "linux") {
+    const musl = (() => {
+      try {
+        if (fs.existsSync("/etc/alpine-release")) return true
+      } catch {
+        // ignore
+      }
+
+      try {
+        const result = childProcess.spawnSync("ldd", ["--version"], { encoding: "utf8" })
+        const text = ((result.stdout || "") + (result.stderr || "")).toLowerCase()
+        if (text.includes("musl")) return true
+      } catch {
+        // ignore
+      }
+
+      return false
+    })()
+
+    if (musl) {
+      if (arch === "x64") {
+        if (baseline) return [`${base}-baseline-musl`, `${base}-musl`, `${base}-baseline`, base]
+        return [`${base}-musl`, `${base}-baseline-musl`, base, `${base}-baseline`]
+      }
+      return [`${base}-musl`, base]
+    }
+
+    if (arch === "x64") {
+      if (baseline) return [`${base}-baseline`, base, `${base}-baseline-musl`, `${base}-musl`]
+      return [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+    }
+    return [base, `${base}-musl`]
+  }
+
+  if (arch === "x64") {
+    if (baseline) return [`${base}-baseline`, base]
+    return [base, `${base}-baseline`]
+  }
+  return [base]
+})()
+
+function findBinary(startDir) {
+  let current = startDir
+  for (;;) {
+    const modules = path.join(current, "node_modules")
+    if (fs.existsSync(modules)) {
+      for (const name of names) {
+        const candidate = path.join(modules, name, "bin", binary)
+        if (fs.existsSync(candidate)) return candidate
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) {
+      return
+    }
+    current = parent
+  }
+}
+
+const resolved = findBinary(scriptDir)
+if (!resolved) {
+  console.error(
+    "It seems that your package manager failed to install the right version of the facet CLI for your platform. You can try manually installing " +
+      names.map((n) => `"${n}"`).join(" or ") +
+      " package",
+  )
+  process.exit(1)
+}
+
+run(resolved)

--- a/packages/cli/bin/package.json
+++ b/packages/cli/bin/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,10 +8,11 @@
   "version": "0.2.2",
   "type": "module",
   "bin": {
-    "facet": "./dist/facet"
+    "facet": "./bin/facet"
   },
   "scripts": {
     "build": "bun build src/index.ts --compile --outfile dist/facet",
+    "postinstall": "node scripts/postinstall.mjs",
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
     "types": "tsc --noEmit",

--- a/packages/cli/scripts/postinstall.mjs
+++ b/packages/cli/scripts/postinstall.mjs
@@ -1,0 +1,210 @@
+/**
+ * Postinstall script for agent-facets.
+ *
+ * Detects the current platform, architecture, AVX2 support, and musl libc,
+ * then hard-links the optimal binary to bin/.facet for fast launcher resolution.
+ *
+ * Silent failure — if anything goes wrong, the launcher's fallback logic handles it.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { chmodSync, copyFileSync, existsSync, linkSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { arch as osArch, platform as osPlatform } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+
+// ---------------------------------------------------------------------------
+// Platform detection
+// ---------------------------------------------------------------------------
+
+function detectPlatform() {
+  const platformMap = { darwin: 'darwin', linux: 'linux', win32: 'windows' }
+  const archMap = { x64: 'x64', arm64: 'arm64', arm: 'arm' }
+  const platform = platformMap[osPlatform()] || osPlatform()
+  const arch = archMap[osArch()] || osArch()
+  return { platform, arch }
+}
+
+// ---------------------------------------------------------------------------
+// AVX2 detection
+// ---------------------------------------------------------------------------
+
+function supportsAvx2(platform) {
+  if (platform === 'linux') {
+    try {
+      return /(^|\s)avx2(\s|$)/i.test(readFileSync('/proc/cpuinfo', 'utf8'))
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === 'darwin') {
+    try {
+      const result = spawnSync('sysctl', ['-n', 'hw.optional.avx2_0'], {
+        encoding: 'utf8',
+        timeout: 1500,
+      })
+      if (result.status !== 0) return false
+      return (result.stdout || '').trim() === '1'
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === 'windows') {
+    const cmd =
+      '(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 -PassThru)::IsProcessorFeaturePresent(40)'
+
+    for (const exe of ['powershell.exe', 'pwsh.exe', 'pwsh', 'powershell']) {
+      try {
+        const result = spawnSync(exe, ['-NoProfile', '-NonInteractive', '-Command', cmd], {
+          encoding: 'utf8',
+          timeout: 3000,
+          windowsHide: true,
+        })
+        if (result.status !== 0) continue
+        const out = (result.stdout || '').trim().toLowerCase()
+        if (out === 'true' || out === '1') return true
+        if (out === 'false' || out === '0') return false
+      } catch {}
+    }
+    return false
+  }
+
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// musl detection (Linux only)
+// ---------------------------------------------------------------------------
+
+function isMusl() {
+  try {
+    if (existsSync('/etc/alpine-release')) return true
+  } catch {
+    // ignore
+  }
+
+  try {
+    const result = spawnSync('ldd', ['--version'], { encoding: 'utf8' })
+    const text = ((result.stdout || '') + (result.stderr || '')).toLowerCase()
+    if (text.includes('musl')) return true
+  } catch {
+    // ignore
+  }
+
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Build priority-ordered candidate list
+// ---------------------------------------------------------------------------
+
+function buildCandidates(platform, arch, opts = {}) {
+  const base = `agent-facets-${platform}-${arch}`
+  const avx2 = opts.avx2 !== undefined ? opts.avx2 : arch === 'x64' ? supportsAvx2(platform) : false
+  const baseline = arch === 'x64' && !avx2
+
+  if (platform === 'linux') {
+    const musl = opts.musl !== undefined ? opts.musl : isMusl()
+
+    if (musl) {
+      if (arch === 'x64') {
+        if (baseline) return [`${base}-baseline-musl`, `${base}-musl`, `${base}-baseline`, base]
+        return [`${base}-musl`, `${base}-baseline-musl`, base, `${base}-baseline`]
+      }
+      return [`${base}-musl`, base]
+    }
+
+    if (arch === 'x64') {
+      if (baseline) return [`${base}-baseline`, base, `${base}-baseline-musl`, `${base}-musl`]
+      return [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+    }
+    return [base, `${base}-musl`]
+  }
+
+  if (arch === 'x64') {
+    if (baseline) return [`${base}-baseline`, base]
+    return [base, `${base}-baseline`]
+  }
+  return [base]
+}
+
+// ---------------------------------------------------------------------------
+// Find the binary via require.resolve
+// ---------------------------------------------------------------------------
+
+function findBinary(candidates) {
+  const binaryName = osPlatform() === 'win32' ? 'facet.exe' : 'facet'
+
+  for (const candidate of candidates) {
+    try {
+      const pkgPath = require.resolve(`${candidate}/package.json`)
+      const pkgDir = dirname(pkgPath)
+      const binaryPath = join(pkgDir, 'bin', binaryName)
+      if (existsSync(binaryPath)) return binaryPath
+    } catch {
+      // Package not installed — try next candidate
+    }
+  }
+
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  // Windows: no-op — the .exe is used directly
+  if (osPlatform() === 'win32') return
+
+  const { platform, arch } = detectPlatform()
+  const candidates = buildCandidates(platform, arch)
+  const binaryPath = findBinary(candidates)
+
+  if (!binaryPath) return // No binary found — launcher fallback handles it
+
+  const binDir = join(__dirname, '..', 'bin')
+  const targetPath = join(binDir, '.facet')
+
+  // Ensure bin directory exists
+  mkdirSync(binDir, { recursive: true })
+
+  // Remove existing cached binary
+  try {
+    unlinkSync(targetPath)
+  } catch {
+    // Doesn't exist — fine
+  }
+
+  // Hard-link (copy fallback on cross-device)
+  try {
+    linkSync(binaryPath, targetPath)
+  } catch {
+    copyFileSync(binaryPath, targetPath)
+  }
+
+  chmodSync(targetPath, 0o755)
+}
+
+// Guard: only run main() when executed directly, not when imported by tests
+const scriptPath = fileURLToPath(import.meta.url)
+const isDirectExecution = process.argv[1] && resolve(process.argv[1]) === scriptPath
+
+if (isDirectExecution) {
+  try {
+    main()
+  } catch (e) {
+    // Log the error but exit 0 — launcher fallback will handle binary resolution.
+    // We don't want a postinstall failure to break `npm install`.
+    console.error('[agent-facets postinstall] failed to cache platform binary:', e.message || e)
+  }
+}
+
+// Exports for testing — these are no-ops when run as a script
+export { buildCandidates, detectPlatform }

--- a/packages/cli/src/__tests__/launcher.test.ts
+++ b/packages/cli/src/__tests__/launcher.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const LAUNCHER_PATH = resolve(import.meta.dir, '..', '..', 'bin', 'facet')
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+async function runLauncher(args: string[] = [], env: Record<string, string> = {}): Promise<ExecResult> {
+  const proc = Bun.spawn(['node', LAUNCHER_PATH, ...args], {
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  const exitCode = await proc.exited
+
+  return { stdout, stderr, exitCode }
+}
+
+describe('launcher — FACET_BIN_PATH override', () => {
+  let tmpDir: string
+  let mockBinaryPath: string
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'launcher-test-'))
+    mockBinaryPath = join(tmpDir, 'mock-facet')
+    await writeFile(mockBinaryPath, '#!/bin/sh\necho "mock-facet: $@"\n')
+    await chmod(mockBinaryPath, 0o755)
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('runs the binary at FACET_BIN_PATH', async () => {
+    const result = await runLauncher(['--version'], { FACET_BIN_PATH: mockBinaryPath })
+    expect(result.stdout).toContain('mock-facet:')
+    expect(result.exitCode).toBe(0)
+  })
+
+  test('forwards arguments to the target binary', async () => {
+    const result = await runLauncher(['build', '--force', 'my-dir'], { FACET_BIN_PATH: mockBinaryPath })
+    expect(result.stdout).toContain('build --force my-dir')
+  })
+})
+
+describe('launcher — forwards exit code', () => {
+  let tmpDir: string
+  let exitingBinaryPath: string
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'launcher-exit-'))
+    exitingBinaryPath = join(tmpDir, 'exit-42')
+    await writeFile(exitingBinaryPath, '#!/bin/sh\nexit 42\n')
+    await chmod(exitingBinaryPath, 0o755)
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('exits with the same code as the target binary', async () => {
+    const result = await runLauncher([], { FACET_BIN_PATH: exitingBinaryPath })
+    expect(result.exitCode).toBe(42)
+  })
+})
+
+describe('launcher — no binary found', () => {
+  let tmpDir: string
+  let isolatedLauncherPath: string
+
+  beforeAll(async () => {
+    // Create an isolated copy of the launcher in a directory with no node_modules
+    // and no .facet, so resolution falls through to the error path.
+    tmpDir = await mkdtemp(join(tmpdir(), 'launcher-nobin-'))
+    isolatedLauncherPath = join(tmpDir, 'facet')
+    await Bun.write(isolatedLauncherPath, await Bun.file(LAUNCHER_PATH).text())
+    await chmod(isolatedLauncherPath, 0o755)
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('prints error with candidate package names and exits 1', async () => {
+    const proc = Bun.spawn(['node', isolatedLauncherPath], {
+      env: { ...process.env, FACET_BIN_PATH: undefined },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const stderr = await new Response(proc.stderr).text()
+    const exitCode = await proc.exited
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('agent-facets-')
+    expect(stderr).toContain('package manager failed')
+  })
+})

--- a/packages/cli/src/__tests__/postinstall.test.ts
+++ b/packages/cli/src/__tests__/postinstall.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from 'bun:test'
+import { resolve } from 'node:path'
+
+// Import the pure functions from the postinstall script
+const postinstallPath = resolve(import.meta.dir, '..', '..', 'scripts', 'postinstall.mjs')
+const { buildCandidates, detectPlatform } = await import(postinstallPath)
+
+describe('detectPlatform', () => {
+  test('returns an object with platform and arch strings', () => {
+    const result = detectPlatform()
+    expect(typeof result.platform).toBe('string')
+    expect(typeof result.arch).toBe('string')
+    expect(result.platform.length).toBeGreaterThan(0)
+    expect(result.arch.length).toBeGreaterThan(0)
+  })
+
+  test('maps darwin correctly', () => {
+    // We're running on macOS in this project
+    const result = detectPlatform()
+    if (process.platform === 'darwin') {
+      expect(result.platform).toBe('darwin')
+    }
+  })
+})
+
+describe('buildCandidates', () => {
+  // ---------------------------------------------------------------------------
+  // Linux glibc
+  // ---------------------------------------------------------------------------
+
+  test('linux x64 avx2 glibc', () => {
+    const result = buildCandidates('linux', 'x64', { avx2: true, musl: false })
+    expect(result).toEqual([
+      'agent-facets-linux-x64',
+      'agent-facets-linux-x64-baseline',
+      'agent-facets-linux-x64-musl',
+      'agent-facets-linux-x64-baseline-musl',
+    ])
+  })
+
+  test('linux x64 no-avx2 glibc', () => {
+    const result = buildCandidates('linux', 'x64', { avx2: false, musl: false })
+    expect(result).toEqual([
+      'agent-facets-linux-x64-baseline',
+      'agent-facets-linux-x64',
+      'agent-facets-linux-x64-baseline-musl',
+      'agent-facets-linux-x64-musl',
+    ])
+  })
+
+  test('linux arm64 glibc', () => {
+    const result = buildCandidates('linux', 'arm64', { avx2: false, musl: false })
+    expect(result).toEqual(['agent-facets-linux-arm64', 'agent-facets-linux-arm64-musl'])
+  })
+
+  // ---------------------------------------------------------------------------
+  // Linux musl
+  // ---------------------------------------------------------------------------
+
+  test('linux x64 avx2 musl', () => {
+    const result = buildCandidates('linux', 'x64', { avx2: true, musl: true })
+    expect(result).toEqual([
+      'agent-facets-linux-x64-musl',
+      'agent-facets-linux-x64-baseline-musl',
+      'agent-facets-linux-x64',
+      'agent-facets-linux-x64-baseline',
+    ])
+  })
+
+  test('linux x64 no-avx2 musl', () => {
+    const result = buildCandidates('linux', 'x64', { avx2: false, musl: true })
+    expect(result).toEqual([
+      'agent-facets-linux-x64-baseline-musl',
+      'agent-facets-linux-x64-musl',
+      'agent-facets-linux-x64-baseline',
+      'agent-facets-linux-x64',
+    ])
+  })
+
+  test('linux arm64 musl', () => {
+    const result = buildCandidates('linux', 'arm64', { avx2: false, musl: true })
+    expect(result).toEqual(['agent-facets-linux-arm64-musl', 'agent-facets-linux-arm64'])
+  })
+
+  // ---------------------------------------------------------------------------
+  // Non-Linux
+  // ---------------------------------------------------------------------------
+
+  test('darwin arm64', () => {
+    const result = buildCandidates('darwin', 'arm64', { avx2: false })
+    expect(result).toEqual(['agent-facets-darwin-arm64'])
+  })
+
+  test('darwin x64 avx2', () => {
+    const result = buildCandidates('darwin', 'x64', { avx2: true })
+    expect(result).toEqual(['agent-facets-darwin-x64', 'agent-facets-darwin-x64-baseline'])
+  })
+
+  test('darwin x64 no-avx2', () => {
+    const result = buildCandidates('darwin', 'x64', { avx2: false })
+    expect(result).toEqual(['agent-facets-darwin-x64-baseline', 'agent-facets-darwin-x64'])
+  })
+
+  test('windows x64 avx2', () => {
+    const result = buildCandidates('windows', 'x64', { avx2: true })
+    expect(result).toEqual(['agent-facets-windows-x64', 'agent-facets-windows-x64-baseline'])
+  })
+
+  test('windows arm64', () => {
+    const result = buildCandidates('windows', 'arm64', { avx2: false })
+    expect(result).toEqual(['agent-facets-windows-arm64'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Consistency: launcher and postinstall must produce identical candidate lists
+// ---------------------------------------------------------------------------
+
+describe('consistency — launcher and postinstall candidate lists match', () => {
+  /**
+   * Reimplements the launcher's candidate-building logic as a pure function.
+   * This is intentionally a direct translation of the CommonJS code in bin/facet
+   * so the test catches any drift between the two implementations.
+   */
+  function launcherCandidates(platform: string, arch: string, opts: { avx2: boolean; musl?: boolean }): string[] {
+    const base = `agent-facets-${platform}-${arch}`
+    const baseline = arch === 'x64' && !opts.avx2
+
+    if (platform === 'linux') {
+      const musl = !!opts.musl
+
+      if (musl) {
+        if (arch === 'x64') {
+          if (baseline) return [`${base}-baseline-musl`, `${base}-musl`, `${base}-baseline`, base]
+          return [`${base}-musl`, `${base}-baseline-musl`, base, `${base}-baseline`]
+        }
+        return [`${base}-musl`, base]
+      }
+
+      if (arch === 'x64') {
+        if (baseline) return [`${base}-baseline`, base, `${base}-baseline-musl`, `${base}-musl`]
+        return [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+      }
+      return [base, `${base}-musl`]
+    }
+
+    if (arch === 'x64') {
+      if (baseline) return [`${base}-baseline`, base]
+      return [base, `${base}-baseline`]
+    }
+    return [base]
+  }
+
+  const cases: Array<{ platform: string; arch: string; avx2: boolean; musl?: boolean }> = [
+    // Linux glibc
+    { platform: 'linux', arch: 'x64', avx2: true, musl: false },
+    { platform: 'linux', arch: 'x64', avx2: false, musl: false },
+    { platform: 'linux', arch: 'arm64', avx2: false, musl: false },
+    // Linux musl
+    { platform: 'linux', arch: 'x64', avx2: true, musl: true },
+    { platform: 'linux', arch: 'x64', avx2: false, musl: true },
+    { platform: 'linux', arch: 'arm64', avx2: false, musl: true },
+    // Darwin
+    { platform: 'darwin', arch: 'arm64', avx2: false },
+    { platform: 'darwin', arch: 'x64', avx2: true },
+    { platform: 'darwin', arch: 'x64', avx2: false },
+    // Windows
+    { platform: 'windows', arch: 'arm64', avx2: false },
+    { platform: 'windows', arch: 'x64', avx2: true },
+    { platform: 'windows', arch: 'x64', avx2: false },
+  ]
+
+  for (const c of cases) {
+    const label = `${c.platform}/${c.arch} avx2=${c.avx2}${c.musl !== undefined ? ` musl=${c.musl}` : ''}`
+    test(label, () => {
+      const fromPostinstall = buildCandidates(c.platform, c.arch, { avx2: c.avx2, musl: c.musl })
+      const fromLauncher = launcherCandidates(c.platform, c.arch, { avx2: c.avx2, musl: c.musl })
+      expect(fromPostinstall).toEqual(fromLauncher)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Silent failure
+// ---------------------------------------------------------------------------
+
+describe('postinstall — silent failure', () => {
+  test('exits 0 when no platform packages are installed', async () => {
+    const proc = Bun.spawn(['node', resolve(import.meta.dir, '..', '..', 'scripts', 'postinstall.mjs')], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const exitCode = await proc.exited
+    expect(exitCode).toBe(0)
+  })
+})

--- a/scripts/build-cli.ts
+++ b/scripts/build-cli.ts
@@ -1,0 +1,98 @@
+/**
+ * Cross-compilation build script for the `agent-facets` CLI.
+ *
+ * Produces standalone Bun-compiled binaries for 12 platform/arch/ABI targets.
+ *
+ * Usage:
+ *   bun scripts/build-cli.ts                      # Build all 12 targets
+ *   bun scripts/build-cli.ts --single             # Build for the current platform only
+ *   bun scripts/build-cli.ts --single --baseline  # Build baseline variant for the current platform
+ */
+
+import { resolve } from 'node:path'
+import { $ } from 'bun'
+import {
+  allTargets,
+  buildPackageJson,
+  bunTarget,
+  filterTargets,
+  outfilePath,
+  packageJsonPath,
+  packageName,
+  shouldSmokeTest,
+} from './lib/build-cli.ts'
+
+const cliDir = resolve(import.meta.dir, '..', 'packages', 'cli')
+const pkg = await Bun.file(resolve(cliDir, 'package.json')).json()
+const version: string = pkg.version
+
+// ---------------------------------------------------------------------------
+// CLI flags
+// ---------------------------------------------------------------------------
+
+const singleFlag = process.argv.includes('--single')
+const baselineFlag = process.argv.includes('--baseline')
+
+const targets = filterTargets(allTargets, {
+  single: singleFlag,
+  baseline: baselineFlag,
+  platform: process.platform,
+  arch: process.arch,
+})
+
+if (targets.length === 0) {
+  console.error(`No matching targets for ${process.platform}/${process.arch}`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Build loop
+// ---------------------------------------------------------------------------
+
+console.log(`Building ${targets.length} target(s) — version ${version}\n`)
+
+for (const item of targets) {
+  const name = packageName(item)
+  const target = bunTarget(name)
+  const outfile = outfilePath(cliDir, name)
+
+  console.log(`  Building ${name} (${target})...`)
+
+  const result = await Bun.build({
+    entrypoints: [resolve(cliDir, 'src', 'index.ts')],
+    compile: {
+      target: target as Bun.Build.CompileTarget,
+      outfile,
+      autoloadBunfig: false,
+      autoloadDotenv: false,
+      autoloadTsconfig: true,
+      autoloadPackageJson: true,
+    },
+  })
+
+  if (!result.success) {
+    console.error(`  Build failed for ${name}:`)
+    for (const log of result.logs) {
+      console.error(`    ${log}`)
+    }
+    process.exit(1)
+  }
+
+  const pkgJson = buildPackageJson(name, version, item)
+  await Bun.file(packageJsonPath(cliDir, name)).write(`${JSON.stringify(pkgJson, null, 2)}\n`)
+
+  console.log(`  ✓ ${name}`)
+
+  if (shouldSmokeTest(item, process.platform, process.arch)) {
+    console.log(`  Running smoke test: ${outfile} --version`)
+    try {
+      const versionOutput = await $`${outfile} --version`.text()
+      console.log(`  ✓ Smoke test passed: ${versionOutput.trim()}`)
+    } catch (e) {
+      console.error(`  ✗ Smoke test failed for ${name}:`, e)
+      process.exit(1)
+    }
+  }
+}
+
+console.log(`\nDone — ${targets.length} target(s) built.`)

--- a/scripts/lib/build-cli.test.ts
+++ b/scripts/lib/build-cli.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  allTargets,
+  buildPackageJson,
+  bunTarget,
+  filterTargets,
+  outfilePath,
+  packageJsonPath,
+  packageName,
+  shouldSmokeTest,
+  type Target,
+} from './build-cli.ts'
+
+describe('packageName', () => {
+  test.each<[Target, string]>([
+    [{ os: 'linux', arch: 'arm64' }, 'agent-facets-linux-arm64'],
+    [{ os: 'linux', arch: 'x64' }, 'agent-facets-linux-x64'],
+    [{ os: 'linux', arch: 'x64', avx2: false }, 'agent-facets-linux-x64-baseline'],
+    [{ os: 'linux', arch: 'arm64', abi: 'musl' }, 'agent-facets-linux-arm64-musl'],
+    [{ os: 'linux', arch: 'x64', abi: 'musl' }, 'agent-facets-linux-x64-musl'],
+    [{ os: 'linux', arch: 'x64', avx2: false, abi: 'musl' }, 'agent-facets-linux-x64-baseline-musl'],
+    [{ os: 'darwin', arch: 'arm64' }, 'agent-facets-darwin-arm64'],
+    [{ os: 'darwin', arch: 'x64' }, 'agent-facets-darwin-x64'],
+    [{ os: 'darwin', arch: 'x64', avx2: false }, 'agent-facets-darwin-x64-baseline'],
+    [{ os: 'win32', arch: 'arm64' }, 'agent-facets-windows-arm64'],
+    [{ os: 'win32', arch: 'x64' }, 'agent-facets-windows-x64'],
+    [{ os: 'win32', arch: 'x64', avx2: false }, 'agent-facets-windows-x64-baseline'],
+  ])('%j → %s', (target, expected) => {
+    expect(packageName(target)).toBe(expected)
+  })
+})
+
+describe('bunTarget', () => {
+  test.each([
+    ['agent-facets-darwin-arm64', 'bun-darwin-arm64'],
+    ['agent-facets-linux-x64-baseline-musl', 'bun-linux-x64-baseline-musl'],
+    ['agent-facets-windows-x64', 'bun-windows-x64'],
+    ['agent-facets-linux-arm64-musl', 'bun-linux-arm64-musl'],
+  ])('%s → %s', (name, expected) => {
+    expect(bunTarget(name)).toBe(expected)
+  })
+})
+
+describe('allTargets', () => {
+  test('has exactly 12 entries', () => {
+    expect(allTargets).toHaveLength(12)
+  })
+
+  test('every target produces a valid package name starting with agent-facets-', () => {
+    for (const target of allTargets) {
+      expect(packageName(target)).toStartWith('agent-facets-')
+    }
+  })
+
+  test('every package name produces a bun target starting with bun-', () => {
+    for (const target of allTargets) {
+      expect(bunTarget(packageName(target))).toStartWith('bun-')
+    }
+  })
+
+  test('all package names are unique', () => {
+    const names = allTargets.map(packageName)
+    expect(new Set(names).size).toBe(names.length)
+  })
+})
+
+describe('filterTargets', () => {
+  test('single: false returns all 12', () => {
+    const result = filterTargets(allTargets, { single: false, platform: 'darwin', arch: 'arm64' })
+    expect(result).toHaveLength(12)
+  })
+
+  test('single darwin arm64 returns exactly 1', () => {
+    const result = filterTargets(allTargets, { single: true, platform: 'darwin', arch: 'arm64' })
+    expect(result).toHaveLength(1)
+    expect(result.map(packageName)).toEqual(['agent-facets-darwin-arm64'])
+  })
+
+  test('single linux x64 returns exactly 1 (no baseline, no musl)', () => {
+    const result = filterTargets(allTargets, { single: true, platform: 'linux', arch: 'x64' })
+    expect(result).toHaveLength(1)
+    expect(result.map(packageName)).toEqual(['agent-facets-linux-x64'])
+  })
+
+  test('single+baseline linux x64 returns exactly 1 (baseline only)', () => {
+    const result = filterTargets(allTargets, { single: true, baseline: true, platform: 'linux', arch: 'x64' })
+    expect(result).toHaveLength(1)
+    expect(result.map(packageName)).toEqual(['agent-facets-linux-x64-baseline'])
+  })
+
+  test('single linux arm64 returns exactly 1 (skips musl)', () => {
+    const result = filterTargets(allTargets, { single: true, platform: 'linux', arch: 'arm64' })
+    expect(result).toHaveLength(1)
+    expect(result.map(packageName)).toEqual(['agent-facets-linux-arm64'])
+  })
+
+  test('single win32 x64 returns exactly 1', () => {
+    const result = filterTargets(allTargets, { single: true, platform: 'win32', arch: 'x64' })
+    expect(result).toHaveLength(1)
+    expect(result.map(packageName)).toEqual(['agent-facets-windows-x64'])
+  })
+
+  test('single with unknown platform returns empty', () => {
+    const result = filterTargets(allTargets, { single: true, platform: 'freebsd', arch: 'x64' })
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('buildPackageJson', () => {
+  test('produces correct os and cpu fields for linux x64', () => {
+    const target: Target = { os: 'linux', arch: 'x64' }
+    const result = buildPackageJson('agent-facets-linux-x64', '1.0.0', target)
+    expect(result).toEqual({
+      name: 'agent-facets-linux-x64',
+      version: '1.0.0',
+      os: ['linux'],
+      cpu: ['x64'],
+    })
+  })
+
+  test('uses raw os value (win32) not the display name (windows)', () => {
+    const target: Target = { os: 'win32', arch: 'x64' }
+    const result = buildPackageJson('agent-facets-windows-x64', '2.0.0', target)
+    expect(result.os).toEqual(['win32'])
+    expect(result.cpu).toEqual(['x64'])
+  })
+
+  test('uses the provided version', () => {
+    const target: Target = { os: 'darwin', arch: 'arm64' }
+    const result = buildPackageJson('agent-facets-darwin-arm64', '3.5.7', target)
+    expect(result.version).toBe('3.5.7')
+  })
+})
+
+describe('shouldSmokeTest', () => {
+  test('returns true when target matches current platform and arch', () => {
+    expect(shouldSmokeTest({ os: 'darwin', arch: 'arm64' }, 'darwin', 'arm64')).toBe(true)
+  })
+
+  test('returns false when os differs', () => {
+    expect(shouldSmokeTest({ os: 'linux', arch: 'arm64' }, 'darwin', 'arm64')).toBe(false)
+  })
+
+  test('returns false when arch differs', () => {
+    expect(shouldSmokeTest({ os: 'darwin', arch: 'x64' }, 'darwin', 'arm64')).toBe(false)
+  })
+
+  test('returns false for musl target even when os/arch match', () => {
+    expect(shouldSmokeTest({ os: 'linux', arch: 'x64', abi: 'musl' }, 'linux', 'x64')).toBe(false)
+  })
+
+  test('returns true for baseline target when os/arch match', () => {
+    expect(shouldSmokeTest({ os: 'linux', arch: 'x64', avx2: false }, 'linux', 'x64')).toBe(true)
+  })
+})
+
+describe('outfilePath', () => {
+  test('produces correct path structure', () => {
+    const result = outfilePath('/opt/cli', 'agent-facets-darwin-arm64')
+    expect(result).toBe('/opt/cli/dist/agent-facets-darwin-arm64/bin/facet')
+  })
+})
+
+describe('packageJsonPath', () => {
+  test('produces correct path structure', () => {
+    const result = packageJsonPath('/opt/cli', 'agent-facets-darwin-arm64')
+    expect(result).toBe('/opt/cli/dist/agent-facets-darwin-arm64/package.json')
+  })
+})

--- a/scripts/lib/build-cli.ts
+++ b/scripts/lib/build-cli.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared types and pure functions for the CLI cross-compilation build script.
+ * Extracted for testability — the runner script (scripts/build-cli.ts) imports from here.
+ */
+
+import { resolve } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Target {
+  os: string
+  arch: 'arm64' | 'x64'
+  abi?: 'musl'
+  avx2?: false
+}
+
+export interface FilterOptions {
+  single: boolean
+  baseline?: boolean
+  platform: string
+  arch: string
+}
+
+export interface TargetPackageJson {
+  name: string
+  version: string
+  os: string[]
+  cpu: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Target matrix
+// ---------------------------------------------------------------------------
+
+export const allTargets: Target[] = [
+  { os: 'linux', arch: 'arm64' },
+  { os: 'linux', arch: 'x64' },
+  { os: 'linux', arch: 'x64', avx2: false },
+  { os: 'linux', arch: 'arm64', abi: 'musl' },
+  { os: 'linux', arch: 'x64', abi: 'musl' },
+  { os: 'linux', arch: 'x64', avx2: false, abi: 'musl' },
+  { os: 'darwin', arch: 'arm64' },
+  { os: 'darwin', arch: 'x64' },
+  { os: 'darwin', arch: 'x64', avx2: false },
+  { os: 'win32', arch: 'arm64' },
+  { os: 'win32', arch: 'x64' },
+  { os: 'win32', arch: 'x64', avx2: false },
+]
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+export function packageName(item: Target): string {
+  return [
+    'agent-facets',
+    item.os === 'win32' ? 'windows' : item.os,
+    item.arch,
+    item.avx2 === false ? 'baseline' : undefined,
+    item.abi,
+  ]
+    .filter(Boolean)
+    .join('-')
+}
+
+export function bunTarget(name: string): string {
+  return name.replace('agent-facets', 'bun')
+}
+
+export function filterTargets(targets: Target[], opts: FilterOptions): Target[] {
+  if (!opts.single) return targets
+
+  return targets.filter((item) => {
+    if (item.os !== opts.platform || item.arch !== opts.arch) return false
+    // Skip ABI-specific builds (e.g. musl) in single mode
+    if (item.abi !== undefined) return false
+    // When --baseline: only include baseline.
+    if (opts.baseline) return item.avx2 === false
+    // Otherwise: only include non-baseline.
+    return item.avx2 !== false
+  })
+}
+
+export function buildPackageJson(name: string, version: string, item: Target): TargetPackageJson {
+  return {
+    name,
+    version,
+    os: [item.os],
+    cpu: [item.arch],
+  }
+}
+
+export function shouldSmokeTest(item: Target, platform: string, arch: string): boolean {
+  return item.os === platform && item.arch === arch && !item.abi
+}
+
+export function outfilePath(cliDir: string, name: string): string {
+  return resolve(cliDir, 'dist', name, 'bin', 'facet')
+}
+
+export function packageJsonPath(cliDir: string, name: string): string {
+  return resolve(cliDir, 'dist', name, 'package.json')
+}


### PR DESCRIPTION
## Summary

The CLI currently ships a single Bun-compiled binary built on Linux x86-64. Users on macOS, Windows, or Linux ARM get `ENOEXEC` because the binary doesn't match their platform. This change adds the foundation for cross-platform binary distribution.

## What this does

Adds a cross-compilation build script that produces standalone binaries for 12 platform/arch/ABI targets (darwin, linux, windows × arm64/x64 × baseline/musl variants) using `Bun.build({ compile: true })`.

Introduces a Node.js launcher script (`bin/facet`) that detects the user's platform, architecture, and CPU capabilities (AVX2, musl) and execs the correct binary. Resolution order: `FACET_BIN_PATH` env override → cached hard-link → platform package lookup in `node_modules`.

Adds a postinstall script that performs platform/AVX2/musl detection once at install time and hard-links the optimal binary to `bin/.facet`, so the launcher doesn't re-detect on every invocation.

The `bin.facet` field in `packages/cli/package.json` now points at the launcher instead of the compiled binary. Local dev (`bun run dev`, `bun link`) is unaffected.

## What this doesn't do

This is the first of three changes. Per-platform npm package publishing and CI automation come in follow-up PRs (`platform-package-seeding`, `platform-builds-ci`).