### PR TITLE
Fix tag-release gate to include private CLI package

### DIFF
--- a/scripts/ci-tag-release.test.ts
+++ b/scripts/ci-tag-release.test.ts
@@ -100,6 +100,34 @@ describe('ci-tag-release', () => {
       expect(pushSpy).toHaveBeenCalledWith('origin')
     })
 
+    test('creates tag when only the private CLI package has a version bump', async () => {
+      process.env.CIRCLE_SHA1 = 'abc123'
+      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
+      ])
+      spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
+      spyOn(io, 'gitConfig').mockResolvedValue(shellResult())
+      spyOn(io, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
+        { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli', private: true },
+      ])
+      spyOn(io, 'npmViewVersion').mockImplementation(async (pkg: string) => {
+        if (pkg === '@agent-facets/core') return '1.0.0' // unchanged
+        if (pkg === 'agent-facets') return '0.3.0' // bumped
+        return null
+      })
+      const tagSpy = spyOn(io, 'gitTagAt').mockResolvedValue(shellResult())
+      const pushSpy = spyOn(io, 'gitPushAllTags').mockResolvedValue(shellResult())
+
+      const { tagRelease } = await import('./ci-tag-release')
+      const code = await tagRelease()
+
+      expect(code).toBe(0)
+      expect(tagSpy).toHaveBeenCalledWith('agent-facets@0.4.0', 'original-sha')
+      expect(tagSpy).not.toHaveBeenCalledWith('@agent-facets/core@1.0.0', 'original-sha')
+      expect(pushSpy).toHaveBeenCalledWith('origin')
+    })
+
     test('fetches the original branch commit SHA', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
       spyOn(io, 'ghGetPrForCommit').mockResolvedValue([

--- a/scripts/lib/changesets.test.ts
+++ b/scripts/lib/changesets.test.ts
@@ -86,13 +86,13 @@ describe('hasUnpublishedVersions', () => {
     expect(result).toBe(true)
   })
 
-  test('skips private packages', async () => {
+  test('includes private packages in version check', async () => {
     const packages: WorkspacePackage[] = [
       { name: 'private-pkg', version: '1.0.0', dir: 'packages/private', private: true },
       { name: '@agent-facets/core', version: '0.1.1', dir: 'packages/core' },
     ]
     const result = await hasUnpublishedVersions(packages, mockNpm({ '@agent-facets/core': '0.1.1' }))
-    expect(result).toBe(false)
+    expect(result).toBe(true)
   })
 
   test('returns false for empty package list', async () => {

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -24,16 +24,14 @@ export function shouldPublish(pendingChangesets: string[]): boolean {
 }
 
 /**
- * Check whether any non-private workspace package has a local version
+ * Check whether any workspace package has a local version
  * that doesn't yet exist on the npm registry.
  */
 export async function hasUnpublishedVersions(
   packages: WorkspacePackage[],
   npmViewFn: (pkg: string) => Promise<string | null>,
 ): Promise<boolean> {
-  const publishable = packages.filter((p) => !p.private)
-
-  for (const pkg of publishable) {
+  for (const pkg of packages) {
     const npmVersion = await npmViewFn(pkg.name)
     if (npmVersion !== pkg.version) return true
   }


### PR DESCRIPTION
### Why

The `hasUnpublishedVersions` function filtered out private packages before checking npm for version bumps. Since `agent-facets` (the CLI) is marked `private: true` — a hack to prevent changesets from publishing it directly — the tag-release pipeline would exit early with "No tags needed" whenever the CLI was the only bumped package. Without a tag push, `release.yml` never triggers, and the entire platform binary build/publish pipeline silently does nothing.

### Details

The `private: true` on the CLI package only exists to stop changesets from running `npm publish` on it directly. The CLI is actually published to npm via a custom pipeline (`publish-cli.ts`) that cross-compiles 12 platform binaries. Removing the private filter from `hasUnpublishedVersions` is safe — it's the only caller, and the npm version check works correctly for the CLI since `agent-facets` is a real published package on the registry.

### Verification

TDD: wrote the failing test first (CLI-only version bump scenario), confirmed it failed, applied the one-line fix, confirmed it passed. Full `bun check` passes.