### PR TITLE
Make .facet file a self-contained archive with embedded build manifest

### DIFF
--- a/.changeset/pretty-eagles-brush.md
+++ b/.changeset/pretty-eagles-brush.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": minor
+---
+
+Build should result in a single-file facet archive that contains the manifest and integrity-checked assets.

--- a/.changeset/six-falcons-sleep.md
+++ b/.changeset/six-falcons-sleep.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": minor
+---
+
+Reset facetVersion in manifest to `0.1` since `1` was premature and should be used for general availability

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -60,6 +60,7 @@
         </list>
       </option>
     </inspection_tool>
+    <inspection_tool class="JSIgnoredPromiseFromCall" enabled="true" level="INFORMATION" enabled_by_default="true" />
     <inspection_tool class="JSUnusedGlobalSymbols" enabled="true" level="INFORMATION" enabled_by_default="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     <inspection_tool class="JSXUnresolvedComponent" enabled="true" level="INFORMATION" enabled_by_default="true" />
     <inspection_tool class="MarkdownIncorrectTableFormatting" enabled="true" level="INFORMATION" enabled_by_default="true" />

--- a/.opencode/command/opsx-explore.md
+++ b/.opencode/command/opsx-explore.md
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│   ┌────────┐         ┌────────┐         │
+│   │ State  │────────▶│ State  │         │
+│   │   A    │         │   B    │         │
+│   └────────┘         └────────┘         │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│   ┌────────┐         ┌────────┐         │
+│   │ State  │────────▶│ State  │         │
+│   │   A    │         │   B    │         │
+│   └────────┘         └────────┘         │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │

--- a/docs/cli/build.mdx
+++ b/docs/cli/build.mdx
@@ -22,14 +22,21 @@ The build command runs a validation pipeline, assembles an archive, and computes
 3. **Validate assets** — checks that all content files are non-empty and contain no YAML front matter. The manifest is the single source of truth for metadata — content files must be pure markdown.
 4. **Check collisions** — validates compact facets entries match the `name@version` format. Fails if the same name is used more than once within the same asset type.
 5. **Validate platforms** — validates platform configuration for known platforms (e.g., `opencode`, `claude-code`). Unknown platforms produce a warning but do not fail the build.
-6. **Assemble archive** — collects the manifest and all resolved text assets into a tar archive, computes the integrity hash, then compresses it with gzip for the `.facet` file.
+6. **Assemble archive** — collects the manifest and all resolved text assets into a deterministic tar archive, computes the integrity hash, compresses it with gzip, then wraps the compressed archive and a build manifest into the self-contained `.facet` file.
 
 On success, the build writes output to `dist/`:
 
-- `dist/<name>-<version>.facet` — a gzip-compressed tar archive
-- `dist/build-manifest.json` — records the archive filename, integrity hash, and per-asset content hashes
+- `dist/<name>-<version>.facet` — a self-contained archive (uncompressed tar containing `build-manifest.json` and `archive.tar.gz`)
+
+The `.facet` file is the single distributable artifact. The build manifest is embedded inside it. Use `--emit-manifest` to also write a loose copy of `build-manifest.json` to `dist/` for debugging or tooling integration.
 
 If the build fails, errors are displayed inline under the failed pipeline stage, with a suggestion to run `facet edit` to fix the issues.
+
+## Flags
+
+| Flag | Description |
+| ---- | ----------- |
+| `--emit-manifest` | Write a loose `build-manifest.json` to `dist/` alongside the `.facet` file |
 
 ## Exit codes
 

--- a/openspec/specs/content-hashing/spec.md
+++ b/openspec/specs/content-hashing/spec.md
@@ -26,24 +26,31 @@ The system SHALL compute a SHA-256 content hash for each resolved text asset (sk
 
 ### Requirement: Build output is assembled into a compressed archive
 
-The system SHALL assemble all resolved build output into a single compressed archive file. The archive SHALL contain the facet manifest and all resolved text asset files. The archive SHALL be a gzip-compressed tar with the extension `.facet`. The archive filename SHALL follow the pattern `<name>-<version>.facet` where `name` and `version` come from the facet manifest.
+The system SHALL assemble all resolved build output into a two-layer archive file with the extension `.facet`. The outer layer SHALL be an uncompressed tar containing exactly two entries: `build-manifest.json` and `archive.tar.gz`. The inner `archive.tar.gz` SHALL be a gzip-compressed tar containing the facet manifest and all resolved text asset files. The archive filename SHALL follow the pattern `<name>-<version>.facet` where `name` and `version` come from the facet manifest.
 
-#### Scenario: Successful build produces a .facet archive
+#### Scenario: Successful build produces a self-contained .facet archive
 
 - **WHEN** a facet named "example-facet" at version "1.0.0" is built successfully
 - **THEN** the system SHALL write `dist/example-facet-1.0.0.facet`
-- **AND** the archive SHALL contain the facet manifest and all resolved text asset files
+- **AND** the `.facet` file SHALL be an uncompressed tar archive
+- **AND** the tar SHALL contain exactly two entries: `build-manifest.json` and `archive.tar.gz`
 
-#### Scenario: Archive contains all declared assets
+#### Scenario: Inner archive contains all declared assets
 
 - **WHEN** a facet with two skills, one agent, and one command is built
-- **THEN** the archive SHALL contain the facet manifest, two skill files, the agent file, and the command file
+- **THEN** the `archive.tar.gz` entry within the `.facet` file SHALL be a gzip-compressed tar
+- **AND** the inner tar SHALL contain the facet manifest, two skill files, the agent file, and the command file
 
-#### Scenario: Archive does not contain extraneous files
+#### Scenario: Inner archive does not contain extraneous files
 
 - **WHEN** a facet is built
-- **THEN** the archive SHALL contain only the facet manifest and resolved text assets
-- **AND** the archive SHALL NOT contain the build manifest or any other metadata files
+- **THEN** the inner `archive.tar.gz` SHALL contain only the facet manifest and resolved text assets
+- **AND** the inner archive SHALL NOT contain the build manifest or any other metadata files
+
+#### Scenario: Inner archive name is fixed
+
+- **WHEN** any facet is built, regardless of name or version
+- **THEN** the inner archive entry SHALL be named `archive.tar.gz`
 
 ### Requirement: Archive assembly is deterministic
 
@@ -82,46 +89,54 @@ The system SHALL compute a SHA-256 content hash of the uncompressed tar archive 
 
 ### Requirement: A build manifest records content hashes
 
-The system SHALL write a build manifest file named `build-manifest.json` to the `dist/` directory alongside the archive. The manifest SHALL contain a `facetVersion` field (integer, currently `1`), the archive filename, the integrity hash, and a map of per-asset content hashes keyed by relative path within the archive. The manifest SHALL be a flat JSON object.
+The system SHALL produce a build manifest named `build-manifest.json` embedded inside the `.facet` archive as an entry in the outer tar. The manifest SHALL contain a `facetVersion` field set to `0.1` (number), an `archive` field set to `"archive.tar.gz"`, an `integrity` field with the integrity hash, and an `assets` object mapping relative paths to content hashes. The manifest SHALL be a flat JSON object.
 
-#### Scenario: Build manifest is written on successful build
+#### Scenario: Build manifest is embedded in the .facet archive
 
 - **WHEN** a facet is built successfully
-- **THEN** the system SHALL write `dist/build-manifest.json`
-- **AND** the manifest SHALL contain a `facetVersion` field set to `1`
-- **AND** the manifest SHALL contain an `archive` field with the archive filename
+- **THEN** the `.facet` file SHALL contain a `build-manifest.json` entry in the outer tar
+- **AND** the manifest SHALL contain a `facetVersion` field set to `0.1`
+- **AND** the manifest SHALL contain an `archive` field set to `"archive.tar.gz"`
 - **AND** the manifest SHALL contain an `integrity` field with the integrity hash
 - **AND** the manifest SHALL contain an `assets` object mapping relative paths to content hashes
 
-#### Scenario: Build manifest integrity hash matches actual archive contents
+#### Scenario: Build manifest integrity hash matches inner archive contents
 
-- **WHEN** a consumer reads `build-manifest.json`, decompresses the `.facet` file, and hashes the resulting tar bytes
+- **WHEN** a consumer extracts `build-manifest.json` and `archive.tar.gz` from the `.facet` file, decompresses `archive.tar.gz`, and hashes the resulting tar bytes
 - **THEN** the computed hash SHALL match the `integrity` value in the manifest
 
-#### Scenario: Build manifest asset hashes match archive contents
+#### Scenario: Build manifest asset hashes match inner archive contents
 
-- **WHEN** a consumer extracts the archive and hashes each individual file
+- **WHEN** a consumer extracts `archive.tar.gz` from the `.facet` file, decompresses it, and hashes each individual file
 - **THEN** each computed hash SHALL match the corresponding entry in the manifest's `assets` map
 
-#### Scenario: Build manifest points to the correct archive filename
+#### Scenario: Build manifest can be read without decompressing the inner archive
 
-- **WHEN** a facet named "my-facet" at version "2.1.0" is built
-- **THEN** the manifest's `archive` field SHALL be `my-facet-2.1.0.facet`
+- **WHEN** a consumer parses the outer tar of a `.facet` file
+- **THEN** the consumer SHALL be able to read `build-manifest.json` directly from the outer tar entries
+- **AND** the consumer SHALL NOT need to decompress `archive.tar.gz` to access the manifest
 
-### Requirement: Build output contains only the archive and manifest
+### Requirement: Build output contains the self-contained archive
 
-The `dist/` directory SHALL contain exactly the compressed archive and the build manifest after a successful build. The system SHALL NOT write loose resolved asset files or manifest copies to `dist/`. The archive is the single distributable artifact; the build manifest is metadata about the archive.
+The `dist/` directory SHALL contain the `.facet` archive after a successful build. By default, `dist/` SHALL contain only the `.facet` file. When the `--emit-manifest` flag is passed to the build command, the system SHALL also write a loose copy of `build-manifest.json` to `dist/` alongside the archive. The system SHALL NOT write loose resolved asset files to `dist/`.
 
-#### Scenario: dist/ contains exactly two files
+#### Scenario: dist/ contains one file by default
 
-- **WHEN** a facet is built successfully
-- **THEN** `dist/` SHALL contain exactly the `.facet` archive file and `build-manifest.json`
+- **WHEN** a facet is built successfully without the `--emit-manifest` flag
+- **THEN** `dist/` SHALL contain exactly the `.facet` archive file
+- **AND** `dist/` SHALL NOT contain `build-manifest.json`
 - **AND** `dist/` SHALL NOT contain loose facet manifest, `skills/`, `agents/`, or `commands/` files
+
+#### Scenario: dist/ contains two files with --emit-manifest
+
+- **WHEN** a facet is built successfully with the `--emit-manifest` flag
+- **THEN** `dist/` SHALL contain the `.facet` archive file and `build-manifest.json`
+- **AND** the loose `build-manifest.json` SHALL be identical in content to the one embedded in the `.facet` file
 
 #### Scenario: Previous build output is cleaned
 
-- **WHEN** a facet is rebuilt and the previous `dist/` directory contains loose files from an older build format
-- **THEN** the system SHALL remove the previous `dist/` contents before writing the new archive and manifest
+- **WHEN** a facet is rebuilt and the previous `dist/` directory contains files from an older build
+- **THEN** the system SHALL remove the previous `dist/` contents before writing the new output
 
 ### Requirement: Integrity hash information is displayed in build output
 

--- a/packages/cli/src/__tests__/create-build.test.ts
+++ b/packages/cli/src/__tests__/create-build.test.ts
@@ -159,14 +159,15 @@ describe('writeScaffold', () => {
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('Built buildable')
 
-    // Verify dist/ output exists — archive + build manifest
+    // Verify dist/ output exists — self-contained .facet archive only
     const distArchive = await Bun.file(join(dir, `dist/buildable-${DEFAULT_VERSION}.facet`)).exists()
     expect(distArchive).toBe(true)
 
+    // No loose manifest by default (requires --emit-manifest)
     const distManifest = await Bun.file(join(dir, 'dist/build-manifest.json')).exists()
-    expect(distManifest).toBe(true)
+    expect(distManifest).toBe(false)
 
-    // No loose files
+    // No loose asset files
     const looseManifest = await Bun.file(join(dir, 'dist/facet.json')).exists()
     expect(looseManifest).toBe(false)
   })

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -8,7 +8,13 @@ export const buildCommand: Command = {
   name: 'build',
   description: 'Build a facet from the current directory',
   usage: '[directory]',
-  run: async (args: string[], _flags: Record<string, unknown>): Promise<number> => {
+  flags: {
+    'emit-manifest': {
+      type: 'boolean',
+      description: 'Write a loose build-manifest.json to dist/ alongside the .facet file',
+    },
+  },
+  run: async (args: string[], flags: Record<string, unknown>): Promise<number> => {
     const resolved = await resolveTargetDir(args[0], { mustExist: true, facetMustExist: true })
     if (!resolved.ok) {
       console.error(resolved.message)
@@ -17,6 +23,7 @@ export const buildCommand: Command = {
 
     const rootDir = resolved.dir
     const displayDir = resolved.display
+    const emitManifest = flags['emit-manifest'] === true
 
     // Track result for stdout summary after Ink exits
     let buildName = ''
@@ -28,6 +35,7 @@ export const buildCommand: Command = {
     const instance = render(
       createElement(BuildView, {
         rootDir,
+        emitManifest,
         onSuccess: (name: string, version: string, fileCount: number, hash: string) => {
           buildName = name
           buildVersion = version

--- a/packages/cli/src/tui/views/build/build-view.tsx
+++ b/packages/cli/src/tui/views/build/build-view.tsx
@@ -22,10 +22,12 @@ interface BuildViewResult {
 
 export function BuildView({
   rootDir,
+  emitManifest = false,
   onSuccess,
   onFailure,
 }: {
   rootDir: string
+  emitManifest?: boolean
   onSuccess?: (name: string, version: string, fileCount: number, integrity: string) => void
   onFailure?: (errorCount: number) => void
 }) {
@@ -37,12 +39,6 @@ export function BuildView({
   // Deferred exit: set this to an Error to exit after the next render cycle,
   // ensuring error/stage state updates are painted before Ink unmounts.
   const [pendingExit, setPendingExit] = useState<Error | null>(null)
-
-  useEffect(() => {
-    if (pendingExit) {
-      exit(pendingExit)
-    }
-  }, [pendingExit, exit])
 
   // Build a stable lookup from stage label to index
   const stageIndexMap = useMemo(() => Object.fromEntries(BUILD_STAGES.map((label, i) => [label, i])), [])
@@ -57,52 +53,64 @@ export function BuildView({
     [stageIndexMap],
   )
 
-  useEffect(() => {
-    async function run() {
-      const pipelineResult = await runBuildPipeline(rootDir, (progress: BuildProgress) => {
-        updateStage(progress.stage, {
-          status: progress.status === 'running' ? 'running' : progress.status === 'done' ? 'done' : 'failed',
-        })
+  const run = useCallback(async () => {
+    const pipelineResult = await runBuildPipeline(rootDir, (progress: BuildProgress) => {
+      updateStage(progress.stage, {
+        status: progress.status === 'running' ? 'running' : progress.status === 'done' ? 'done' : 'failed',
       })
+    })
 
-      setWarnings(pipelineResult.warnings)
+    setWarnings(pipelineResult.warnings)
 
-      if (!pipelineResult.ok) {
-        const formatted = pipelineResult.errors.map((e) => e.message)
-        // Find the stage that failed and attach errors to it
-        setStages((prev) => prev.map((s) => (s.status === 'failed' ? { ...s, errors: formatted } : s)))
-        onFailure?.(pipelineResult.errors.length)
-        // Defer exit so React renders the errors and failed stage status first
-        setPendingExit(new Error('Build failed'))
-        return
-      }
+    if (!pipelineResult.ok) {
+      const formatted = pipelineResult.errors.map((e) => e.message)
+      // Find the stage that failed and attach errors to it
+      setStages((prev) => prev.map((s) => (s.status === 'failed' ? { ...s, errors: formatted } : s)))
+      onFailure?.(pipelineResult.errors.length)
+      // Defer exit so React renders the errors and failed stage status first
+      setPendingExit(new Error('Build failed'))
+      return
+    }
 
-      // Writing output stage — handled here, not by the pipeline
-      updateStage('Writing output', { status: 'running' })
-      try {
-        await writeBuildOutput(pipelineResult, rootDir)
+    // Writing output stage — handled here, not by the pipeline
+    updateStage('Writing output', { status: 'running' })
+    try {
+      await writeBuildOutput(pipelineResult, rootDir, { emitManifest })
 
-        const files = Object.keys(pipelineResult.assetHashes).sort()
+      const files = Object.keys(pipelineResult.assetHashes).sort()
 
-        updateStage('Writing output', { status: 'done' })
-        setResult({
-          name: pipelineResult.data.name,
-          version: pipelineResult.data.version,
-          files,
-          archiveFilename: pipelineResult.archiveFilename,
-          integrity: pipelineResult.integrity,
-          warnings: pipelineResult.warnings,
-        })
-        onSuccess?.(pipelineResult.data.name, pipelineResult.data.version, files.length, pipelineResult.integrity)
-        exit()
-      } catch (err) {
-        updateStage('Writing output', { status: 'failed', detail: String(err) })
-        setPendingExit(err instanceof Error ? err : new Error(String(err)))
-      }
+      updateStage('Writing output', { status: 'done' })
+      setResult({
+        name: pipelineResult.data.name,
+        version: pipelineResult.data.version,
+        files,
+        archiveFilename: pipelineResult.archiveFilename,
+        integrity: pipelineResult.integrity,
+        warnings: pipelineResult.warnings,
+      })
+      onSuccess?.(pipelineResult.data.name, pipelineResult.data.version, files.length, pipelineResult.integrity)
+      exit()
+    } catch (err) {
+      updateStage('Writing output', { status: 'failed', detail: String(err) })
+      setPendingExit(err instanceof Error ? err : new Error(String(err)))
+    }
+  }, [
+    emitManifest,
+    exit,
+    onFailure,
+    onSuccess,
+    rootDir, // Writing output stage — handled here, not by the pipeline
+    updateStage,
+  ])
+
+  useEffect(() => {
+    if (pendingExit) {
+      exit(pendingExit)
+      return
     }
 
     run()
-  }, [rootDir, exit, onSuccess, onFailure, updateStage])
+  }, [pendingExit, exit, run])
 
   return (
     <Box flexDirection="column" padding={1} gap={1}>

--- a/packages/core/src/__tests__/build-pipeline.test.ts
+++ b/packages/core/src/__tests__/build-pipeline.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import dedent from 'dedent'
+import { parseTar, parseTarGzip } from 'nanotar'
+import { computeContentHash } from '../build/content-hash.ts'
 import { detectNamingCollisions } from '../build/detect-collisions.ts'
 import { runBuildPipeline } from '../build/pipeline.ts'
 import { validateCompactFacets } from '../build/validate-facets.ts'
@@ -439,7 +441,7 @@ describe('content validation', () => {
 // --- Build output generation ---
 
 describe('writeBuildOutput', () => {
-  test('writes archive and build manifest to dist/', async () => {
+  test('writes self-contained .facet archive with embedded manifest', async () => {
     const dir = await createFixtureDir('write-output')
     await Bun.write(join(dir, 'skills/example/SKILL.md'), '# Resolved content')
     await Bun.write(
@@ -459,22 +461,111 @@ describe('writeBuildOutput', () => {
 
     await writeBuildOutput(result, dir)
 
-    // Archive exists
-    const archiveExists = await Bun.file(join(dir, 'dist/test-facet-1.0.0.facet')).exists()
+    // .facet file exists
+    const archivePath = join(dir, 'dist/test-facet-1.0.0.facet')
+    const archiveExists = await Bun.file(archivePath).exists()
     expect(archiveExists).toBe(true)
 
-    // Build manifest exists and has correct structure
-    const manifestText = await Bun.file(join(dir, 'dist/build-manifest.json')).text()
-    const manifest = JSON.parse(manifestText)
-    expect(manifest.facetVersion).toBe(1)
-    expect(manifest.archive).toBe('test-facet-1.0.0.facet')
+    // dist/ contains exactly one file (no loose manifest)
+    const distFiles = await readdir(join(dir, 'dist'))
+    expect(distFiles).toEqual(['test-facet-1.0.0.facet'])
+
+    // Outer tar contains exactly two entries: build-manifest.json and archive.tar.gz
+    const outerBytes = await Bun.file(archivePath).arrayBuffer()
+    const outerEntries = parseTar(outerBytes)
+    const outerNames = outerEntries.map((e) => e.name).sort()
+    expect(outerNames).toEqual(['archive.tar.gz', 'build-manifest.json'])
+
+    // Embedded manifest has correct structure
+    const manifestEntry = outerEntries.find((e) => e.name === 'build-manifest.json')
+    if (!manifestEntry) throw new Error('build-manifest.json not found in outer tar')
+    const manifest = JSON.parse(manifestEntry.text)
+    expect(manifest.facetVersion).toBe(0.1)
+    expect(manifest.archive).toBe('archive.tar.gz')
     expect(manifest.integrity).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(manifest.assets['facet.json']).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(manifest.assets['skills/example/SKILL.md']).toMatch(/^sha256:[a-f0-9]{64}$/)
 
-    // No loose files
+    // Inner archive contains expected assets
+    const innerEntry = outerEntries.find((e) => e.name === 'archive.tar.gz')
+    if (!innerEntry?.data) throw new Error('archive.tar.gz not found in outer tar')
+    const innerFiles = await parseTarGzip(innerEntry.data)
+    const innerNames = innerFiles.map((f) => f.name).sort()
+    expect(innerNames).toEqual(['facet.json', 'skills/example/SKILL.md'])
+
+    // No loose files in dist/
     const looseManifest = await Bun.file(join(dir, 'dist/facet.json')).exists()
     expect(looseManifest).toBe(false)
+  })
+
+  test('integrity hash matches inner archive bytes', async () => {
+    const dir = await createFixtureDir('integrity-check')
+    await Bun.write(join(dir, 'skills/example/SKILL.md'), '# Skill content')
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name: 'hash-test',
+        version: '1.0.0',
+        skills: {
+          example: { description: 'A skill' },
+        },
+      }),
+    )
+
+    const result = await runBuildPipeline(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    await writeBuildOutput(result, dir)
+
+    // Extract manifest and inner archive from outer tar
+    const outerBytes = await Bun.file(join(dir, 'dist/hash-test-1.0.0.facet')).arrayBuffer()
+    const outerEntries = parseTar(outerBytes)
+    const manifestEntry = outerEntries.find((e) => e.name === 'build-manifest.json')
+    if (!manifestEntry) throw new Error('build-manifest.json not found in outer tar')
+    const manifest = JSON.parse(manifestEntry.text)
+    const innerEntry = outerEntries.find((e) => e.name === 'archive.tar.gz')
+    if (!innerEntry?.data) throw new Error('archive.tar.gz not found in outer tar')
+
+    // Decompress inner archive and hash the raw tar bytes
+    const innerGzBuffer = new Uint8Array(innerEntry.data).buffer
+    const innerTarBytes = Bun.gunzipSync(innerGzBuffer)
+    const computedHash = computeContentHash(innerTarBytes)
+
+    expect(computedHash).toBe(manifest.integrity)
+  })
+
+  test('--emit-manifest writes loose build-manifest.json', async () => {
+    const dir = await createFixtureDir('emit-manifest')
+    await Bun.write(join(dir, 'skills/example/SKILL.md'), '# Skill')
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name: 'emit-test',
+        version: '1.0.0',
+        skills: {
+          example: { description: 'A skill' },
+        },
+      }),
+    )
+
+    const result = await runBuildPipeline(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    await writeBuildOutput(result, dir, { emitManifest: true })
+
+    // dist/ contains both files
+    const distFiles = (await readdir(join(dir, 'dist'))).sort()
+    expect(distFiles).toEqual(['build-manifest.json', 'emit-test-1.0.0.facet'])
+
+    // Loose manifest matches embedded manifest
+    const looseText = await Bun.file(join(dir, 'dist/build-manifest.json')).text()
+    const outerBytes = await Bun.file(join(dir, 'dist/emit-test-1.0.0.facet')).arrayBuffer()
+    const outerEntries = parseTar(outerBytes)
+    const embeddedEntry = outerEntries.find((e) => e.name === 'build-manifest.json')
+    if (!embeddedEntry) throw new Error('build-manifest.json not found in outer tar')
+    expect(looseText).toBe(embeddedEntry.text)
   })
 
   test('cleans previous dist/ before writing', async () => {
@@ -503,10 +594,8 @@ describe('writeBuildOutput', () => {
     const staleExists = await Bun.file(join(dir, 'dist/stale.txt')).exists()
     expect(staleExists).toBe(false)
 
-    // Archive and manifest should exist
-    const archiveExists = await Bun.file(join(dir, 'dist/test-1.0.0.facet')).exists()
-    expect(archiveExists).toBe(true)
-    const manifestExists = await Bun.file(join(dir, 'dist/build-manifest.json')).exists()
-    expect(manifestExists).toBe(true)
+    // Only the .facet archive should exist (no loose manifest by default)
+    const distFiles = await readdir(join(dir, 'dist'))
+    expect(distFiles).toEqual(['test-1.0.0.facet'])
   })
 })

--- a/packages/core/src/build/content-hash.ts
+++ b/packages/core/src/build/content-hash.ts
@@ -50,7 +50,7 @@ export function collectArchiveEntries(resolved: ResolvedFacetManifest, manifestC
 
 /**
  * Computes SHA-256 content hashes for each archive entry.
- * Returns a map of relative path to `sha256:<hex>`.
+ * Returns a map of a relative path to `sha256:<hex>`.
  */
 export function computeAssetHashes(entries: ArchiveEntry[]): Record<string, string> {
   const hashes: Record<string, string> = {}
@@ -59,6 +59,15 @@ export function computeAssetHashes(entries: ArchiveEntry[]): Record<string, stri
   }
   return hashes
 }
+
+const DETERMINISTIC_ATTRS = {
+  mtime: 0,
+  uid: 0,
+  gid: 0,
+  mode: '644',
+  user: '',
+  group: '',
+} as const
 
 /**
  * Assembles a deterministic uncompressed tar archive from archive entries.
@@ -76,20 +85,11 @@ export function assembleTar(entries: ArchiveEntry[]): Uint8Array {
     data: entry.content,
   }))
 
-  return createTar(files, {
-    attrs: {
-      mtime: 0,
-      uid: 0,
-      gid: 0,
-      mode: '644',
-      user: '',
-      group: '',
-    },
-  })
+  return createTar(files, { attrs: DETERMINISTIC_ATTRS })
 }
 
 /**
- * Compresses tar bytes with gzip for the `.facet` delivery format.
+ * Compresses tar bytes with gzip for the inner archive.
  *
  * Compression is a delivery concern — the integrity hash covers the
  * uncompressed tar bytes, not the compressed output. This allows
@@ -99,4 +99,32 @@ export function compressArchive(tarBytes: Uint8Array): Uint8Array {
   const buffer = new ArrayBuffer(tarBytes.byteLength)
   new Uint8Array(buffer).set(tarBytes)
   return Bun.gzipSync(buffer)
+}
+
+/** Fixed name for the inner archive within the outer `.facet` tar. */
+export const INNER_ARCHIVE_NAME = 'archive.tar.gz'
+
+/** Fixed name for the build manifest within the outer `.facet` tar. */
+export const BUILD_MANIFEST_NAME = 'build-manifest.json'
+
+/**
+ * Assembles the outer uncompressed tar that forms the `.facet` file.
+ *
+ * The outer tar contains exactly two entries:
+ * - `build-manifest.json` — the build manifest as a JSON string
+ * - `archive.tar.gz` — the gzip-compressed inner tar of assets
+ *
+ * The outer tar is uncompressed so that the manifest can be read
+ * without decompressing the inner archive.
+ *
+ * Deterministic metadata is applied for consistency, though the
+ * integrity hash covers only the inner tar bytes.
+ */
+export function assembleOuterTar(manifestJson: string, innerArchiveBytes: Uint8Array): Uint8Array {
+  const files: TarFileInput[] = [
+    { name: BUILD_MANIFEST_NAME, data: manifestJson },
+    { name: INNER_ARCHIVE_NAME, data: innerArchiveBytes },
+  ]
+
+  return createTar(files, { attrs: DETERMINISTIC_ATTRS })
 }

--- a/packages/core/src/build/pipeline.ts
+++ b/packages/core/src/build/pipeline.ts
@@ -2,11 +2,13 @@ import { join } from 'node:path'
 import { FACET_MANIFEST_FILE, loadManifest, type ResolvedFacetManifest, resolvePrompts } from '../loaders/facet.ts'
 import type { ValidationError } from '../types.ts'
 import {
+  assembleOuterTar,
   assembleTar,
   collectArchiveEntries,
   compressArchive,
   computeAssetHashes,
   computeContentHash,
+  INNER_ARCHIVE_NAME,
 } from './content-hash.ts'
 import { detectNamingCollisions } from './detect-collisions.ts'
 import { validateContentFiles } from './validate-content.ts'
@@ -22,10 +24,13 @@ export interface BuildResult {
   ok: true
   data: ResolvedFacetManifest
   warnings: string[]
+  /** The complete .facet file bytes (outer uncompressed tar containing manifest + inner archive) */
   archiveBytes: Uint8Array
   integrity: string
   archiveFilename: string
   assetHashes: Record<string, string>
+  /** Serialized build-manifest.json content (for --emit-manifest and test verification) */
+  manifestJson: string
 }
 
 export interface BuildFailure {
@@ -127,7 +132,7 @@ export async function runBuildPipeline(
 
   onProgress?.({ stage: 'Validating platforms', status: 'done' })
 
-  // Stage 6: Assemble archive, compute content hashes, and compress for delivery
+  // Stage 6: Assemble archive, compute content hashes, and wrap into self-contained .facet
   onProgress?.({ stage: 'Assembling archive', status: 'running' })
 
   const resolved = resolveResult.data
@@ -136,8 +141,18 @@ export async function runBuildPipeline(
   const assetHashes = computeAssetHashes(entries)
   const tarBytes = assembleTar(entries)
   const integrity = computeContentHash(tarBytes)
-  const archiveBytes = compressArchive(tarBytes)
+  const innerArchiveBytes = compressArchive(tarBytes)
   const archiveFilename = `${resolved.name}-${resolved.version}.facet`
+
+  // Build the build manifest and wrap into the outer tar
+  const buildManifest = {
+    facetVersion: 0.1,
+    archive: INNER_ARCHIVE_NAME,
+    integrity,
+    assets: assetHashes,
+  }
+  const manifestJson = JSON.stringify(buildManifest, null, 2)
+  const archiveBytes = assembleOuterTar(manifestJson, innerArchiveBytes)
 
   onProgress?.({ stage: 'Assembling archive', status: 'done' })
 
@@ -149,5 +164,6 @@ export async function runBuildPipeline(
     integrity,
     archiveFilename,
     assetHashes,
+    manifestJson,
   }
 }

--- a/packages/core/src/build/write-output.ts
+++ b/packages/core/src/build/write-output.ts
@@ -1,34 +1,38 @@
 import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
-import type { BuildManifest } from '../schemas/build-manifest.ts'
 import type { BuildResult } from './pipeline.ts'
 
 const DIST_DIR = 'dist'
 const BUILD_MANIFEST_FILE = 'build-manifest.json'
 
+export interface WriteBuildOutputOptions {
+  /** When true, also write a loose build-manifest.json to dist/ alongside the .facet file. */
+  emitManifest?: boolean
+}
+
 /**
  * Writes the build output to dist/.
  *
  * - Cleans (removes and recreates) the dist/ directory
- * - Writes the .facet archive (gzip-compressed tar)
- * - Writes build-manifest.json with integrity hash and per-asset hashes
+ * - Writes the self-contained .facet archive (outer uncompressed tar)
+ * - Optionally writes a loose build-manifest.json when emitManifest is true
  */
-export async function writeBuildOutput(result: BuildResult, rootDir: string): Promise<void> {
+export async function writeBuildOutput(
+  result: BuildResult,
+  rootDir: string,
+  options: WriteBuildOutputOptions = {},
+): Promise<void> {
   const distDir = join(rootDir, DIST_DIR)
 
   // Clean previous output
   await rm(distDir, { recursive: true, force: true })
   await mkdir(distDir, { recursive: true })
 
-  // Write the .facet archive
+  // Write the .facet archive (self-contained outer tar)
   await Bun.write(join(distDir, result.archiveFilename), result.archiveBytes)
 
-  // Write build manifest
-  const manifest: BuildManifest = {
-    facetVersion: 1,
-    archive: result.archiveFilename,
-    integrity: result.integrity,
-    assets: result.assetHashes,
+  // Optionally write loose build manifest
+  if (options.emitManifest) {
+    await Bun.write(join(distDir, BUILD_MANIFEST_FILE), result.manifestJson)
   }
-  await Bun.write(join(distDir, BUILD_MANIFEST_FILE), JSON.stringify(manifest, null, 2))
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,14 @@
 // types
 export type { ArchiveEntry } from './build/content-hash.ts'
 export {
+  assembleOuterTar,
   assembleTar,
+  BUILD_MANIFEST_NAME,
   collectArchiveEntries,
   compressArchive,
   computeAssetHashes,
   computeContentHash,
+  INNER_ARCHIVE_NAME,
 } from './build/content-hash.ts'
 export { detectNamingCollisions } from './build/detect-collisions.ts'
 export type { BuildFailure, BuildProgress, BuildResult, BuildStage } from './build/pipeline.ts'
@@ -14,6 +17,7 @@ export { BUILD_STAGES, runBuildPipeline } from './build/pipeline.ts'
 export { validateCompactFacets } from './build/validate-facets.ts'
 export type { PlatformValidationResult } from './build/validate-platforms.ts'
 export { validatePlatformConfigs } from './build/validate-platforms.ts'
+export type { WriteBuildOutputOptions } from './build/write-output.ts'
 export { writeBuildOutput } from './build/write-output.ts'
 export { writeManifest } from './edit/manifest-writer.ts'
 export type { MatchedAsset, MissingAsset, ReconciliationResult } from './edit/reconcile.ts'


### PR DESCRIPTION
### Why

The `.facet` archive and `build-manifest.json` were two separate files in `dist/`. Distributing a facet meant sharing a directory, not a single artifact. Every packaging ecosystem (npm tarballs, OCI images, JARs, wheels) ships a single self-contained artifact with metadata embedded.

### Details

The `.facet` file becomes an uncompressed outer tar containing two entries: `build-manifest.json` (readable without decompression) and `archive.tar.gz` (the gzip-compressed inner tar of assets). The integrity hash still covers the uncompressed inner tar bytes -- no change to the hashing model from ADR-004.

Other changes:
- `facetVersion` resets from `1` to `0.1` since the format is pre-release with no existing consumers
- `dist/` now contains only the `.facet` file by default; a new `--emit-manifest` flag writes a loose `build-manifest.json` for debugging/tooling
- Inner archive uses the fixed name `archive.tar.gz` regardless of facet name/version

This is preparatory work for Phase 3 (Local Installation) which needs a self-contained artifact to resolve from.