### PR TITLE
Update Dependabot config to include multiple directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,11 @@ version: 2
 enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "bun"
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/brand"
+      - "/packages/cli"
+      - "/packages/core"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Added multiple directories for Dependabot updates.

### Why

For obvious reasons.

### Details

Make sure we check all the monorepo packages.

### Verification

It works or it doesn't.