### PR TITLE
Add harness SDK and CLI-driven harness management

### DIFF
--- a/.changeset/petite-pets-battle.md
+++ b/.changeset/petite-pets-battle.md
@@ -1,0 +1,7 @@
+---
+"@agent-facets/harness": minor
+"@agent-facets/common": minor
+"agent-facets": minor
+---
+
+Add in @agent-facets/harness and @agent-facets/common packages

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -36,8 +36,14 @@ jobs:
         steps:
             - setup-mise
             - run:
+                command: cp packages/cli/turbo.ci.json packages/cli/turbo.json
+                name: Disable CLI build cache
+            - run:
                 command: bun run check
                 name: Check
+            - run:
+                command: git checkout packages/cli/turbo.json
+                name: Restore CLI turbo config
             - store_test_results:
                 path: test-results
     main-pipeline:

--- a/.circleci/development/jobs/check.yml
+++ b/.circleci/development/jobs/check.yml
@@ -4,8 +4,14 @@ resource_class: small
 steps:
   - setup-mise
   - run:
+      name: Disable CLI build cache
+      command: cp packages/cli/turbo.ci.json packages/cli/turbo.json
+  - run:
       name: Check
       command: bun run check
+  - run:
+      name: Restore CLI turbo config
+      command: git checkout packages/cli/turbo.json
   - store_test_results:
       path: test-results
 

--- a/.idea/facets.iml
+++ b/.idea/facets.iml
@@ -3,7 +3,13 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.opencode/plans" />
+      <excludeFolder url="file://$MODULE_DIR$/.turbo" />
       <excludeFolder url="file://$MODULE_DIR$/openspec/changes/archive" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/brand/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/cli/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/core/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/harness/.turbo" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="splitLayout" value="SHOW_PREVIEW" />
+  </component>
+</project>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 
 ## Source Code Map
 
-Turborepo monorepo with Bun workspaces. Two packages under `packages/`.
+Turborepo monorepo with Bun workspaces. Five packages under `packages/`.
 
 ### `packages/core` — `@agent-facets/core`
 
@@ -40,6 +40,25 @@ src/
 ├── cli.ts          # CLI entry point
 └── __tests__/      # Unit tests
 ```
+
+### `packages/harness` — `@agent-facets/harness`
+
+Harness SDK for defining abstractions over AI coding tools. Entry point: `src/index.ts`
+
+```
+src/
+├── define-harness.ts  # Factory function: defineHarness()
+├── types.ts           # Harness, HarnessDefinition, HarnessMetadata types
+└── index.ts           # Public API entry point
+```
+
+### `packages/brand` — `@agent-facets/brand`
+
+Brand colors and visual identity constants.
+
+### `packages/common` — `@agent-facets/common`
+
+Shared types used across packages. Private — not published to npm.
 
 ### Other directories
 
@@ -89,6 +108,28 @@ test("hello world", () => {
   expect(1).toBe(1);
 });
 ```
+
+## Turbo Caching
+
+The `check` pipeline (`bun check`) orchestrates `test`, `types`, `lint`, and other tasks via Turborepo. Caching rules:
+
+- **`build`** is cached by default. The CLI package (`packages/cli`) overrides this with `cache: false` in its package-level `turbo.json` because the compiled binary is too large for remote cache.
+- **`test`** and **`types`** are cached. By default, `test` has no dependency on `build`. The CLI package overrides this to add `test.dependsOn: ["build"]` since its integration tests need the compiled binary.
+- Package-level overrides live in `packages/<name>/turbo.json`.
+
+### CLI build caching
+
+The CLI compiled binary is too large for remote cache (causes upload failures in CI). To handle this:
+
+- **Locally**: `packages/cli/turbo.json` has caching enabled — the CLI build caches normally.
+- **In CI**: The pipeline copies `packages/cli/turbo.ci.json` over `turbo.json` before running checks, which sets `cache: false` on the build task. After checks pass, it restores the original via `git checkout`.
+- **Keep in sync**: When modifying `packages/cli/turbo.json`, also update `turbo.ci.json`. The only difference between them should be `"cache": false` on the build task in the CI variant.
+
+### When adding a new package
+
+1. Add `"test": "bun test"` and `"types": "tsc --noEmit"` scripts to its `package.json` so turbo picks them up for the `check` pipeline.
+2. If the package's tests depend on build output, create a `turbo.json` in the package directory with `"test": { "dependsOn": ["build"] }`.
+3. If the package's build output is too large for remote cache, add `"build": { "cache": false }` to the package-level `turbo.json`.
 
 ## Frontend
 

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,10 @@
         "typescript": "^5 || ^6",
       },
     },
+    "packages/common": {
+      "name": "@agent-facets/common",
+      "version": "0.0.0",
+    },
     "packages/core": {
       "name": "@agent-facets/core",
       "version": "0.3.3",
@@ -72,11 +76,24 @@
         "typescript": "^5 || ^6",
       },
     },
+    "packages/harness": {
+      "name": "@agent-facets/harness",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@agent-facets/common": "workspace:*",
+        "tsdown": "^0.21.8",
+        "typescript": "^6.0.0",
+      },
+    },
   },
   "packages": {
     "@agent-facets/brand": ["@agent-facets/brand@workspace:packages/brand"],
 
+    "@agent-facets/common": ["@agent-facets/common@workspace:packages/common"],
+
     "@agent-facets/core": ["@agent-facets/core@workspace:packages/core"],
+
+    "@agent-facets/harness": ["@agent-facets/harness@workspace:packages/harness"],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -92,9 +109,17 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/generator": ["@babel/generator@8.0.0-rc.3", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
+
+    "@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
 
@@ -158,7 +183,11 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@fission-ai/openspec": ["@fission-ai/openspec@1.2.0", "", { "dependencies": { "@inquirer/core": "^10.2.2", "@inquirer/prompts": "^7.8.0", "chalk": "^5.5.0", "commander": "^14.0.0", "fast-glob": "^3.3.3", "ora": "^8.2.0", "posthog-node": "^5.20.0", "yaml": "^2.8.2", "zod": "^4.0.17" }, "bin": { "openspec": "bin/openspec.js" } }, "sha512-2XDmPZcVY0Bs014lP9aoxe3VoEU8hFvqaBFxQaiJO2nhC8vTKCyo6sT/5YpQcOTfR/a64Hht2anTyqLR4eNhlg=="],
 
@@ -284,6 +313,8 @@
 
     "@mintlify/validation": ["@mintlify/validation@0.1.663", "", { "dependencies": { "@mintlify/mdx": "^3.0.4", "@mintlify/models": "0.0.290", "arktype": "2.1.27", "js-yaml": "4.1.0", "lcm": "0.0.3", "lodash": "4.18.1", "neotraverse": "0.6.18", "object-hash": "3.0.0", "openapi-types": "12.1.3", "uuid": "11.1.0", "zod": "3.24.0", "zod-to-json-schema": "3.20.4" } }, "sha512-MU2PECIyOJaS0VHokMp4snEERSBzeHdMtGAMteRr9gl76hTlRKmp+i/9GUQL1XxrGfzY9s2D30YJjsMUUq2Lyw=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -314,9 +345,13 @@
 
     "@openapi-contrib/openapi-schema-to-json-schema": ["@openapi-contrib/openapi-schema-to-json-schema@3.2.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" } }, "sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
     "@posthog/core": ["@posthog/core@1.23.1", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.3.0", "", { "dependencies": { "debug": "^4.3.5", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.4.0", "semver": "^7.6.3", "tar-fs": "^3.0.6", "unbzip2-stream": "^1.4.3", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA=="],
+
+    "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -361,6 +396,38 @@
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
@@ -434,6 +501,8 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
     "@types/acorn": ["@types/acorn@4.0.6", "", { "dependencies": { "@types/estree": "*" } }, "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
@@ -455,6 +524,8 @@
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
+
+    "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -518,6 +589,8 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
@@ -543,6 +616,8 @@
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
 
     "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
@@ -590,6 +665,8 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
+
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@1.20.1", "", { "dependencies": { "bytes": "3.1.2", "content-type": "~1.0.4", "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "on-finished": "2.4.1", "qs": "6.11.0", "raw-body": "2.5.1", "type-is": "~1.6.18", "unpipe": "1.0.0" } }, "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw=="],
@@ -605,6 +682,8 @@
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "cacheable-lookup": ["cacheable-lookup@7.0.0", "", {}, "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w=="],
 
@@ -732,6 +811,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
@@ -768,11 +849,15 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
+    "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
@@ -932,6 +1017,8 @@
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
+    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
@@ -1002,6 +1089,8 @@
 
     "hex-rgb": ["hex-rgb@5.0.0", "", {}, "sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w=="],
 
+    "hookable": ["hookable@6.1.0", "", {}, "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw=="],
+
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
@@ -1027,6 +1116,8 @@
     "immer": ["immer@9.0.21", "", {}, "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -1161,6 +1252,8 @@
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -1418,6 +1511,8 @@
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -1488,11 +1583,13 @@
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
@@ -1636,6 +1733,8 @@
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "responselike": ["responselike@3.0.0", "", { "dependencies": { "lowercase-keys": "^3.0.0" } }, "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
@@ -1649,6 +1748,10 @@
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.23.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.3", "@babel/helper-validator-identifier": "8.0.0-rc.3", "@babel/parser": "8.0.0-rc.3", "@babel/types": "8.0.0-rc.3", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.7", "obug": "^2.1.1", "picomatch": "^4.0.4" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0-rc.12", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ=="],
 
     "run-async": ["run-async@3.0.0", "", {}, "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="],
 
@@ -1808,7 +1911,9 @@
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tinygradient": ["tinygradient@1.1.5", "", { "dependencies": { "@types/tinycolor2": "^1.4.0", "tinycolor2": "^1.0.0" } }, "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw=="],
 
@@ -1822,6 +1927,8 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
     "trim": ["trim@0.0.1", "", {}, "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
@@ -1831,6 +1938,8 @@
     "trough": ["trough@1.0.5", "", {}, "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tsdown": ["tsdown@0.21.8", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.0", "hookable": "^6.1.0", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.4", "rolldown": "1.0.0-rc.15", "rolldown-plugin-dts": "^0.23.2", "semver": "^7.7.4", "tinyexec": "^1.1.1", "tinyglobby": "^0.2.16", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "unrun": "^0.2.34" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.8", "@tsdown/exe": "0.21.8", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "typescript", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-rHDIER4JU5owYTWptvyDk6pwfA5lCft1P+11HLGeF0uj0CB7vopFvr/E8QOaRmegeyHIEsu4+03j7ysvdgBAVA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1859,6 +1968,8 @@
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "unbzip2-stream": ["unbzip2-stream@1.4.3", "", { "dependencies": { "buffer": "^5.2.1", "through": "^2.3.8" } }, "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg=="],
+
+    "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1899,6 +2010,8 @@
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "unrun": ["unrun@0.2.35", "", { "dependencies": { "rolldown": "1.0.0-rc.15" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-nDP7mA4Fu5owDarQtLiiN3lq7tJZHFEAVIchnwP8U3wMeEkLoUNT37Hva85H05Rdw8CArpGmtY+lBjpk9fruVQ=="],
 
     "urijs": ["urijs@1.19.11", "", {}, "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="],
 
@@ -1988,9 +2101,13 @@
 
     "@asyncapi/parser/node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
 
+    "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@changesets/parse/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "@fission-ai/openspec/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -2102,6 +2219,8 @@
 
     "@puppeteer/browsers/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
     "@shikijs/core/hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "@sindresorhus/slugify/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -2143,6 +2262,8 @@
     "@types/yauzl/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
     "agent-facets/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -2316,6 +2437,8 @@
 
     "micromark-util-events-to-acorn/vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "next-mdx-remote-client/react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
@@ -2345,6 +2468,8 @@
     "read-cache/pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "recma-build-jsx/vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -2406,13 +2531,15 @@
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
+    "sucrase/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "tailwindcss/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "unist-builder/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -3005,6 +3132,8 @@
     "retext/unified/vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "sucrase/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/openspec/changes/harness-sdk/.openspec.yaml
+++ b/openspec/changes/harness-sdk/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/harness-sdk/design.md
+++ b/openspec/changes/harness-sdk/design.md
@@ -1,0 +1,293 @@
+## Context
+
+Harness-specific logic is currently hardcoded in `packages/core/src/build/validate-platforms.ts` as a `KNOWN_PLATFORMS` map binding harness names to inline arktype schemas. This couples core to every harness — adding Claude Code required editing core, and adding Codex will require the same. The install pipeline (next change) needs harnesses that do far more than validate config: asset management, config mutation, harness detection, and metadata validation. These responsibilities diverge significantly per harness and cannot remain hardcoded.
+
+A spike on branch `julian/bun-dynamic-import-spike` proved that compiled Bun binaries can dynamically `import()` pre-bundled `.js` files from the filesystem at runtime, with one critical constraint: the binary's internal module graph is NOT accessible to dynamically imported code. Bare specifier imports (e.g., `import { X } from '@agent-facets/harness'`) fail even when the package is bundled into the binary. Pre-bundling harnesses into single `.js` files (all dependencies inlined via `bun build`) resolves this completely.
+
+The facet manifest currently uses `platforms` for harness-specific config. This field SHALL be renamed to `harnesses` to align with the chosen terminology and avoid collision with OS/architecture platform targets used for binary distribution.
+
+### Stakeholders
+
+- **Facet authors**: Write `harnesses` metadata in manifests; unaffected beyond the field rename.
+- **Harness authors** (first-party now, third-party later): Use the Harness SDK to author harnesses. Write TypeScript, call `defineHarness()`, publish. The CLI handles installation and bundling.
+- **CLI consumers**: Transparent — harness loading is internal to the CLI.
+
+### Constraints
+
+- [ADR-7](https://www.notion.so/exmachina-co/ADR-7) governs the plugin model: dynamic `import()` of pre-bundled JavaScript, no external runtime dependency.
+- [ADR-1](https://www.notion.so/exmachina-co/ADR-1) defines the manifest schema — `platforms` field SHALL be renamed to `harnesses`.
+- [ADR-3](https://www.notion.so/exmachina-co/ADR-3) states directory mapping is a CLI concern — this change formalizes that delegation to harnesses.
+- Phase 3 (Local Installation) at `../strategy/facets/roadmap/03-local-installation.md` is the roadmap context. This change is preparatory — it does not complete the phase.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extract shared foundational types (`ValidationError`, `Result<T>`, `AssetType`, `Location`) into `@agent-facets/common`
+- Build a Harness SDK that makes authoring harnesses straightforward
+- Establish the harness as a full abstraction layer over its tool's storage and configuration
+- Extract harness knowledge from core into separate harness packages built with the SDK
+- Enable core to accept harnesses as inputs rather than hardcode them
+- Provide `facet harness install/list/remove` commands for CLI-driven harness lifecycle management
+- Rename `platforms` → `harnesses` across manifest schema, validation, and documentation
+
+**Non-Goals:**
+
+- Facet installation, asset placement, or directory writing (belongs to `local-install-pipeline`)
+- Asset CRUD implementation (interface declared with stubs, deferred to install pipeline)
+- `facet init` with interactive harness detection and project setup (belongs to `local-install-pipeline`)
+- Config CRUD — MCP getters/setters, harness config mutation (pattern established, implementation deferred)
+- MCP server configuration (harnesses MAY eventually manage MCP, but not in this change)
+- Third-party harness registry, marketplace, or discovery
+- Harness sandboxing or trust model
+- `facet harness update` (deferred; users re-run `facet harness install` to update)
+
+## Decisions
+
+### 1. Shared foundation: `@agent-facets/common`
+
+**Decision**: Create `packages/common/` as the shared foundational package. It exports:
+
+- `ValidationError` — with fields `path`, `message`, `expected`, `actual`
+- `Validated<T>` — discriminated union: `{ ok: true; data: T } | { ok: false; errors: ValidationError[] }`. `T` is required — every validation operation returns data on success. This replaces the previous `Result<T>` (which was only used for validation contexts) and `ValidationResult` (which was `Result<void>`). A single type covers all validation use cases: loaders return `Validated<FacetManifest>`, harnesses return `Validated<HarnessMetadata>`, etc.
+- `AssetType` — singular form: `'skill' | 'agent' | 'command'`
+- `Location` — `{ path: string, scope: 'system' | 'user' | 'project', type: 'directory' | 'file' }`
+
+Pure TypeScript, zero dependencies. Private workspace package — not published to npm. Dev dependency for all other packages.
+
+These types move out of `packages/core/src/types.ts`. `AssetType` is currently defined in three places with two incompatible shapes (singular in `detect-collisions.ts` and CLI, plural in `scanner.ts`). The canonical form SHALL be singular — the conceptual noun, not the filesystem/manifest key. Code that needs the plural form SHALL derive it.
+
+The common package stays private because the SDK inlines its types at publish time via tsdown (see Decision 3). External consumers get these types from `@agent-facets/harness` directly.
+
+**Rationale**: `ValidationError` and `Validated<T>` are generic patterns used across package boundaries. The `Location` type is shared between the SDK (harness definitions) and core (accepting harness inputs). `Validated<T>` unifies what was previously two types (`Result<T>` and `ValidationResult`) into a single type that reads naturally: `Validated<FacetManifest>`, `Validated<ServerManifest>`, `Validated<HarnessMetadata>`. Defining these in core creates a problematic dependency direction. A dedicated common package sits at the bottom of the dependency graph with zero dependencies.
+
+**Alternatives considered**:
+- *Define shared types in the SDK* — rejected because `ValidationError`, `Validated<T>`, and `Location` are not harness-specific concepts.
+- *Keep types in core* — rejected because it creates a circular dependency (core depends on SDK, SDK depends on core).
+- *Publish common to npm* — rejected; SDK inlines the types at publish time, so consumers never reference common directly.
+- *Structural typing per package* — rejected because it creates duplicate sources of truth that can drift.
+- *Separate `Result<T>` and `ValidationResult` types* — rejected; every use of `Result<T>` in the codebase is a validation context. A single `Validated<T>` type is cleaner and reads naturally.
+
+### 2. Harness SDK: `@agent-facets/harness`
+
+**Decision**: Create `packages/harness/` as the Harness SDK. It provides:
+
+- **`defineHarness()` factory** — accepts a harness definition and returns a validated `Harness` object. This is the primary authoring surface.
+- **`Harness` interface** — the full harness contract:
+  - `name: string`
+  - `assetLocations: Location[]` — ordered by precedence (highest first), where assets are stored
+  - `configLocations: Location[]` — ordered by precedence (highest first), where config files live
+  - `buildAssetMetadata(data: unknown): Validated<HarnessMetadata>` — takes raw per-asset metadata from a facet manifest, validates it, applies harness-specific defaults, and returns the enriched metadata object
+  - `createAsset(location: Location, assetType: AssetType, name: string, content: string, metadata: unknown): void`
+  - `readAsset(location: Location, assetType: AssetType, name: string): string`
+  - `updateAsset(location: Location, assetType: AssetType, name: string, content: string, metadata: unknown): void`
+  - `deleteAsset(location: Location, assetType: AssetType, name: string): void`
+- **`Validated<T>`** — re-exported from `@agent-facets/common`. Used as the return type for `buildAssetMetadata`. No warnings — warnings are a pipeline-level concern.
+
+The SDK does NOT contain build tooling or self-install logic. The CLI owns harness installation and bundling. Depends on `@agent-facets/common` as a dev dependency.
+
+The harness is a full abstraction layer. The CLI never directly reads or writes assets — it always goes through the harness's CRUD methods. This means the harness owns all knowledge of its tool's directory structures, file formats, frontmatter conventions, and serialization. A harness could store assets in directories (markdown files), in a single JSON file, or in any other format — the CLI doesn't know or care.
+
+CRUD methods SHALL always receive `Location` objects with absolute paths. The CLI is responsible for resolving any relative paths (e.g., from project-scoped locations) to absolute paths before calling CRUD. This resolution happens once at init time and is persisted in `facets.json` — the install pipeline's concern, not this change's. The harness's static `assetLocations` and `configLocations` arrays serve as the menu of possible locations; they MAY contain relative paths for project-scoped entries.
+
+Harness availability detection (`isHarnessAvailable`) is intentionally omitted. The user's act of installing a harness via `facet harness install` is the availability signal. Attempting to auto-detect whether a tool is installed is unreliable (global binaries, npm local installs, Docker, custom setups) and not worth the complexity.
+
+Asset CRUD methods SHALL be declared in the interface with stubs in this change. Full implementation belongs to the install pipeline. The stubs exist so the interface is complete and testable.
+
+**Rationale**: `defineHarness()` as a factory provides validation, defaults, and a versioning path. Future interface versions can add methods (e.g., `getMcpConfig`, `setMcpConfig`) while the factory provides no-op defaults for backward compatibility. `buildAssetMetadata` both validates and enriches — harnesses can enforce defaults on metadata, and the build pipeline receives the fully resolved metadata object rather than just a pass/fail signal. The CRUD model over path resolution means the CLI never needs to understand how a harness stores assets — this is strictly better for extensibility and safety.
+
+**Alternatives considered**:
+- *Path resolution model (harness returns paths, CLI writes files)* — rejected because it forces the CLI to understand every harness's file format, directory structure, and serialization conventions. The CRUD model keeps that complexity in the harness.
+- *SDK owns build tooling and self-install* — rejected; CLI owns installation and bundling.
+- *Contract-only package (just types, no factory)* — rejected; `defineHarness()` provides validation, defaults, and versioning.
+
+### 3. SDK publishing via tsdown
+
+**Decision**: The SDK SHALL be published to npm via tsdown, which bundles JS and generates `.d.ts` declarations with types from `@agent-facets/common` inlined via `deps.alwaysBundle`. External consumers install `@agent-facets/harness` and get all types without needing `@agent-facets/common`.
+
+tsdown is added as a dev dependency of the SDK package only.
+
+**Rationale**: The SDK is the external-facing package for third-party harness authors. Not all consumers use Bun or TypeScript. Shipping bundled JS + `.d.ts` works everywhere. tsdown handles both in one tool, and `deps.alwaysBundle` cleanly inlines the private common package's types.
+
+**Alternatives considered**:
+- *Publish common to npm* — rejected; adds unnecessary package for consumers.
+- *Ship raw `.ts`* — rejected for the SDK; third-party authors may not use Bun.
+- *`dts-bundle-generator` or `api-extractor`* — rejected; tsdown handles both JS and declarations.
+
+### 4. Location type: scoped paths with directory/file discriminant
+
+**Decision**: The `Location` type SHALL be `{ path: string, scope: 'system' | 'user' | 'project', type: 'directory' | 'file' }`. Both `assetLocations` and `configLocations` on the harness are `Location[]`, ordered by precedence (highest first).
+
+- `path` is a filesystem path — relative for project scope (e.g., `.opencode`), absolute for user/system scope (e.g., `~/.config/opencode`).
+- `scope` classifies whether the location is system-level, user-level, or project-level.
+- `type` discriminates between directories (containers for assets) and files (config targets).
+
+Asset locations are typically directories (`type: 'directory'`). Config locations are typically files (`type: 'file'`). But the type discriminant is general — a future harness MAY store assets in a single file, or configs in a directory of YAML files. The `type` field is extensible (could add `'url'`, `'database'` in the future).
+
+Precedence ordering means the first element is highest priority. For most tools, project-level locations have the highest precedence (they override user-level, which overrides system-level). The harness determines this ordering.
+
+**Rationale**: Asset locations and config locations are conceptually similar (scoped paths) but serve different purposes. `assetLocations` feed into asset CRUD methods. `configLocations` will feed into future config CRUD methods. Keeping them as separate arrays with a shared type provides clarity without redundancy.
+
+**Alternatives considered**:
+- *Single `rootDir` string* — rejected; too simplistic for tools with multiple config directories at different scopes.
+- *Combined locations array with type discriminant for asset/config* — rejected as premature; separate arrays are clearer and every consumer would need to filter.
+- *Separate types for asset dirs and config files* — rejected; structurally identical today, and the `type` field already discriminates between directory and file.
+
+### 5. Harness as full abstraction layer with CRUD operations
+
+**Decision**: The harness SHALL be a full abstraction layer over its tool's storage. The CLI SHALL NOT directly read or write assets. Instead, the harness exposes CRUD methods:
+
+- `createAsset(location, assetType, name, content, metadata)` — creates an asset at the given location. The harness handles path resolution, frontmatter/metadata assembly, file format, and directory creation internally.
+- `readAsset(location, assetType, name)` — reads an asset's content from the given location.
+- `updateAsset(location, assetType, name, content, metadata)` — updates an existing asset.
+- `deleteAsset(location, assetType, name)` — removes an asset.
+
+The `metadata` parameter on `createAsset` and `updateAsset` is the per-asset harness metadata from the facet manifest — the same data that `buildAssetMetadata` validates and enriches. The harness internally translates this into whatever format its tool expects (frontmatter, YAML headers, JSON properties, etc.).
+
+This replaces the previous `resolveAssetPath` + separate `assembleFrontmatter` approach, which required the CLI to understand file formats and compose paths with frontmatter.
+
+**Rationale**: Each AI coding tool has different conventions for asset storage — different directory structures, file extensions, frontmatter formats, and config file layouts. Rather than the CLI knowing every convention, the harness owns all of that complexity. The CLI becomes a thin orchestrator: it asks the harness for locations, lets the user choose, and delegates all I/O through CRUD methods.
+
+This also enables future harnesses that store assets in unconventional ways — a single JSON file, a database, a remote API. The CRUD interface is storage-agnostic.
+
+**Alternatives considered**:
+- *Path resolution + frontmatter assembly (CLI writes files)* — rejected because the CLI would need to understand every harness's file format and directory structure. Adding a new harness would require CLI changes.
+- *Path resolution only (no metadata handling)* — rejected because metadata/frontmatter is harness-specific and inseparable from asset creation.
+
+### 6. CLI-driven harness installation
+
+**Decision**: New `facet harness install` CLI command SHALL own the full harness installation pipeline. It accepts multiple specifier formats:
+
+- **Built-in names**: `opencode`, `claude-code`, `codex` — hardcoded mapping to known npm packages.
+- **npm packages**: `@scope/package` or `package-name` — downloaded from the npm registry.
+- **Git URLs**: `git+https://...`, `git+ssh://...`, `git+http://...`, `git://...` — cloned using the `git` binary (same assumption as npm). Optional `#<commit-ish>` suffix.
+- **Local paths**: `./path/to/harness` or `/absolute/path` — used directly from the filesystem.
+
+The install flow:
+
+1. Resolve specifier to a source (npm tarball, Git clone, or local directory)
+2. Place source in a temp directory (except local paths, which are used in-place)
+3. Run `bun install` in the source directory to resolve dependencies
+4. Run `Bun.build()` on the entry point to produce a single self-contained `harness.js` with all dependencies inlined
+5. Verify the bundle: load the built `harness.js`, check that it exports a valid `Harness` object, and read the `name` field to determine the harness identity
+6. Place the bundle in `~/.facets/harnesses/<name>/harness.js` (where `<name>` comes from the harness's own `name` field)
+7. Clean up temp directory
+
+Additionally: `facet harness list` SHALL list installed harnesses from `~/.facets/harnesses/`, and `facet harness remove <name>` SHALL remove a harness from that directory.
+
+Git URL support shells out to the `git` binary, which is assumed to be available on the user's machine (same assumption npm makes). If `git` is not installed, the CLI SHALL produce a clear error.
+
+**Rationale**: CLI-driven installation eliminates friction for harness authors — they write TypeScript, publish, and the CLI handles bundling. The spike proved `Bun.build()` is available at runtime in compiled binaries. Post-bundle verification catches authoring errors at install time. The harness's `name` field is the single source of truth for identity.
+
+**Alternatives considered**:
+- *SDK handles bundling + postinstall self-install* — rejected; postinstall hooks are unreliable and burden authors.
+- *Embed first-party in CLI binary* — rejected; divergent path, can't update independently.
+- *Require authors to pre-bundle* — rejected; forces authors to understand the bundling constraint.
+
+### 7. One harness package per AI coding tool
+
+**Decision**: Create `packages/harnesses/opencode/`, `packages/harnesses/claude-code/`, and `packages/harnesses/codex/` as separate workspace packages, each authored with the SDK using `defineHarness()`.
+
+**Rationale**: Each harness has distinct directory conventions, config schemas, asset storage patterns, and metadata schemas. Separate packages enforce clean boundaries. Each produces an independently installable harness.
+
+**Alternatives considered**:
+- *Single monolithic package* — rejected; blurs boundaries, no per-harness versioning.
+- *Keep harness logic in core* — rejected; the status quo this change eliminates.
+
+### 8. Pre-bundled JavaScript distribution
+
+**Decision**: Each harness is loaded as a single self-contained `harness.js` file with all dependencies inlined. The CLI produces these bundles at install time using `Bun.build()`. The compiled CLI binary loads them at runtime via dynamic `import()`.
+
+**Rationale**: The spike proved compiled Bun binaries cannot resolve bare specifier imports in dynamically imported files. Pre-bundling eliminates external resolution. Bundles are typically under 5KB and load in sub-millisecond time.
+
+**Alternatives considered**:
+- *Raw `.ts` files at runtime* — rejected; fails with bare specifier imports.
+- *JSON-RPC / stdio protocol* — rejected; unnecessary complexity for function calls.
+
+### 9. First-party and third-party harnesses use the same install mechanism
+
+**Decision**: First-party harnesses (OpenCode, Claude Code, Codex) and third-party harnesses SHALL use the same install mechanism. That mechanism is: the CLI downloads the harness source, bundles the source into a self-contained `harness.js` via `Bun.build()`, installs the bundle into `~/.facets/harnesses/<name>/`, and later loads the bundle at runtime via dynamic `import()`. There is no separate code path for first-party harnesses.
+
+**Rationale**: Dogfooding ensures the install and loading path works end-to-end. If first-party harnesses were statically bundled into the CLI or used a different delivery mechanism, bugs in the shared path could go undetected until third-party harnesses arrive. The performance difference is negligible (sub-millisecond import for a <5KB file).
+
+**Alternatives considered**:
+- *Static bundling for first-party, dynamic for third-party* — rejected because divergent paths hide bugs. Could be revisited as a performance optimization if harness loading ever becomes measurable, but current measurements show no need.
+- *Ship first-party harnesses inside the CLI npm package* — rejected because it creates a divergent delivery path and prevents harnesses from being updated independently of CLI releases.
+
+### 10. Core accepts harnesses as inputs
+
+**Decision**: The build pipeline's validation stage SHALL accept an array of `Harness` objects as a parameter. `validate-platforms.ts` SHALL be renamed to `validate-harnesses.ts` and refactored to call each harness's `buildAssetMetadata()`. The enriched metadata returned on success SHALL be used by the pipeline. Unknown harnesses (in manifest but no matching harness provided) SHALL produce a warning.
+
+Core is fully harness-agnostic — it has no knowledge of which specific harnesses exist, no alias mappings, and no hardcoded validation schemas. The old `KNOWN_PLATFORMS` map (which hardcoded per-harness arktype schemas in core) is removed entirely. Core receives `Harness[]` and works with whatever it gets.
+
+The CLI maintains a small alias map for first-party convenience names (`opencode` → `@agent-facets/harness-opencode`, etc.) used during `facet harness install` specifier resolution. This is a CLI concern, not a core concern. For any tooling that needs to discover available harnesses (e.g., scaffolding, suggestions), the installed harnesses in `~/.facets/harnesses/` serve as the discovery mechanism — no hardcoded list needed.
+
+**Rationale**: Core becomes fully harness-agnostic. Testable with mock harnesses. Extensible without modification. Adding a new harness never requires changes to core.
+
+**Alternatives considered**:
+- *Core discovers harnesses from disk* — rejected; core is a library, no filesystem opinions.
+- *Core imports harness packages directly* — rejected; reintroduces coupling.
+- *Alias map in core instead of CLI* — rejected; core doesn't need to know package names. The CLI is the only consumer of alias resolution. Installed harnesses serve as the discovery mechanism for other tooling.
+
+### 11. `platforms` → `harnesses` rename in the manifest schema
+
+**Decision**: The `platforms` field in `FacetManifestSchema` SHALL be renamed to `harnesses`.
+
+**Rationale**: "Platform" collides with OS/architecture platforms per [ADR-7](https://www.notion.so/exmachina-co/ADR-7). "Harness" accurately describes the concept.
+
+**Breaking change scope**: Limited blast radius — no consumer-facing install pipeline exists. Only internal test fixtures are affected.
+
+### 12. Workspace configuration
+
+**Decision**: Root `package.json` workspaces glob SHALL add `packages/harnesses/*`.
+
+**Rationale**: Bun workspaces match one glob level. `packages/*` covers `packages/harness/` but not `packages/harnesses/opencode/`.
+
+## Risks / Trade-offs
+
+**[Risk] Dynamic `import()` of untrusted code** → Harnesses run with full process privileges. No sandboxing. Mitigation: deferred to future security hardening. Only first-party harnesses are loaded for now.
+
+**[Risk] CLI-side bundling requires temp directory + `bun install`** → I/O and network overhead during harness installation. Mitigation: one-time cost at install time. Temp dirs cleaned up after. CLI binary includes the full Bun runtime.
+
+**[Risk] Breaking manifest rename (`platforms` → `harnesses`)** → Existing `facet.json` files with `platforms` will fail. Mitigation: minimal blast radius — internal fixtures only.
+
+**[Risk] Git URL support adds complexity** → Parsing Git URLs, cloning repos, finding entry points. Shells out to `git` binary (assumed available, same as npm). Clear error if missing. Mitigation: follow npm's Git URL format. Isolate resolution logic.
+
+**[Trade-off] Same installation path for first-party and third-party** → First-party could be faster if statically bundled. Accepted: negligible performance difference, dogfooding is more valuable.
+
+**[Trade-off] Zero arktype dependency in the SDK** → Authors can't reuse arktype from SDK. Accepted: framework freedom outweighs convenience. Authors add arktype directly if wanted.
+
+**[Trade-off] tsdown as build dependency for SDK** → New tool in monorepo. Accepted: scoped to SDK only, solves declaration inlining cleanly.
+
+**[Trade-off] CRUD stubs instead of full implementation** → Asset CRUD methods are stubs in this change. Accepted: the interface is correct and testable; full implementation deferred to install pipeline to keep this change focused.
+
+## Documentation Impact
+
+The following docs SHALL be updated:
+
+| File | What changes |
+|---|---|
+| `docs/specification/manifest.mdx` | `platforms` → `harnesses`; field descriptions and examples |
+| `docs/specification/publish.mdx` | "Validate platform config" → "Validate harness metadata" |
+| `docs/specification/install.mdx` | "platform adapters" → "harnesses" |
+| `docs/specification/architecture.mdx` | "Platform-agnostic format" prose; harness extension points |
+| `docs/cli/build.mdx` | "Validate platforms" → "Validate harnesses" |
+| `docs/learn/agents.mdx` | "platform-level configuration" → "harness-level configuration" |
+| `docs/specification/terminology.mdx` | Add "harness" definition |
+| `README.md` (root) | Update platform references |
+
+New CLI documentation needed for `facet harness install/list/remove` commands.
+
+Note: `docs/contributing/` references to "platform" in the binary distribution context do NOT need updating.
+
+## Open Questions
+
+None — all questions resolved.
+
+### Resolved Questions
+
+- **HARNESS_API_VERSION constant**: Resolved — removed. The SDK's own package version serves as the API version. When the CLI bundles a harness at install time, the SDK version the harness was built against is baked into the bundle. No separate constant needed.
+
+- **Post-bundle verification**: Resolved — yes. The CLI SHALL load the built `harness.js` after bundling and verify it exports a valid `Harness` object before placement. Catches authoring errors at install time. Cost is negligible.
+
+- **Harness name from Git URL / local path**: Resolved — use the `name` field from the `Harness` object itself (set via `defineHarness({ name: '...' })`). The CLI reads the name during post-bundle verification.

--- a/openspec/changes/harness-sdk/proposal.md
+++ b/openspec/changes/harness-sdk/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Harness-specific logic is hardcoded in `packages/core/src/build/validate-platforms.ts` as a `KNOWN_PLATFORMS` map of harness names to arktype schemas. A "harness" is an AI coding tool (OpenCode, Claude Code, Codex) that wraps around an LLM and provides it with skills, agents, commands, and configuration. The term "harness" is chosen over "platform" to avoid collision with OS/architecture platforms (Darwin, Linux, Windows) already used in this project for binary distribution targets.
+
+This cannot scale — adding new harnesses requires modifying core for every addition. The install pipeline (next change) needs harnesses that handle asset management, config mutation, harness detection, and metadata validation, and these concerns diverge significantly per harness. The harness must be a full abstraction layer over its tool's storage and configuration — the CLI should never directly read or write files for a harness. Each harness owns the complexity of its own directory structures, file formats, and conventions.
+
+This change extracts harness knowledge into an SDK for authoring harnesses, separate harness packages per AI coding tool, a CLI-driven installation pipeline that downloads and bundles harnesses, and a runtime loading mechanism validated by spike (`julian/bun-dynamic-import-spike`). The SDK provides a `defineHarness()` factory and types, published professionally via tsdown (which inlines types from the internal common package). The CLI owns the full harness lifecycle: `facet harness install` downloads harness source from npm, Git repos, or local paths, bundles it into a self-contained `harness.js`, and places it in `~/.facets/harnesses/<name>/`. Harness authors write TypeScript, call `defineHarness()`, and publish — no build tooling knowledge required.
+
+## What Changes
+
+- **BREAKING**: The facet manifest field `platforms` SHALL be renamed to `harnesses`. All existing references to "platform" in manifest schemas, validation, and documentation SHALL be updated.
+- New `@agent-facets/common` package (`packages/common/`) containing shared foundational types: `ValidationError`, `Validated<T>` (discriminated union: `{ ok: true; data: T } | { ok: false; errors: ValidationError[] }`), `AssetType` (singular form: `'skill' | 'agent' | 'command'`), and `Location` (`{ path: string, scope: 'system' | 'user' | 'project', type: 'directory' | 'file' }`). Pure TypeScript, zero dependencies. Private workspace package. Dev dependency for all other packages. The SDK inlines these types at publish time via tsdown.
+- New `@agent-facets/harness` package (`packages/harness/`) — the Harness SDK. Contains the `Harness` interface, `Validated<T>` (re-exported from `@agent-facets/common`), and a `defineHarness()` factory function for authoring harnesses. Published to npm via tsdown, which bundles JS + `.d.ts` declarations with types from `@agent-facets/common` inlined. The SDK does NOT contain build tooling or self-install logic — the CLI owns harness installation.
+- Harness authoring SHALL use `defineHarness()` from the SDK, which accepts: `name`, `assetLocations` (ordered array of `Location` objects for asset storage), `configLocations` (ordered array of `Location` objects for config files), `buildAssetMetadata` (validates and enriches per-asset harness metadata from a facet manifest, applying harness-specific defaults), and asset CRUD methods (`createAsset`, `readAsset`, `updateAsset`, `deleteAsset`). Asset CRUD methods SHALL be declared in the interface with stubs in this change — full implementation belongs to the install pipeline. The harness is a full abstraction layer: the CLI never directly reads or writes assets, it always goes through the harness's CRUD methods.
+- `buildAssetMetadata` SHALL validate and enrich per-asset harness metadata from a facet manifest, applying harness-specific defaults, and returning a `Validated<HarnessMetadata>`: `{ ok: true; data: HarnessMetadata } | { ok: false; errors: ValidationError[] }`. No warnings — warnings are a pipeline-level concern.
+- New `@agent-facets/harness-opencode`, `@agent-facets/harness-claude-code`, and `@agent-facets/harness-codex` packages implementing the harness for each AI coding tool using the SDK. Each harness owns its tool's `assetLocations`, `configLocations`, metadata building/validation schema, and harness detection logic.
+- Harnesses SHALL be distributed as pre-bundled JavaScript files (single `.js`, all dependencies inlined). The CLI produces these bundles at install time using `Bun.build()` — harness authors do not need any build tooling. The compiled CLI binary loads harness bundles at runtime via dynamic `import()` per [ADR-7](https://www.notion.so/exmachina-co/ADR-7). The compiled binary's bundled modules are NOT accessible to dynamically imported code — pre-bundling is required.
+- New `facet harness install` CLI command SHALL handle harness installation. It accepts multiple specifier formats: built-in names (`opencode`, `claude-code`, `codex`), npm packages, Git URLs (`git+https://...`, `git+ssh://...` — same format as npm Git dependencies), and local paths. The CLI downloads/clones the source, runs `bun install` to resolve dependencies, runs `Bun.build()` to produce a self-contained `harness.js`, verifies the bundle exports a valid harness, reads the harness's `name` field, and places the bundle in `~/.facets/harnesses/<name>/`. First-party harnesses SHALL use the same mechanism as third-party.
+- New `facet harness list` and `facet harness remove <name>` CLI commands.
+- Move harness validation out of `packages/core/src/build/validate-platforms.ts`. Core SHALL depend on `@agent-facets/common` for shared types and accept harnesses as inputs. The build pipeline SHALL delegate metadata building to each harness's `buildAssetMetadata` method.
+- Workspace configuration SHALL add `packages/harnesses/*` to the workspace glob.
+
+## Capabilities
+
+### New Capabilities
+
+- `harness__sdk`: The Harness SDK — `defineHarness()` factory, `Harness` interface, `Location` type, `@agent-facets/common` shared types, `@agent-facets/harness` package publishing via tsdown, and the authoring experience for harness developers.
+- `harness__assets`: Asset management within harnesses — asset CRUD interface (`createAsset`, `readAsset`, `updateAsset`, `deleteAsset`), `buildAssetMetadata` (validation + enrichment with defaults), asset locations, and how assets are stored and managed per-harness.
+- `harness__management`: CLI-driven harness lifecycle — `facet harness install/list/remove` commands, multi-source specifier resolution (npm, Git, local path), CLI-side bundling via `Bun.build()`, post-bundle verification, `~/.facets/harnesses/` directory, and runtime loading.
+
+### Modified Capabilities
+
+None. The build pipeline's validation behavior is unchanged from a requirements perspective — only the source of harness schemas changes and the manifest field is renamed.
+
+## Non-Goals
+
+- Facet installation, asset placement, or directory writing — belongs to `local-install-pipeline`. Harness installation IS in scope; facet installation is not.
+- Asset CRUD implementation — interface declared with stubs, full implementation deferred to install pipeline
+- `facet init` with interactive harness detection and project setup — belongs to `local-install-pipeline`
+- Config CRUD (MCP getters/setters, harness config mutation) — the pattern is established but implementation is deferred
+- MCP server configuration — harnesses MAY eventually manage MCP servers, but this is deferred
+- Third-party harness registry or marketplace — harnesses are installed via npm, Git repos, or local paths
+- Harness sandboxing or trust model — security implications of dynamic `import()` are acknowledged but deferred
+- Harness configuration files (`.facets/config.local.json`, `~/.config/facets/`) — that is a `local-install-pipeline` concern
+- `facet harness update` — deferred; users can re-run `facet harness install` to update
+
+## Impact
+
+- **New packages**: `packages/common/` (shared types, private), `packages/harness/` (SDK, published via tsdown), `packages/harnesses/opencode/`, `packages/harnesses/claude-code/`, `packages/harnesses/codex/`. Harness packages are published to npm as installable sources.
+- **New CLI commands**: `facet harness install`, `facet harness list`, `facet harness remove`.
+- **New ADR**: [ADR-7](https://www.notion.so/exmachina-co/ADR-7) (Harness Plugin Model) documents the dynamic `import()` approach, spike results, terminology decision, and compiled binary constraints.
+- **BREAKING — Manifest rename**: `platforms` → `harnesses` in the facet manifest schema, all validation code, ADR-001, and documentation. Blast radius is limited to internal/author usage since no consumer-facing install pipeline exists yet.
+- **Workspace config**: Root `package.json` workspaces updated to include `packages/harnesses/*`.
+- **`packages/core`**: Depends on `@agent-facets/common` (dev dependency). `validate-platforms.ts` renamed and refactored to accept harnesses rather than hardcode schemas. `ValidationError` and `Validated<T>` imported from `@agent-facets/common`; `AssetType` unified to singular form.
+- **`packages/cli`**: Gains `facet harness install/list/remove` commands. Dynamically imports harness bundles from `~/.facets/harnesses/`.
+- **New build dependency**: tsdown added as dev dependency for the SDK package only.
+- **Existing ADRs**: [ADR-1](https://www.notion.so/exmachina-co/ADR-1) — `platforms` field renamed to `harnesses`. [ADR-3](https://www.notion.so/exmachina-co/ADR-3) — directory mapping formalized as harness concern.
+- **Roadmap**: Preparatory work for Phase 3 (Local Installation) at `../strategy/facets/roadmap/03-local-installation.md`, currently `planned`. This change alone does not complete the phase.

--- a/openspec/changes/harness-sdk/specs/harness__assets/spec.md
+++ b/openspec/changes/harness-sdk/specs/harness__assets/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Harnesses build per-asset metadata with validation and defaults
+
+A harness SHALL accept raw per-asset metadata from a facet manifest, validate it, apply harness-specific defaults, and return the enriched metadata object. The result SHALL be a discriminated type: either success with the enriched metadata or failure with structured errors. Each error SHALL include the path to the invalid field, a human-readable message, what was expected, and what was actually found.
+
+#### Scenario: Metadata builds successfully
+
+- **WHEN** a harness builds metadata from input that conforms to its schema
+- **THEN** the result SHALL indicate success
+- **AND** the result SHALL include the enriched metadata object with any harness-specific defaults applied
+
+#### Scenario: Metadata build fails validation
+
+- **WHEN** a harness builds metadata from input that does not conform to its schema
+- **THEN** the result SHALL indicate failure
+- **AND** the result SHALL include one or more errors, each with a field path, message, expected value, and actual value
+
+#### Scenario: Harness applies default values
+
+- **WHEN** a harness builds metadata from input that omits optional fields
+- **THEN** the enriched metadata SHALL include the harness's default values for those fields
+
+### Requirement: Harnesses provide asset creation
+
+A harness SHALL accept a request to create an asset at a given location. The harness SHALL receive the location, asset type, asset name, content, and per-asset metadata. The harness SHALL handle all storage concerns internally — including path resolution, directory creation, metadata assembly, and file format.
+
+#### Scenario: Create a skill asset
+
+- **WHEN** the system requests a harness to create a skill with a name, content, and metadata at a given location
+- **THEN** the harness SHALL store the asset at the appropriate place within that location
+- **AND** the harness SHALL incorporate the metadata into the stored asset according to its tool's conventions
+
+#### Scenario: Create an asset at a user-scoped location
+
+- **WHEN** the system requests a harness to create an asset at a user-scoped location
+- **THEN** the harness SHALL store the asset using the absolute path from that location
+
+### Requirement: Harnesses provide asset reading
+
+A harness SHALL accept a request to read an asset from a given location. The harness SHALL receive the location, asset type, and asset name, and SHALL return the asset's content.
+
+#### Scenario: Read an existing asset
+
+- **WHEN** the system requests a harness to read a skill by name from a given location
+- **THEN** the harness SHALL return the asset's content
+
+#### Scenario: Read a non-existent asset
+
+- **WHEN** the system requests a harness to read an asset that does not exist at the given location
+- **THEN** the harness SHALL indicate that the asset was not found
+
+### Requirement: Harnesses provide asset updating
+
+A harness SHALL accept a request to update an existing asset at a given location. The harness SHALL receive the location, asset type, asset name, new content, and updated metadata. The harness SHALL handle all storage concerns internally.
+
+#### Scenario: Update an existing asset
+
+- **WHEN** the system requests a harness to update a skill with new content and metadata
+- **THEN** the harness SHALL replace the asset's content and metadata at that location
+
+### Requirement: Harnesses provide asset deletion
+
+A harness SHALL accept a request to delete an asset from a given location. The harness SHALL receive the location, asset type, and asset name.
+
+#### Scenario: Delete an existing asset
+
+- **WHEN** the system requests a harness to delete a skill by name from a given location
+- **THEN** the harness SHALL remove the asset from that location
+
+#### Scenario: Delete a non-existent asset
+
+- **WHEN** the system requests a harness to delete an asset that does not exist at the given location
+- **THEN** the harness SHALL indicate that the asset was not found
+
+### Requirement: Asset CRUD is the only interface for asset storage
+
+The system SHALL NOT directly read or write assets for any harness. All asset operations SHALL go through the harness's CRUD methods. The harness owns all knowledge of its tool's storage format, directory structure, and metadata conventions. CRUD methods SHALL always receive location objects with absolute paths — the system is responsible for resolving any relative paths before calling CRUD.
+
+#### Scenario: CLI delegates asset creation to harness
+
+- **WHEN** the system needs to install an asset for a specific harness
+- **THEN** the system SHALL call the harness's create method
+- **AND** the system SHALL NOT directly write files to the harness's asset directories
+
+#### Scenario: CRUD receives absolute paths
+
+- **WHEN** the system calls any CRUD method on a harness
+- **THEN** the location passed to the method SHALL have an absolute path
+- **AND** the system SHALL have resolved any relative paths before the call

--- a/openspec/changes/harness-sdk/specs/harness__management/spec.md
+++ b/openspec/changes/harness-sdk/specs/harness__management/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Users can install harnesses from multiple sources
+
+The system SHALL provide a command to install harnesses. The command SHALL accept specifiers in multiple formats: built-in names for first-party harnesses, npm package names, Git URLs using standard Git protocols, and local filesystem paths.
+
+#### Scenario: Install a first-party harness by name
+
+- **WHEN** a user runs the install command with a built-in name (e.g., "opencode")
+- **THEN** the system SHALL resolve the name to the corresponding official package
+- **AND** download, bundle, verify, and install the harness
+
+#### Scenario: Install a harness from an npm package
+
+- **WHEN** a user runs the install command with an npm package specifier
+- **THEN** the system SHALL download the package from the npm registry
+- **AND** bundle, verify, and install the harness
+
+#### Scenario: Install a harness from a Git repository
+
+- **WHEN** a user runs the install command with a Git URL
+- **THEN** the system SHALL clone the repository using the system's `git` binary
+- **AND** bundle, verify, and install the harness
+
+#### Scenario: Git is not available for Git URL install
+
+- **WHEN** a user runs the install command with a Git URL
+- **AND** the `git` binary is not available on the system
+- **THEN** the system SHALL produce a clear error indicating that `git` is required
+
+#### Scenario: Install a harness from a local path
+
+- **WHEN** a user runs the install command with a local filesystem path
+- **THEN** the system SHALL use the path directly
+- **AND** bundle, verify, and install the harness
+
+### Requirement: Harness installation produces a self-contained bundle
+
+The system SHALL produce a single self-contained JavaScript file with all dependencies inlined when installing a harness. The bundle SHALL be loadable at runtime without any external dependency resolution.
+
+#### Scenario: Bundle includes all dependencies
+
+- **WHEN** the system installs a harness whose source imports third-party packages
+- **THEN** the produced bundle SHALL be self-contained with all dependencies inlined
+- **AND** the bundle SHALL be loadable at runtime without any external dependency resolution
+
+### Requirement: Harness installation verifies the bundle before placement
+
+The system SHALL verify that a produced harness bundle is valid before placing it in the harness directory. Verification SHALL check that the bundle exports a valid harness object.
+
+#### Scenario: Valid bundle passes verification
+
+- **WHEN** the system bundles a harness that correctly exports a harness object via the SDK factory
+- **THEN** verification SHALL succeed
+- **AND** the bundle SHALL be placed in the harness directory
+
+#### Scenario: Invalid bundle fails verification
+
+- **WHEN** the system bundles a harness that does not export a valid harness object
+- **THEN** verification SHALL fail
+- **AND** the system SHALL report which validation checks failed
+- **AND** the bundle SHALL NOT be placed in the harness directory
+
+### Requirement: Harness identity is determined by the harness itself
+
+The system SHALL determine a harness's name from the harness object's own name field after bundling and verification. This name SHALL be used as the directory name under the harness installation directory.
+
+#### Scenario: Harness names itself
+
+- **WHEN** the system installs a harness from any source
+- **AND** the harness object declares its name
+- **THEN** the bundle SHALL be placed at the path corresponding to that harness name
+
+#### Scenario: Harness name conflict overwrites
+
+- **WHEN** the system installs a harness whose name matches an already-installed harness
+- **THEN** the system SHALL overwrite the existing harness bundle with the new one
+
+### Requirement: Users can list installed harnesses
+
+The system SHALL provide a command to list all harnesses currently installed in the harness directory.
+
+#### Scenario: List with installed harnesses
+
+- **WHEN** a user runs the list command
+- **AND** harnesses are installed
+- **THEN** the system SHALL display the name of each installed harness
+
+#### Scenario: List with no installed harnesses
+
+- **WHEN** a user runs the list command
+- **AND** no harnesses are installed
+- **THEN** the system SHALL indicate that no harnesses are installed
+
+### Requirement: Users can remove installed harnesses
+
+The system SHALL provide a command to remove an installed harness by name.
+
+#### Scenario: Remove an existing harness
+
+- **WHEN** a user runs the remove command with the name of an installed harness
+- **THEN** the system SHALL delete the harness from the harness directory
+
+#### Scenario: Remove a non-existent harness
+
+- **WHEN** a user runs the remove command with a name that does not match any installed harness
+- **THEN** the system SHALL report that no harness with that name is installed
+
+### Requirement: The system loads installed harness bundles at runtime
+
+The system SHALL load installed harness bundles from the harness directory at runtime. Loaded harnesses SHALL be passed to the build pipeline for metadata building.
+
+#### Scenario: Load installed harnesses for a build
+
+- **WHEN** the system runs a build command
+- **THEN** the system SHALL scan the harness directory for installed harness bundles
+- **AND** load each bundle
+- **AND** pass the loaded harness objects to the build pipeline
+
+#### Scenario: No harnesses installed during build
+
+- **WHEN** the system runs a build command
+- **AND** no harnesses are installed
+- **THEN** the build SHALL proceed
+- **AND** any harness metadata in the manifest SHALL produce warnings for unknown harnesses

--- a/openspec/changes/harness-sdk/specs/harness__sdk/spec.md
+++ b/openspec/changes/harness-sdk/specs/harness__sdk/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Harness authors can define a harness using the SDK
+
+A harness author SHALL be able to create a harness by importing the SDK and calling a factory function with a definition object. The factory SHALL validate the definition shape and return a harness object. The definition SHALL accept a name, asset locations, config locations, a function to build per-asset harness metadata (validating and enriching with defaults), and asset CRUD methods.
+
+#### Scenario: Author creates a valid harness
+
+- **WHEN** an author calls the factory function with a complete definition
+- **THEN** the factory SHALL return a valid harness object with all provided properties and methods
+
+#### Scenario: Author provides an invalid definition
+
+- **WHEN** an author calls the factory function with a definition missing required fields
+- **THEN** the factory SHALL throw an error describing which fields are missing
+
+### Requirement: Harnesses provide asset locations as scoped paths
+
+A harness SHALL provide an ordered array of asset locations. Each location SHALL include a path, a scope classification (system, user, or project), and a type discriminant (directory or file). The array SHALL be ordered by precedence, with the highest-precedence location first.
+
+#### Scenario: Harness provides project and user asset locations
+
+- **WHEN** the system queries a harness for its asset locations
+- **THEN** the harness SHALL return an ordered array of locations with path, scope, and type
+- **AND** the first element SHALL be the highest-precedence location
+
+#### Scenario: Asset location scopes determine path format
+
+- **WHEN** an asset location has project scope
+- **THEN** its path SHALL be relative to the project root
+- **WHEN** an asset location has user or system scope
+- **THEN** its path SHALL be an absolute filesystem path
+
+### Requirement: Harnesses provide config locations as scoped paths
+
+A harness SHALL provide an ordered array of config locations. Each location SHALL include a path, a scope classification, and a type discriminant. The array SHALL be ordered by precedence, with the highest-precedence location first. Config locations typically point to specific files rather than directories.
+
+#### Scenario: Harness provides config file locations
+
+- **WHEN** the system queries a harness for its config locations
+- **THEN** the harness SHALL return an ordered array of locations with path, scope, and type
+
+### Requirement: The SDK provides default behavior for optional methods
+
+The factory function SHALL provide default behavior for methods that are optional in this change. When a harness author omits asset CRUD methods, the factory SHALL provide stub implementations. Future optional methods (e.g., config CRUD) SHALL follow the same pattern.
+
+#### Scenario: Author omits asset CRUD methods
+
+- **WHEN** an author calls the factory function without providing asset CRUD methods
+- **THEN** the factory SHALL return a valid harness object
+- **AND** the CRUD methods SHALL have stub implementations
+
+### Requirement: The facet manifest uses "harnesses" for per-asset harness metadata
+
+The facet manifest schema SHALL use the field name `harnesses` (not `platforms`) for per-asset harness metadata. All validation, documentation, and tooling SHALL reference this field name.
+
+#### Scenario: Manifest with harnesses field
+
+- **WHEN** a facet author writes a manifest with a `harnesses` field containing metadata for one or more harnesses
+- **THEN** the system SHALL accept the manifest as valid
+
+#### Scenario: Manifest with legacy platforms field
+
+- **WHEN** a facet author writes a manifest with a `platforms` field
+- **THEN** the system SHALL reject the manifest as invalid
+
+### Requirement: The build pipeline accepts harnesses as inputs
+
+The build pipeline SHALL accept an array of harness objects as a parameter for metadata building. The pipeline SHALL delegate metadata building (validation + enrichment) to each harness rather than maintaining an internal registry.
+
+#### Scenario: Build metadata with matching harness
+
+- **WHEN** the build pipeline processes a facet manifest that includes harness metadata for "opencode"
+- **AND** an "opencode" harness object is provided
+- **THEN** the pipeline SHALL pass the metadata to the harness's build function
+- **AND** use the enriched metadata returned on success
+- **AND** report any errors returned on failure
+
+#### Scenario: Unknown harness in manifest
+
+- **WHEN** the build pipeline processes a facet manifest that includes harness metadata for "cursor"
+- **AND** no "cursor" harness object is provided
+- **THEN** the pipeline SHALL produce a warning that the harness is unknown
+- **AND** the pipeline SHALL NOT produce an error
+
+### Requirement: First-party and third-party harnesses use the same installation and loading mechanism
+
+First-party harnesses (for AI coding tools maintained by the project) SHALL be installed and loaded using the same mechanism as third-party harnesses. There SHALL be no separate code path for first-party harnesses.
+
+#### Scenario: First-party harness installed via CLI
+
+- **WHEN** a user installs a first-party harness using a built-in name
+- **THEN** the system SHALL install the harness using the same pipeline as any third-party harness
+
+#### Scenario: First-party harness loaded at runtime
+
+- **WHEN** the system loads harnesses at runtime
+- **THEN** first-party and third-party harnesses SHALL be loaded from the same directory using the same mechanism

--- a/openspec/changes/harness-sdk/tasks.md
+++ b/openspec/changes/harness-sdk/tasks.md
@@ -1,0 +1,109 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Show the user intended changes and ask for approval
+  using the `question` tool. Do not write anything. Do not proceed until the user approves.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Analyze what was done or found, present findings
+  to the user, and wait for feedback before proceeding.
+
+## 1. Foundation Packages — Research
+
+- [x] 1.1 Explore: Investigate existing `packages/core/src/types.ts` to understand current `ValidationError` and `Result<T>` usage across the codebase, identify all import sites that need updating
+- [x] 1.2 Explore: Investigate existing `AssetType` definitions across the codebase (scanner.ts, detect-collisions.ts, CLI) to catalog all locations that need unification to the singular form
+- [x] 1.3 Explore: Research tsdown configuration patterns — `deps.alwaysBundle`, `.d.ts` generation, and how to inline types from a workspace dependency into the SDK's published output
+- [x] 1.4 Propose: Approach for creating `@agent-facets/common` and `@agent-facets/harness` packages, including directory structure, package.json configuration, and the migration path for moving types out of core
+
+## 2. Foundation Packages — Implementation
+
+- [x] 2.1 Implement: Create `@agent-facets/common` package at `packages/common/` — `ValidationError`, `Validated<T>`, `AssetType` (singular), `Location` type. Private workspace package, zero dependencies.
+- [x] 2.2 Implement: Create `@agent-facets/harness` SDK package at `packages/harness/` — `Harness` interface, `defineHarness()` factory, re-export types from common. Dev dependency on common.
+- [x] 2.3 Implement: Add asset CRUD method stubs in `defineHarness()` — `createAsset`, `readAsset`, `updateAsset`, `deleteAsset` with stub implementations as defaults
+- [x] 2.4 Implement: Add `buildAssetMetadata` as a required method in the `Harness` interface, accepting raw metadata and returning `Validated<HarnessMetadata>`
+- [x] 2.5 Implement: Add tsdown build configuration for the SDK package — bundle JS + `.d.ts` with types from `@agent-facets/common` inlined via `deps.alwaysBundle`
+- [x] 2.6 Implement: Update root `package.json` workspaces glob to include `packages/harnesses/*`
+- [x] 2.7 Verify: Foundation packages — run `bun check`, verify SDK builds via tsdown, verify types are properly inlined in output
+
+## 3. Core Refactoring — Research
+
+- [ ] 3.1 Explore: Investigate `packages/core/src/build/validate-platforms.ts` — current `KNOWN_PLATFORMS` map, validation flow, and build pipeline integration
+- [ ] 3.2 Explore: Investigate `packages/core/src/schemas/facet-manifest.ts` — `platforms` field definition and all downstream usage of the field name
+- [ ] 3.3 Explore: Catalog all references to `platforms` across the codebase — schema definitions, tests, documentation, CLI commands — to determine the full rename blast radius
+- [ ] 3.4 Propose: Approach for refactoring core to accept `Harness[]` as inputs, renaming `platforms` → `harnesses` in the manifest schema, and migrating `ValidationError`/`Result<T>` imports to `@agent-facets/common`
+
+## 4. Core Refactoring — Implementation
+
+- [ ] 4.1 Implement: Migrate `packages/core/src/types.ts` — replace `Result<T>` with import of `Validated<T>` from `@agent-facets/common`, update all import sites across core
+- [ ] 4.2 Implement: Unify `AssetType` — replace all plural forms (`'skills' | 'agents' | 'commands'`) with singular form imported from `@agent-facets/common`, update derivation sites
+- [ ] 4.3 Implement: Rename `platforms` → `harnesses` in `FacetManifestSchema` and all downstream types
+- [ ] 4.4 Implement: Rename `validate-platforms.ts` → `validate-harnesses.ts`, refactor to accept `Harness[]` parameter and call `buildAssetMetadata()` on each harness. Remove `KNOWN_PLATFORMS` map and inline arktype schemas.
+- [ ] 4.5 Implement: Update `packages/core/src/build/pipeline.ts` to pass harnesses to the renamed validation function
+- [ ] 4.6 Implement: Update `packages/core/src/index.ts` public API exports to reflect renames
+- [ ] 4.7 Implement: Update all core tests to use new types, imports, and harness-based validation
+- [ ] 4.8 Verify: Core refactoring — run `bun check`, ensure all tests pass, verify no remaining references to `platforms` or `KNOWN_PLATFORMS`
+
+## 5. First-Party Harness Packages — Research
+
+- [ ] 5.1 Explore: Investigate OpenCode directory conventions — `.opencode/` structure, asset paths for skills/agents/commands, config file locations, metadata schema
+- [ ] 5.2 Explore: Investigate Claude Code directory conventions — `.claude/` structure, asset paths, config file locations, metadata schema
+- [ ] 5.3 Explore: Investigate Codex directory conventions — `.codex/` structure, asset paths, config file locations, metadata schema
+- [ ] 5.4 Propose: Approach for implementing the three first-party harness packages, including `assetLocations`, `configLocations`, `buildAssetMetadata` schemas, and package structure
+
+## 6. First-Party Harness Packages — Implementation
+
+- [ ] 6.1 Implement: Create `@agent-facets/harness-opencode` at `packages/harnesses/opencode/` — `defineHarness()` with OpenCode-specific asset locations, config locations, and `buildAssetMetadata` using arktype
+- [ ] 6.2 Implement: Create `@agent-facets/harness-claude-code` at `packages/harnesses/claude-code/` — `defineHarness()` with Claude Code-specific locations and metadata validation
+- [ ] 6.3 Implement: Create `@agent-facets/harness-codex` at `packages/harnesses/codex/` — `defineHarness()` with Codex-specific locations and metadata validation
+- [ ] 6.4 Implement: Add tests for each first-party harness — metadata validation, location correctness, factory validation
+- [ ] 6.5 Verify: First-party harness packages — run `bun check`, verify each harness builds and exports a valid `Harness` object
+
+## 7. CLI Harness Management Commands — Research
+
+- [ ] 7.1 Explore: Investigate existing CLI command structure in `packages/cli/src/commands/` to understand patterns for adding new commands and subcommand groups
+- [ ] 7.2 Explore: Research npm registry API and tarball download mechanisms available in Bun — how to download and extract an npm package programmatically
+- [ ] 7.3 Explore: Research Git URL parsing — npm's Git URL format (`git+https://`, `git+ssh://`, `#<commit-ish>`), how to shell out to `git clone` from a compiled Bun binary
+- [ ] 7.4 Explore: Confirm `Bun.build()` runtime API works in compiled binary — reference spike results on branch `julian/bun-dynamic-import-spike`, determine entry point resolution strategy for downloaded packages
+- [ ] 7.5 Propose: Approach for implementing `facet harness install/list/remove` commands, including specifier resolution, temp directory management, bundling flow, verification, and placement
+
+## 8. CLI Harness Management Commands — Implementation
+
+- [ ] 8.1 Implement: Create specifier resolution module — resolve built-in names to npm packages, parse npm specifiers, parse Git URLs, detect local paths
+- [ ] 8.2 Implement: Create npm source resolver — download npm package tarball to temp directory, extract
+- [ ] 8.3 Implement: Create Git source resolver — parse Git URL, shell out to `git clone` in temp directory, handle `#<commit-ish>` suffix, produce clear error if `git` binary is missing
+- [ ] 8.4 Implement: Create local path source resolver — validate path exists, use in-place
+- [ ] 8.5 Implement: Create harness bundling module — run `bun install` in source directory, run `Bun.build()` on entry point, produce self-contained `harness.js`
+- [ ] 8.6 Implement: Create post-bundle verification — load built `harness.js`, verify it exports a valid `Harness` object, read `name` field
+- [ ] 8.7 Implement: Create harness placement — create `~/.facets/harnesses/<name>/` directory, place verified `harness.js`, clean up temp directory
+- [ ] 8.8 Implement: Wire `facet harness install` command — integrate specifier resolution, source downloading, bundling, verification, and placement
+- [ ] 8.9 Implement: Create `facet harness list` command — scan `~/.facets/harnesses/` directory, display installed harness names
+- [ ] 8.10 Implement: Create `facet harness remove` command — delete harness directory from `~/.facets/harnesses/<name>/`, report error if not found
+- [ ] 8.11 Implement: Create harness runtime loading — scan `~/.facets/harnesses/` at CLI startup, dynamically import each `harness.js`, pass loaded harnesses to core build pipeline
+- [ ] 8.12 Implement: Add tests for harness management commands — install from local path, list, remove, verification failure, missing git binary error
+- [ ] 8.13 Verify: CLI harness management — run `bun check`, test end-to-end flow with first-party harness packages
+
+## 9. Documentation Updates — Research
+
+- [ ] 9.1 Explore: Catalog all docs referencing `platforms` or platform-related behavior — identify specific files and lines that need updating
+
+## 10. Documentation Updates — Implementation
+
+- [ ] 10.1 Implement: Update `docs/specification/manifest.mdx` — `platforms` → `harnesses`, update field descriptions and examples
+- [ ] 10.2 Implement: Update `docs/specification/publish.mdx` — "Validate platform config" → "Validate harness metadata"
+- [ ] 10.3 Implement: Update `docs/specification/install.mdx` — "platform adapters" → "harnesses"
+- [ ] 10.4 Implement: Update `docs/specification/architecture.mdx` — "Platform-agnostic format" prose, clarify harness extension points
+- [ ] 10.5 Implement: Update `docs/cli/build.mdx` — "Validate platforms" → "Validate harnesses"
+- [ ] 10.6 Implement: Update `docs/learn/agents.mdx` — "platform-level configuration" → "harness-level configuration"
+- [ ] 10.7 Implement: Update `docs/specification/terminology.mdx` — add "harness" definition
+- [ ] 10.8 Implement: Update root `README.md` — update platform references to harness terminology
+- [ ] 10.9 Implement: Add CLI documentation for `facet harness install/list/remove` commands
+- [ ] 10.10 Verify: Documentation — check no remaining references to `platforms` in docs (except binary distribution context in `docs/contributing/`)
+
+## 11. Final Verification
+
+- [ ] 11.1 Verify: Full integration — run `bun check` across the entire monorepo, ensure all tests pass, all packages build correctly
+- [ ] 11.2 Review: Roadmap phase status — check whether Phase 3 (Local Installation) success criteria at `../strategy/facets/roadmap/03-local-installation.md` are fully met. This change is preparatory and does NOT complete the phase — note explicitly what remains (facet installation, asset CRUD implementation, `facet init`, config cascade).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "bun@1.3.11",
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "packages/harnesses/*"
     ]
   },
   "scripts": {
@@ -23,7 +24,7 @@
     "docs:validate": "bun --cwd docs mint validate",
     "docs:broken-links": "bun --cwd docs mint broken-links",
     "postinstall": "mise exec -- lefthook install",
-    "clean": "rm -rf .turbo node_modules packages/*/node_modules packages/*/.turbo packages/*/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify"
+    "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.11",

--- a/packages/cli/src/commands/create/types.ts
+++ b/packages/cli/src/commands/create/types.ts
@@ -1,9 +1,1 @@
 export type AssetType = 'skill' | 'agent' | 'command'
-
-export const ASSET_TYPES: AssetType[] = ['skill', 'command', 'agent']
-
-export const ASSET_LABELS: Record<AssetType, string> = {
-  skill: 'Skills',
-  agent: 'Agents',
-  command: 'Commands',
-}

--- a/packages/cli/src/tui/views/create/create-view.tsx
+++ b/packages/cli/src/tui/views/create/create-view.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from 'ink'
 import { useCallback, useEffect } from 'react'
-import { ASSET_LABELS, ASSET_TYPES } from '../../../commands/create/types.ts'
+import type { AssetType } from '../../../commands/create/types'
 import { DEFAULT_VERSION, isValidKebabCase } from '../../../commands/create-scaffold.ts'
 import { AssetSection } from '../../components/asset-section.tsx'
 import { Button } from '../../components/button.tsx'
@@ -8,6 +8,14 @@ import { EditableField } from '../../components/editable-field.tsx'
 import { useFocusOrder } from '../../context/focus-order-context.ts'
 import { useFormState } from '../../context/form-state-context.ts'
 import { WizardLayout } from '../../layouts/wizard-layout.tsx'
+
+const ASSET_TYPES: AssetType[] = ['skill', 'command', 'agent']
+
+const ASSET_LABELS: Record<AssetType, string> = {
+  skill: 'Skills',
+  agent: 'Agents',
+  command: 'Commands',
+}
 
 function computeFocusIds(form: ReturnType<typeof useFormState>['form']): string[] {
   const ids: string[] = ['field-name', 'field-description', 'field-version']

--- a/packages/cli/turbo.ci.json
+++ b/packages/cli/turbo.ci.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["build"]
+    }
+  }
+}

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {},
+    "test": {
+      "dependsOn": ["build"]
+    }
+  }
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@agent-facets/common",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,1 @@
+export type { AssetType, Location, Validated, ValidationError } from './types.ts'

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,0 +1,57 @@
+/**
+ * A structured validation error decoupled from any specific validation library.
+ * Used across all packages to report schema and parsing failures.
+ */
+export interface ValidationError {
+  /** Dot-separated path to the invalid field (e.g., "agents.reviewer.prompt") */
+  path: string
+  /** Human-readable error message */
+  message: string
+  /** What was expected at this location */
+  expected: string
+  /** What was actually found */
+  actual: string
+}
+
+/**
+ * Discriminated result type for validation operations.
+ * Callers check `ok` to determine success or failure.
+ *
+ * Replaces the previous `Result<T>` (which required a type parameter)
+ * and `ValidationResult` (which was `Result<void>`). Every validation
+ * operation returns data on success — `T` is always required.
+ *
+ * @example
+ * ```ts
+ * const result: Validated<FacetManifest> = loadManifest(dir)
+ * if (result.ok) {
+ *   console.log(result.data) // FacetManifest
+ * } else {
+ *   console.error(result.errors) // ValidationError[]
+ * }
+ * ```
+ */
+export type Validated<T> = { ok: true; data: T } | { ok: false; errors: ValidationError[] }
+
+/**
+ * The canonical asset type — singular form.
+ * Code that needs the plural/manifest-key form should derive it.
+ */
+export type AssetType = 'skill' | 'agent' | 'command'
+
+/**
+ * A scoped filesystem location used by harnesses to declare
+ * where assets or config files live.
+ *
+ * - `path`: relative for project scope, absolute for user/system scope
+ * - `scope`: classifies the location's ownership level
+ * - `type`: discriminates between directories (asset containers) and files (config targets)
+ */
+export interface Location {
+  /** Filesystem path — relative for project scope, absolute for user/system scope */
+  path: string
+  /** Ownership level of this location */
+  scope: 'system' | 'user' | 'project'
+  /** Whether this location is a directory (container) or a file (target) */
+  type: 'directory' | 'file'
+}

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@agent-facets/harness",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agent-facets/facets",
+    "directory": "packages/harness"
+  },
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "bun test",
+    "types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@agent-facets/common": "workspace:*",
+    "tsdown": "^0.21.8",
+    "typescript": "^6.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": false,
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "types": "./dist/index.d.mts"
+      }
+    }
+  }
+}

--- a/packages/harness/src/__tests__/index.test.ts
+++ b/packages/harness/src/__tests__/index.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, test } from 'bun:test'
+
+describe('scanAssets', () => {
+  test('discovers skills in directory convention', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/packages/harness/src/define-harness.ts
+++ b/packages/harness/src/define-harness.ts
@@ -1,0 +1,92 @@
+import type { Harness, HarnessDefinition } from './types.ts'
+
+/**
+ * Create a harness from a definition object.
+ *
+ * Validates the definition shape and provides stub defaults for optional
+ * CRUD methods. Returns a frozen `Harness` object.
+ *
+ * @example
+ * ```ts
+ * import { defineHarness } from '@agent-facets/harness'
+ *
+ * export default defineHarness({
+ *   name: 'opencode',
+ *   assetLocations: [
+ *     { path: '.opencode', scope: 'project', type: 'directory' },
+ *     { path: '~/.config/opencode', scope: 'user', type: 'directory' },
+ *   ],
+ *   configLocations: [
+ *     { path: '.opencode/opencode.jsonc', scope: 'project', type: 'file' },
+ *   ],
+ *   buildAssetMetadata(data) {
+ *     // validate and enrich metadata using arktype or any other library
+ *   },
+ * })
+ * ```
+ */
+export function defineHarness(definition: HarnessDefinition): Harness {
+  // Validate required fields
+  if (!definition.name || typeof definition.name !== 'string') {
+    throw new Error('defineHarness: "name" is required and must be a non-empty string')
+  }
+
+  if (!Array.isArray(definition.assetLocations)) {
+    throw new Error('defineHarness: "assetLocations" is required and must be an array')
+  }
+
+  if (!Array.isArray(definition.configLocations)) {
+    throw new Error('defineHarness: "configLocations" is required and must be an array')
+  }
+
+  if (typeof definition.buildAssetMetadata !== 'function') {
+    throw new Error('defineHarness: "buildAssetMetadata" is required and must be a function')
+  }
+
+  // Validate each location has required fields
+  for (const loc of [...definition.assetLocations, ...definition.configLocations]) {
+    if (!loc.path || typeof loc.path !== 'string') {
+      throw new Error('defineHarness: each location must have a non-empty "path" string')
+    }
+    if (!['system', 'user', 'project'].includes(loc.scope)) {
+      throw new Error(`defineHarness: location scope must be "system", "user", or "project", got "${loc.scope}"`)
+    }
+    if (!['directory', 'file'].includes(loc.type)) {
+      throw new Error(`defineHarness: location type must be "directory" or "file", got "${loc.type}"`)
+    }
+  }
+
+  const harness: Harness = {
+    name: definition.name,
+    assetLocations: Object.freeze([...definition.assetLocations]),
+    configLocations: Object.freeze([...definition.configLocations]),
+    buildAssetMetadata: definition.buildAssetMetadata.bind(definition),
+
+    // CRUD stubs — full implementations deferred to install pipeline
+    createAsset:
+      definition.createAsset?.bind(definition) ??
+      (async () => {
+        throw new Error(`Harness "${definition.name}" does not implement createAsset`)
+      }),
+
+    readAsset:
+      definition.readAsset?.bind(definition) ??
+      (async () => {
+        throw new Error(`Harness "${definition.name}" does not implement readAsset`)
+      }),
+
+    updateAsset:
+      definition.updateAsset?.bind(definition) ??
+      (async () => {
+        throw new Error(`Harness "${definition.name}" does not implement updateAsset`)
+      }),
+
+    deleteAsset:
+      definition.deleteAsset?.bind(definition) ??
+      (async () => {
+        throw new Error(`Harness "${definition.name}" does not implement deleteAsset`)
+      }),
+  }
+
+  return Object.freeze(harness)
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,0 +1,10 @@
+export { defineHarness } from './define-harness.ts'
+export type {
+  AssetType,
+  Harness,
+  HarnessDefinition,
+  HarnessMetadata,
+  Location,
+  Validated,
+  ValidationError,
+} from './types.ts'

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -1,0 +1,92 @@
+import type { AssetType, Location, Validated, ValidationError } from '@agent-facets/common'
+
+/**
+ * Opaque record type for harness-specific asset metadata.
+ * Each harness defines its own schema — this is the generic container.
+ */
+export type HarnessMetadata = Record<string, unknown>
+
+/**
+ * The full harness contract. Returned by `defineHarness()`.
+ *
+ * A harness is an AI coding tool (OpenCode, Claude Code, Codex, etc.)
+ * that wraps around an LLM. The harness is a full abstraction layer
+ * over its tool's storage and configuration.
+ */
+export interface Harness {
+  /** Unique harness name (e.g., "opencode", "claude-code", "codex") */
+  readonly name: string
+
+  /** Ordered array of asset storage locations (highest precedence first) */
+  readonly assetLocations: readonly Location[]
+
+  /** Ordered array of config file locations (highest precedence first) */
+  readonly configLocations: readonly Location[]
+
+  /**
+   * Validate and enrich per-asset harness metadata from a facet manifest.
+   * Takes raw metadata, validates it against the harness's schema,
+   * applies harness-specific defaults, and returns the enriched object.
+   */
+  buildAssetMetadata(data: unknown): Validated<HarnessMetadata>
+
+  /** Create an asset at the given location */
+  createAsset(location: Location, assetType: AssetType, name: string, content: string, metadata: unknown): Promise<void>
+
+  /** Read an asset's content from the given location */
+  readAsset(location: Location, assetType: AssetType, name: string): Promise<string>
+
+  /** Update an existing asset at the given location */
+  updateAsset(location: Location, assetType: AssetType, name: string, content: string, metadata: unknown): Promise<void>
+
+  /** Delete an asset from the given location */
+  deleteAsset(location: Location, assetType: AssetType, name: string): Promise<void>
+}
+
+/**
+ * Input to `defineHarness()`. Authors provide this definition object.
+ * Optional methods receive stub defaults from the factory.
+ */
+export interface HarnessDefinition {
+  /** Unique harness name */
+  name: string
+
+  /** Ordered array of asset storage locations (highest precedence first) */
+  assetLocations: Location[]
+
+  /** Ordered array of config file locations (highest precedence first) */
+  configLocations: Location[]
+
+  /**
+   * Validate and enrich per-asset harness metadata.
+   * This is required — every harness must define its metadata schema.
+   */
+  buildAssetMetadata(data: unknown): Validated<HarnessMetadata>
+
+  /** Create an asset at the given location (optional — stub provided by default) */
+  createAsset?(
+    location: Location,
+    assetType: AssetType,
+    name: string,
+    content: string,
+    metadata: unknown,
+  ): Promise<void>
+
+  /** Read an asset's content (optional — stub provided by default) */
+  readAsset?(location: Location, assetType: AssetType, name: string): Promise<string>
+
+  /** Update an existing asset (optional — stub provided by default) */
+  updateAsset?(
+    location: Location,
+    assetType: AssetType,
+    name: string,
+    content: string,
+    metadata: unknown,
+  ): Promise<void>
+
+  /** Delete an asset (optional — stub provided by default) */
+  deleteAsset?(location: Location, assetType: AssetType, name: string): Promise<void>
+}
+
+// Re-export common types for convenience — SDK consumers don't need to install common
+export type { AssetType, Location, Validated, ValidationError }

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/harness/tsdown.config.ts
+++ b/packages/harness/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: {
+    eager: true,
+  },
+  clean: true,
+  deps: {
+    alwaysBundle: ['@agent-facets/common'],
+  },
+})

--- a/turbo.json
+++ b/turbo.json
@@ -5,11 +5,10 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
-      "outputs": ["dist/**"],
-      "cache": false
+      "outputs": ["dist/**"]
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": [],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
       "outputs": ["$TURBO_ROOT$/test-results/**"]
     },


### PR DESCRIPTION
### Why

Harness-specific logic is currently hardcoded in core as a `KNOWN_PLATFORMS` map, coupling core to every harness and requiring core changes for each new AI coding tool. This change extracts harness knowledge into a dedicated SDK and separate packages, enabling extensible harness management without modifying core.

### Details

Creates a foundational architecture for harness extensibility:

- **New packages**: `@agent-facets/common` (shared types), `@agent-facets/harness` (SDK), and separate harness packages for OpenCode, Claude Code, and Codex
- **Harness SDK**: Provides `defineHarness()` factory and `Harness` interface with asset locations, config locations, metadata building, and CRUD methods (stubs for now)
- **CLI harness management**: `facet harness install/list/remove` commands supporting npm packages, Git URLs, and local paths with CLI-side bundling via `Bun.build()`
- **Runtime loading**: Harnesses distributed as pre-bundled JavaScript files loaded via dynamic `import()` from `~/.facets/harnesses/`
- **Core refactoring**: Accepts harnesses as inputs rather than hardcoding schemas, delegates metadata building to harness `buildAssetMetadata()` methods
- **Breaking change**: Renames manifest field `platforms` → `harnesses` to avoid collision with OS/architecture platforms

The harness becomes a full abstraction layer - CLI never directly reads/writes assets, always goes through harness CRUD methods. First-party and third-party harnesses use identical installation and loading mechanisms for consistency.

### Verification

Spike on `julian/bun-dynamic-import-spike` validated that compiled Bun binaries can dynamically import pre-bundled JavaScript files. Asset CRUD methods are interface stubs in this change - full implementation deferred to the install pipeline to maintain focused scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds specification/design documents and makes a small internal refactor in the CLI create TUI; no runtime-critical logic or data handling changes.
> 
> **Overview**
> **Adds a new OpenSpec change bundle** under `openspec/changes/harness-sdk/`, including design/proposal docs plus detailed requirements specs for `harness__sdk`, `harness__assets`, and `harness__management`.
> 
> **Minor CLI refactor**: removes exported `ASSET_TYPES`/`ASSET_LABELS` constants from `packages/cli/src/commands/create/types.ts` and inlines them in the `CreateView` TUI (`create-view.tsx`), leaving only the `AssetType` type exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184da19f331b1639b1dacd262d72015d6edcdc1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->