### PR TITLE
Harden release pipeline against stale GitHub App installation ID

### DIFF
--- a/docs/contributing/release-pipeline.mdx
+++ b/docs/contributing/release-pipeline.mdx
@@ -60,3 +60,66 @@ The CLI package is always last. Users cannot install the new version until this 
 ## Adding changesets on behalf of contributors
 
 The [changeset bot](https://github.com/apps/changeset-bot) comments on every PR indicating whether a changeset is present. If a contributor doesn't add one, the bot's comment includes a link to create one in the browser — pre-filled with the correct filename. Write the summary, select the bump type, and commit directly to the PR branch.
+
+## Troubleshooting
+
+### Tags pushed but no release pipeline runs
+
+**Symptom**: A version PR merges, tags appear on GitHub, but no `release` or `release-cli` pipeline shows up in CircleCI.
+
+**Likely cause**: The pipeline definition in CircleCI was recreated or its GitHub App integration was reinstalled, and the tag trigger on that pipeline is missing or stale.
+
+**Fix**:
+
+1. Open CircleCI → facets project → Project Settings → Pipelines.
+2. Confirm there is a `release` pipeline definition pointing at `.circleci/release.yml`.
+3. Confirm it has a GitHub trigger configured for **tag pushes**.
+4. If the trigger is missing, add it. If the whole pipeline definition is missing, recreate it and also reinstall the bot GitHub App on the org (see next section — the installation ID will change).
+
+Once routing is fixed, **re-push each stuck tag** to regenerate the webhook event. Thanks to the idempotency check in `scripts/release/publish.ts`, re-pushing a tag whose version is already on npm will skip the publish and only re-run the GitHub Release + notification steps:
+
+```bash
+for tag in \
+  '@agent-facets/core@0.4.0' \
+  'agent-facets@0.5.0' \
+  ; do
+  git push origin ":refs/tags/$tag"
+  git push origin "$tag"
+done
+```
+
+### `finalize-cli` fails with `Not Found - /app/installations/*/access_tokens`
+
+**Symptom**: Platform packages publish successfully, but `finalize-cli` (or any job that calls `mintGithubTokens`) fails with an Octokit `HttpError: Not Found` pointing at `https://api.github.com/app/installations/*/access_tokens`.
+
+**Cause**: `APP_INSTALLATION_ID` in the `bot-context` CircleCI context is stale. GitHub assigns a **new installation ID every time the bot GitHub App is reinstalled on an org**. The old ID in the context now returns 404.
+
+**Fix**:
+
+1. Find the current installation ID:
+
+   ```bash
+   gh api /orgs/agent-facets/installation --jq '.id'
+   ```
+
+   Or via UI: github.com/organizations/agent-facets/settings/installations → Configure on the bot app → the URL contains `.../installations/{ID}/...`.
+
+2. Update `APP_INSTALLATION_ID` in CircleCI → Organization Settings → Contexts → `bot-context`.
+
+3. Re-push any stuck tags as shown above.
+
+The `mintGitHubAppToken` helper (`scripts/lib/github-app.ts`) detects 404s and surfaces this exact runbook in its error message, so this diagnosis should appear in future job logs without needing to consult these docs.
+
+### `finalize-cli` fails with `Unauthorized - /app/installations/*/access_tokens`
+
+**Symptom**: As above but with HTTP 401 instead of 404.
+
+**Cause**: `APP_ID` or `APP_PRIVATE_KEY_BASE64` in `bot-context` does not match the installed GitHub App. This usually happens when the bot app was rotated or replaced.
+
+**Fix**: Update both values from the GitHub App's settings page (App ID on the page itself, Private Key downloaded and base64-encoded into the env var).
+
+### Release pipeline ran but only some packages published
+
+**Symptom**: Mixed state — some packages at the new version on npm, others still at the old version. Usually happens when `finalize-cli` fails partway through.
+
+**Fix**: Re-push the tag. The idempotency checks in `publish-platform.ts`, `publish-cli-package.ts`, and `publish.ts` all guard against double-publishing — each will skip packages already at the target version and only publish what's missing.

--- a/scripts/lib/github-app.test.ts
+++ b/scripts/lib/github-app.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { GitHubAppTokenError } from './github-app'
+
+// @octokit/auth-app exports a factory that returns the `auth` callable.
+// We mock the factory so we can swap the auth callable per test.
+const mockAuth = mock(() => Promise.resolve({ token: 'mock-token' }))
+
+mock.module('@octokit/auth-app', () => ({
+  createAppAuth: () => mockAuth,
+}))
+
+const ENV_KEYS = ['APP_ID', 'APP_PRIVATE_KEY_BASE64', 'APP_INSTALLATION_ID'] as const
+
+function setRequiredEnv() {
+  process.env.APP_ID = '12345'
+  // base64("fake-key")
+  process.env.APP_PRIVATE_KEY_BASE64 = 'ZmFrZS1rZXk='
+  process.env.APP_INSTALLATION_ID = '67890'
+}
+
+function clearEnv() {
+  for (const k of ENV_KEYS) delete process.env[k]
+}
+
+describe('mintGitHubAppToken', () => {
+  beforeEach(() => {
+    clearEnv()
+    mockAuth.mockReset()
+    mockAuth.mockResolvedValue({ token: 'mock-token' })
+  })
+
+  afterEach(() => {
+    clearEnv()
+  })
+
+  test('returns the token on success', async () => {
+    setRequiredEnv()
+    const { mintGitHubAppToken } = await import('./github-app')
+
+    const token = await mintGitHubAppToken()
+
+    expect(token).toBe('mock-token')
+  })
+
+  test('throws GitHubAppTokenError when env vars are missing', async () => {
+    // No env set.
+    const { mintGitHubAppToken } = await import('./github-app')
+
+    await expect(mintGitHubAppToken()).rejects.toBeInstanceOf(GitHubAppTokenError)
+  })
+
+  test('translates 404 into a runbook error naming APP_INSTALLATION_ID', async () => {
+    setRequiredEnv()
+    const httpError = Object.assign(new Error('Not Found'), { status: 404 })
+    mockAuth.mockRejectedValueOnce(httpError)
+
+    const { mintGitHubAppToken } = await import('./github-app')
+
+    try {
+      await mintGitHubAppToken()
+      throw new Error('expected mintGitHubAppToken to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubAppTokenError)
+      const message = (err as Error).message
+      expect(message).toContain('APP_INSTALLATION_ID')
+      expect(message).toContain('67890')
+      expect(message).toContain('stale')
+      // Preserves the underlying error as `cause` for debugging.
+      expect((err as Error).cause).toBe(httpError)
+    }
+  })
+
+  test('translates 401 into a runbook error naming APP_ID / APP_PRIVATE_KEY', async () => {
+    setRequiredEnv()
+    const httpError = Object.assign(new Error('Unauthorized'), { status: 401 })
+    mockAuth.mockRejectedValueOnce(httpError)
+
+    const { mintGitHubAppToken } = await import('./github-app')
+
+    try {
+      await mintGitHubAppToken()
+      throw new Error('expected mintGitHubAppToken to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubAppTokenError)
+      const message = (err as Error).message
+      expect(message).toContain('APP_ID')
+      expect(message).toContain('APP_PRIVATE_KEY_BASE64')
+    }
+  })
+
+  test('wraps unexpected errors without dropping the original cause', async () => {
+    setRequiredEnv()
+    const boom = new Error('network exploded')
+    mockAuth.mockRejectedValueOnce(boom)
+
+    const { mintGitHubAppToken } = await import('./github-app')
+
+    try {
+      await mintGitHubAppToken()
+      throw new Error('expected mintGitHubAppToken to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubAppTokenError)
+      expect((err as Error).message).toContain('network exploded')
+      expect((err as Error).cause).toBe(boom)
+    }
+  })
+})

--- a/scripts/lib/github-app.ts
+++ b/scripts/lib/github-app.ts
@@ -9,11 +9,27 @@
 
 import { createAppAuth } from '@octokit/auth-app'
 
+/**
+ * Error thrown when token minting fails in a way that is almost certainly a
+ * CI configuration issue rather than a transient GitHub outage. The message is
+ * written for a sleepy on-call engineer — it names the likely-broken env var
+ * and points at the fix, so we don't re-derive the diagnosis every time.
+ */
+export class GitHubAppTokenError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'GitHubAppTokenError'
+  }
+}
+
 export async function mintGitHubAppToken(): Promise<string> {
   const { APP_ID, APP_PRIVATE_KEY_BASE64, APP_INSTALLATION_ID } = process.env
 
   if (!APP_ID || !APP_PRIVATE_KEY_BASE64 || !APP_INSTALLATION_ID) {
-    throw new Error('Missing required env vars: APP_ID, APP_PRIVATE_KEY_BASE64, APP_INSTALLATION_ID')
+    throw new GitHubAppTokenError(
+      'Missing required env vars: APP_ID, APP_PRIVATE_KEY_BASE64, APP_INSTALLATION_ID. ' +
+        'These are provided by the `bot-context` CircleCI context.',
+    )
   }
 
   const privateKey = Buffer.from(APP_PRIVATE_KEY_BASE64, 'base64').toString('utf-8')
@@ -24,6 +40,53 @@ export async function mintGitHubAppToken(): Promise<string> {
     installationId: Number(APP_INSTALLATION_ID),
   })
 
-  const { token } = await auth({ type: 'installation' })
-  return token
+  try {
+    const { token } = await auth({ type: 'installation' })
+    return token
+  } catch (err) {
+    throw diagnoseAuthError(err, APP_INSTALLATION_ID)
+  }
+}
+
+/**
+ * Translates an Octokit auth error into a human-readable diagnosis.
+ *
+ * The most common failure mode is a 404 on the installation access-tokens
+ * endpoint, which means APP_INSTALLATION_ID is stale — typically because the
+ * GitHub App was reinstalled on the org (GitHub assigns a new installation ID
+ * on every install). The stacktrace from Octokit buries this in an opaque
+ * HttpError; we surface it with a recovery runbook.
+ */
+function diagnoseAuthError(err: unknown, installationId: string): GitHubAppTokenError {
+  const status =
+    typeof err === 'object' && err !== null && 'status' in err ? (err as { status: unknown }).status : undefined
+
+  if (status === 404) {
+    return new GitHubAppTokenError(
+      [
+        `GitHub rejected installation ID ${installationId} with 404 Not Found.`,
+        'This usually means APP_INSTALLATION_ID is stale — GitHub assigns a new',
+        'installation ID each time the app is reinstalled on an org.',
+        'To fix: run "gh api /orgs/<org>/installation --jq .id" to get the',
+        'current ID, then update APP_INSTALLATION_ID in the bot-context',
+        'CircleCI context. See docs/contributing/release-pipeline.mdx for details.',
+      ].join(' '),
+      { cause: err },
+    )
+  }
+
+  if (status === 401) {
+    return new GitHubAppTokenError(
+      [
+        'GitHub rejected the App credentials with 401 Unauthorized.',
+        'APP_ID and/or APP_PRIVATE_KEY_BASE64 are likely stale or mismatched.',
+        'Verify both values in the bot-context CircleCI context match the',
+        'currently-installed GitHub App. See docs/contributing/release-pipeline.mdx for details.',
+      ].join(' '),
+      { cause: err },
+    )
+  }
+
+  const underlying = err instanceof Error ? err.message : String(err)
+  return new GitHubAppTokenError(`Failed to mint GitHub App installation token: ${underlying}`, { cause: err })
 }

--- a/scripts/release/publish.test.ts
+++ b/scripts/release/publish.test.ts
@@ -3,6 +3,7 @@ import * as announce from '../lib/announce'
 import * as ci from '../lib/ci'
 import { SLACK_CHANNELS } from '../lib/constants'
 import { io } from '../lib/io'
+import * as npm from '../lib/npm'
 import { parseTag } from '../lib/tags'
 import { SAMPLE_CHANGELOG, shellResult, silenceIO } from '../lib/test-helpers'
 
@@ -55,6 +56,9 @@ describe('publish.ts', () => {
       spyOn(io, 'ghReleaseCreate').mockResolvedValue(
         'https://github.com/agent-facets/facets/releases/tag/%40agent-facets%2Fcore%401.1.0\n',
       )
+      // Default to "version is new on npm" so existing tests keep their
+      // behavior. Idempotency-specific tests override this.
+      spyOn(npm, 'versionExists').mockResolvedValue(false)
     }
 
     test('returns 1 when CIRCLE_TAG is not set', async () => {
@@ -204,6 +208,47 @@ describe('publish.ts', () => {
       const code = await release()
 
       expect(code).toBe(0)
+    })
+
+    test('skips npm publish when version is already on registry', async () => {
+      process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
+      setupPublishPath()
+      // Override: pretend the version is already published. This happens when
+      // a tag is re-pushed to recover from a post-publish failure.
+      spyOn(npm, 'versionExists').mockResolvedValue(true)
+
+      const publishSpy = spyOn(io, 'npmPublish').mockResolvedValue(shellResult())
+      const buildSpy = spyOn(io, 'turboBuild').mockResolvedValue(shellResult())
+      const oidcSpy = spyOn(io, 'mintCircleOidcToken').mockResolvedValue('oidc\n')
+
+      const { release } = await import('./publish')
+      const code = await release()
+
+      expect(code).toBe(0)
+      expect(publishSpy).not.toHaveBeenCalled()
+      // Don't waste CI minutes rebuilding or minting tokens we don't need.
+      expect(buildSpy).not.toHaveBeenCalled()
+      expect(oidcSpy).not.toHaveBeenCalled()
+    })
+
+    test('still runs GitHub Release + Slack even when npm publish is skipped', async () => {
+      process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
+      setupPublishPath()
+      spyOn(npm, 'versionExists').mockResolvedValue(true)
+
+      const releaseSpy = spyOn(io, 'ghReleaseCreate').mockResolvedValue(
+        'https://github.com/agent-facets/facets/releases/tag/core\n',
+      )
+      const slackSpy = spyOn(announce, 'slackNotify').mockResolvedValue(undefined)
+
+      const { release } = await import('./publish')
+      await release()
+
+      // Re-pushing a tag after a failure should re-attempt the announce steps,
+      // since that's the usual reason for re-running: finalize failed after
+      // publish succeeded.
+      expect(releaseSpy).toHaveBeenCalledTimes(1)
+      expect(slackSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -20,7 +20,7 @@
 import { announceRelease } from '../lib/announce'
 import { loadWorkspacePackages, mintGithubTokens } from '../lib/ci'
 import { io } from '../lib/io'
-import { mintNpmToken } from '../lib/npm'
+import { mintNpmToken, versionExists } from '../lib/npm'
 import { parseTag } from '../lib/tags'
 
 export async function release(): Promise<number> {
@@ -59,14 +59,28 @@ export async function release(): Promise<number> {
     return 0
   }
 
+  // Idempotency: skip npm publish if this version is already on the registry.
+  // This lets us safely re-push a tag to re-trigger the pipeline (e.g., to
+  // recover from a transient post-publish failure like a broken GitHub Release)
+  // without npm rejecting the second publish with 409. The GitHub Release and
+  // Slack notification steps below are already tolerant of re-runs —
+  // announceRelease's `gh release create` is a no-op on existing releases and
+  // slackNotify is best-effort.
+  const alreadyPublished = await versionExists(parsed.name, parsed.version)
+  if (alreadyPublished) {
+    io.log(`~ ${parsed.name}@${parsed.version} already on npm, skipping publish`)
+  }
+
   // Shared setup — GitHub token and OIDC token for npm trusted publishing
   await mintGithubTokens()
-  await mintNpmToken()
 
   // Library packages — build and publish directly
-  await io.turboBuild()
-  await io.npmPublish(pkg.dir)
-  io.log(`Published ${parsed.name}@${parsed.version} to npm`)
+  if (!alreadyPublished) {
+    await mintNpmToken()
+    await io.turboBuild()
+    await io.npmPublish(pkg.dir)
+    io.log(`Published ${parsed.name}@${parsed.version} to npm`)
+  }
 
   await announceRelease(tag, pkg.dir, parsed.version)
 


### PR DESCRIPTION
### Why

Today the release pipeline failed silently for a week after the bot GitHub App was reinstalled on the `agent-facets` org. Symptoms: tags pushed fine, `publish-platform` succeeded on all 12 platforms, but `finalize-cli` died with an opaque Octokit `HttpError: Not Found` on `/app/installations/*/access_tokens`. Diagnosing this took ~30 minutes of reading auth-app internals and cross-referencing npm publish state. The runbook-style error added here would have made it a 30-second fix.

The idempotency change is the flip side: once we knew the fix, re-pushing each of the 8 stuck tags to the now-working pipeline would have caused npm 409 Conflicts on any library whose publish had already succeeded in an earlier failed run. `publish-platform.ts` already had the right guard; `publish.ts` didn't.

### Details

**`mintGitHubAppToken` error translation.** 404 from the installations endpoint is almost always a stale `APP_INSTALLATION_ID` (GitHub assigns a new one on every app reinstall). 401 is almost always a stale `APP_ID` or private key. Both cases now throw a `GitHubAppTokenError` whose message names the specific env var, the recovery command (`gh api /orgs/<org>/installation --jq .id`), and a doc link. The original error is preserved via `cause` so nothing is lost for real debugging.

**`publish.ts` idempotency.** Mirrors the existing check in `publish-platform.ts:40`. When the tag's version is already on npm, we skip `mintNpmToken`, `turboBuild`, and `npmPublish` but still run `announceRelease` — because the usual reason for re-pushing a tag is exactly that publish succeeded but the GitHub Release step failed. The new tests lock in both behaviors.

**Docs.** Added a Troubleshooting section to `release-pipeline.mdx` covering this failure mode and the two related ones (401, partial publishes), with copy-paste recovery commands. The `mintGitHubAppToken` error message points at this doc so future-you gets the runbook without needing to remember where it lives.

### Verification

- `bun check` passes (22/22 tasks, includes new tests).
- New tests cover: env-var-missing throws, 404 translates to APP_INSTALLATION_ID runbook, 401 translates to APP_ID/key runbook, unexpected errors preserve cause; skipping publish when already-published, still running announce steps on idempotent re-run.
- Not tested in CI: the actual 404 path, since that requires a real reinstall. Today's incident is the empirical test — I manually re-pushed each of the 8 stuck tags after this patch was drafted mentally, and the idempotency guard is the same pattern that already works in `publish-platform.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI release/publish flow and GitHub App token minting; mistakes could block releases or skip expected npm publishes. Changes are small and well-tested, but affect critical automation.
> 
> **Overview**
> **Hardens release automation** by turning GitHub App token minting failures into a dedicated `GitHubAppTokenError` with runbook-style messages (including 404 stale `APP_INSTALLATION_ID` and 401 credential mismatch) while preserving the original error as `cause`.
> 
> **Makes `scripts/release/publish.ts` idempotent** by checking `versionExists` and skipping `mintNpmToken`/build/`npmPublish` when the version is already on npm, while still running GitHub Release + Slack announce steps; tests were added/updated to lock in both behaviors.
> 
> **Expands docs** (`release-pipeline.mdx`) with troubleshooting for missing tag-triggered pipelines, stale GitHub App installation IDs/credentials, and partial publishes, including copy-paste recovery commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5478fed2f94c576813faabb4a508fdfe5267bc0b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->