### PR TITLE
Publish tags directly...and refactor io stuff

### DIFF
--- a/.changeset/great-phones-bow.md
+++ b/.changeset/great-phones-bow.md
@@ -1,0 +1,12 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/common": patch
+"@agent-facets/core": patch
+---
+
+CircleCI

--- a/docs/contributing/ci-architecture.mdx
+++ b/docs/contributing/ci-architecture.mdx
@@ -51,7 +51,7 @@ Runs on pushes to `main` only. Executes three steps sequentially in a single job
 
 ## Release workflows
 
-Triggered by tag pushes. The tag pattern determines which workflow runs.
+Triggered explicitly via CircleCI API v2 by `scripts/release/tag.ts` after pushing tags (see [Release Pipeline](./release-pipeline#flow) for why we don't rely on tag-push webhooks). The tag pattern determines which workflow within the release pipeline runs.
 
 ### `release` (library packages)
 
@@ -99,11 +99,13 @@ Both workflows send failure notifications via the `notify-failure` reusable comm
 
 CircleCI contexts provide environment variables to jobs.
 
-| Context         | Variables                               | Used by                                    |
-|-----------------|-----------------------------------------|--------------------------------------------|
-| `turbo-cache`   | Turborepo remote cache credentials      | `check`, `main-pipeline`, all release jobs |
-| `bot-context`   | npm OIDC config, GitHub app credentials | `main-pipeline`, all release jobs          |
-| `slack-secrets` | Notification webhook credentials        | `main-pipeline`, all release jobs          |
+| Context         | Variables                                                             | Used by                                    |
+|-----------------|-----------------------------------------------------------------------|--------------------------------------------|
+| `turbo-cache`   | Turborepo remote cache credentials                                    | `check`, `main-pipeline`, all release jobs |
+| `bot-context`   | npm OIDC config, GitHub app credentials, CircleCI API token           | `main-pipeline`, all release jobs          |
+| `slack-secrets` | Notification webhook credentials                                      | `main-pipeline`, all release jobs          |
+
+`bot-context` includes `CIRCLECI_API_TOKEN` (a personal API token with write access to the project), which `scripts/release/tag.ts` uses to explicitly trigger release pipelines via the [CircleCI v2 API](https://circleci.com/docs/api/v2/index.html#operation/triggerPipelineRun). See [Release Pipeline troubleshooting](./release-pipeline#circleci-trigger-api-returns-401-or-404) for rotation steps.
 
 ## Config source structure
 

--- a/docs/contributing/release-pipeline.mdx
+++ b/docs/contributing/release-pipeline.mdx
@@ -19,8 +19,8 @@ Releases are fully automated. Merging a PR with changesets triggers a pipeline t
   <Step title="Version PR merged">
     A maintainer reviews and merges the version PR. CI detects the merge, compares each package version against what is published on npm, and creates a git tag for each package that has an unpublished version (e.g. `@agent-facets/core@0.3.0` or `agent-facets@1.0.0`).
   </Step>
-  <Step title="Tag push triggers release">
-    Each tag push triggers a release workflow. Scoped tags (`@agent-facets/*@*`) trigger the `release` workflow for library packages. Unscoped tags (`agent-facets@*`) trigger the `release-cli` workflow for the CLI.
+  <Step title="Release pipeline triggered per tag">
+    After pushing tags, the `tag.ts` script also calls CircleCI's API v2 `pipeline/run` endpoint once per tag to explicitly trigger the release pipeline. We do not rely on GitHub-to-CircleCI tag-push webhooks because they are unreliable when the bot GitHub App pushes tags — CircleCI appears to filter events from other bot actors. The pipeline's workflow filters (tag regex in `.circleci/release.yml`) still apply, so scoped tags (`@agent-facets/*@*`) run the `release` workflow and unscoped tags (`agent-facets@*`) run `release-cli`.
   </Step>
   <Step title="Publish to npm">
     The publish path depends on the package type:
@@ -67,26 +67,44 @@ The [changeset bot](https://github.com/apps/changeset-bot) comments on every PR 
 
 **Symptom**: A version PR merges, tags appear on GitHub, but no `release` or `release-cli` pipeline shows up in CircleCI.
 
-**Likely cause**: The pipeline definition in CircleCI was recreated or its GitHub App integration was reinstalled, and the tag trigger on that pipeline is missing or stale.
+**Background**: The release pipeline is triggered via CircleCI's API v2 `pipeline/run` endpoint, not via GitHub webhooks. `scripts/release/tag.ts` calls the API explicitly after pushing tags. If the API call fails, `tag.ts` throws and the `main-pipeline` job fails with a Slack notification — so a silent "no pipeline ran" failure usually means the trigger call never executed (tag push failed, or the job was cancelled before reaching the trigger step).
 
 **Fix**:
 
-1. Open CircleCI → facets project → Project Settings → Pipelines.
-2. Confirm there is a `release` pipeline definition pointing at `.circleci/release.yml`.
-3. Confirm it has a GitHub trigger configured for **tag pushes**.
-4. If the trigger is missing, add it. If the whole pipeline definition is missing, recreate it and also reinstall the bot GitHub App on the org (see next section — the installation ID will change).
+1. Check the `main-pipeline` job log for the most recent version PR merge. Look for `Triggering CircleCI release pipeline for <tag>` lines and their `→ pipeline #N` responses.
+2. If those log lines are missing, the job died before tagging completed. Fix the underlying failure and re-run the job from main.
+3. If those log lines show errors (401/404 from the CircleCI API), see the CIRCLECI_API_TOKEN section below.
 
-Once routing is fixed, **re-push each stuck tag** to regenerate the webhook event. Thanks to the idempotency check in `scripts/release/publish.ts`, re-pushing a tag whose version is already on npm will skip the publish and only re-run the GitHub Release + notification steps:
+To manually trigger a release pipeline for a tag that's already pushed, POST to the API directly:
 
 ```bash
 for tag in \
   '@agent-facets/core@0.4.0' \
   'agent-facets@0.5.0' \
   ; do
-  git push origin ":refs/tags/$tag"
-  git push origin "$tag"
+  curl -X POST \
+    "https://circleci.com/api/v2/project/gh/agent-facets/facets/pipeline/run" \
+    -H "Circle-Token: $CIRCLECI_API_TOKEN" \
+    -H "content-type: application/json" \
+    --data "{\"definition_id\":\"229d2f5823-f2c9-4cba-918a-e7d0dc2f658a\",\"config\":{\"tag\":\"$tag\"},\"checkout\":{\"tag\":\"$tag\"}}"
 done
 ```
+
+The idempotency checks in `scripts/release/publish.ts`, `publish-platform.ts`, and `publish-cli-package.ts` mean re-triggering for an already-published version will skip the npm publish and only re-run the GitHub Release + notification steps.
+
+### CircleCI trigger API returns 401 or 404
+
+**Symptom**: `tag.ts` fails with `CircleCI pipeline trigger failed for tag <tag>: 401` or `404`.
+
+**Cause**:
+
+- **401** — `CIRCLECI_API_TOKEN` is missing, revoked, or belongs to a user without write access to the project.
+- **404** — `CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID` is stale. If the release pipeline definition was recreated in the CircleCI UI, the UUID in `scripts/lib/constants.ts` needs updating.
+
+**Fix**:
+
+- For 401: rotate the `CIRCLECI_API_TOKEN` in the `bot-context` CircleCI context. Mint a new token at CircleCI → User Settings → Personal API Tokens.
+- For 404: grab the current definition ID from CircleCI → Project Settings → Pipelines → copy Definition ID for the release pipeline, then update `CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID` in `scripts/lib/constants.ts`.
 
 ### `finalize-cli` fails with `Not Found - /app/installations/*/access_tokens`
 
@@ -106,7 +124,7 @@ done
 
 2. Update `APP_INSTALLATION_ID` in CircleCI → Organization Settings → Contexts → `bot-context`.
 
-3. Re-push any stuck tags as shown above.
+3. Manually trigger any stuck release pipelines using the curl snippet in the "Tags pushed but no release pipeline runs" section above.
 
 The `mintGitHubAppToken` helper (`scripts/lib/github-app.ts`) detects 404s and surfaces this exact runbook in its error message, so this diagnosis should appear in future job logs without needing to consult these docs.
 

--- a/scripts/lib/announce.ts
+++ b/scripts/lib/announce.ts
@@ -23,7 +23,7 @@ export async function slackNotify(channels: string, text: string): Promise<void>
     return
   }
   for (const channel of channels.split(',').map((c) => c.trim())) {
-    const body = (await io.httpPost(
+    const body = (await io.shell.httpPost(
       'https://slack.com/api/chat.postMessage',
       { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
       { channel, text },
@@ -37,17 +37,17 @@ export async function slackNotify(channels: string, text: string): Promise<void>
 /** Create a GitHub Release and send a notification. Non-fatal — failures are logged but don't fail the release. */
 export async function announceRelease(tag: string, dir: string, version: string): Promise<void> {
   try {
-    const changelog = await io.readFile(`${dir}/CHANGELOG.md`)
+    const changelog = await io.shell.readFile(`${dir}/CHANGELOG.md`)
     const entry = getChangelogEntry(changelog, version)
-    const url = (await io.ghReleaseCreate(tag, tag, transformChangelogContent(entry.content))).trim()
-    io.log(`Created GitHub Release: ${url}`)
+    const url = (await io.gh.releaseCreate(tag, tag, transformChangelogContent(entry.content))).trim()
+    io.console.log(`Created GitHub Release: ${url}`)
 
     try {
       await slackNotify(SLACK_CHANNELS.auto_cli_deploys, `🚀 Published: <${url}|${tag}>`)
     } catch (err) {
-      io.error(`Failed to send Slack notification: ${(err as Error).message}`)
+      io.console.error(`Failed to send Slack notification: ${(err as Error).message}`)
     }
   } catch (err) {
-    io.error(`Failed to create GitHub Release for ${tag}: ${(err as Error).message}`)
+    io.console.error(`Failed to create GitHub Release for ${tag}: ${(err as Error).message}`)
   }
 }

--- a/scripts/lib/ci.ts
+++ b/scripts/lib/ci.ts
@@ -10,22 +10,22 @@ import { io } from './io'
 
 /** Mint a GitHub App installation token and set GH_TOKEN + GITHUB_TOKEN. */
 export async function mintGithubTokens(): Promise<void> {
-  const token = await io.mintGitHubAppToken()
+  const token = await io.shell.mintGitHubAppToken()
   process.env.GH_TOKEN = token
   process.env.GITHUB_TOKEN = token
 }
 
 /** Discover all workspace packages by scanning workspace patterns from root package.json. */
 export async function loadWorkspacePackages(): Promise<WorkspacePackage[]> {
-  const root = await io.readJson('package.json')
+  const root = await io.shell.readJson('package.json')
   const patterns: string[] = root.workspaces?.packages ?? root.workspaces ?? []
   const results: WorkspacePackage[] = []
 
   for (const pattern of patterns) {
-    const dirs = await io.globScan(pattern, { onlyFiles: false })
+    const dirs = await io.shell.globScan(pattern, { onlyFiles: false })
     for (const dir of dirs) {
-      if (await io.fileExists(`${dir}/package.json`)) {
-        const pkg = await io.readJson(`${dir}/package.json`)
+      if (await io.shell.fileExists(`${dir}/package.json`)) {
+        const pkg = await io.shell.readJson(`${dir}/package.json`)
         results.push({ name: pkg.name, version: pkg.version, dir, private: pkg.private })
       }
     }

--- a/scripts/lib/constants.ts
+++ b/scripts/lib/constants.ts
@@ -43,3 +43,9 @@ export const DIST_DIR = path.join(CLI_DIR, 'dist')
 
 /** Dist-tag used when publishing CLI packages to npm. */
 export const PUBLISH_TAG = 'latest'
+
+/** CircleCI project slug for triggering pipelines via API v2. */
+export const CIRCLECI_PROJECT_SLUG = 'gh/agent-facets/facets'
+
+/** CircleCI pipeline definition ID for the release pipeline (.circleci/release.yml). */
+export const CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID = '229d2f5823-f2c9-4cba-918a-e7d0dc2f658a'

--- a/scripts/lib/io/circleci.ts
+++ b/scripts/lib/io/circleci.ts
@@ -1,0 +1,58 @@
+/**
+ * CircleCI API v2 operations.
+ *
+ * Used by the release pipeline to explicitly trigger downstream workflows.
+ * We trigger rather than relying on GitHub-to-CircleCI tag-push webhooks
+ * because those webhooks have proven unreliable when the bot GitHub App
+ * pushes tags — the CircleCI GitHub App installation appears to drop or
+ * filter events originating from other bot actors. See
+ * docs/contributing/release-pipeline.mdx for the full story.
+ */
+
+export const circleciIo = {
+  /**
+   * Trigger a pipeline run for a specific tag via CircleCI API v2.
+   *
+   * The target pipeline's internal workflow filters (tag regex in
+   * release.yml) still apply, so calling this with `agent-facets@1.0.0`
+   * fires only the `release-cli` workflow; calling with
+   * `@agent-facets/core@1.0.0` fires only the `release` workflow. The
+   * caller does not need to select which one.
+   *
+   * Requires the CIRCLECI_API_TOKEN env var (provisioned via the
+   * `bot-context` CircleCI context).
+   */
+  triggerPipelineForTag: async (
+    projectSlug: string,
+    definitionId: string,
+    tag: string,
+  ): Promise<{ id: string; number: number }> => {
+    const token = process.env.CIRCLECI_API_TOKEN
+    if (!token) {
+      throw new Error(
+        'CIRCLECI_API_TOKEN not set. Expected from the `bot-context` CircleCI context. ' +
+          'See docs/contributing/release-pipeline.mdx for setup instructions.',
+      )
+    }
+
+    const resp = await fetch(`https://circleci.com/api/v2/project/${projectSlug}/pipeline/run`, {
+      method: 'POST',
+      headers: {
+        'Circle-Token': token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        definition_id: definitionId,
+        config: { tag },
+        checkout: { tag },
+      }),
+    })
+
+    if (!resp.ok) {
+      const body = await resp.text()
+      throw new Error(`CircleCI pipeline trigger failed for tag ${tag}: ${resp.status} ${body}`)
+    }
+
+    return (await resp.json()) as { id: string; number: number }
+  },
+}

--- a/scripts/lib/io/git.ts
+++ b/scripts/lib/io/git.ts
@@ -5,17 +5,17 @@
 import { $ } from 'bun'
 
 export const gitIo = {
-  gitDiff: () => $`git diff --quiet`.nothrow(),
-  gitDiffCached: () => $`git diff --cached --quiet`.nothrow(),
-  gitConfig: (key: string, value: string) => $`git config ${key} ${value}`,
-  gitCheckout: (branch: string) => $`git checkout -B ${branch}`,
-  gitAdd: () => $`git add -A`,
-  gitCommit: (message: string) => $`git commit -m ${message}`,
-  gitPush: (remote: string, ref: string, force = false) =>
+  diff: () => $`git diff --quiet`.nothrow(),
+  diffCached: () => $`git diff --cached --quiet`.nothrow(),
+  config: (key: string, value: string) => $`git config ${key} ${value}`,
+  checkout: (branch: string) => $`git checkout -B ${branch}`,
+  add: () => $`git add -A`,
+  commit: (message: string) => $`git commit -m ${message}`,
+  push: (remote: string, ref: string, force = false) =>
     force ? $`git push ${remote} ${ref} --force` : $`git push ${remote} ${ref}`,
-  gitPushTags: (remote: string, ref: string) => $`git push --follow-tags ${remote} ${ref}`,
-  gitFetch: (remote: string, branch: string) => $`git fetch ${remote} ${branch}`,
-  gitFetchSha: (remote: string, sha: string) => $`git fetch ${remote} ${sha}`,
-  gitTagAt: (tag: string, sha: string) => $`git tag ${tag} -m ${tag} ${sha}`,
-  gitPushAllTags: (remote: string) => $`git push ${remote} --tags`,
+  pushTags: (remote: string, ref: string) => $`git push --follow-tags ${remote} ${ref}`,
+  fetch: (remote: string, branch: string) => $`git fetch ${remote} ${branch}`,
+  fetchSha: (remote: string, sha: string) => $`git fetch ${remote} ${sha}`,
+  tagAt: (tag: string, sha: string) => $`git tag ${tag} -m ${tag} ${sha}`,
+  pushAllTags: (remote: string) => $`git push ${remote} --tags`,
 }

--- a/scripts/lib/io/github.ts
+++ b/scripts/lib/io/github.ts
@@ -6,19 +6,17 @@ import { $ } from 'bun'
 import { GITHUB_REPO } from '../constants'
 
 export const githubIo = {
-  ghAuthSetupGit: () => $`gh auth setup-git`,
-  ghPrList: (head: string) => $`gh pr list --head ${head} --state open --json number --jq .[0].number`.text(),
-  ghPrCreate: (base: string, head: string, title: string, body: string) =>
+  authSetupGit: () => $`gh auth setup-git`,
+  prList: (head: string) => $`gh pr list --head ${head} --state open --json number --jq .[0].number`.text(),
+  prCreate: (base: string, head: string, title: string, body: string) =>
     $`gh pr create --base ${base} --head ${head} --title ${title} --body ${body}`,
-  ghPrUpdate: (prNumber: string, title: string, body: string) =>
+  prUpdate: (prNumber: string, title: string, body: string) =>
     $`gh pr edit ${prNumber} --title ${title} --body ${body}`,
-  ghGetPrForCommit: async (
-    sha: string,
-  ): Promise<Array<{ number: number; headRefName: string; headRefOid: string }>> => {
+  getPrForCommit: async (sha: string): Promise<Array<{ number: number; headRefName: string; headRefOid: string }>> => {
     const result =
       await $`gh api repos/${GITHUB_REPO}/commits/${sha}/pulls --jq '[.[] | {number, headRefName: .head.ref, headRefOid: .head.sha}]'`.text()
     return JSON.parse(result.trim() || '[]')
   },
-  ghReleaseCreate: (tag: string, title: string, notes: string) =>
+  releaseCreate: (tag: string, title: string, notes: string) =>
     $`gh release create ${tag} --title ${title} --notes ${notes}`.text(),
 }

--- a/scripts/lib/io/index.ts
+++ b/scripts/lib/io/index.ts
@@ -2,19 +2,22 @@
  * I/O adapter — the single source of ALL external side effects.
  *
  * Every shell command, file operation, network call, and console output
- * goes through this object. Tests mock individual methods via spyOn(io, "method").
+ * goes through this object. Tests mock individual methods via
+ * spyOn(io.<domain>, "method").
  *
  * NO logic lives here — only raw operations. Logic that composes these
  * operations belongs in domain-specific modules (ci.ts, npm.ts, etc.).
  *
- * Split into domain files for readability:
- * - npm.ts    — npm CLI commands
- * - git.ts    — git CLI commands
- * - github.ts — GitHub CLI commands
- * - shell.ts  — shell, filesystem, build pipeline, CI tokens, network
- * - console.ts — log and error output
+ * Split into domain namespaces:
+ * - io.npm      — npm CLI commands
+ * - io.git      — git CLI commands
+ * - io.gh       — GitHub CLI commands
+ * - io.circleci — CircleCI API v2 calls
+ * - io.shell    — shell, filesystem, build pipeline, CI tokens, network
+ * - io.console  — log and error output
  */
 
+import { circleciIo } from './circleci'
 import { consoleIo } from './console'
 import { gitIo } from './git'
 import { githubIo } from './github'
@@ -22,9 +25,10 @@ import { npmIo } from './npm'
 import { shellIo } from './shell'
 
 export const io = {
-  ...npmIo,
-  ...gitIo,
-  ...githubIo,
-  ...shellIo,
-  ...consoleIo,
+  npm: npmIo,
+  git: gitIo,
+  gh: githubIo,
+  circleci: circleciIo,
+  shell: shellIo,
+  console: consoleIo,
 }

--- a/scripts/lib/io/npm.ts
+++ b/scripts/lib/io/npm.ts
@@ -7,26 +7,30 @@ import { $ } from 'bun'
 export const npmIo = {
   whoami: () => $`npm whoami`.quiet(),
   viewName: (pkg: string) => $`npm view ${pkg} name`.quiet(),
-  viewVersion: (pkg: string, ver: string) => $`npm view ${pkg}@${ver} version`.quiet(),
+  /** Check that a specific version of a package exists — returns the shell result. */
+  checkVersion: (pkg: string, ver: string) => $`npm view ${pkg}@${ver} version`.quiet(),
   viewDistTag: (pkg: string, tag: string) => $`npm view ${pkg}@${tag} version`.quiet(),
-  publish: (cwd: string, tag: string) => $`npm publish *.tgz --access public --tag ${tag}`.cwd(cwd),
-  publishPlain: (cwd: string) => {
+  /** Publish a pre-packed .tgz with an explicit dist-tag. */
+  publishTarball: (cwd: string, tag: string) => $`npm publish *.tgz --access public --tag ${tag}`.cwd(cwd),
+  /** Publish interactively with inherited stdio — used for OIDC bootstrap flows. */
+  publishPlain: async (cwd: string) => {
     const proc = Bun.spawn(['npm', 'publish', '--access', 'public'], {
       cwd,
       stdin: 'inherit',
       stdout: 'inherit',
       stderr: 'pipe',
     })
-    return proc.exited.then(async (code) => {
-      if (code !== 0) {
-        const stderr = await new Response(proc.stderr).text()
-        console.error(stderr)
-        throw new Error(stderr || `Failed with exit code ${code}`)
-      }
-    })
+    const code = await proc.exited
+    if (code !== 0) {
+      const stderr = await new Response(proc.stderr).text()
+      console.error(stderr)
+      throw new Error(stderr || `Failed with exit code ${code}`)
+    }
   },
-  npmPublish: (dir: string) => $`npm publish --access public`.cwd(dir),
-  npmViewVersion: async (pkg: string): Promise<string | null> => {
+  /** Publish the package in `dir` using its own package.json dist-tag. */
+  publish: (dir: string) => $`npm publish --access public`.cwd(dir),
+  /** Get the currently-published latest version of a package, or null if never published. */
+  viewVersion: async (pkg: string): Promise<string | null> => {
     const result = await $`npm view ${pkg} version`.nothrow().quiet()
     return result.exitCode === 0 ? result.text().trim() : null
   },

--- a/scripts/lib/npm.ts
+++ b/scripts/lib/npm.ts
@@ -10,7 +10,7 @@ import { io } from './io'
 /** Check if the current user is logged in to npm. Returns the username or null. */
 export async function whoami(): Promise<string | null> {
   try {
-    const result = await io.whoami()
+    const result = await io.npm.whoami()
     return result.stdout.toString().trim() || null
   } catch {
     return null
@@ -20,7 +20,7 @@ export async function whoami(): Promise<string | null> {
 /** Check if a package name exists in the npm registry (any version). */
 export async function packageExists(pkg: string): Promise<boolean> {
   try {
-    await io.viewName(pkg)
+    await io.npm.viewName(pkg)
     return true
   } catch {
     return false
@@ -30,7 +30,7 @@ export async function packageExists(pkg: string): Promise<boolean> {
 /** Check if a specific version of a package exists in the npm registry. */
 export async function versionExists(pkg: string, version: string): Promise<boolean> {
   try {
-    const result = await io.viewVersion(pkg, version)
+    const result = await io.npm.checkVersion(pkg, version)
     return result.stdout.toString().trim() === version
   } catch {
     return false
@@ -43,10 +43,10 @@ export async function versionExists(pkg: string, version: string): Promise<boole
  */
 export async function publishPlaceholder(pkg: string): Promise<void> {
   const tmp = path.join(import.meta.dir, '..', '..', '.tmp-bootstrap')
-  await io.rm(tmp)
-  await io.mkdir(tmp)
+  await io.shell.rm(tmp)
+  await io.shell.mkdir(tmp)
 
-  await io.writeFile(
+  await io.shell.writeFile(
     path.join(tmp, 'package.json'),
     JSON.stringify(
       {
@@ -60,13 +60,13 @@ export async function publishPlaceholder(pkg: string): Promise<void> {
   )
 
   try {
-    await io.publishPlain(tmp)
+    await io.npm.publishPlain(tmp)
   } finally {
-    await io.rm(tmp)
+    await io.shell.rm(tmp)
   }
 }
 
 /** Mint a CircleCI OIDC token for npm trusted publishing and set NPM_ID_TOKEN. */
 export async function mintNpmToken(): Promise<void> {
-  process.env.NPM_ID_TOKEN = (await io.mintCircleOidcToken()).trim()
+  process.env.NPM_ID_TOKEN = (await io.shell.mintCircleOidcToken()).trim()
 }

--- a/scripts/lib/test-helpers.ts
+++ b/scripts/lib/test-helpers.ts
@@ -12,10 +12,10 @@ export function shellPromise(stdout = '', exitCode = 0) {
   return Promise.resolve({ stdout: Buffer.from(stdout), exitCode }) as $.ShellPromise
 }
 
-/** Silence io.log and io.error for test output. */
+/** Silence io.console.log and io.console.error for test output. */
 export function silenceIO() {
-  spyOn(io, 'log').mockImplementation(() => {})
-  spyOn(io, 'error').mockImplementation(() => {})
+  spyOn(io.console, 'log').mockImplementation(() => {})
+  spyOn(io.console, 'error').mockImplementation(() => {})
 }
 
 /** Sample CHANGELOG.md content for release pipeline tests. */

--- a/scripts/release-cli/finalize.test.ts
+++ b/scripts/release-cli/finalize.test.ts
@@ -20,14 +20,14 @@ describe('finalize.ts', () => {
   })
 
   function setupFinalizePath() {
-    spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
-    spyOn(io, 'publishCliPackage').mockResolvedValue(shellResult())
-    spyOn(io, 'verifyPackages').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+    spyOn(io.shell, 'publishCliPackage').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'verifyPackages').mockResolvedValue(shellResult())
     spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
       { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli' },
     ])
-    spyOn(io, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
-    spyOn(io, 'ghReleaseCreate').mockResolvedValue(
+    spyOn(io.shell, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
+    spyOn(io.gh, 'releaseCreate').mockResolvedValue(
       'https://github.com/agent-facets/facets/releases/tag/agent-facets%400.4.0\n',
     )
     spyOn(announce, 'slackNotify').mockResolvedValue(undefined)
@@ -49,8 +49,8 @@ describe('finalize.ts', () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
-    const publishSpy = spyOn(io, 'publishCliPackage').mockResolvedValue(shellResult())
-    const verifySpy = spyOn(io, 'verifyPackages').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(io.shell, 'publishCliPackage').mockResolvedValue(shellResult())
+    const verifySpy = spyOn(io.shell, 'verifyPackages').mockResolvedValue(shellResult())
 
     const code = await finalize()
 
@@ -64,11 +64,11 @@ describe('finalize.ts', () => {
     setupFinalizePath()
 
     const callOrder: Array<{ phase: string; args?: unknown[] }> = []
-    spyOn(io, 'verifyPackages').mockImplementation((packages: string[], version: string) => {
+    spyOn(io.shell, 'verifyPackages').mockImplementation((packages: string[], version: string) => {
       callOrder.push({ phase: 'verify', args: [packages, version] })
       return shellPromise()
     })
-    spyOn(io, 'publishCliPackage').mockImplementation(() => {
+    spyOn(io.shell, 'publishCliPackage').mockImplementation(() => {
       callOrder.push({ phase: 'publish' })
       return shellPromise()
     })
@@ -92,7 +92,7 @@ describe('finalize.ts', () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
-    const ghSpy = spyOn(io, 'mintGitHubAppToken').mockResolvedValue('gh-token')
+    const ghSpy = spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('gh-token')
 
     await finalize()
 
@@ -105,7 +105,7 @@ describe('finalize.ts', () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
-    const verifySpy = spyOn(io, 'verifyPackages').mockResolvedValue(shellResult())
+    const verifySpy = spyOn(io.shell, 'verifyPackages').mockResolvedValue(shellResult())
 
     await finalize()
 
@@ -118,7 +118,7 @@ describe('finalize.ts', () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
 
-    const releaseSpy = spyOn(io, 'ghReleaseCreate').mockResolvedValue(
+    const releaseSpy = spyOn(io.gh, 'releaseCreate').mockResolvedValue(
       'https://github.com/agent-facets/facets/releases/tag/agent-facets%400.4.0\n',
     )
 
@@ -148,7 +148,7 @@ describe('finalize.ts', () => {
   test('continues even if GitHub Release creation fails', async () => {
     process.env.CIRCLE_TAG = 'agent-facets@0.4.0'
     setupFinalizePath()
-    spyOn(io, 'readFile').mockRejectedValue(new Error('CHANGELOG.md not found'))
+    spyOn(io.shell, 'readFile').mockRejectedValue(new Error('CHANGELOG.md not found'))
 
     const code = await finalize()
 

--- a/scripts/release-cli/finalize.ts
+++ b/scripts/release-cli/finalize.ts
@@ -28,37 +28,37 @@ import { platformPackageNames } from './targets'
 export async function finalize(): Promise<number> {
   const tag = process.env.CIRCLE_TAG
   if (!tag) {
-    io.error('CIRCLE_TAG not set.')
+    io.console.error('CIRCLE_TAG not set.')
     return 1
   }
 
   const parsed = parseTag(tag)
   if (!parsed) {
-    io.error(`Could not parse tag: ${tag}`)
+    io.console.error(`Could not parse tag: ${tag}`)
     return 1
   }
 
-  io.log(`Finalizing release for ${parsed.name}@${parsed.version}`)
+  io.console.log(`Finalizing release for ${parsed.name}@${parsed.version}`)
 
   // Mint GitHub token (for Release creation; npm OIDC is handled by the publish script)
   await mintGithubTokens()
 
   // Verify the 12 platform packages are visible on npm before publishing the CLI wrapper.
   // The CLI package's optionalDependencies must be resolvable when users install it.
-  io.log('Verifying platform packages in registry...')
-  await io.verifyPackages(platformPackageNames(), parsed.version)
+  io.console.log('Verifying platform packages in registry...')
+  await io.shell.verifyPackages(platformPackageNames(), parsed.version)
 
   // Publish CLI package to latest (synthesizes from build output, mints its own OIDC token).
   // The wrapper is always the LAST package published — users cannot install the new version
   // until this completes successfully.
-  io.log('Publishing CLI package...')
-  await io.publishCliPackage()
+  io.console.log('Publishing CLI package...')
+  await io.shell.publishCliPackage()
 
   // Verify the CLI wrapper itself propagated to npm before announcing.
-  io.log('Verifying CLI package in registry...')
-  await io.verifyPackages([CLI_PACKAGE_NAME], parsed.version)
+  io.console.log('Verifying CLI package in registry...')
+  await io.shell.verifyPackages([CLI_PACKAGE_NAME], parsed.version)
 
-  io.log(`Published ${parsed.name}@${parsed.version} (all platform packages)`)
+  io.console.log(`Published ${parsed.name}@${parsed.version} (all platform packages)`)
 
   // Announce
   const packages = await loadWorkspacePackages()
@@ -67,7 +67,7 @@ export async function finalize(): Promise<number> {
     await announceRelease(tag, pkg.dir, parsed.version)
   }
 
-  io.log('Done.')
+  io.console.log('Done.')
   return 0
 }
 

--- a/scripts/release-cli/publish-cli-package.test.ts
+++ b/scripts/release-cli/publish-cli-package.test.ts
@@ -9,7 +9,7 @@ describe('publish-cli-package.ts', () => {
   beforeEach(() => {
     spyOn(console, 'log').mockImplementation(() => {})
     spyOn(console, 'error').mockImplementation(() => {})
-    spyOn(io, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
+    spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
   })
 
   afterEach(() => {
@@ -31,12 +31,12 @@ describe('publish-cli-package.ts', () => {
     spyOn(Bun.Glob.prototype, 'scanSync').mockImplementation(function* () {
       yield '@agent-facets/cli-darwin-arm64/package.json'
     })
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-darwin-arm64',
       version: '1.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(true)
-    const packSpy = spyOn(io, 'pack').mockResolvedValue(shellResult())
+    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
 
     const code = await publishCliPackage()
 
@@ -50,15 +50,15 @@ describe('publish-cli-package.ts', () => {
       yield '@agent-facets/cli-linux-x64/package.json'
     })
     let callIndex = 0
-    spyOn(io, 'readJson').mockImplementation(async () => {
+    spyOn(io.shell, 'readJson').mockImplementation(async () => {
       callIndex++
       if (callIndex === 1) return { name: '@agent-facets/cli-darwin-arm64', version: '2.0.0' }
       return { name: '@agent-facets/cli-linux-x64', version: '2.0.0' }
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
-    const writeSpy = spyOn(io, 'writeFile').mockResolvedValue(0)
-    spyOn(io, 'pack').mockResolvedValue(shellResult())
-    spyOn(io, 'publish').mockResolvedValue(shellResult())
+    const writeSpy = spyOn(io.shell, 'writeFile').mockResolvedValue(0)
+    spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
 
     await publishCliPackage()
 
@@ -77,14 +77,14 @@ describe('publish-cli-package.ts', () => {
     spyOn(Bun.Glob.prototype, 'scanSync').mockImplementation(function* () {
       yield '@agent-facets/cli-darwin-arm64/package.json'
     })
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-darwin-arm64',
       version: '3.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
-    spyOn(io, 'writeFile').mockResolvedValue(0)
-    const packSpy = spyOn(io, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io, 'publish').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'writeFile').mockResolvedValue(0)
+    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
 
     const code = await publishCliPackage()
 

--- a/scripts/release-cli/publish-cli-package.ts
+++ b/scripts/release-cli/publish-cli-package.ts
@@ -22,7 +22,7 @@ import { mintNpmToken, versionExists } from '../lib/npm'
 async function discoverPlatformPackages(): Promise<Record<string, string>> {
   const binaries: Record<string, string> = {}
   for await (const filepath of new Bun.Glob('@*/*/package.json').scanSync({ cwd: DIST_DIR })) {
-    const pkg = await io.readJson(path.join(DIST_DIR, filepath))
+    const pkg = await io.shell.readJson(path.join(DIST_DIR, filepath))
     binaries[pkg.name] = pkg.version
   }
   return binaries
@@ -58,7 +58,7 @@ export async function publishCliPackage(): Promise<number> {
   await $`cp ${path.join(CLI_DIR, 'bin', 'package.json')} ${cliPkgDir}/bin/package.json`
   await $`cp ${path.join(CLI_DIR, 'scripts', 'postinstall.mjs')} ${cliPkgDir}/postinstall.mjs`
 
-  await io.writeFile(
+  await io.shell.writeFile(
     path.join(cliPkgDir, 'package.json'),
     JSON.stringify(
       {
@@ -73,8 +73,8 @@ export async function publishCliPackage(): Promise<number> {
     ),
   )
 
-  await io.pack(cliPkgDir)
-  await io.publish(cliPkgDir, PUBLISH_TAG)
+  await io.shell.pack(cliPkgDir)
+  await io.npm.publishTarball(cliPkgDir, PUBLISH_TAG)
 
   console.log(`+ ${CLI_PACKAGE_NAME}@${version} published (latest)`)
   return 0

--- a/scripts/release-cli/publish-platform.test.ts
+++ b/scripts/release-cli/publish-platform.test.ts
@@ -10,7 +10,7 @@ describe('publish-platform.ts', () => {
   beforeEach(() => {
     spyOn(console, 'log').mockImplementation(() => {})
     spyOn(console, 'error').mockImplementation(() => {})
-    spyOn(io, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
+    spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
   })
 
   afterEach(() => {
@@ -18,19 +18,19 @@ describe('publish-platform.ts', () => {
   })
 
   test('returns 1 when package.json cannot be read', async () => {
-    spyOn(io, 'readJson').mockRejectedValue(new Error('ENOENT'))
+    spyOn(io.shell, 'readJson').mockRejectedValue(new Error('ENOENT'))
 
     const code = await publishSingle('nonexistent-target')
     expect(code).toBe(1)
   })
 
   test('skips publish when version already exists on npm', async () => {
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-darwin-arm64',
       version: '1.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(true)
-    const publishSpy = spyOn(io, 'publish').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
 
     const code = await publishSingle('cli-darwin-arm64')
 
@@ -39,14 +39,14 @@ describe('publish-platform.ts', () => {
   })
 
   test('runs chmod, pack, publish when version is not yet on npm', async () => {
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-linux-x64',
       version: '2.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
-    const chmodSpy = spyOn(io, 'chmod').mockResolvedValue(shellResult())
-    const packSpy = spyOn(io, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io, 'publish').mockResolvedValue(shellResult())
+    const chmodSpy = spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
+    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
 
     const code = await publishSingle('cli-linux-x64')
 
@@ -57,14 +57,14 @@ describe('publish-platform.ts', () => {
   })
 
   test('publishes to the latest dist-tag', async () => {
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-windows-x64',
       version: '3.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
-    spyOn(io, 'chmod').mockResolvedValue(shellResult())
-    spyOn(io, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io, 'publish').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
 
     await publishSingle('cli-windows-x64')
 
@@ -72,14 +72,14 @@ describe('publish-platform.ts', () => {
   })
 
   test('passes the correct package directory to pack and publish', async () => {
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-darwin-x64',
       version: '4.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
-    spyOn(io, 'chmod').mockResolvedValue(shellResult())
-    const packSpy = spyOn(io, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io, 'publish').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
+    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
 
     await publishSingle('cli-darwin-x64')
 
@@ -89,20 +89,20 @@ describe('publish-platform.ts', () => {
   })
 
   test('propagates error when publish throws', async () => {
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-linux-arm64',
       version: '6.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
-    spyOn(io, 'chmod').mockResolvedValue(shellResult())
-    spyOn(io, 'pack').mockResolvedValue(shellResult())
-    spyOn(io, 'publish').mockRejectedValue(new Error('npm publish failed'))
+    spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    spyOn(io.npm, 'publishTarball').mockRejectedValue(new Error('npm publish failed'))
 
     await expect(publishSingle('cli-linux-arm64')).rejects.toThrow('npm publish failed')
   })
 
   test('checks versionExists with name and version from package.json', async () => {
-    spyOn(io, 'readJson').mockResolvedValue({
+    spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-linux-arm64',
       version: '5.0.0',
     })

--- a/scripts/release-cli/publish-platform.ts
+++ b/scripts/release-cli/publish-platform.ts
@@ -27,7 +27,7 @@ export async function publishSingle(target: string): Promise<number> {
 
   let pkgJson: { name: string; version: string }
   try {
-    pkgJson = await io.readJson(pkgJsonPath)
+    pkgJson = await io.shell.readJson(pkgJsonPath)
   } catch {
     console.error(`Could not read ${pkgJsonPath}. Did the build job produce this target?`)
     return 1
@@ -43,10 +43,10 @@ export async function publishSingle(target: string): Promise<number> {
   }
 
   if (process.platform !== 'win32') {
-    await io.chmod(pkgDir)
+    await io.shell.chmod(pkgDir)
   }
-  await io.pack(pkgDir)
-  await io.publish(pkgDir, PUBLISH_TAG)
+  await io.shell.pack(pkgDir)
+  await io.npm.publishTarball(pkgDir, PUBLISH_TAG)
 
   console.log(`+ ${name}@${version} published (latest)`)
   return 0

--- a/scripts/release/publish.test.ts
+++ b/scripts/release/publish.test.ts
@@ -47,13 +47,13 @@ describe('publish.ts', () => {
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core', private: false },
       ])
-      spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
-      spyOn(io, 'turboBuild').mockResolvedValue(shellResult())
-      spyOn(io, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
-      spyOn(io, 'npmPublish').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+      spyOn(io.shell, 'turboBuild').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
+      spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
       spyOn(announce, 'slackNotify').mockResolvedValue(undefined)
-      spyOn(io, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
-      spyOn(io, 'ghReleaseCreate').mockResolvedValue(
+      spyOn(io.shell, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
+      spyOn(io.gh, 'releaseCreate').mockResolvedValue(
         'https://github.com/agent-facets/facets/releases/tag/%40agent-facets%2Fcore%401.1.0\n',
       )
       // Default to "version is new on npm" so existing tests keep their
@@ -107,7 +107,7 @@ describe('publish.ts', () => {
       process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
       setupPublishPath()
 
-      const publishSpy = spyOn(io, 'npmPublish').mockResolvedValue(shellResult())
+      const publishSpy = spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
 
       const { release } = await import('./publish')
       const code = await release()
@@ -121,7 +121,7 @@ describe('publish.ts', () => {
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/platform-opencode', version: '0.1.0', dir: 'packages/platform-opencode', private: true },
       ])
-      const publishSpy = spyOn(io, 'npmPublish').mockResolvedValue(shellResult())
+      const publishSpy = spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
 
       const { release } = await import('./publish')
       const code = await release()
@@ -134,7 +134,7 @@ describe('publish.ts', () => {
       process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
       setupPublishPath()
 
-      const mintSpy = spyOn(io, 'mintCircleOidcToken').mockResolvedValue('oidc-token\n')
+      const mintSpy = spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('oidc-token\n')
 
       const { release } = await import('./publish')
       await release()
@@ -147,7 +147,7 @@ describe('publish.ts', () => {
       process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
       setupPublishPath()
 
-      const releaseSpy = spyOn(io, 'ghReleaseCreate').mockResolvedValue(
+      const releaseSpy = spyOn(io.gh, 'releaseCreate').mockResolvedValue(
         'https://github.com/agent-facets/facets/releases/tag/core\n',
       )
 
@@ -179,7 +179,7 @@ describe('publish.ts', () => {
     test('sets both GH_TOKEN and GITHUB_TOKEN', async () => {
       process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
       setupPublishPath()
-      spyOn(io, 'mintGitHubAppToken').mockResolvedValue('release-token')
+      spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('release-token')
 
       const { release } = await import('./publish')
       await release()
@@ -191,7 +191,7 @@ describe('publish.ts', () => {
     test('continues even if GitHub Release creation fails', async () => {
       process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
       setupPublishPath()
-      spyOn(io, 'readFile').mockRejectedValue(new Error('CHANGELOG.md not found'))
+      spyOn(io.shell, 'readFile').mockRejectedValue(new Error('CHANGELOG.md not found'))
 
       const { release } = await import('./publish')
       const code = await release()
@@ -217,9 +217,9 @@ describe('publish.ts', () => {
       // a tag is re-pushed to recover from a post-publish failure.
       spyOn(npm, 'versionExists').mockResolvedValue(true)
 
-      const publishSpy = spyOn(io, 'npmPublish').mockResolvedValue(shellResult())
-      const buildSpy = spyOn(io, 'turboBuild').mockResolvedValue(shellResult())
-      const oidcSpy = spyOn(io, 'mintCircleOidcToken').mockResolvedValue('oidc\n')
+      const publishSpy = spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
+      const buildSpy = spyOn(io.shell, 'turboBuild').mockResolvedValue(shellResult())
+      const oidcSpy = spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('oidc\n')
 
       const { release } = await import('./publish')
       const code = await release()
@@ -236,7 +236,7 @@ describe('publish.ts', () => {
       setupPublishPath()
       spyOn(npm, 'versionExists').mockResolvedValue(true)
 
-      const releaseSpy = spyOn(io, 'ghReleaseCreate').mockResolvedValue(
+      const releaseSpy = spyOn(io.gh, 'releaseCreate').mockResolvedValue(
         'https://github.com/agent-facets/facets/releases/tag/core\n',
       )
       const slackSpy = spyOn(announce, 'slackNotify').mockResolvedValue(undefined)

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -26,27 +26,27 @@ import { parseTag } from '../lib/tags'
 export async function release(): Promise<number> {
   const tag = process.env.CIRCLE_TAG
   if (!tag) {
-    io.error('CIRCLE_TAG not set. Not running on a tag push?')
+    io.console.error('CIRCLE_TAG not set. Not running on a tag push?')
     return 1
   }
 
   const parsed = parseTag(tag)
   if (!parsed) {
-    io.error(`Could not parse package name and version from tag: ${tag}`)
+    io.console.error(`Could not parse package name and version from tag: ${tag}`)
     return 1
   }
 
-  io.log(`Release triggered for ${parsed.name}@${parsed.version} (tag: ${tag})`)
+  io.console.log(`Release triggered for ${parsed.name}@${parsed.version} (tag: ${tag})`)
 
   const packages = await loadWorkspacePackages()
   const pkg = packages.find((p) => p.name === parsed.name)
   if (!pkg) {
-    io.error(`Package "${parsed.name}" not found in workspace`)
+    io.console.error(`Package "${parsed.name}" not found in workspace`)
     return 1
   }
 
   if (pkg.version !== parsed.version) {
-    io.error(`Version mismatch: tag says ${parsed.version}, package.json says ${pkg.version}`)
+    io.console.error(`Version mismatch: tag says ${parsed.version}, package.json says ${pkg.version}`)
     return 1
   }
 
@@ -55,7 +55,7 @@ export async function release(): Promise<number> {
   // the binary release pipeline, or internal adapter packages that participate
   // in changeset versioning). This guard prevents accidental npm publish attempts.
   if (pkg.private) {
-    io.log(`Skipping release for private package ${parsed.name}@${parsed.version}`)
+    io.console.log(`Skipping release for private package ${parsed.name}@${parsed.version}`)
     return 0
   }
 
@@ -68,7 +68,7 @@ export async function release(): Promise<number> {
   // slackNotify is best-effort.
   const alreadyPublished = await versionExists(parsed.name, parsed.version)
   if (alreadyPublished) {
-    io.log(`~ ${parsed.name}@${parsed.version} already on npm, skipping publish`)
+    io.console.log(`~ ${parsed.name}@${parsed.version} already on npm, skipping publish`)
   }
 
   // Shared setup — GitHub token and OIDC token for npm trusted publishing
@@ -77,14 +77,14 @@ export async function release(): Promise<number> {
   // Library packages — build and publish directly
   if (!alreadyPublished) {
     await mintNpmToken()
-    await io.turboBuild()
-    await io.npmPublish(pkg.dir)
-    io.log(`Published ${parsed.name}@${parsed.version} to npm`)
+    await io.shell.turboBuild()
+    await io.npm.publish(pkg.dir)
+    io.console.log(`Published ${parsed.name}@${parsed.version} to npm`)
   }
 
   await announceRelease(tag, pkg.dir, parsed.version)
 
-  io.log('Done.')
+  io.console.log('Done.')
   return 0
 }
 

--- a/scripts/release/tag.test.ts
+++ b/scripts/release/tag.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as ci from '../lib/ci'
+import { CIRCLECI_PROJECT_SLUG, CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID } from '../lib/constants'
 import { io } from '../lib/io'
 import { shellResult, silenceIO } from '../lib/test-helpers'
 
 describe('tag.ts', () => {
   beforeEach(() => {
     silenceIO()
-    spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
-    spyOn(io, 'ghAuthSetupGit').mockResolvedValue(shellResult())
+    spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+    spyOn(io.gh, 'authSetupGit').mockResolvedValue(shellResult())
   })
 
   afterEach(() => {
@@ -28,8 +29,8 @@ describe('tag.ts', () => {
 
     test('exits early when commit has no associated PRs', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([])
-      const fetchSpy = spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([])
+      const fetchSpy = spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
 
       const code = await tagRelease()
 
@@ -39,10 +40,10 @@ describe('tag.ts', () => {
 
     test('exits early when commit is not a version PR merge', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 99, headRefName: 'feature/something', headRefOid: 'def456' },
       ])
-      const fetchSpy = spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
+      const fetchSpy = spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
 
       const code = await tagRelease()
 
@@ -52,42 +53,45 @@ describe('tag.ts', () => {
 
     test('does not create tags when all versions are already published', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
       ])
-      spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
       ])
-      spyOn(io, 'npmViewVersion').mockResolvedValue('1.0.0')
-      const tagSpy = spyOn(io, 'gitTagAt').mockResolvedValue(shellResult())
+      spyOn(io.npm, 'viewVersion').mockResolvedValue('1.0.0')
+      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      const triggerSpy = spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
 
       const code = await tagRelease()
 
       expect(code).toBe(0)
       expect(tagSpy).not.toHaveBeenCalled()
+      expect(triggerSpy).not.toHaveBeenCalled()
     })
 
     test('creates and pushes tags for unpublished packages on the original PR commit', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
       ])
-      spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
-      spyOn(io, 'gitConfig').mockResolvedValue(shellResult())
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
         { name: '@agent-facets/brand', version: '0.2.0', dir: 'packages/brand' },
         { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli', private: true },
       ])
-      spyOn(io, 'npmViewVersion').mockImplementation(async (pkg: string) => {
+      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
         if (pkg === '@agent-facets/core') return '1.0.0' // bumped
         if (pkg === '@agent-facets/brand') return '0.2.0' // unchanged
         if (pkg === 'agent-facets') return null // private, never published
         return null
       })
-      const tagSpy = spyOn(io, 'gitTagAt').mockResolvedValue(shellResult())
-      const pushSpy = spyOn(io, 'gitPushAllTags').mockResolvedValue(shellResult())
+      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      const pushSpy = spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
 
       const code = await tagRelease()
 
@@ -100,22 +104,23 @@ describe('tag.ts', () => {
 
     test('creates tag when only the private CLI package has a version bump', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
       ])
-      spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
-      spyOn(io, 'gitConfig').mockResolvedValue(shellResult())
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
         { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli', private: true },
       ])
-      spyOn(io, 'npmViewVersion').mockImplementation(async (pkg: string) => {
+      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
         if (pkg === '@agent-facets/core') return '1.0.0' // unchanged
         if (pkg === 'agent-facets') return '0.3.0' // bumped
         return null
       })
-      const tagSpy = spyOn(io, 'gitTagAt').mockResolvedValue(shellResult())
-      const pushSpy = spyOn(io, 'gitPushAllTags').mockResolvedValue(shellResult())
+      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      const pushSpy = spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
 
       const code = await tagRelease()
 
@@ -127,14 +132,14 @@ describe('tag.ts', () => {
 
     test('fetches the original branch commit SHA', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 52, headRefName: 'changeset-release/main', headRefOid: 'the-real-sha' },
       ])
-      const fetchSpy = spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
+      const fetchSpy = spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
       ])
-      spyOn(io, 'npmViewVersion').mockResolvedValue('1.0.0')
+      spyOn(io.npm, 'viewVersion').mockResolvedValue('1.0.0')
 
       await tagRelease()
 
@@ -143,22 +148,79 @@ describe('tag.ts', () => {
 
     test('configures git identity before creating tags', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io, 'ghGetPrForCommit').mockResolvedValue([
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
       ])
-      spyOn(io, 'gitFetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
       ])
-      spyOn(io, 'npmViewVersion').mockResolvedValue('1.0.0')
-      spyOn(io, 'gitTagAt').mockResolvedValue(shellResult())
-      spyOn(io, 'gitPushAllTags').mockResolvedValue(shellResult())
-      const configSpy = spyOn(io, 'gitConfig').mockResolvedValue(shellResult())
+      spyOn(io.npm, 'viewVersion').mockResolvedValue('1.0.0')
+      spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      const configSpy = spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
 
       await tagRelease()
 
       expect(configSpy).toHaveBeenCalledWith('user.name', 'the-faceter[bot]')
       expect(configSpy).toHaveBeenCalledWith('user.email', '272408671+the-faceter[bot]@users.noreply.github.com')
+    })
+
+    test('triggers CircleCI pipeline for each pushed tag', async () => {
+      process.env.CIRCLE_SHA1 = 'abc123'
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
+        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
+      ])
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
+        { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli', private: true },
+      ])
+      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
+        if (pkg === '@agent-facets/core') return '1.0.0' // bumped
+        if (pkg === 'agent-facets') return '0.3.0' // bumped
+        return null
+      })
+      spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      const triggerSpy = spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
+
+      const code = await tagRelease()
+
+      expect(code).toBe(0)
+      expect(triggerSpy).toHaveBeenCalledTimes(2)
+      expect(triggerSpy).toHaveBeenCalledWith(
+        CIRCLECI_PROJECT_SLUG,
+        CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
+        '@agent-facets/core@1.1.0',
+      )
+      expect(triggerSpy).toHaveBeenCalledWith(
+        CIRCLECI_PROJECT_SLUG,
+        CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
+        'agent-facets@0.4.0',
+      )
+    })
+
+    test('propagates trigger failures so CI marks the job as failed', async () => {
+      process.env.CIRCLE_SHA1 = 'abc123'
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
+        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
+      ])
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
+      ])
+      spyOn(io.npm, 'viewVersion').mockResolvedValue('1.0.0')
+      spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      spyOn(io.circleci, 'triggerPipelineForTag').mockRejectedValue(
+        new Error('CircleCI pipeline trigger failed for tag @agent-facets/core@1.1.0: 401 Unauthorized'),
+      )
+
+      await expect(tagRelease()).rejects.toThrow('CircleCI pipeline trigger failed')
     })
   })
 })

--- a/scripts/release/tag.ts
+++ b/scripts/release/tag.ts
@@ -1,5 +1,6 @@
 /**
- * CI tag-release script — create version tags after a version PR merges.
+ * CI tag-release script — create version tags after a version PR merges,
+ * then explicitly trigger the CircleCI release pipeline for each new tag.
  *
  * Runs on the `main` branch. Checks whether the current commit is a
  * merged version PR (by querying the GitHub API for associated PRs
@@ -7,59 +8,86 @@
  * PR branch commit, creates annotated version tags on that commit for
  * any unpublished packages, and pushes the tags.
  *
+ * After pushing, explicitly fires a CircleCI pipeline per tag via the
+ * API v2 `pipeline/run` endpoint. We do this because GitHub-to-CircleCI
+ * tag-push webhooks have proven unreliable when this bot pushes tags
+ * (the CircleCI GitHub App appears to drop events from other bot actors).
+ * The tag push itself remains useful for GitHub Releases, `git describe`,
+ * and human history browsing — we just don't trust it to trigger CI.
+ *
  * Invoked by the `main-pipeline` CircleCI job on the `main` branch.
  */
 
 import { hasUnpublishedVersions } from '../lib/changesets'
 import { loadWorkspacePackages, mintGithubTokens } from '../lib/ci'
-import { CHANGESET_RELEASE_BRANCH, GIT_BOT } from '../lib/constants'
+import {
+  CHANGESET_RELEASE_BRANCH,
+  CIRCLECI_PROJECT_SLUG,
+  CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
+  GIT_BOT,
+} from '../lib/constants'
 import { io } from '../lib/io'
 
 export async function tagRelease(): Promise<number> {
   const sha = process.env.CIRCLE_SHA1
   if (!sha) {
-    io.error('CIRCLE_SHA1 not set. Not running in CI?')
+    io.console.error('CIRCLE_SHA1 not set. Not running in CI?')
     return 1
   }
 
   await mintGithubTokens()
-  await io.ghAuthSetupGit()
+  await io.gh.authSetupGit()
 
-  const prs = await io.ghGetPrForCommit(sha)
+  const prs = await io.gh.getPrForCommit(sha)
   const versionPr = prs.find((p) => p.headRefName === CHANGESET_RELEASE_BRANCH)
 
   if (!versionPr) {
-    io.log('Current commit is not a version PR merge. Nothing to do.')
+    io.console.log('Current commit is not a version PR merge. Nothing to do.')
     return 0
   }
 
   const headSha = versionPr.headRefOid
-  io.log(`Version PR #${versionPr.number} detected. Original branch commit: ${headSha}`)
+  io.console.log(`Version PR #${versionPr.number} detected. Original branch commit: ${headSha}`)
 
-  await io.gitFetchSha('origin', headSha)
+  await io.git.fetchSha('origin', headSha)
 
   const packages = await loadWorkspacePackages()
-  const unpublished = await hasUnpublishedVersions(packages, io.npmViewVersion)
+  const unpublished = await hasUnpublishedVersions(packages, io.npm.viewVersion)
 
   if (!unpublished) {
-    io.log('All package versions already published. No tags needed.')
+    io.console.log('All package versions already published. No tags needed.')
     return 0
   }
 
-  await io.gitConfig('user.name', GIT_BOT.name)
-  await io.gitConfig('user.email', GIT_BOT.email)
+  await io.git.config('user.name', GIT_BOT.name)
+  await io.git.config('user.email', GIT_BOT.email)
 
+  const pushedTags: string[] = []
   for (const pkg of packages) {
-    const npmVersion = await io.npmViewVersion(pkg.name)
+    const npmVersion = await io.npm.viewVersion(pkg.name)
     if (npmVersion !== pkg.version) {
       const tag = `${pkg.name}@${pkg.version}`
-      io.log(`Tagging: ${tag} -> ${headSha}`)
-      await io.gitTagAt(tag, headSha)
+      io.console.log(`Tagging: ${tag} -> ${headSha}`)
+      await io.git.tagAt(tag, headSha)
+      pushedTags.push(tag)
     }
   }
 
-  await io.gitPushAllTags('origin')
-  io.log('Tags pushed successfully.')
+  await io.git.pushAllTags('origin')
+  io.console.log('Tags pushed successfully.')
+
+  // Explicitly trigger the release pipeline for each tag. See module docblock
+  // for why we don't rely on GitHub-to-CircleCI webhooks for this.
+  for (const tag of pushedTags) {
+    io.console.log(`Triggering CircleCI release pipeline for ${tag}`)
+    const result = await io.circleci.triggerPipelineForTag(
+      CIRCLECI_PROJECT_SLUG,
+      CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
+      tag,
+    )
+    io.console.log(`  → pipeline #${result.number} (${result.id})`)
+  }
+
   return 0
 }
 

--- a/scripts/release/version.test.ts
+++ b/scripts/release/version.test.ts
@@ -15,31 +15,31 @@ describe('version.ts', () => {
 
   describe('buildChangesets', () => {
     function setupVersionPath() {
-      spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
-      spyOn(io, 'ghAuthSetupGit').mockResolvedValue(shellResult())
-      spyOn(io, 'changesetVersion').mockResolvedValue(shellResult())
-      spyOn(io, 'bunInstall').mockResolvedValue(shellResult())
-      spyOn(io, 'gitDiff').mockResolvedValue(shellResult('', 1))
-      spyOn(io, 'gitDiffCached').mockResolvedValue(shellResult('', 0))
-      spyOn(io, 'gitConfig').mockResolvedValue(shellResult())
-      spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
-      spyOn(io, 'gitAdd').mockResolvedValue(shellResult())
-      spyOn(io, 'gitCommit').mockResolvedValue(shellResult())
-      spyOn(io, 'gitPush').mockResolvedValue(shellResult())
-      spyOn(io, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
-      spyOn(io, 'writeFile').mockResolvedValue(0)
+      spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+      spyOn(io.gh, 'authSetupGit').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'changesetVersion').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'bunInstall').mockResolvedValue(shellResult())
+      spyOn(io.git, 'diff').mockResolvedValue(shellResult('', 1))
+      spyOn(io.git, 'diffCached').mockResolvedValue(shellResult('', 0))
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(io.git, 'checkout').mockResolvedValue(shellResult())
+      spyOn(io.git, 'add').mockResolvedValue(shellResult())
+      spyOn(io.git, 'commit').mockResolvedValue(shellResult())
+      spyOn(io.git, 'push').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
+      spyOn(io.shell, 'writeFile').mockResolvedValue(0)
     }
 
     test('creates a new PR with rich body when changesets are pending', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md', 'README.md'])
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['funny-turtle.md', 'README.md'])
       setupVersionPath()
 
       const loadSpy = spyOn(ci, 'loadWorkspacePackages')
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' }])
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' }])
 
-      spyOn(io, 'ghPrList').mockResolvedValue('')
-      const prCreateSpy = spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
+      spyOn(io.gh, 'prList').mockResolvedValue('')
+      const prCreateSpy = spyOn(io.gh, 'prCreate').mockResolvedValue(shellResult())
 
       const { buildChangesets } = await import('./version')
       const code = await buildChangesets()
@@ -64,16 +64,16 @@ describe('version.ts', () => {
     })
 
     test('updates existing PR body instead of creating a new one', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       setupVersionPath()
 
       spyOn(ci, 'loadWorkspacePackages')
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' }])
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' }])
 
-      spyOn(io, 'ghPrList').mockResolvedValue('42\n')
-      const prCreateSpy = spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
-      const prUpdateSpy = spyOn(io, 'ghPrUpdate').mockResolvedValue(shellResult())
+      spyOn(io.gh, 'prList').mockResolvedValue('42\n')
+      const prCreateSpy = spyOn(io.gh, 'prCreate').mockResolvedValue(shellResult())
+      const prUpdateSpy = spyOn(io.gh, 'prUpdate').mockResolvedValue(shellResult())
 
       const { buildChangesets } = await import('./version')
       const code = await buildChangesets()
@@ -98,18 +98,18 @@ describe('version.ts', () => {
     })
 
     test('exits early when changeset version produces no diff', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
-      spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['funny-turtle.md'])
+      spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
       ])
-      spyOn(io, 'changesetVersion').mockResolvedValue(shellResult())
-      spyOn(io, 'bunInstall').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'changesetVersion').mockResolvedValue(shellResult())
+      spyOn(io.shell, 'bunInstall').mockResolvedValue(shellResult())
 
-      spyOn(io, 'gitDiff').mockResolvedValue(shellResult('', 0))
-      spyOn(io, 'gitDiffCached').mockResolvedValue(shellResult('', 0))
+      spyOn(io.git, 'diff').mockResolvedValue(shellResult('', 0))
+      spyOn(io.git, 'diffCached').mockResolvedValue(shellResult('', 0))
 
-      const gitCheckoutSpy = spyOn(io, 'gitCheckout').mockResolvedValue(shellResult())
+      const gitCheckoutSpy = spyOn(io.git, 'checkout').mockResolvedValue(shellResult())
 
       const { buildChangesets } = await import('./version')
       const code = await buildChangesets()
@@ -119,15 +119,15 @@ describe('version.ts', () => {
     })
 
     test('sets both GH_TOKEN and GITHUB_TOKEN', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       setupVersionPath()
 
       spyOn(ci, 'loadWorkspacePackages')
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' }])
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' }])
 
-      spyOn(io, 'ghPrList').mockResolvedValue('')
-      spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
+      spyOn(io.gh, 'prList').mockResolvedValue('')
+      spyOn(io.gh, 'prCreate').mockResolvedValue(shellResult())
 
       const { buildChangesets } = await import('./version')
       await buildChangesets()
@@ -137,15 +137,15 @@ describe('version.ts', () => {
     })
 
     test('creates PR targeting main branch', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['funny-turtle.md'])
       setupVersionPath()
 
       spyOn(ci, 'loadWorkspacePackages')
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' }])
         .mockResolvedValueOnce([{ name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' }])
 
-      spyOn(io, 'ghPrList').mockResolvedValue('')
-      const prCreateSpy = spyOn(io, 'ghPrCreate').mockResolvedValue(shellResult())
+      spyOn(io.gh, 'prList').mockResolvedValue('')
+      const prCreateSpy = spyOn(io.gh, 'prCreate').mockResolvedValue(shellResult())
 
       const { buildChangesets } = await import('./version')
       await buildChangesets()
@@ -156,7 +156,7 @@ describe('version.ts', () => {
 
   describe('no pending changesets', () => {
     test('exits 0 when no changesets are pending', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['README.md'])
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['README.md'])
 
       const { buildChangesets } = await import('./version')
       const code = await buildChangesets()
@@ -167,12 +167,12 @@ describe('version.ts', () => {
 
   describe('error handling', () => {
     test('returns 1 when changeset version fails', async () => {
-      spyOn(io, 'scanDir').mockResolvedValue(['funny-turtle.md'])
-      spyOn(io, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+      spyOn(io.shell, 'scanDir').mockResolvedValue(['funny-turtle.md'])
+      spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
       ])
-      spyOn(io, 'changesetVersion').mockRejectedValue(new Error('changeset version failed'))
+      spyOn(io.shell, 'changesetVersion').mockRejectedValue(new Error('changeset version failed'))
 
       const { buildChangesets } = await import('./version')
       const code = await buildChangesets().catch(() => 1)

--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -14,57 +14,57 @@ import { CHANGESET_COMMIT_MESSAGE, CHANGESET_PR_TITLE, CHANGESET_RELEASE_BRANCH,
 import { io } from '../lib/io'
 
 export async function buildChangesets(): Promise<number> {
-  const files = await io.scanDir('.changeset')
+  const files = await io.shell.scanDir('.changeset')
   const pending = filterPendingChangesets(files)
 
   if (shouldPublish(pending)) {
-    io.log('No pending changesets. Nothing to do.')
+    io.console.log('No pending changesets. Nothing to do.')
     return 0
   }
 
-  io.log(`Found ${pending.length} pending changeset(s). Creating version PR...`)
+  io.console.log(`Found ${pending.length} pending changeset(s). Creating version PR...`)
 
   await mintGithubTokens()
-  await io.ghAuthSetupGit()
+  await io.gh.authSetupGit()
 
   const packagesBefore = await loadWorkspacePackages()
   const versionsBefore = new Map(packagesBefore.map((p) => [p.name, p.version]))
 
-  await io.changesetVersion()
-  await io.bunInstall()
+  await io.shell.changesetVersion()
+  await io.shell.bunInstall()
 
-  const diff = await io.gitDiff()
-  const diffCached = await io.gitDiffCached()
+  const diff = await io.git.diff()
+  const diffCached = await io.git.diffCached()
   if (diff.exitCode === 0 && diffCached.exitCode === 0) {
-    io.log('No changes after versioning, nothing to do.')
+    io.console.log('No changes after versioning, nothing to do.')
     return 0
   }
 
   const packagesAfter = await loadWorkspacePackages()
   const changedPackages = packagesAfter.filter((p) => versionsBefore.get(p.name) !== p.version)
-  const { body: prBody, entries } = await buildVersionPrBody(changedPackages, io.readFile)
+  const { body: prBody, entries } = await buildVersionPrBody(changedPackages, io.shell.readFile)
 
   for (const entry of entries) {
     const changelogPath = `${entry.dir}/CHANGELOG.md`
-    const original = await io.readFile(changelogPath)
+    const original = await io.shell.readFile(changelogPath)
     const rewritten = replaceChangelogEntry(original, entry.version, entry.content)
-    await io.writeFile(changelogPath, rewritten)
+    await io.shell.writeFile(changelogPath, rewritten)
   }
 
-  await io.gitConfig('user.name', GIT_BOT.name)
-  await io.gitConfig('user.email', GIT_BOT.email)
-  await io.gitCheckout(CHANGESET_RELEASE_BRANCH)
-  await io.gitAdd()
-  await io.gitCommit(CHANGESET_COMMIT_MESSAGE)
-  await io.gitPush('origin', CHANGESET_RELEASE_BRANCH, true)
+  await io.git.config('user.name', GIT_BOT.name)
+  await io.git.config('user.email', GIT_BOT.email)
+  await io.git.checkout(CHANGESET_RELEASE_BRANCH)
+  await io.git.add()
+  await io.git.commit(CHANGESET_COMMIT_MESSAGE)
+  await io.git.push('origin', CHANGESET_RELEASE_BRANCH, true)
 
-  const prNumber = (await io.ghPrList(CHANGESET_RELEASE_BRANCH)).trim()
+  const prNumber = (await io.gh.prList(CHANGESET_RELEASE_BRANCH)).trim()
   if (prNumber) {
-    await io.ghPrUpdate(prNumber, CHANGESET_PR_TITLE, prBody)
-    io.log(`Updated existing PR #${prNumber}`)
+    await io.gh.prUpdate(prNumber, CHANGESET_PR_TITLE, prBody)
+    io.console.log(`Updated existing PR #${prNumber}`)
   } else {
-    await io.ghPrCreate('main', CHANGESET_RELEASE_BRANCH, CHANGESET_PR_TITLE, prBody)
-    io.log('Created new Version Packages PR.')
+    await io.gh.prCreate('main', CHANGESET_RELEASE_BRANCH, CHANGESET_PR_TITLE, prBody)
+    io.console.log('Created new Version Packages PR.')
   }
 
   return 0


### PR DESCRIPTION
### Why

<!-- Why does this change exist? Link an issue or describe the motivation. Remove this section for trivial changes where the title says it all. -->

### Details

<!-- What should the reviewer know that isn't obvious from the diff? Approach, trade-offs, edge cases. Remove this section if the change is self-explanatory. -->

### Verification

<!-- How do you know it works? Manual test steps, deployment notes, or just "CI". Remove this section if CI covers it. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the automated release/tagging path and introduces a new CircleCI API-trigger mechanism that depends on new secrets/constants; misconfiguration could prevent releases from running. The `io` refactor is broad and could break scripts/tests if any call sites were missed.
> 
> **Overview**
> **Release pipelines are now triggered explicitly via CircleCI API v2 after tags are pushed.** `scripts/release/tag.ts` collects newly-created version tags and calls a new `io.circleci.triggerPipelineForTag` using `CIRCLECI_API_TOKEN`, `CIRCLECI_PROJECT_SLUG`, and `CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID`, with updated docs/runbooks describing 401/404 troubleshooting and manual triggers.
> 
> **Refactors the scripts I/O adapter into namespaced domains** (`io.git`, `io.npm`, `io.gh`, `io.shell`, `io.console`, `io.circleci`) and updates all release/version/publish scripts and tests accordingly, including minor npm IO API renames (`publishTarball`, `checkVersion`).
> 
> Adds a changeset bumping multiple packages for this CI/release infrastructure change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62c097cfff9c82f1438406d3bf61aa6152ea246. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->