### PR TITLE
Fix adapter bundling with prebuilt fast path and self-contained bundles

### DIFF
--- a/.changeset/eighty-ducks-camp.md
+++ b/.changeset/eighty-ducks-camp.md
@@ -1,0 +1,8 @@
+---
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/adapter-codex": patch
+"agent-facets": patch
+---
+
+Fixed bundling of adapters

--- a/.opencode/tools/viper-write-plan.ts
+++ b/.opencode/tools/viper-write-plan.ts
@@ -20,7 +20,7 @@ export default tool({
       return JSON.stringify({ success: false, reason: 'invalid_name', name: args.plan })
     }
 
-    const artifact = args.artifact ?? 'plan'
+    const artifact = (args.artifact ?? 'plan').replace(/\.md$/, '')
     if (!SAFE_NAME.test(artifact)) {
       return JSON.stringify({ success: false, reason: 'invalid_artifact', artifact })
     }

--- a/bun.lock
+++ b/bun.lock
@@ -31,12 +31,10 @@
     "packages/adapters/claude-code": {
       "name": "@agent-facets/adapter-claude-code",
       "version": "0.2.0",
-      "dependencies": {
-        "@agent-facets/adapter": "workspace:*",
-        "arktype": "2.2.0",
-      },
       "devDependencies": {
+        "@agent-facets/adapter": "workspace:*",
         "@types/bun": "1.3.11",
+        "arktype": "2.2.0",
         "tsdown": "^0.21.9",
         "typescript": "^6.0.3",
       },
@@ -44,10 +42,8 @@
     "packages/adapters/codex": {
       "name": "@agent-facets/adapter-codex",
       "version": "0.2.0",
-      "dependencies": {
-        "@agent-facets/adapter": "workspace:*",
-      },
       "devDependencies": {
+        "@agent-facets/adapter": "workspace:*",
         "@types/bun": "1.3.11",
         "tsdown": "^0.21.9",
         "typescript": "^6.0.3",
@@ -56,12 +52,10 @@
     "packages/adapters/opencode": {
       "name": "@agent-facets/adapter-opencode",
       "version": "0.2.0",
-      "dependencies": {
-        "@agent-facets/adapter": "workspace:*",
-        "arktype": "2.2.0",
-      },
       "devDependencies": {
+        "@agent-facets/adapter": "workspace:*",
         "@types/bun": "1.3.11",
+        "arktype": "2.2.0",
         "tsdown": "^0.21.9",
         "typescript": "^6.0.3",
       },
@@ -96,6 +90,7 @@
       },
       "devDependencies": {
         "@agent-facets/adapter": "workspace:*",
+        "@agent-facets/adapter-opencode": "workspace:*",
         "@agent-facets/brand": "workspace:*",
         "@agent-facets/core": "workspace:*",
         "@types/bun": "1.3.10",

--- a/docs/cli/adapter.mdx
+++ b/docs/cli/adapter.mdx
@@ -25,13 +25,13 @@ Installs an adapter from the given specifier. The install flow downloads the sou
 
 **Specifier formats:**
 
-| Format | Example | Description |
-|--------|---------|-------------|
-| Built-in name | `opencode` | Resolves to the first-party npm package |
-| npm package | `@acme/adapter-custom` | Downloads from the npm registry |
-| Git URL | `git+https://github.com/user/repo.git` | Clones the repository |
-| Git URL with ref | `git+https://github.com/user/repo.git#v1.0.0` | Clones at a specific tag/branch |
-| Local path | `./path/to/adapter` | Uses a local directory |
+| Format           | Example                                       | Description                             |
+|------------------|-----------------------------------------------|-----------------------------------------|
+| Built-in name    | `opencode`                                    | Resolves to the first-party npm package |
+| npm package      | `@acme/adapter-custom`                        | Downloads from the npm registry         |
+| Git URL          | `git+https://github.com/user/repo.git`        | Clones the repository                   |
+| Git URL with ref | `git+https://github.com/user/repo.git#v1.0.0` | Clones at a specific tag/branch         |
+| Local path       | `./path/to/adapter`                           | Uses a local directory                  |
 
 **Built-in names:**
 
@@ -54,3 +54,19 @@ facet adapter remove <name>
 ```
 
 Removes an installed adapter by deleting its directory from `~/.facets/adapters/`.
+
+## Environment variables
+
+### `FACETS_ADAPTERS_DIR`
+
+Overrides the base directory used for installed adapters. When set, `install`, `list`, `remove`, and `build` all read from and write to this directory instead of the default `~/.facets/adapters/`.
+
+```sh
+export FACETS_ADAPTERS_DIR=/path/to/adapters
+facet adapter install opencode
+# adapter lands in /path/to/adapters/opencode/adapter.js
+```
+
+The directory is created automatically if it does not exist. Set the variable in your shell profile to make the override persist across sessions.
+
+This is currently the only supported way to change the adapter install location. A per-install `--target-dir` flag is not supported because it would require persistent configuration so that later invocations (such as `facet build`) could locate adapters placed in non-default locations.

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -20,12 +20,10 @@
     "types": "tsc --noEmit",
     "test": "bun test"
   },
-  "dependencies": {
-    "@agent-facets/adapter": "workspace:*",
-    "arktype": "2.2.0"
-  },
   "devDependencies": {
+    "@agent-facets/adapter": "workspace:*",
     "@types/bun": "1.3.11",
+    "arktype": "2.2.0",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.3"
   },

--- a/packages/adapters/claude-code/tsdown.config.ts
+++ b/packages/adapters/claude-code/tsdown.config.ts
@@ -7,4 +7,10 @@ export default defineConfig({
     eager: true,
   },
   clean: true,
+  // Inline runtime dependencies so the published dist/index.mjs is a fully
+  // self-contained bundle. The CLI loads this file directly at install time
+  // without needing a node_modules tree.
+  deps: {
+    alwaysBundle: ['@agent-facets/adapter', 'arktype'],
+  },
 })

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -20,10 +20,8 @@
     "types": "tsc --noEmit",
     "test": "bun test"
   },
-  "dependencies": {
-    "@agent-facets/adapter": "workspace:*"
-  },
   "devDependencies": {
+    "@agent-facets/adapter": "workspace:*",
     "@types/bun": "1.3.11",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.3"

--- a/packages/adapters/codex/tsdown.config.ts
+++ b/packages/adapters/codex/tsdown.config.ts
@@ -7,4 +7,10 @@ export default defineConfig({
     eager: true,
   },
   clean: true,
+  // Inline runtime dependencies so the published dist/index.mjs is a fully
+  // self-contained bundle. The CLI loads this file directly at install time
+  // without needing a node_modules tree.
+  deps: {
+    alwaysBundle: ['@agent-facets/adapter'],
+  },
 })

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -20,12 +20,10 @@
     "types": "tsc --noEmit",
     "test": "bun test"
   },
-  "dependencies": {
-    "@agent-facets/adapter": "workspace:*",
-    "arktype": "2.2.0"
-  },
   "devDependencies": {
+    "@agent-facets/adapter": "workspace:*",
     "@types/bun": "1.3.11",
+    "arktype": "2.2.0",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.3"
   },

--- a/packages/adapters/opencode/tsdown.config.ts
+++ b/packages/adapters/opencode/tsdown.config.ts
@@ -7,4 +7,10 @@ export default defineConfig({
     eager: true,
   },
   clean: true,
+  // Inline runtime dependencies so the published dist/index.mjs is a fully
+  // self-contained bundle. The CLI loads this file directly at install time
+  // without needing a node_modules tree.
+  deps: {
+    alwaysBundle: ['@agent-facets/adapter', 'arktype'],
+  },
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "@agent-facets/brand": "workspace:*",
     "@agent-facets/core": "workspace:*",
     "@agent-facets/adapter": "workspace:*",
+    "@agent-facets/adapter-opencode": "workspace:*",
     "@types/bun": "1.3.10",
     "ink-testing-library": "4.0.0"
   },

--- a/packages/cli/src/__tests__/adapter-bundler.test.ts
+++ b/packages/cli/src/__tests__/adapter-bundler.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { bundleAdapter, resolveEntryPoint } from '../commands/adapter/bundler.ts'
+
+/**
+ * Unit tests for `resolveEntryPoint()`.
+ *
+ * Each test builds a minimal fixture directory with a `package.json` (and
+ * sometimes fixture source files) and confirms the resolver picks the
+ * expected entry point with the right `kind` classification.
+ */
+
+async function makeFixture(pkg: Record<string, unknown>, files: Record<string, string> = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'facet-bundler-test-'))
+  await Bun.write(join(dir, 'package.json'), JSON.stringify(pkg, null, 2))
+  for (const [relative, content] of Object.entries(files)) {
+    const absolute = join(dir, relative)
+    // Ensure parent dir exists. Use `dirname()` rather than slicing on '/'
+    // so this works on any platform (and matches the convention used
+    // elsewhere in the codebase).
+    await mkdir(dirname(absolute), { recursive: true })
+    await Bun.write(absolute, content)
+  }
+  return dir
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true }).catch(() => {})
+}
+
+describe('resolveEntryPoint', () => {
+  test('exports as a string pointing at a prebuilt .mjs', async () => {
+    const dir = await makeFixture({ name: 'a', exports: './dist/index.mjs' }, { 'dist/index.mjs': 'export default {}' })
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
+      expect(resolved.kind).toBe('prebuilt')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('exports["."] as a string pointing at a prebuilt .mjs', async () => {
+    const dir = await makeFixture(
+      { name: 'a', exports: { '.': './dist/index.mjs' } },
+      { 'dist/index.mjs': 'export default {}' },
+    )
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
+      expect(resolved.kind).toBe('prebuilt')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('exports["."] as a conditional object with .import', async () => {
+    const dir = await makeFixture(
+      {
+        name: 'a',
+        exports: { '.': { import: './dist/index.mjs', types: './dist/index.d.mts' } },
+      },
+      { 'dist/index.mjs': 'export default {}' },
+    )
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
+      expect(resolved.kind).toBe('prebuilt')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('exports["."] pointing at TypeScript source is classified as source', async () => {
+    const dir = await makeFixture(
+      { name: 'a', exports: { '.': './src/index.ts' } },
+      { 'src/index.ts': 'export default {}' },
+    )
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'src/index.ts'))
+      expect(resolved.kind).toBe('source')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('main field only, pointing at prebuilt .mjs', async () => {
+    const dir = await makeFixture({ name: 'a', main: './dist/index.mjs' }, { 'dist/index.mjs': 'export default {}' })
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
+      expect(resolved.kind).toBe('prebuilt')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('disk fallback to dist/index.mjs when no exports/main', async () => {
+    const dir = await makeFixture({ name: 'a' }, { 'dist/index.mjs': 'export default {}' })
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
+      expect(resolved.kind).toBe('prebuilt')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('disk fallback to dist/index.js when dist/index.mjs missing', async () => {
+    const dir = await makeFixture({ name: 'a' }, { 'dist/index.js': 'export default {}' })
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.js'))
+      expect(resolved.kind).toBe('prebuilt')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('disk fallback to src/index.ts is classified as source', async () => {
+    const dir = await makeFixture({ name: 'a' }, { 'src/index.ts': 'export default {}' })
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'src/index.ts'))
+      expect(resolved.kind).toBe('source')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('prebuilt path declared in package.json but not on disk falls through', async () => {
+    // exports points at dist/index.mjs but the file doesn't exist — resolver
+    // should fall through to the disk-fallback stage and find src/index.ts.
+    const dir = await makeFixture(
+      { name: 'a', exports: { '.': { import: './dist/index.mjs' } } },
+      { 'src/index.ts': 'export default {}' },
+    )
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'src/index.ts'))
+      expect(resolved.kind).toBe('source')
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('throws when no entry point can be found, listing what was tried', async () => {
+    const dir = await makeFixture({ name: 'a', exports: './does-not-exist.mjs', main: './also-missing.js' })
+    try {
+      await expect(resolveEntryPoint(dir)).rejects.toThrow(
+        /Cannot determine entry point.*does-not-exist.mjs.*also-missing.js.*dist\/index.mjs/s,
+      )
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('throws when package.json is missing', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'facet-bundler-test-'))
+    try {
+      await expect(resolveEntryPoint(dir)).rejects.toThrow(/No package.json found/)
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('prefers exports over main when both are set', async () => {
+    const dir = await makeFixture(
+      {
+        name: 'a',
+        exports: { '.': './dist/index.mjs' },
+        main: './dist/fallback.js',
+      },
+      {
+        'dist/index.mjs': 'export default {}',
+        'dist/fallback.js': 'export default {}',
+      },
+    )
+    try {
+      const resolved = await resolveEntryPoint(dir)
+      expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
+    } finally {
+      await cleanup(dir)
+    }
+  })
+})
+
+/**
+ * Tests for the BundleResult.cleanup contract introduced in PR #142
+ * follow-up: every bundler entry point returns `{ bundlePath, cleanup }`,
+ * and callers MUST be able to invoke `cleanup()` safely (whether or not
+ * a temp dir was created).
+ *
+ * The slow-path `rebundleAdapter` cleanup is exercised end-to-end by the
+ * adapter-install-cli test suite (which checks that `facet-adapter-build-*`
+ * dirs don't accumulate in tmpdir across installs). Here we cover the fast
+ * path: it must return a no-op cleanup that doesn't throw and doesn't
+ * delete anything in the source tree.
+ */
+describe('bundleAdapter — fast path returns a safe no-op cleanup', () => {
+  test('cleanup is callable and resolves without throwing', async () => {
+    const dir = await makeFixture(
+      { name: 'noop-cleanup-fixture', exports: { '.': { import: './dist/index.mjs' } } },
+      { 'dist/index.mjs': 'export default { name: "noop-cleanup-fixture" }' },
+    )
+    try {
+      const result = await bundleAdapter(dir)
+      // Fast path: bundlePath should point AT the source tree's prebuilt
+      expect(result.bundlePath).toBe(join(dir, 'dist/index.mjs'))
+      // Cleanup must not throw
+      await expect(result.cleanup()).resolves.toBeUndefined()
+      // And critically: the prebuilt file must still exist after cleanup,
+      // because the fast path doesn't own the source tree.
+      const stats = await stat(result.bundlePath)
+      expect(stats.isFile()).toBe(true)
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('cleanup is idempotent — calling it multiple times is safe', async () => {
+    const dir = await makeFixture(
+      { name: 'idempotent-cleanup', exports: { '.': { import: './dist/index.mjs' } } },
+      { 'dist/index.mjs': 'export default { name: "idempotent-cleanup" }' },
+    )
+    try {
+      const result = await bundleAdapter(dir)
+      await result.cleanup()
+      await expect(result.cleanup()).resolves.toBeUndefined()
+      await expect(result.cleanup()).resolves.toBeUndefined()
+    } finally {
+      await cleanup(dir)
+    }
+  })
+})

--- a/packages/cli/src/__tests__/adapter-install-cli.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.test.ts
@@ -1,0 +1,537 @@
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+/**
+ * End-to-end integration tests that spawn the compiled `./dist/facet` binary
+ * as a subprocess and verify adapter install / list / remove behavior.
+ *
+ * These tests exercise the full real code path:
+ *   - argv parsing and exit codes
+ *   - `parseSpecifier` + source resolution
+ *   - `bundleAdapter` (fast path + slow-path fallback in `locateAndVerifyAdapter`)
+ *   - `verifyAdapter` (dynamic import of the bundle)
+ *   - `placeAdapter` / `listInstalledAdapters` / `removeAdapter`
+ *   - temp-dir cleanup in the `handleInstall` finally block
+ *
+ * Isolation: each test sets `FACETS_ADAPTERS_DIR` to a unique `mkdtemp` dir
+ * so the user's real `~/.facets/adapters/` is never touched.
+ */
+
+const CLI_PATH = resolve(import.meta.dir, '../../dist/facet')
+const REPO_ROOT = resolve(import.meta.dir, '../../../..')
+
+type ExecResult = {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+/**
+ * Spawn the compiled CLI with the given args and an optional env override.
+ * Always merges onto the current `process.env` so PATH / HOME stay intact.
+ */
+async function runCli(args: string[], env?: Record<string, string>): Promise<ExecResult> {
+  const proc = Bun.spawn([CLI_PATH, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, ...env },
+  })
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  const exitCode = await proc.exited
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode }
+}
+
+/**
+ * Pack the opencode adapter once per test run and extract the tarball.
+ * Returns the extracted `package/` directory path — this mirrors exactly
+ * what `downloadNpmPackage` would produce if the adapter were installed
+ * from npm, without any network I/O.
+ */
+let extractedOpencodeDir: string | undefined
+async function packOpencode(): Promise<string> {
+  if (extractedOpencodeDir) return extractedOpencodeDir
+
+  const adapterDir = resolve(REPO_ROOT, 'packages/adapters/opencode')
+  const workDir = await mkdtemp(join(tmpdir(), 'facet-pack-opencode-'))
+
+  // Run `npm pack --pack-destination <workDir>` inside the adapter directory.
+  // This triggers prepack (rewrites workspace:* deps + hoists publishConfig)
+  // and produces a .tgz identical to what `npm publish` would upload.
+  const packProc = Bun.spawn(['npm', 'pack', '--pack-destination', workDir], {
+    cwd: adapterDir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const packStdout = await new Response(packProc.stdout).text()
+  const packStderr = await new Response(packProc.stderr).text()
+  const packExit = await packProc.exited
+  if (packExit !== 0) {
+    throw new Error(`npm pack failed (${packExit}):\nstdout: ${packStdout}\nstderr: ${packStderr}`)
+  }
+
+  // Find the produced tarball
+  const entries = await readdir(workDir)
+  const tarball = entries.find((name) => name.endsWith('.tgz'))
+  if (!tarball) {
+    throw new Error(`npm pack produced no tarball in ${workDir}`)
+  }
+
+  // Extract the tarball via `tar -xzf`
+  const tarProc = Bun.spawn(['tar', '-xzf', tarball], {
+    cwd: workDir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const tarExit = await tarProc.exited
+  if (tarExit !== 0) {
+    const stderr = await new Response(tarProc.stderr).text()
+    throw new Error(`tar extract failed (${tarExit}): ${stderr}`)
+  }
+
+  extractedOpencodeDir = join(workDir, 'package')
+  return extractedOpencodeDir
+}
+
+/** Absolute path to the SDK source, for fixtures that need to inline it. */
+const ADAPTER_SDK_SOURCE = resolve(REPO_ROOT, 'packages/adapter/src/index.ts')
+
+/**
+ * Write a minimal hand-crafted adapter fixture into `dir`.
+ *
+ * - `unbuilt`: only `package.json` + `src/index.ts`. The source inlines the
+ *   SDK by absolute path so the slow-path Bun.build can find it without
+ *   `bun install` needing to resolve `@agent-facets/adapter` externally.
+ *
+ * - `broken-prebuilt`: `package.json` points at `dist/index.mjs`. That
+ *   bundle imports a package that doesn't exist, simulating a self-contained
+ *   bundle that was published broken. A working `src/index.ts` is also
+ *   written so the slow-path fallback has somewhere to go.
+ *
+ * - `externalized-prebuilt`: `package.json` points at `dist/index.mjs`. That
+ *   bundle imports a runtime dep that IS present in the source tree's
+ *   `node_modules/`, so an in-place verification would succeed — but the
+ *   dep would vanish after `placeAdapter()` copies the bundle to
+ *   `~/.facets/adapters/<name>/adapter.js`. This is the regression scenario
+ *   from PR #142 / Codex review. Our fix verifies the bundle in an isolated
+ *   temp dir (no neighboring node_modules), so the import correctly fails
+ *   and the slow-path fallback kicks in. A working `src/index.ts` is
+ *   provided so the slow path can complete.
+ */
+async function makeMinimalAdapter(
+  dir: string,
+  opts: { kind: 'unbuilt' | 'broken-prebuilt' | 'externalized-prebuilt'; name: string },
+): Promise<void> {
+  await mkdir(dir, { recursive: true })
+
+  const workingSource = `
+import { defineAdapter } from '${ADAPTER_SDK_SOURCE}'
+
+export default defineAdapter({
+  name: '${opts.name}',
+  buildAssetMetadata(data) {
+    return { ok: true, data: (data ?? {}) }
+  },
+})
+`
+
+  if (opts.kind === 'unbuilt') {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify(
+        {
+          name: opts.name,
+          version: '0.0.1',
+          type: 'module',
+          exports: { '.': './src/index.ts' },
+        },
+        null,
+        2,
+      ),
+    )
+    await mkdir(join(dir, 'src'), { recursive: true })
+    await writeFile(join(dir, 'src/index.ts'), workingSource)
+    return
+  }
+
+  if (opts.kind === 'broken-prebuilt') {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify(
+        {
+          name: opts.name,
+          version: '0.0.1',
+          type: 'module',
+          exports: { '.': { import: './dist/index.mjs' } },
+        },
+        null,
+        2,
+      ),
+    )
+    await mkdir(join(dir, 'dist'), { recursive: true })
+    // This import cannot resolve — verifyAdapter()'s dynamic import() will throw
+    // and trigger the slow-path fallback.
+    await writeFile(
+      join(dir, 'dist/index.mjs'),
+      `import { nope } from 'this-package-does-not-exist-anywhere'\nexport default nope\n`,
+    )
+    await mkdir(join(dir, 'src'), { recursive: true })
+    await writeFile(join(dir, 'src/index.ts'), workingSource)
+    return
+  }
+
+  // externalized-prebuilt: dist/index.mjs imports a runtime dep that IS
+  // present in the source tree's node_modules, but the bundle does NOT
+  // inline it. Verifying the bundle in-place would falsely succeed (Node
+  // resolution finds the dep via the source tree). Verifying it from an
+  // isolated temp dir surfaces the missing external — which is exactly
+  // what /the fix added in PR #142 does.
+  const externalDep = 'fixture-runtime-dep'
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify(
+      {
+        name: opts.name,
+        version: '0.0.1',
+        type: 'module',
+        exports: { '.': { import: './dist/index.mjs' } },
+      },
+      null,
+      2,
+    ),
+  )
+  await mkdir(join(dir, 'dist'), { recursive: true })
+  // The published bundle imports an external. If we re-imported it in-place,
+  // Node would resolve `fixture-runtime-dep` via `<sourceDir>/node_modules/`
+  // — but after copy to ~/.facets/adapters/<name>/adapter.js, that lookup
+  // would fail. Our isolation strategy catches that ahead of time.
+  await writeFile(join(dir, 'dist/index.mjs'), `import { adapter } from '${externalDep}'\nexport default adapter\n`)
+  // Plant the runtime dep in node_modules so an in-place verify would succeed.
+  const depDir = join(dir, 'node_modules', externalDep)
+  await mkdir(depDir, { recursive: true })
+  await writeFile(
+    join(depDir, 'package.json'),
+    JSON.stringify({ name: externalDep, version: '1.0.0', type: 'module', main: 'index.mjs' }, null, 2),
+  )
+  await writeFile(
+    join(depDir, 'index.mjs'),
+    `export const adapter = { name: '${opts.name}', buildAssetMetadata() { return { ok: true } } }\n`,
+  )
+  // Working source so the slow-path fallback can rebundle.
+  await mkdir(join(dir, 'src'), { recursive: true })
+  await writeFile(join(dir, 'src/index.ts'), workingSource)
+}
+
+/** Create a fresh temp base dir for FACETS_ADAPTERS_DIR. */
+async function makeBaseDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'facets-install-cli-test-'))
+}
+
+beforeAll(async () => {
+  // Verify the compiled binary exists — if it doesn't, the test suite can't
+  // run. The turbo config declares test depends on build, but surface a
+  // clearer error if somebody runs `bun test` directly without building.
+  try {
+    await stat(CLI_PATH)
+  } catch {
+    throw new Error(`CLI binary not found at ${CLI_PATH}. Run 'bun --filter=agent-facets run build' first.`)
+  }
+})
+
+describe('facet adapter install — fast path from extracted npm tarball', () => {
+  test('installs from a packed tarball using the prebuilt dist/index.mjs', async () => {
+    const extractedDir = await packOpencode()
+    const baseDir = await makeBaseDir()
+    try {
+      const result = await runCli(['adapter', 'install', extractedDir], { FACETS_ADAPTERS_DIR: baseDir })
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Using prebuilt bundle...')
+      expect(result.stdout).toContain('Adapter "opencode" installed successfully.')
+
+      // Adapter should be placed at <baseDir>/opencode/adapter.js
+      const installedBundle = join(baseDir, 'opencode', 'adapter.js')
+      const stats = await stat(installedBundle)
+      expect(stats.isFile()).toBe(true)
+
+      // And should have the same content size as the packed dist/index.mjs,
+      // since the fast path is a direct copy.
+      const sourceBundle = join(extractedDir, 'dist/index.mjs')
+      const sourceStats = await stat(sourceBundle)
+      expect(stats.size).toBe(sourceStats.size)
+    } finally {
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter install — slow path from unbuilt local source', () => {
+  test('bundles from src/index.ts when no prebuilt dist exists', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
+    const adapterDir = join(workDir, 'my-adapter')
+    const baseDir = await makeBaseDir()
+    try {
+      await makeMinimalAdapter(adapterDir, { kind: 'unbuilt', name: 'my-unbuilt-adapter' })
+
+      const result = await runCli(['adapter', 'install', adapterDir], { FACETS_ADAPTERS_DIR: baseDir })
+
+      expect(result.exitCode).toBe(0)
+      // Fast path is NOT used (exports pointed at .ts, classified as 'source')
+      expect(result.stdout).not.toContain('Using prebuilt bundle...')
+      expect(result.stdout).toContain('Adapter "my-unbuilt-adapter" installed successfully.')
+
+      const installedBundle = join(baseDir, 'my-unbuilt-adapter', 'adapter.js')
+      const stats = await stat(installedBundle)
+      expect(stats.isFile()).toBe(true)
+      expect(stats.size).toBeGreaterThan(0)
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+
+  test("does not pollute the user's source tree with .facet-build artifacts", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
+    const adapterDir = join(workDir, 'my-adapter')
+    const baseDir = await makeBaseDir()
+    try {
+      await makeMinimalAdapter(adapterDir, { kind: 'unbuilt', name: 'my-clean-adapter' })
+
+      const result = await runCli(['adapter', 'install', adapterDir], { FACETS_ADAPTERS_DIR: baseDir })
+      expect(result.exitCode).toBe(0)
+
+      // The slow path must NOT write `.facet-build/` (or any other scratch
+      // dir) inside the user's adapter source tree. The historical behavior
+      // wrote to `<sourceDir>/.facet-build/`, which polluted local installs
+      // and left build artifacts behind even after the install completed.
+      await expect(stat(join(adapterDir, '.facet-build'))).rejects.toThrow()
+
+      // Source tree should only contain the files we put there (package.json,
+      // src/, plus bun's node_modules + bun.lock from `bun install`).
+      const entries = await readdir(adapterDir)
+      for (const entry of entries) {
+        expect(entry).not.toBe('.facet-build')
+      }
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter install — slow-path fallback after broken prebuilt', () => {
+  test('falls back to rebundling from source when the prebuilt bundle fails to load', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
+    const adapterDir = join(workDir, 'my-adapter')
+    const baseDir = await makeBaseDir()
+    try {
+      await makeMinimalAdapter(adapterDir, { kind: 'broken-prebuilt', name: 'my-fallback-adapter' })
+
+      const result = await runCli(['adapter', 'install', adapterDir], { FACETS_ADAPTERS_DIR: baseDir })
+
+      expect(result.exitCode).toBe(0)
+      // Fast path is attempted then rejected — both logs should appear
+      expect(result.stdout).toContain('Using prebuilt bundle...')
+      expect(result.stdout).toContain('Prebuilt bundle did not load cleanly')
+      expect(result.stdout).toContain('Rebundling from source')
+      expect(result.stdout).toContain('Adapter "my-fallback-adapter" installed successfully.')
+
+      // No double resolution: `Using prebuilt bundle...` must appear exactly
+      // once. If the slow-path dispatch erroneously called bundleAdapter()
+      // (which re-runs resolveEntryPoint), a stale prebuilt could be picked
+      // again and we'd see the log twice. Guards against the regression
+      // described in the Cursor review for PR #142.
+      const prebuiltLogCount = (result.stdout.match(/Using prebuilt bundle\.\.\./g) ?? []).length
+      expect(prebuiltLogCount).toBe(1)
+
+      const installedBundle = join(baseDir, 'my-fallback-adapter', 'adapter.js')
+      const stats = await stat(installedBundle)
+      expect(stats.isFile()).toBe(true)
+      expect(stats.size).toBeGreaterThan(0)
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter install — externalized prebuilt (PR #142 P1 regression)', () => {
+  test('rejects an in-place-verifiable prebuilt that depends on the source tree node_modules', async () => {
+    // This guards against the Codex P1 from PR #142: a prebuilt bundle
+    // that imports externals which happen to be present in the source
+    // tree's `node_modules/` would falsely pass the old in-place
+    // verification, then break later when copied to ~/.facets/adapters.
+    // The fix verifies the bundle in an isolated tmpdir (no node_modules
+    // siblings), so unresolved externals fail fast and we fall back to
+    // the slow path.
+    const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
+    const adapterDir = join(workDir, 'my-adapter')
+    const baseDir = await makeBaseDir()
+    try {
+      await makeMinimalAdapter(adapterDir, { kind: 'externalized-prebuilt', name: 'my-externalized-adapter' })
+
+      const result = await runCli(['adapter', 'install', adapterDir], { FACETS_ADAPTERS_DIR: baseDir })
+
+      expect(result.exitCode).toBe(0)
+      // The fast path is tried (the bundle looks OK from package.json's
+      // POV) but isolated verification fails because `fixture-runtime-dep`
+      // can't be resolved away from the source tree.
+      expect(result.stdout).toContain('Using prebuilt bundle...')
+      expect(result.stdout).toContain('Prebuilt bundle did not load cleanly')
+      expect(result.stdout).toContain('Rebundling from source')
+      expect(result.stdout).toContain('Adapter "my-externalized-adapter" installed successfully.')
+
+      // The placed bundle should be the rebundled (self-contained) output,
+      // NOT the original dist/index.mjs. We assert by comparing sizes:
+      // the rebundled file inlines `fixture-runtime-dep` so it must be
+      // strictly larger than the 2-line stub in dist/index.mjs.
+      const installedBundle = join(baseDir, 'my-externalized-adapter', 'adapter.js')
+      const installedStats = await stat(installedBundle)
+      const sourceStats = await stat(join(adapterDir, 'dist/index.mjs'))
+      expect(installedStats.size).toBeGreaterThan(sourceStats.size)
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter install — temp dir cleanup (PR #142 follow-up)', () => {
+  test('does not leak facet-adapter-build-* dirs in tmpdir after a slow-path install', async () => {
+    // Regression test for the Copilot-suppressed comment on PR #142:
+    // `rebundleAdapter` creates `mkdtemp(tmpdir(), 'facet-adapter-build-')`
+    // for its build output. Without an explicit cleanup, these would
+    // accumulate in the OS temp directory across installs. Our fix
+    // returns a `cleanup()` from rebundleAdapter and `handleInstall`
+    // calls it in the finally block.
+    //
+    // We can't easily isolate this from other tests running in parallel
+    // (they all share the same tmpdir), so we count `facet-adapter-build-*`
+    // entries before and after THIS install and require the count to be
+    // unchanged. Even if a sibling test creates one mid-flight, our
+    // delta against this single install should be 0.
+    const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
+    const adapterDir = join(workDir, 'my-adapter')
+    const baseDir = await makeBaseDir()
+    try {
+      await makeMinimalAdapter(adapterDir, { kind: 'unbuilt', name: 'cleanup-check-adapter' })
+
+      const before = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
+      const result = await runCli(['adapter', 'install', adapterDir], { FACETS_ADAPTERS_DIR: baseDir })
+      const after = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
+
+      expect(result.exitCode).toBe(0)
+      // The set of facet-adapter-build-* dirs created by THIS install
+      // must be empty after the install completes.
+      const newlyCreated = after.filter((n) => !before.includes(n))
+      expect(newlyCreated).toEqual([])
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+
+  test('also cleans up after the slow-path-fallback (broken-prebuilt) flow', async () => {
+    // Same as above, but for the broken-prebuilt fixture which exercises
+    // the prebuilt → fail → rebundle path.
+    const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
+    const adapterDir = join(workDir, 'my-adapter')
+    const baseDir = await makeBaseDir()
+    try {
+      await makeMinimalAdapter(adapterDir, { kind: 'broken-prebuilt', name: 'cleanup-fallback-adapter' })
+
+      const before = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
+      const result = await runCli(['adapter', 'install', adapterDir], { FACETS_ADAPTERS_DIR: baseDir })
+      const after = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
+
+      expect(result.exitCode).toBe(0)
+      const newlyCreated = after.filter((n) => !before.includes(n))
+      expect(newlyCreated).toEqual([])
+    } finally {
+      await rm(workDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter install + list + remove — round trip', () => {
+  test('all three subcommands share the same FACETS_ADAPTERS_DIR', async () => {
+    const extractedDir = await packOpencode()
+    const baseDir = await makeBaseDir()
+    const env = { FACETS_ADAPTERS_DIR: baseDir }
+    try {
+      // Install
+      const installResult = await runCli(['adapter', 'install', extractedDir], env)
+      expect(installResult.exitCode).toBe(0)
+
+      // List — should show the adapter
+      const listResult = await runCli(['adapter', 'list'], env)
+      expect(listResult.exitCode).toBe(0)
+      expect(listResult.stdout).toContain('opencode')
+      expect(listResult.stdout).not.toContain('No adapters installed')
+
+      // Remove
+      const removeResult = await runCli(['adapter', 'remove', 'opencode'], env)
+      expect(removeResult.exitCode).toBe(0)
+      expect(removeResult.stdout).toContain('Adapter "opencode" removed.')
+
+      // List again — should show empty
+      const listAfterResult = await runCli(['adapter', 'list'], env)
+      expect(listAfterResult.exitCode).toBe(0)
+      expect(listAfterResult.stdout).toContain('No adapters installed')
+      expect(listAfterResult.stdout).not.toContain('opencode')
+
+      // Filesystem confirms
+      const adapterDir = join(baseDir, 'opencode')
+      await expect(stat(adapterDir)).rejects.toThrow()
+    } finally {
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('FACETS_ADAPTERS_DIR redirect', () => {
+  test('install writes to the env-var dir, leaving ~/.facets/adapters untouched', async () => {
+    const extractedDir = await packOpencode()
+    const baseDir = await makeBaseDir()
+    try {
+      // We don't have a safe way to snapshot the user's real ~/.facets/adapters
+      // and compare before/after, so this test asserts the positive: the
+      // adapter DEFINITELY lands in the temp dir. Combined with the fact that
+      // every other test also uses the env var, this guards against anyone
+      // accidentally changing `resolveAdapterBaseDir()` to ignore it.
+      const result = await runCli(['adapter', 'install', extractedDir], { FACETS_ADAPTERS_DIR: baseDir })
+
+      expect(result.exitCode).toBe(0)
+
+      const installedBundle = join(baseDir, 'opencode', 'adapter.js')
+      const stats = await stat(installedBundle)
+      expect(stats.isFile()).toBe(true)
+    } finally {
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter install — error handling', () => {
+  test('install from a nonexistent local path exits 1 with a clear error', async () => {
+    const baseDir = await makeBaseDir()
+    const missingPath = join(baseDir, 'does-not-exist')
+    try {
+      const result = await runCli(['adapter', 'install', missingPath], { FACETS_ADAPTERS_DIR: baseDir })
+
+      expect(result.exitCode).toBe(1)
+      // Error should mention the path or "does not exist" / "not an adapter"
+      const combined = `${result.stdout}\n${result.stderr}`
+      expect(combined.toLowerCase()).toMatch(/does not exist|not.*adapter|no such file/)
+
+      // No adapter should have been placed
+      const entries = await readdir(baseDir).catch(() => [])
+      // The temp dir is empty except for any other files tests created (none)
+      expect(entries.filter((e) => !e.startsWith('.'))).toEqual([])
+    } finally {
+      await rm(baseDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/__tests__/placement.test.ts
+++ b/packages/cli/src/__tests__/placement.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { getAdapterBaseDir, getAdapterBundlePath, getAdapterDir } from '../commands/adapter/placement.ts'
+
+/**
+ * Unit tests for `placement.ts`'s env-var handling. Specifically validates
+ * that `FACETS_ADAPTERS_DIR` is treated robustly:
+ *   - Unset → default (~/.facets/adapters)
+ *   - Empty string → default
+ *   - Whitespace-only → default
+ *   - Whitespace-padded → trimmed
+ *
+ * The end-to-end CLI tests cover the happy path; these tests cover the
+ * edge cases that motivated the Copilot review feedback on PR #142.
+ */
+
+const ENV_VAR = 'FACETS_ADAPTERS_DIR'
+const DEFAULT_DIR = join(homedir(), '.facets', 'adapters')
+
+let originalValue: string | undefined
+
+beforeEach(() => {
+  originalValue = process.env[ENV_VAR]
+  delete process.env[ENV_VAR]
+})
+
+afterEach(() => {
+  if (originalValue === undefined) {
+    delete process.env[ENV_VAR]
+  } else {
+    process.env[ENV_VAR] = originalValue
+  }
+})
+
+describe('getAdapterBaseDir — FACETS_ADAPTERS_DIR handling', () => {
+  test('returns the default ~/.facets/adapters when env var is unset', () => {
+    expect(getAdapterBaseDir()).toBe(DEFAULT_DIR)
+  })
+
+  test('returns the default when env var is set to empty string', () => {
+    process.env[ENV_VAR] = ''
+    expect(getAdapterBaseDir()).toBe(DEFAULT_DIR)
+  })
+
+  test('returns the default when env var is whitespace-only (spaces)', () => {
+    process.env[ENV_VAR] = '   '
+    expect(getAdapterBaseDir()).toBe(DEFAULT_DIR)
+  })
+
+  test('returns the default when env var is whitespace-only (tabs and newlines)', () => {
+    process.env[ENV_VAR] = '\t\n  '
+    expect(getAdapterBaseDir()).toBe(DEFAULT_DIR)
+  })
+
+  test('returns the env-var value when set to a valid path', () => {
+    process.env[ENV_VAR] = '/tmp/my-custom-adapters'
+    expect(getAdapterBaseDir()).toBe('/tmp/my-custom-adapters')
+  })
+
+  test('trims surrounding whitespace from the env-var value', () => {
+    process.env[ENV_VAR] = '  /tmp/padded-adapters  '
+    expect(getAdapterBaseDir()).toBe('/tmp/padded-adapters')
+  })
+})
+
+describe('getAdapterDir / getAdapterBundlePath — env-var propagation', () => {
+  test('getAdapterDir uses the resolved base dir when no override is passed', () => {
+    process.env[ENV_VAR] = '/tmp/from-env'
+    expect(getAdapterDir('opencode')).toBe('/tmp/from-env/opencode')
+  })
+
+  test('getAdapterBundlePath uses the resolved base dir when no override is passed', () => {
+    process.env[ENV_VAR] = '/tmp/from-env'
+    expect(getAdapterBundlePath('opencode')).toBe('/tmp/from-env/opencode/adapter.js')
+  })
+
+  test('getAdapterDir prefers the explicit baseDir argument over the env var', () => {
+    process.env[ENV_VAR] = '/tmp/from-env'
+    expect(getAdapterDir('opencode', '/tmp/explicit')).toBe('/tmp/explicit/opencode')
+  })
+
+  test('falls back to default when env var is empty AND no explicit baseDir is passed', () => {
+    process.env[ENV_VAR] = ''
+    expect(getAdapterDir('opencode')).toBe(join(DEFAULT_DIR, 'opencode'))
+  })
+})

--- a/packages/cli/src/commands/adapter/bundler.ts
+++ b/packages/cli/src/commands/adapter/bundler.ts
@@ -1,16 +1,74 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 /**
- * Bundles an adapter source directory into a self-contained adapter.js file.
+ * The result of building (or locating) an adapter bundle. Includes the
+ * absolute path to the bundle and a `cleanup` function that removes any
+ * temp directory the build created. Callers MUST invoke `cleanup()` after
+ * they're done consuming `bundlePath` (typically in a `finally` block).
  *
- * Steps:
- * 1. Run `bun install` in the source directory to install dependencies
- * 2. Run `Bun.build()` on the entry point to produce a single bundled .js file
+ * The fast path returns a no-op `cleanup` since `bundlePath` points at
+ * a file inside the source tree (or inside the source-tree temp dir,
+ * which has its own cleanup lifecycle).
+ */
+export type BundleResult = {
+  bundlePath: string
+  cleanup: () => Promise<void>
+}
+
+/** A no-op cleanup, used when the fast path needs no temp dir. */
+const noopCleanup = async (): Promise<void> => {}
+
+/**
+ * Produces an adapter bundle path the CLI can install.
+ *
+ * Adapters SHOULD ship a pre-built, fully self-contained ESM bundle at
+ * `dist/index.mjs` (produced by `tsdown` with `noExternal` covering all
+ * runtime deps). When that bundle is present, the fast path simply locates
+ * and returns it — no `bun install`, no re-bundling, no network I/O.
+ *
+ * When the fast path is not available (e.g. a third-party adapter with no
+ * prebuilt dist, a local source tree during development, a git install
+ * without committed build output), the slow path kicks in: run `bun install`
+ * in the source directory and re-bundle the resolved entry point with
+ * `Bun.build()`.
  *
  * @param sourceDir - Path to the adapter source (must contain package.json)
- * @returns Path to the built adapter.js file
+ * @returns A `BundleResult` with the bundle path and a cleanup function.
  */
-export async function bundleAdapter(sourceDir: string): Promise<string> {
+export async function bundleAdapter(sourceDir: string): Promise<BundleResult> {
+  const resolved = await resolveEntryPoint(sourceDir)
+
+  // Fast path: adapter ships a prebuilt bundle. Return it directly — no
+  // install, no build. Verify step will dynamically import() it to confirm
+  // it loads without missing externals; if that fails, the caller will fall
+  // back to the slow path via `rebundleAdapter`.
+  if (resolved.kind === 'prebuilt') {
+    return { bundlePath: resolved.path, cleanup: noopCleanup }
+  }
+
+  // Slow path: source tree (e.g. unbuilt local adapter). Run `bun install`
+  // and re-bundle with Bun.build().
+  return rebundleAdapter(sourceDir, resolved.path)
+}
+
+/**
+ * Slow path: install dependencies in `sourceDir` and bundle `entryPoint`
+ * into a self-contained .js file.
+ *
+ * The bundle output is written to a fresh `mkdtemp` directory (NOT inside
+ * `sourceDir`), so local installs from a user's source tree don't leave
+ * build artifacts behind. Returns the bundle path along with a `cleanup`
+ * function that removes the temp directory; callers MUST invoke `cleanup()`
+ * after consuming the bundle (typically in a `finally` block) so we don't
+ * accumulate `facet-adapter-build-*` dirs in the OS temp directory.
+ *
+ * Exported separately so callers can also invoke it as a retry fallback
+ * when the fast path's prebuilt bundle fails to load (e.g. missing
+ * externals, truncated file).
+ */
+export async function rebundleAdapter(sourceDir: string, entryPoint: string): Promise<BundleResult> {
   // Step 1: Install dependencies
   const installResult = Bun.spawnSync(['bun', 'install', '--frozen-lockfile'], {
     cwd: sourceDir,
@@ -30,37 +88,76 @@ export async function bundleAdapter(sourceDir: string): Promise<string> {
     }
   }
 
-  // Step 2: Determine entry point
-  const entryPoint = await resolveEntryPoint(sourceDir)
+  // Step 2: Bundle with Bun.build() into a fresh temp directory. Writing
+  // outside of `sourceDir` keeps local installs from polluting the user's
+  // source tree.
+  const outdir = await mkdtemp(join(tmpdir(), 'facet-adapter-build-'))
+  const cleanup = async (): Promise<void> => {
+    await rm(outdir, { recursive: true, force: true }).catch(() => {})
+  }
 
-  // Step 3: Bundle with Bun.build()
-  const outdir = join(sourceDir, '.facet-build')
-  const buildResult = await Bun.build({
-    entrypoints: [entryPoint],
-    outdir,
-    target: 'bun',
-    format: 'esm',
-  })
+  let buildResult: Awaited<ReturnType<typeof Bun.build>>
+  try {
+    buildResult = await Bun.build({
+      entrypoints: [entryPoint],
+      outdir,
+      target: 'bun',
+      format: 'esm',
+    })
+  } catch (err) {
+    // If Bun.build itself throws (rare — usually it returns a result with
+    // success: false), make sure we don't leak the outdir.
+    await cleanup()
+    throw err
+  }
 
   if (!buildResult.success) {
+    await cleanup()
     const errors = buildResult.logs.map((l) => l.message).join('\n')
     throw new Error(`Failed to bundle adapter from "${sourceDir}":\n${errors}`)
   }
 
-  // The output file should be at .facet-build/index.js (or similar)
   const outputFile = buildResult.outputs[0]
   if (!outputFile) {
+    await cleanup()
     throw new Error(`Bun.build() produced no output for "${sourceDir}"`)
   }
 
-  return outputFile.path
+  return { bundlePath: outputFile.path, cleanup }
+}
+
+/**
+ * Classification of the resolved entry point:
+ *   - `prebuilt`: points at a `.mjs`/`.js` file — assume it's ready to load.
+ *   - `source`: points at a TypeScript source or an unbuilt entry —
+ *     must go through the slow path (install + build).
+ */
+export type ResolvedEntryPoint = {
+  path: string
+  kind: 'prebuilt' | 'source'
+}
+
+/** Classify a resolved path by its file extension. */
+function classify(path: string): 'prebuilt' | 'source' {
+  return path.endsWith('.mjs') || path.endsWith('.js') || path.endsWith('.cjs') ? 'prebuilt' : 'source'
 }
 
 /**
  * Resolves the entry point for an adapter package.
- * Reads package.json to find the exports/main field.
+ *
+ * Resolution order (first match wins):
+ *   1. `exports` as a string.
+ *   2. `exports["."]` as a string.
+ *   3. `exports["."]` as an object with a string `import` field.
+ *   4. `main` as a string.
+ *   5. Disk fallback: `dist/index.mjs`.
+ *   6. Disk fallback: `dist/index.js`.
+ *   7. Disk fallback: `src/index.ts` (unbuilt local source).
+ *   8. Throws, listing every location that was tried.
+ *
+ * Exported for direct unit testing.
  */
-async function resolveEntryPoint(sourceDir: string): Promise<string> {
+export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntryPoint> {
   const pkgJsonPath = join(sourceDir, 'package.json')
   const pkgFile = Bun.file(pkgJsonPath)
 
@@ -69,30 +166,69 @@ async function resolveEntryPoint(sourceDir: string): Promise<string> {
   }
 
   const pkg = (await pkgFile.json()) as {
-    exports?: Record<string, string> | string
+    exports?: string | { '.'?: string | { import?: string } }
     main?: string
   }
 
-  // Check exports["."] first, then main
-  let entry: string | undefined
+  const tried: string[] = []
+
+  // 1. `exports` as a string
   if (typeof pkg.exports === 'string') {
-    entry = pkg.exports
-  } else if (pkg.exports && typeof pkg.exports['.'] === 'string') {
-    entry = pkg.exports['.']
-  } else if (pkg.main) {
-    entry = pkg.main
-  }
-
-  if (!entry) {
-    // Default fallback: try src/index.ts
-    const defaultEntry = join(sourceDir, 'src/index.ts')
-    if (await Bun.file(defaultEntry).exists()) {
-      return defaultEntry
+    const absolute = join(sourceDir, pkg.exports)
+    tried.push(`exports: "${pkg.exports}"`)
+    if (await Bun.file(absolute).exists()) {
+      return { path: absolute, kind: classify(absolute) }
     }
-    throw new Error(
-      `Cannot determine entry point for adapter in "${sourceDir}". Set "exports" or "main" in package.json.`,
-    )
   }
 
-  return join(sourceDir, entry)
+  // 2. `exports["."]` as a string
+  if (pkg.exports && typeof pkg.exports === 'object' && typeof pkg.exports['.'] === 'string') {
+    const relative = pkg.exports['.']
+    const absolute = join(sourceDir, relative)
+    tried.push(`exports["."]: "${relative}"`)
+    if (await Bun.file(absolute).exists()) {
+      return { path: absolute, kind: classify(absolute) }
+    }
+  }
+
+  // 3. `exports["."]` as an object with a string `import` field
+  if (
+    pkg.exports &&
+    typeof pkg.exports === 'object' &&
+    typeof pkg.exports['.'] === 'object' &&
+    pkg.exports['.'] &&
+    typeof pkg.exports['.'].import === 'string'
+  ) {
+    const relative = pkg.exports['.'].import
+    const absolute = join(sourceDir, relative)
+    tried.push(`exports["."].import: "${relative}"`)
+    if (await Bun.file(absolute).exists()) {
+      return { path: absolute, kind: classify(absolute) }
+    }
+  }
+
+  // 4. `main` as a string
+  if (typeof pkg.main === 'string') {
+    const absolute = join(sourceDir, pkg.main)
+    tried.push(`main: "${pkg.main}"`)
+    if (await Bun.file(absolute).exists()) {
+      return { path: absolute, kind: classify(absolute) }
+    }
+  }
+
+  // 5-7. Disk fallbacks in order
+  const diskFallbacks = ['dist/index.mjs', 'dist/index.js', 'src/index.ts']
+  for (const relative of diskFallbacks) {
+    const absolute = join(sourceDir, relative)
+    tried.push(`disk: "${relative}"`)
+    if (await Bun.file(absolute).exists()) {
+      return { path: absolute, kind: classify(absolute) }
+    }
+  }
+
+  throw new Error(
+    `Cannot determine entry point for adapter in "${sourceDir}". ` +
+      `Tried:\n  - ${tried.join('\n  - ')}\n` +
+      `Set "exports" or "main" in package.json, or ship a prebuilt dist/index.mjs.`,
+  )
 }

--- a/packages/cli/src/commands/adapter/index.ts
+++ b/packages/cli/src/commands/adapter/index.ts
@@ -1,6 +1,9 @@
-import { rm } from 'node:fs/promises'
+import { cp, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
 import type { Command } from '../../commands.ts'
-import { bundleAdapter } from './bundler.ts'
+import { rebundleAdapter, resolveEntryPoint } from './bundler.ts'
 import { listInstalledAdapters, placeAdapter, removeAdapter } from './placement.ts'
 import { cloneGitRepository } from './sources/git.ts'
 import { resolveLocalPath } from './sources/local.ts'
@@ -59,6 +62,7 @@ async function handleInstall(args: string[]): Promise<number> {
   const resolved = parseSpecifier(specifier)
   let sourceDir: string | undefined
   let needsCleanup = true
+  let bundleCleanup: (() => Promise<void>) | undefined
 
   try {
     // Step 1: Resolve source
@@ -79,29 +83,132 @@ async function handleInstall(args: string[]): Promise<number> {
         break
     }
 
-    // Step 2: Bundle
-    console.log('Bundling adapter...')
-    const bundlePath = await bundleAdapter(sourceDir)
+    // Step 2: Locate / build the bundle, with fast-path + slow-path fallback.
+    //   - Fast path: adapter ships a prebuilt dist/index.mjs — return it directly.
+    //   - If that bundle fails to load (missing externals, corrupt, etc.),
+    //     fall back to the slow path: bun install + Bun.build() on the
+    //     package's entry point.
+    const located = await locateAndVerifyAdapter(sourceDir)
+    bundleCleanup = located.cleanup
 
-    // Step 3: Verify
-    console.log('Verifying adapter...')
-    const adapter = await verifyAdapter(bundlePath)
+    // Step 3: Place
+    console.log(`Installing adapter "${located.adapter.name}"...`)
+    await placeAdapter(located.adapter.name, located.bundlePath)
 
-    // Step 4: Place
-    console.log(`Installing adapter "${adapter.name}"...`)
-    await placeAdapter(adapter.name, bundlePath)
-
-    console.log(`Adapter "${adapter.name}" installed successfully.`)
+    console.log(`Adapter "${located.adapter.name}" installed successfully.`)
     return 0
   } catch (err) {
     console.error(`Failed to install adapter: ${err instanceof Error ? err.message : String(err)}`)
     return 1
   } finally {
-    // Clean up temp directory if needed
+    // Clean up the slow-path build output dir, if any.
+    if (bundleCleanup) {
+      await bundleCleanup()
+    }
+    // Clean up source temp directory if needed
     if (needsCleanup && sourceDir) {
       await rm(sourceDir, { recursive: true, force: true }).catch(() => {})
     }
   }
+}
+
+/** A no-op cleanup, used when the fast path needs no temp dir. */
+const noopCleanup = async (): Promise<void> => {}
+
+/**
+ * Locates a usable adapter bundle from `sourceDir` and verifies it loads.
+ *
+ * Tries the fast path first (prebuilt `dist/index.mjs` or whatever the
+ * package's `exports`/`main` points at). If the fast-path bundle fails to
+ * load — typically because it still has unresolved external imports — falls
+ * back to the slow path: `bun install` + `Bun.build()` on the resolved
+ * entry point.
+ *
+ * Fast-path verification is performed by copying the candidate bundle into
+ * a freshly-created temp directory and importing it from there. This is
+ * critical: if we imported it in-place, Node's module resolution would
+ * find unresolved externals via the source tree's neighboring
+ * `node_modules/`, falsely reporting success — only for the bundle to fail
+ * to load later, after `placeAdapter()` copies it to
+ * `~/.facets/adapters/<name>/adapter.js` where no such `node_modules` exists.
+ * The isolated verification dir has no `node_modules`, so any unresolved
+ * import fails fast and triggers the slow-path fallback.
+ *
+ * Returns the path to the final bundle, the verified Adapter object, and a
+ * `cleanup` function that removes any temp build output created by the
+ * slow path. The caller is responsible for invoking `cleanup()` after
+ * placement (e.g. in a `finally` block). The fast path returns a no-op
+ * cleanup since the original `resolved.path` is owned by the source tree
+ * (or the source-tree temp dir, which has its own cleanup).
+ *
+ * Exported for integration testing.
+ */
+export async function locateAndVerifyAdapter(
+  sourceDir: string,
+): Promise<{ bundlePath: string; adapter: Adapter; cleanup: () => Promise<void> }> {
+  const resolved = await resolveEntryPoint(sourceDir)
+
+  // Fast path candidate: the resolver returned a prebuilt .mjs/.js.
+  if (resolved.kind === 'prebuilt') {
+    console.log('Using prebuilt bundle...')
+    const verifyResult = await verifyPrebuiltInIsolation(resolved.path)
+    if (verifyResult.ok) {
+      return { bundlePath: resolved.path, adapter: verifyResult.adapter, cleanup: noopCleanup }
+    }
+    console.log(`Prebuilt bundle did not load cleanly (${verifyResult.message}). Rebundling from source...`)
+    // Fall through to slow path. Re-resolve the source entry: the prebuilt
+    // path itself is unusable as a build entrypoint, so prefer src/index.ts.
+    const sourceEntry = await resolveSourceEntry(sourceDir, resolved.path)
+    const built = await rebundleAdapter(sourceDir, sourceEntry)
+    const adapter = await verifyAdapter(built.bundlePath)
+    return { bundlePath: built.bundlePath, adapter, cleanup: built.cleanup }
+  }
+
+  // Source-kind entry: feed `resolved.path` straight into rebundleAdapter.
+  // We deliberately do NOT call `bundleAdapter(sourceDir)` here, even
+  // though it would do the same thing — that would re-run `resolveEntryPoint`,
+  // and if filesystem state has changed (e.g. a prebuilt has appeared) it
+  // could incorrectly take the fast path and bypass the install+build we
+  // just decided we need.
+  const built = await rebundleAdapter(sourceDir, resolved.path)
+  const adapter = await verifyAdapter(built.bundlePath)
+  return { bundlePath: built.bundlePath, adapter, cleanup: built.cleanup }
+}
+
+/**
+ * Verifies a prebuilt bundle by copying it into a fresh temp directory
+ * (with no `node_modules` siblings) and importing it from there.
+ *
+ * Returns a discriminated result rather than throwing, so the caller can
+ * trivially distinguish "bundle is good, here's the adapter" from "bundle
+ * failed, here's why we're falling through to the slow path" without
+ * re-stringifying error messages.
+ */
+async function verifyPrebuiltInIsolation(
+  prebuiltPath: string,
+): Promise<{ ok: true; adapter: Adapter } | { ok: false; message: string }> {
+  const isolationDir = await mkdtemp(join(tmpdir(), 'facet-adapter-verify-'))
+  try {
+    const isolatedPath = join(isolationDir, basename(prebuiltPath))
+    await cp(prebuiltPath, isolatedPath)
+    const adapter = await verifyAdapter(isolatedPath)
+    return { ok: true, adapter }
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  } finally {
+    await rm(isolationDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+/**
+ * When the fast-path prebuilt bundle fails, find a source-level entry to
+ * feed into `rebundleAdapter()`. Prefers `src/index.ts` if present;
+ * otherwise reuses the original resolved path (it may still be usable as
+ * a Bun.build entrypoint).
+ */
+async function resolveSourceEntry(sourceDir: string, fallbackEntry: string): Promise<string> {
+  const srcIndex = join(sourceDir, 'src/index.ts')
+  return (await Bun.file(srcIndex).exists()) ? srcIndex : fallbackEntry
 }
 
 async function handleList(): Promise<number> {

--- a/packages/cli/src/commands/adapter/placement.ts
+++ b/packages/cli/src/commands/adapter/placement.ts
@@ -2,26 +2,53 @@ import { mkdir, rm } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-/** Default base directory for installed adapters */
-const ADAPTER_BASE_DIR = join(homedir(), '.facets', 'adapters')
-
 /** The filename for the bundled adapter file */
 const ADAPTER_BUNDLE_FILENAME = 'adapter.js'
 
 /**
+ * Resolves the base directory for installed adapters.
+ *
+ * Precedence:
+ *   1. `process.env.FACETS_ADAPTERS_DIR` — if set to a non-empty value,
+ *      overrides the default. Whitespace-only values are treated as unset
+ *      (and trimmed if otherwise valid) so that misconfigurations like
+ *      `FACETS_ADAPTERS_DIR=` or `FACETS_ADAPTERS_DIR=" "` don't cause
+ *      installs to land in a relative path.
+ *   2. Default: `~/.facets/adapters`.
+ *
+ * The env var is currently the ONLY supported override mechanism. A per-
+ * install `--target-dir` CLI flag was considered but deliberately deferred:
+ * a per-install override would require persistent config so that later
+ * invocations (`facet adapter list`, `facet build`, etc.) could locate
+ * adapters installed to a non-default location. That requires real config
+ * plumbing which isn't built yet.
+ *
+ * Because this function reads `process.env` on every call (rather than at
+ * module-evaluation time), Bun test runs can redirect the dir per-test by
+ * spawning the binary with a different `FACETS_ADAPTERS_DIR` in each
+ * subprocess, without the env var being captured by a cached constant.
+ */
+function resolveAdapterBaseDir(): string {
+  const override = process.env.FACETS_ADAPTERS_DIR?.trim()
+  return override ? override : join(homedir(), '.facets', 'adapters')
+}
+
+/**
  * Returns the default base directory for all installed adapters.
+ * Respects `FACETS_ADAPTERS_DIR` if set.
  */
 export function getAdapterBaseDir(): string {
-  return ADAPTER_BASE_DIR
+  return resolveAdapterBaseDir()
 }
 
 /**
  * Returns the path to a specific adapter's directory.
  *
  * @param name - The adapter name
- * @param baseDir - Base directory for installed adapters (defaults to `~/.facets/adapters`)
+ * @param baseDir - Base directory for installed adapters (defaults to the
+ *   resolved base dir, which honors `FACETS_ADAPTERS_DIR`).
  */
-export function getAdapterDir(name: string, baseDir: string = ADAPTER_BASE_DIR): string {
+export function getAdapterDir(name: string, baseDir: string = resolveAdapterBaseDir()): string {
   return join(baseDir, name)
 }
 
@@ -29,9 +56,10 @@ export function getAdapterDir(name: string, baseDir: string = ADAPTER_BASE_DIR):
  * Returns the path to an adapter's bundle file.
  *
  * @param name - The adapter name
- * @param baseDir - Base directory for installed adapters (defaults to `~/.facets/adapters`)
+ * @param baseDir - Base directory for installed adapters (defaults to the
+ *   resolved base dir, which honors `FACETS_ADAPTERS_DIR`).
  */
-export function getAdapterBundlePath(name: string, baseDir: string = ADAPTER_BASE_DIR): string {
+export function getAdapterBundlePath(name: string, baseDir: string = resolveAdapterBaseDir()): string {
   return join(baseDir, name, ADAPTER_BUNDLE_FILENAME)
 }
 
@@ -40,12 +68,13 @@ export function getAdapterBundlePath(name: string, baseDir: string = ADAPTER_BAS
  *
  * @param name - The adapter name (used as the directory name)
  * @param bundlePath - Absolute path to the built adapter.js file
- * @param baseDir - Base directory for installed adapters (defaults to `~/.facets/adapters`)
+ * @param baseDir - Base directory for installed adapters (defaults to the
+ *   resolved base dir, which honors `FACETS_ADAPTERS_DIR`).
  */
 export async function placeAdapter(
   name: string,
   bundlePath: string,
-  baseDir: string = ADAPTER_BASE_DIR,
+  baseDir: string = resolveAdapterBaseDir(),
 ): Promise<void> {
   const adapterDir = getAdapterDir(name, baseDir)
   await mkdir(adapterDir, { recursive: true })
@@ -59,10 +88,11 @@ export async function placeAdapter(
  * Removes an installed adapter by deleting its directory.
  *
  * @param name - The adapter name to remove
- * @param baseDir - Base directory for installed adapters (defaults to `~/.facets/adapters`)
+ * @param baseDir - Base directory for installed adapters (defaults to the
+ *   resolved base dir, which honors `FACETS_ADAPTERS_DIR`).
  * @returns true if the adapter was removed, false if it didn't exist
  */
-export async function removeAdapter(name: string, baseDir: string = ADAPTER_BASE_DIR): Promise<boolean> {
+export async function removeAdapter(name: string, baseDir: string = resolveAdapterBaseDir()): Promise<boolean> {
   const adapterDir = getAdapterDir(name, baseDir)
   const exists = await Bun.file(join(adapterDir, ADAPTER_BUNDLE_FILENAME)).exists()
 
@@ -77,9 +107,10 @@ export async function removeAdapter(name: string, baseDir: string = ADAPTER_BASE
 /**
  * Lists the names of all installed adapters by scanning the base directory.
  *
- * @param baseDir - Base directory for installed adapters (defaults to `~/.facets/adapters`)
+ * @param baseDir - Base directory for installed adapters (defaults to the
+ *   resolved base dir, which honors `FACETS_ADAPTERS_DIR`).
  */
-export async function listInstalledAdapters(baseDir: string = ADAPTER_BASE_DIR): Promise<string[]> {
+export async function listInstalledAdapters(baseDir: string = resolveAdapterBaseDir()): Promise<string[]> {
   try {
     const { readdir } = await import('node:fs/promises')
     const entries = await readdir(baseDir, { withFileTypes: true })

--- a/packages/cli/turbo.ci.json
+++ b/packages/cli/turbo.ci.json
@@ -6,7 +6,7 @@
       "cache": false
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build", "^build"]
     }
   }
 }

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {},
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build", "^build"]
     }
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ scripts/
 │   ├── notify-failure.ts       # Slack failure notification (on_fail step)
 │   └── test-helpers.ts         # Test utilities (mock helpers, fixtures)
 │
-├── prepack.ts                  # Rewrite workspace:* deps before npm publish
+├── prepack.ts                  # Rewrite workspace:* deps + hoist publishConfig overrides before npm publish
 ├── postpack.ts                 # Restore package.json after pack
 └── check-bun-version.ts        # Verify Bun version matches mise.toml
 ```

--- a/scripts/lib/prepack.test.ts
+++ b/scripts/lib/prepack.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { rewriteWorkspaceDeps, type VersionResolver } from './prepack'
+import { applyPublishConfig, rewriteWorkspaceDeps, type VersionResolver } from './prepack'
 
 /** Helper: creates a resolver from a name→version map. */
 function mockResolver(versions: Record<string, string>): VersionResolver {
@@ -97,7 +97,7 @@ describe('rewriteWorkspaceDeps', () => {
       },
     }
 
-    expect(rewriteWorkspaceDeps(pkg, mockResolver({}))).rejects.toThrow(
+    await expect(rewriteWorkspaceDeps(pkg, mockResolver({}))).rejects.toThrow(
       'prepack: could not resolve workspace package "@my/nonexistent"',
     )
   })
@@ -197,5 +197,189 @@ describe('rewriteWorkspaceDeps', () => {
 
     expect(modified).toBe(true)
     expect((result.devDependencies as Record<string, string>)['@my/core']).toBe('1.0.0')
+  })
+})
+
+describe('applyPublishConfig', () => {
+  test('returns unmodified when no publishConfig is present', () => {
+    const pkg = { name: 'plain-pkg', version: '1.0.0' }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(false)
+    expect(result).toEqual(pkg)
+  })
+
+  test('returns unmodified when publishConfig has no override keys', () => {
+    const pkg = {
+      name: 'npm-only-config',
+      publishConfig: { access: 'public', registry: 'https://registry.npmjs.org' },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(false)
+    expect(result).toEqual(pkg)
+  })
+
+  test('hoists publishConfig.exports object form to top-level exports', () => {
+    const pkg = {
+      name: 'adapter-opencode',
+      exports: { '.': './src/index.ts' },
+      publishConfig: {
+        access: 'public',
+        exports: {
+          '.': { import: './dist/index.mjs', types: './dist/index.d.mts' },
+        },
+      },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(true)
+    expect(result.exports).toEqual({
+      '.': { import: './dist/index.mjs', types: './dist/index.d.mts' },
+    })
+    // publishConfig itself is preserved so npm still reads access/registry
+    expect((result.publishConfig as Record<string, unknown>).access).toBe('public')
+    expect((result.publishConfig as Record<string, unknown>).exports).toEqual({
+      '.': { import: './dist/index.mjs', types: './dist/index.d.mts' },
+    })
+  })
+
+  test('hoists publishConfig.main to top-level main', () => {
+    const pkg = {
+      name: 'cjs-pkg',
+      publishConfig: { main: './dist/index.cjs' },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(true)
+    expect(result.main).toBe('./dist/index.cjs')
+  })
+
+  test('hoists publishConfig.types to top-level types', () => {
+    const pkg = {
+      name: 'typed-pkg',
+      publishConfig: { types: './dist/index.d.ts' },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(true)
+    expect(result.types).toBe('./dist/index.d.ts')
+  })
+
+  test('hoists publishConfig.module to top-level module', () => {
+    const pkg = {
+      name: 'esm-pkg',
+      publishConfig: { module: './dist/index.mjs' },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(true)
+    expect(result.module).toBe('./dist/index.mjs')
+  })
+
+  test('hoists publishConfig.bin to top-level bin', () => {
+    const pkg = {
+      name: 'cli-pkg',
+      publishConfig: { bin: { mycli: './dist/cli.mjs' } },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(true)
+    expect(result.bin).toEqual({ mycli: './dist/cli.mjs' })
+  })
+
+  test('does not hoist npm CLI config keys (access, registry, tag, provenance)', () => {
+    const pkg = {
+      name: 'mixed',
+      publishConfig: {
+        access: 'public',
+        registry: 'https://registry.npmjs.org',
+        tag: 'next',
+        provenance: true,
+      },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(false)
+    // None of these should be hoisted — they stay under publishConfig
+    expect((result as Record<string, unknown>).access).toBeUndefined()
+    expect((result as Record<string, unknown>).registry).toBeUndefined()
+    expect((result as Record<string, unknown>).tag).toBeUndefined()
+    expect((result as Record<string, unknown>).provenance).toBeUndefined()
+  })
+
+  test('hoists override keys but leaves other publishConfig keys untouched', () => {
+    const pkg = {
+      name: 'mixed',
+      publishConfig: {
+        access: 'public',
+        exports: { '.': { import: './dist/index.mjs' } },
+        tag: 'next',
+      },
+    }
+    const { pkg: result, modified } = applyPublishConfig(pkg)
+    expect(modified).toBe(true)
+    expect(result.exports).toEqual({ '.': { import: './dist/index.mjs' } })
+    const pc = result.publishConfig as Record<string, unknown>
+    expect(pc.access).toBe('public')
+    expect(pc.tag).toBe('next')
+  })
+
+  test('does not mutate the input package object', () => {
+    const pkg = {
+      name: 'immutable-input',
+      exports: { '.': './src/index.ts' },
+      publishConfig: { exports: { '.': { import: './dist/index.mjs' } } },
+    }
+    const original = JSON.parse(JSON.stringify(pkg))
+    applyPublishConfig(pkg)
+    expect(pkg).toEqual(original)
+  })
+
+  test('returned object-valued overrides do not share references with the input', () => {
+    // Regression test for the deep-clone-defeated bug spotted by Cursor
+    // in PR #142. Previously the loop pulled overrides from the ORIGINAL
+    // `pkg.publishConfig`, so for object-valued keys like `exports` the
+    // returned `result.exports` shared a reference with the input. That
+    // meant mutating `result.exports` would propagate back to the input.
+    const pkg = {
+      name: 'shared-ref-check',
+      publishConfig: {
+        exports: { '.': { import: './dist/index.mjs', types: './dist/index.d.mts' } },
+        bin: { 'my-cli': './dist/cli.mjs' },
+      },
+    }
+    const { pkg: result } = applyPublishConfig(pkg)
+    const resultExports = result.exports as { '.': { import: string; types: string } }
+    const resultBin = result.bin as { 'my-cli': string }
+
+    // Mutate the result's hoisted overrides
+    resultExports['.'].import = 'mutated-import.mjs'
+    resultBin['my-cli'] = 'mutated-cli.mjs'
+
+    // The original input MUST remain untouched
+    expect(pkg.publishConfig.exports['.'].import).toBe('./dist/index.mjs')
+    expect(pkg.publishConfig.bin['my-cli']).toBe('./dist/cli.mjs')
+
+    // And the references must actually be distinct objects
+    expect(resultExports).not.toBe(pkg.publishConfig.exports)
+    expect(resultExports['.']).not.toBe(pkg.publishConfig.exports['.'])
+    expect(resultBin).not.toBe(pkg.publishConfig.bin)
+  })
+
+  test('composes with rewriteWorkspaceDeps on the same input', async () => {
+    // Simulates the prepack.ts flow: rewrite deps, then apply publishConfig
+    const input = {
+      name: 'adapter-opencode',
+      dependencies: { '@agent-facets/adapter': 'workspace:*' },
+      exports: { '.': './src/index.ts' },
+      publishConfig: {
+        access: 'public',
+        exports: { '.': { import: './dist/index.mjs' } },
+      },
+    }
+
+    const { pkg: afterDeps, modified: depsModified } = await rewriteWorkspaceDeps(
+      input,
+      mockResolver({ '@agent-facets/adapter': '0.3.0' }),
+    )
+    const { pkg: afterPublishConfig, modified: publishConfigModified } = applyPublishConfig(afterDeps)
+
+    expect(depsModified).toBe(true)
+    expect(publishConfigModified).toBe(true)
+    expect((afterPublishConfig.dependencies as Record<string, string>)['@agent-facets/adapter']).toBe('0.3.0')
+    expect(afterPublishConfig.exports).toEqual({ '.': { import: './dist/index.mjs' } })
   })
 })

--- a/scripts/lib/prepack.ts
+++ b/scripts/lib/prepack.ts
@@ -1,13 +1,24 @@
 /**
  * Prepack utilities — rewrites workspace:* dependencies to concrete version
- * specifiers so that `npm publish` produces a valid tarball.
+ * specifiers and applies `publishConfig` field overrides so that
+ * `npm publish` produces a valid tarball.
  *
- * The core logic is a pure function (`rewriteWorkspaceDeps`) that accepts a
- * resolver callback, making it fully testable without touching the filesystem.
+ * The core logic is pure functions (`rewriteWorkspaceDeps`, `applyPublishConfig`)
+ * that are fully testable without touching the filesystem.
  */
 
 /** Dependency field names that may contain workspace: specifiers. */
 const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const
+
+/**
+ * Keys within `publishConfig` that should be hoisted to the top-level package
+ * manifest at publish time. Mirrors pnpm's documented behavior.
+ *
+ * Other `publishConfig` keys (e.g. `access`, `registry`, `tag`, `provenance`)
+ * are npm CLI configuration and remain under `publishConfig` so that
+ * `npm publish` still consumes them.
+ */
+const PUBLISH_CONFIG_OVERRIDE_KEYS = ['exports', 'main', 'types', 'module', 'bin'] as const
 
 /**
  * A version resolver — given a package name, returns its resolved version
@@ -63,6 +74,42 @@ export async function rewriteWorkspaceDeps(
       }
 
       ;(deps as Record<string, string>)[name] = rewritten
+      modified = true
+    }
+  }
+
+  return { pkg: result, modified }
+}
+
+/**
+ * Hoist whitelisted keys from `pkg.publishConfig` to the top-level package
+ * manifest. Mirrors pnpm's `publishConfig` behavior, which npm does not
+ * implement natively.
+ *
+ * Only keys listed in `PUBLISH_CONFIG_OVERRIDE_KEYS` are hoisted. Other keys
+ * (npm CLI config such as `access`, `registry`, `tag`, `provenance`) are
+ * left under `publishConfig` so `npm publish` still consumes them. The
+ * `publishConfig` object itself is preserved on the output.
+ *
+ * Returns `{ pkg, modified }` where `modified` is true if any hoist happened.
+ */
+export function applyPublishConfig(pkg: Record<string, unknown>): { pkg: Record<string, unknown>; modified: boolean } {
+  const publishConfig = pkg.publishConfig
+  if (!publishConfig || typeof publishConfig !== 'object') {
+    return { pkg, modified: false }
+  }
+
+  // Deep-clone so we don't mutate the caller's object
+  const result = JSON.parse(JSON.stringify(pkg)) as Record<string, unknown>
+  // Read overrides from the CLONED publishConfig, not the original — otherwise
+  // object-valued overrides like `exports` would end up sharing references
+  // between input and output, partially defeating the deep clone.
+  const clonedOverrides = result.publishConfig as Record<string, unknown>
+  let modified = false
+
+  for (const key of PUBLISH_CONFIG_OVERRIDE_KEYS) {
+    if (key in clonedOverrides) {
+      result[key] = clonedOverrides[key]
       modified = true
     }
   }

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -2,8 +2,14 @@
  * Prepack entry point — run via `bun <relative-path>/scripts/prepack.ts`
  * from a package directory during `npm publish` or `changeset publish`.
  *
- * Rewrites workspace:* dependencies to concrete versions and saves a
- * backup so that postpack.ts can restore the original.
+ * Does two things before the tarball is packed:
+ *   1. Rewrites workspace:* dependencies to concrete versions.
+ *   2. Hoists whitelisted fields from `publishConfig` (exports, main,
+ *      types, module, bin) to the top-level manifest — mirrors pnpm's
+ *      publishConfig behavior, which npm does not implement natively.
+ *
+ * A backup of the original `package.json` is saved so postpack.ts can
+ * restore it after packing.
  *
  * The monorepo root is discovered by walking upward from the package
  * directory until a `package.json` with a `workspaces` field is found.
@@ -12,7 +18,7 @@
  */
 
 import { dirname, resolve } from 'node:path'
-import { createDiskResolver, rewriteWorkspaceDeps } from './lib/prepack'
+import { applyPublishConfig, createDiskResolver, rewriteWorkspaceDeps } from './lib/prepack'
 
 const cwd = process.cwd()
 const pkgPath = resolve(cwd, 'package.json')
@@ -49,14 +55,21 @@ async function findMonorepoRoot(start: string): Promise<string> {
 const rootDir = await findMonorepoRoot(cwd)
 const resolver = createDiskResolver(rootDir)
 
-const { pkg: rewritten, modified } = await rewriteWorkspaceDeps(pkg, resolver)
+const { pkg: afterDepRewrite, modified: depsModified } = await rewriteWorkspaceDeps(pkg, resolver)
+const { pkg: rewritten, modified: publishConfigModified } = applyPublishConfig(afterDepRewrite)
+
+const modified = depsModified || publishConfigModified
 
 if (modified) {
   // Save backup of the original for postpack restore
   await Bun.file(bakPath).write(original)
   // Write the rewritten package.json
   await Bun.file(pkgPath).write(`${JSON.stringify(rewritten, null, 2)}\n`)
-  console.log('prepack: rewrote workspace:* dependencies to concrete versions')
+
+  const changes: string[] = []
+  if (depsModified) changes.push('rewrote workspace:* dependencies to concrete versions')
+  if (publishConfigModified) changes.push('hoisted publishConfig fields to top-level')
+  console.log(`prepack: ${changes.join('; ')}`)
 } else {
-  console.log('prepack: no workspace:* dependencies found, nothing to rewrite')
+  console.log('prepack: no workspace:* deps and no publishConfig overrides, nothing to rewrite')
 }


### PR DESCRIPTION
### Why

Adapter packages were being published with `@agent-facets/adapter` and `arktype` listed as runtime `dependencies`, meaning consumers would need those packages available in `node_modules` at runtime. Since the CLI loads adapter bundles directly (without a `node_modules` tree), any unresolved external imports would cause the adapter to fail at load time.

### Details

**Bundling fix:** `@agent-facets/adapter` and `arktype` are moved from `dependencies` to `devDependencies` in all three adapter packages (`claude-code`, `opencode`, `codex`). Each adapter's `tsdown.config.ts` is updated to use `deps.alwaysBundle` to inline these packages into the published `dist/index.mjs`, producing a fully self-contained bundle.

**Fast path / slow path install:** The adapter install flow now distinguishes between prebuilt and source entry points. If the resolved entry point is a `.mjs`/`.js` file, the CLI uses it directly without running `bun install` or `Bun.build()`. If the prebuilt bundle fails to load (e.g. missing externals, corrupt file), it falls back to re-bundling from source. Source-kind entries (`.ts`) go straight to the slow path.

**Build artifact isolation:** The slow-path `Bun.build()` output is now written to a `mkdtemp` directory instead of `<sourceDir>/.facet-build/`, so local installs no longer leave build artifacts in the user's source tree.

**`publishConfig` hoisting:** The `prepack.ts` script now applies a second pass after rewriting workspace deps, hoisting whitelisted fields (`exports`, `main`, `types`, `module`, `bin`) from `publishConfig` to the top-level manifest. This mirrors pnpm's behavior, which npm does not implement natively, and allows adapter packages to declare source-level `exports` for local development while publishing dist-level `exports` to npm.

**`FACETS_ADAPTERS_DIR` env var:** The adapter base directory is now resolved dynamically on each call rather than captured as a module-level constant, enabling per-test isolation by setting the env var in subprocess spawns. This is documented in the CLI reference and is the only supported way to override the install location.

### Verification

New unit tests cover `resolveEntryPoint()` across all resolution branches (string exports, conditional exports, `main`, disk fallbacks, missing files, and error cases). New end-to-end integration tests spawn the compiled `facet` binary and exercise the full install/list/remove round trip using a packed tarball of the opencode adapter, an unbuilt local fixture, and a broken-prebuilt fixture that triggers the fallback path. All tests run in isolated temp directories and never touch `~/.facets/adapters/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes adapter packaging and the CLI install/bundling pipeline, which can affect whether adapters load correctly in user environments. New fallback logic and env-based install directory handling reduce failures but broaden the execution paths to validate.
> 
> **Overview**
> **Adapter bundles are now published as self-contained artifacts.** The first-party adapters move runtime deps like `@agent-facets/adapter`/`arktype` out of `dependencies` and configure `tsdown` (`deps.alwaysBundle`) to inline them into `dist/index.mjs`.
> 
> **CLI install now has a prebuilt fast path with verification and fallback.** `facet adapter install` resolves an entry point, directly installs prebuilt `.mjs/.js` bundles when available, and falls back to `bun install` + `Bun.build()` rebundling if the prebuilt bundle fails to `import()`; slow-path output is written to a temp dir instead of polluting the source tree.
> 
> **Publishing and install location controls were tightened.** `scripts/prepack.ts` now hoists select `publishConfig` fields (e.g. `exports`, `main`, `bin`) into the packed manifest, and adapter placement honors `FACETS_ADAPTERS_DIR` (documented in `docs/cli/adapter.mdx`); new unit + end-to-end tests cover entrypoint resolution and install/list/remove flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c0ac097ffbfe2bd50e3d8d9f8809805216a790. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->