### PR TITLE
Remove build-binaries job and gate main jobs on check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,6 @@ commands:
                     - node_modules
                     - ~/.bun/install/cache
 jobs:
-    build-binaries:
-        docker:
-            - image: cimg/base:current
-        resource_class: small
-        steps:
-            - setup-mise
-            - run:
-                command: bun scripts/build-cli.ts
-                name: Build all platform binaries
     changesets:
         docker:
             - image: cimg/base:current
@@ -100,23 +91,8 @@ workflows:
                 context:
                     - turbo-cache
                     - slack-secrets
-                filters:
-                    branches:
-                        ignore:
-                            - main
                 post-steps:
                     - notify-failure
-            - build-binaries:
-                context:
-                    - turbo-cache
-                filters:
-                    branches:
-                        ignore:
-                            - main
-                post-steps:
-                    - notify-failure
-                requires:
-                    - check
             - changesets:
                 context:
                     - release
@@ -127,6 +103,8 @@ workflows:
                             - main
                 post-steps:
                     - notify-failure
+                requires:
+                    - check
             - tag-release:
                 context:
                     - release
@@ -137,4 +115,6 @@ workflows:
                             - main
                 post-steps:
                     - notify-failure
+                requires:
+                    - check
 

--- a/.circleci/src/jobs/build-binaries.yml
+++ b/.circleci/src/jobs/build-binaries.yml
@@ -1,8 +1,0 @@
-docker:
-  - image: cimg/base:current
-resource_class: small
-steps:
-  - setup-mise
-  - run:
-      name: Build all platform binaries
-      command: bun scripts/build-cli.ts

--- a/.circleci/src/workflows/ci.yml
+++ b/.circleci/src/workflows/ci.yml
@@ -3,24 +3,11 @@ jobs:
       context:
         - turbo-cache
         - slack-secrets
-      filters:
-        branches:
-          ignore:
-            - main
-      post-steps:
-        - notify-failure
-  - build-binaries:
-      requires:
-        - check
-      context:
-        - turbo-cache
-      filters:
-        branches:
-          ignore:
-            - main
       post-steps:
         - notify-failure
   - changesets:
+      requires:
+        - check
       context:
         - release
         - slack-secrets
@@ -31,6 +18,8 @@ jobs:
       post-steps:
         - notify-failure
   - tag-release:
+      requires:
+        - check
       context:
         - release
         - slack-secrets
@@ -40,4 +29,3 @@ jobs:
             - main
       post-steps:
         - notify-failure
-


### PR DESCRIPTION
### Why

Two issues with the CI workflow:

1. The `build-binaries` job ran on every PR after `check`, but it was redundant — `check` already builds the compiled binary via `turbo build`, and the release pipeline handles cross-compilation internally via `ci-release.ts`.

2. On main, `changesets` and `tag-release` ran without any dependency on `check`. If main had a type error or test failure, the pipeline would still create version PRs and push release tags.

### Details

- Removed the `build-binaries` job definition and its workflow entry entirely
- Removed the `branches: ignore: main` filter from `check` so it runs on all branches
- Added `requires: [check]` to both `changesets` and `tag-release`

The resulting workflow:
```
All branches:  check
Main only:     check → changesets
               check → tag-release
```

### Verification

CircleCI config validates. `bun check` passes.