### PR TITLE
Disable caching for the build task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .turbo/
 .strategy/
 lefthook-local.yml
+mise.local.toml
 
 *.bun-build
 bun.lockb
@@ -11,7 +12,6 @@ node_modules/
 
 # postinstall cached binary (hard-link created by packages/cli/scripts/postinstall.mjs)
 packages/cli/bin/.facet
-
 
 # prepack/postpack backup (safety net if postpack is interrupted)
 .package.json.bak

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "cache": false
     },
     "test": {
       "dependsOn": ["build"],


### PR DESCRIPTION
### Why

The `build` task compiles a Bun binary (`dist/facet`) that is 63 MB uncompressed / ~20 MB compressed. This exceeds the Lambda function URL payload limit (6 MB in buffered mode), causing 413, 429, and 502 errors from the self-hosted turbo remote cache on every CI run. The build itself takes ~260ms on CI — faster than the cache round-trip would be even if it worked.

### Details

Setting `"cache": false` disables both local and remote caching for the `build` task. Turbo doesn't support disabling remote cache per-task while keeping local cache — it's all or nothing. Since the build is sub-second and deterministic, the trade-off is negligible.

All other tasks (tests, types, lint, docs) remain fully cached. Their artifacts are all under 8 KB.

### Verification

CI + `bun check` locally. Build output shows `cache bypass, force executing` as expected.