### PR TITLE
Split CLI release verification into pre- and post-publish phases

### DIFF
--- a/.changeset/ripe-flowers-invent.md
+++ b/.changeset/ripe-flowers-invent.md
@@ -1,0 +1,12 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/common": patch
+"@agent-facets/core": patch
+---
+
+Bump em all. Test release pipeline

--- a/scripts/lib/io/shell.ts
+++ b/scripts/lib/io/shell.ts
@@ -21,7 +21,8 @@ export const shellIo = {
   turboBuild: () => $`bun turbo build`,
   bunInstall: () => $`bun install`,
   publishCliPackage: () => $`bun scripts/release-cli/publish-cli-package.ts`,
-  verifyCli: (version: string) => $`bun scripts/release-cli/verify.ts ${version}`,
+  verifyPackages: (packages: string[], version: string) =>
+    $`bun scripts/release-cli/verify.ts ${version} ${packages.join(',')}`,
 
   // Filesystem
   readFile: (path: string) => Bun.file(path).text(),

--- a/scripts/release-cli/README.md
+++ b/scripts/release-cli/README.md
@@ -43,7 +43,7 @@ Tag push: agent-facets@X.Y.Z
 | `build.ts`                | `build-cli`                 | Cross-compile 12 standalone binaries                        |
 | `publish-platform.ts`     | `publish-platform` (matrix) | Publish one `@agent-facets/cli-*` package                   |
 | `publish-cli-package.ts`  | (called by finalize)        | Synthesize and publish the `agent-facets` wrapper           |
-| `finalize.ts`             | `finalize-cli`              | Orchestrate: publish wrapper → verify → announce            |
+| `finalize.ts`             | `finalize-cli`              | Orchestrate: verify platforms → publish wrapper → verify wrapper → announce |
 | `verify.ts`               | (called by finalize)        | Verify a given list of packages exists on npm (with retry)  |
 | `seed.ts`                 | (manual, `bun seed:cli`)    | Seed platform package names on npm with v0.0.1 placeholders |
 | `targets.ts`              | (imported)                  | Platform target matrix and pure helper functions            |

--- a/scripts/release-cli/README.md
+++ b/scripts/release-cli/README.md
@@ -27,10 +27,12 @@ Tag push: agent-facets@X.Y.Z
 ┌───────────────────────────────────────────────────────────────┐
 │  finalize.ts                                                  │
 │                                                               │
-│  1. publish-cli-package.ts — synthesize agent-facets wrapper  │
-│     with optionalDependencies → all 12 platform packages      │
-│  2. verify.ts — check all 13 packages exist on npm            │
-│  3. Create GitHub Release + Slack notification                │
+│  1. verify.ts — confirm 12 platform packages on npm           │
+│  2. publish-cli-package.ts — synthesize + publish             │
+│     agent-facets wrapper with optionalDependencies →          │
+│     all 12 platform packages                                  │
+│  3. verify.ts — confirm wrapper on npm                        │
+│  4. Create GitHub Release + Slack notification                │
 └───────────────────────────────────────────────────────────────┘
 ```
 
@@ -42,7 +44,7 @@ Tag push: agent-facets@X.Y.Z
 | `publish-platform.ts`     | `publish-platform` (matrix) | Publish one `@agent-facets/cli-*` package                   |
 | `publish-cli-package.ts`  | (called by finalize)        | Synthesize and publish the `agent-facets` wrapper           |
 | `finalize.ts`             | `finalize-cli`              | Orchestrate: publish wrapper → verify → announce            |
-| `verify.ts`               | (called by finalize)        | Verify all 13 packages exist on npm (with retry)            |
+| `verify.ts`               | (called by finalize)        | Verify a given list of packages exists on npm (with retry)  |
 | `seed.ts`                 | (manual, `bun seed:cli`)    | Seed platform package names on npm with v0.0.1 placeholders |
 | `targets.ts`              | (imported)                  | Platform target matrix and pure helper functions            |
 
@@ -64,6 +66,8 @@ Users install via `npm install agent-facets`. npm resolves the correct platform 
 1. Cross-compiling 12 binaries (can't use `npm publish` on source)
 2. Publishing 12 platform packages first (each in its own CI job to avoid OOM)
 3. Publishing the wrapper package last (it references all 12 via optionalDependencies)
-4. Verifying all 13 packages before announcing (npm registry propagation delay)
+4. Split verification to handle npm registry propagation delay: pre-publish verifies
+   the 12 platforms (so the wrapper's `optionalDependencies` will resolve when users
+   install), and post-publish verifies the wrapper itself before announcing
 
 None of this fits `changeset publish`'s model, so the CLI has its own pipeline.

--- a/scripts/release-cli/finalize.test.ts
+++ b/scripts/release-cli/finalize.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as announce from '../lib/announce'
 import * as ci from '../lib/ci'
-import { SLACK_CHANNELS } from '../lib/constants'
+import { CLI_PACKAGE_NAME, SLACK_CHANNELS } from '../lib/constants'
 import { io } from '../lib/io'
 import { SAMPLE_CHANGELOG, shellPromise, shellResult, silenceIO } from '../lib/test-helpers'
 import { finalize } from './finalize'
+import { platformPackageNames } from './targets'
 
 describe('finalize.ts', () => {
   beforeEach(() => {
@@ -21,7 +22,7 @@ describe('finalize.ts', () => {
   function setupFinalizePath() {
     spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
     spyOn(io, 'publishCliPackage').mockResolvedValue(shellResult())
-    spyOn(io, 'verifyCli').mockResolvedValue(shellResult())
+    spyOn(io, 'verifyPackages').mockResolvedValue(shellResult())
     spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
       { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli' },
     ])
@@ -44,37 +45,47 @@ describe('finalize.ts', () => {
     expect(code).toBe(1)
   })
 
-  test('runs the full verify → publish pipeline', async () => {
+  test('runs the full verify → publish → verify pipeline', async () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
     const publishSpy = spyOn(io, 'publishCliPackage').mockResolvedValue(shellResult())
-    const verifySpy = spyOn(io, 'verifyCli').mockResolvedValue(shellResult())
+    const verifySpy = spyOn(io, 'verifyPackages').mockResolvedValue(shellResult())
 
     const code = await finalize()
 
     expect(code).toBe(0)
     expect(publishSpy).toHaveBeenCalledTimes(1)
-    expect(verifySpy).toHaveBeenCalledTimes(1)
+    expect(verifySpy).toHaveBeenCalledTimes(2)
   })
 
-  test('verifies platform packages before publishing CLI package', async () => {
+  test('verifies platforms, publishes CLI, then verifies CLI wrapper', async () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
-    const callOrder: string[] = []
-    spyOn(io, 'verifyCli').mockImplementation(() => {
-      callOrder.push('verify')
+    const callOrder: Array<{ phase: string; args?: unknown[] }> = []
+    spyOn(io, 'verifyPackages').mockImplementation((packages: string[], version: string) => {
+      callOrder.push({ phase: 'verify', args: [packages, version] })
       return shellPromise()
     })
     spyOn(io, 'publishCliPackage').mockImplementation(() => {
-      callOrder.push('publish')
+      callOrder.push({ phase: 'publish' })
       return shellPromise()
     })
 
     await finalize()
 
-    expect(callOrder).toEqual(['verify', 'publish'])
+    expect(callOrder.map((c) => c.phase)).toEqual(['verify', 'publish', 'verify'])
+
+    // First verify call: the 12 platform packages
+    const firstVerifyArgs = callOrder[0]?.args
+    expect(firstVerifyArgs?.[0]).toEqual(platformPackageNames())
+    expect(firstVerifyArgs?.[1]).toBe('0.4.0')
+
+    // Second verify call: just the CLI wrapper
+    const secondVerifyArgs = callOrder[2]?.args
+    expect(secondVerifyArgs?.[0]).toEqual([CLI_PACKAGE_NAME])
+    expect(secondVerifyArgs?.[1]).toBe('0.4.0')
   })
 
   test('mints GitHub token for release creation', async () => {
@@ -90,15 +101,17 @@ describe('finalize.ts', () => {
     expect(process.env.GITHUB_TOKEN).toBe('gh-token')
   })
 
-  test('passes version to verify', async () => {
+  test('passes version and correct package list to both verify calls', async () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
-    const verifySpy = spyOn(io, 'verifyCli').mockResolvedValue(shellResult())
+    const verifySpy = spyOn(io, 'verifyPackages').mockResolvedValue(shellResult())
 
     await finalize()
 
-    expect(verifySpy).toHaveBeenCalledWith('0.4.0')
+    expect(verifySpy).toHaveBeenCalledTimes(2)
+    expect(verifySpy).toHaveBeenNthCalledWith(1, platformPackageNames(), '0.4.0')
+    expect(verifySpy).toHaveBeenNthCalledWith(2, [CLI_PACKAGE_NAME], '0.4.0')
   })
 
   test('creates GitHub Release after verify', async () => {

--- a/scripts/release-cli/finalize.ts
+++ b/scripts/release-cli/finalize.ts
@@ -20,8 +20,10 @@
 
 import { announceRelease } from '../lib/announce'
 import { loadWorkspacePackages, mintGithubTokens } from '../lib/ci'
+import { CLI_PACKAGE_NAME } from '../lib/constants'
 import { io } from '../lib/io'
 import { parseTag } from '../lib/tags'
+import { platformPackageNames } from './targets'
 
 export async function finalize(): Promise<number> {
   const tag = process.env.CIRCLE_TAG
@@ -41,14 +43,20 @@ export async function finalize(): Promise<number> {
   // Mint GitHub token (for Release creation; npm OIDC is handled by the publish script)
   await mintGithubTokens()
 
-  // Verify platform packages are visible on npm before publishing the CLI package.
+  // Verify the 12 platform packages are visible on npm before publishing the CLI wrapper.
   // The CLI package's optionalDependencies must be resolvable when users install it.
   io.log('Verifying platform packages in registry...')
-  await io.verifyCli(parsed.version)
+  await io.verifyPackages(platformPackageNames(), parsed.version)
 
-  // Publish CLI package to latest (synthesizes from build output, mints its own OIDC token)
+  // Publish CLI package to latest (synthesizes from build output, mints its own OIDC token).
+  // The wrapper is always the LAST package published — users cannot install the new version
+  // until this completes successfully.
   io.log('Publishing CLI package...')
   await io.publishCliPackage()
+
+  // Verify the CLI wrapper itself propagated to npm before announcing.
+  io.log('Verifying CLI package in registry...')
+  await io.verifyPackages([CLI_PACKAGE_NAME], parsed.version)
 
   io.log(`Published ${parsed.name}@${parsed.version} (all platform packages)`)
 

--- a/scripts/release-cli/targets.ts
+++ b/scripts/release-cli/targets.ts
@@ -32,9 +32,14 @@ export interface TargetPackageJson {
   cpu: string[]
 }
 
+/** The 12 platform binary package names (excludes the CLI wrapper). */
+export function platformPackageNames(): string[] {
+  return allTargets.map(packageName)
+}
+
 /** All 13 npm package names: 12 platform binaries + the CLI package. */
 export function allPackageNames(): string[] {
-  return [...allTargets.map(packageName), CLI_PACKAGE_NAME]
+  return [...platformPackageNames(), CLI_PACKAGE_NAME]
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/release-cli/verify.test.ts
+++ b/scripts/release-cli/verify.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { CLI_PACKAGE_NAME } from '../lib/constants'
 import * as npm from '../lib/npm'
-import { allPackageNames } from './targets'
+import { allPackageNames, platformPackageNames } from './targets'
 import { verify } from './verify'
 
 const VERSION = '1.0.0'
 const ALL_PACKAGES = allPackageNames()
+const PLATFORM_PACKAGES = platformPackageNames()
 
 describe('verify.ts', () => {
   beforeEach(() => {
@@ -19,21 +21,45 @@ describe('verify.ts', () => {
   test('returns 0 when all packages are found on first attempt', async () => {
     spyOn(npm, 'versionExists').mockResolvedValue(true)
 
-    const code = await verify(VERSION, 0)
+    const code = await verify(ALL_PACKAGES, VERSION, 0)
 
     expect(code).toBe(0)
   })
 
-  test('verifies all 13 packages (12 platform + main)', async () => {
+  test('verifies all 13 packages (12 platform + main) when given the full list', async () => {
     const veSpy = spyOn(npm, 'versionExists').mockResolvedValue(true)
 
-    await verify(VERSION, 0)
+    await verify(ALL_PACKAGES, VERSION, 0)
 
     const checkedPackages = new Set(veSpy.mock.calls.map(([pkg]) => pkg))
     for (const pkg of ALL_PACKAGES) {
       expect(checkedPackages.has(pkg)).toBe(true)
     }
     expect(checkedPackages.size).toBe(13)
+  })
+
+  test('verifies only the packages provided in the list (platform-only path)', async () => {
+    const veSpy = spyOn(npm, 'versionExists').mockResolvedValue(true)
+
+    await verify(PLATFORM_PACKAGES, VERSION, 0)
+
+    const checkedPackages = new Set(veSpy.mock.calls.map(([pkg]) => pkg))
+    expect(checkedPackages.size).toBe(12)
+    for (const pkg of PLATFORM_PACKAGES) {
+      expect(checkedPackages.has(pkg)).toBe(true)
+    }
+    // CLI wrapper must not be checked when only platforms are passed
+    expect(checkedPackages.has(CLI_PACKAGE_NAME)).toBe(false)
+  })
+
+  test('verifies a single package (CLI wrapper path)', async () => {
+    const veSpy = spyOn(npm, 'versionExists').mockResolvedValue(true)
+
+    await verify([CLI_PACKAGE_NAME], VERSION, 0)
+
+    const checkedPackages = new Set(veSpy.mock.calls.map(([pkg]) => pkg))
+    expect(checkedPackages.size).toBe(1)
+    expect(checkedPackages.has(CLI_PACKAGE_NAME)).toBe(true)
   })
 
   test('retries when some packages are missing, succeeds when they appear', async () => {
@@ -48,7 +74,7 @@ describe('verify.ts', () => {
       return true
     })
 
-    const code = await verify(VERSION, 0)
+    const code = await verify(ALL_PACKAGES, VERSION, 0)
 
     expect(code).toBe(0)
   })
@@ -58,7 +84,7 @@ describe('verify.ts', () => {
 
     spyOn(npm, 'versionExists').mockImplementation(async (pkg: string) => !missing.has(pkg))
 
-    const code = await verify(VERSION, 0)
+    const code = await verify(ALL_PACKAGES, VERSION, 0)
 
     expect(code).toBe(1)
   })
@@ -72,7 +98,7 @@ describe('verify.ts', () => {
       return pkg !== missingPkg
     })
 
-    await verify(VERSION, 0)
+    await verify(ALL_PACKAGES, VERSION, 0)
 
     // Non-missing packages should only be checked once
     for (const pkg of ALL_PACKAGES) {

--- a/scripts/release-cli/verify.ts
+++ b/scripts/release-cli/verify.ts
@@ -1,13 +1,17 @@
 #!/usr/bin/env bun
 
 /**
- * Verify CLI platform packages exist in the npm registry.
+ * Verify packages exist in the npm registry.
  *
- * Checks that all 12 platform packages and the CLI package exist
- * at the expected version. Retries with exponential backoff to handle
- * npm registry propagation delay.
+ * Checks that the given packages exist at the expected version. Retries with
+ * exponential backoff to handle npm registry propagation delay.
  *
- * Usage: bun scripts/release-cli/verify.ts <version>
+ * Usage:
+ *   bun scripts/release-cli/verify.ts <version>
+ *   bun scripts/release-cli/verify.ts <version> <pkg1,pkg2,...>
+ *
+ * If no package list is provided, defaults to all 13 CLI packages
+ * (12 platform binaries + the CLI wrapper) for standalone auditing.
  */
 
 import { versionExists } from '../lib/npm'
@@ -20,12 +24,11 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export async function verify(version: string, initialDelayMs = INITIAL_DELAY_MS): Promise<number> {
-  const packages = allPackageNames()
+export async function verify(packages: string[], version: string, initialDelayMs = INITIAL_DELAY_MS): Promise<number> {
   let pending = new Set(packages)
 
-  console.log(`\n=== Verify CLI Packages ===`)
-  console.log(`\n   Checking ${packages.length} packages at version ${version}...\n`)
+  console.log(`\n=== Verify Packages ===`)
+  console.log(`\n   Checking ${packages.length} package(s) at version ${version}...\n`)
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     if (attempt > 0) {
@@ -47,7 +50,7 @@ export async function verify(version: string, initialDelayMs = INITIAL_DELAY_MS)
     pending = stillPending
 
     if (pending.size === 0) {
-      console.log(`\n=== All ${packages.length} packages verified ===`)
+      console.log(`\n=== All ${packages.length} package(s) verified ===`)
       return 0
     }
 
@@ -67,9 +70,11 @@ export async function verify(version: string, initialDelayMs = INITIAL_DELAY_MS)
 if (import.meta.main) {
   const version = process.argv[2]
   if (!version) {
-    console.error('Usage: bun scripts/release-cli/verify.ts <version>')
+    console.error('Usage: bun scripts/release-cli/verify.ts <version> [pkg1,pkg2,...]')
     process.exit(1)
   }
-  const code = await verify(version)
+  const packagesArg = process.argv[3]
+  const packages = packagesArg ? packagesArg.split(',').filter(Boolean) : allPackageNames()
+  const code = await verify(packages, version)
   process.exit(code)
 }


### PR DESCRIPTION
### Why

The release pipeline previously verified all 13 packages (12 platform binaries + the CLI wrapper) in a single step after publishing the wrapper. This meant the wrapper could be announced before its `optionalDependencies` were resolvable on npm, and there was no confirmation that the wrapper itself had propagated before the GitHub Release and Slack notification were sent.

### Details

The finalize pipeline now runs verification in two distinct phases:

1. **Pre-publish**: Verify the 12 platform packages are visible on npm before publishing the CLI wrapper. This ensures that when users install the newly published wrapper, its `optionalDependencies` will resolve correctly.
2. **Post-publish**: Verify the CLI wrapper itself has propagated to npm before announcing the release.

To support this, `verify.ts` now accepts an explicit package list as its first argument (both as a function parameter and as a CLI argument). When called from the command line without a package list, it defaults to all 13 packages for standalone auditing. The `platformPackageNames()` helper was extracted from `allPackageNames()` in `targets.ts` to make it easy to reference just the 12 platform packages.

### Verification

Tests cover the new two-call verify sequence, asserting that the first call receives the 12 platform package names and the second receives only the CLI wrapper name, both at the correct version. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI release finalization flow and `verify.ts` interface/CLI args, which could break automated publishing/announcement if misconfigured, but scope is limited to release scripts and is covered by updated tests.
> 
> **Overview**
> Updates the CLI release pipeline to **verify npm propagation in two phases**: first confirm the 12 platform binary packages are visible before publishing the `agent-facets` wrapper, then verify the wrapper itself before creating the GitHub Release/Slack announcement.
> 
> Refactors `verify.ts` to accept an explicit package list (function + CLI arg, defaulting to all packages when omitted), adds `platformPackageNames()` in `targets.ts`, and updates `io` (`verifyPackages`) plus tests/docs to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c883944426d522377f2d897daa9c3d118d9ab3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->