### PR TITLE
Fix CircleCI pipeline definition ID and add UUID validation guardrail

### DIFF
--- a/.changeset/honest-bars-begin.md
+++ b/.changeset/honest-bars-begin.md
@@ -1,0 +1,12 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/common": patch
+"@agent-facets/core": patch
+---
+
+Correct CircleCI deployment keys

--- a/docs/contributing/release-pipeline.mdx
+++ b/docs/contributing/release-pipeline.mdx
@@ -86,7 +86,7 @@ for tag in \
     "https://circleci.com/api/v2/project/gh/agent-facets/facets/pipeline/run" \
     -H "Circle-Token: $CIRCLECI_API_TOKEN" \
     -H "content-type: application/json" \
-    --data "{\"definition_id\":\"229d2f5823-f2c9-4cba-918a-e7d0dc2f658a\",\"config\":{\"tag\":\"$tag\"},\"checkout\":{\"tag\":\"$tag\"}}"
+    --data "{\"definition_id\":\"9d2f5823-f2c9-4cba-918a-e7d0dc2f658a\",\"config\":{\"tag\":\"$tag\"},\"checkout\":{\"tag\":\"$tag\"}}"
 done
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,11 +22,12 @@ scripts/
 │   └── targets.ts              # Platform target matrix definitions
 │
 ├── lib/                        # Shared utilities
-│   ├── io/                     # IO adapter (split by domain)
-│   │   ├── index.ts            # Composed io object (re-exports all domains)
+│   ├── io/                     # IO adapter (split by domain, nested namespaces)
+│   │   ├── index.ts            # Composes io = { npm, git, gh, circleci, shell, console }
 │   │   ├── npm.ts              # npm CLI commands
 │   │   ├── git.ts              # git CLI commands
 │   │   ├── github.ts           # GitHub CLI commands
+│   │   ├── circleci.ts         # CircleCI API v2 calls
 │   │   ├── shell.ts            # Shell, filesystem, build, CI tokens, network
 │   │   └── console.ts          # log and error
 │   ├── ci.ts                   # Workspace package loading, token minting
@@ -93,10 +94,19 @@ The CLI package (`agent-facets`) is marked `"private": true` in its `package.jso
 
 ## IO Adapter
 
-All external side effects (shell commands, file operations, network calls) go through the `io` object exported from `lib/io/`. Tests mock individual methods via `spyOn(io, 'method')`.
+All external side effects (shell commands, file operations, network calls) go through the `io` object exported from `lib/io/`. The adapter is split into domain files and exposed as **nested namespaces** — one per domain.
 
-The IO adapter is split into domain files for readability but presents a single flat interface. Import it as:
+Import it as:
 
 ```ts
 import { io } from '../lib/io'
+
+await io.npm.publish(pkgDir)
+await io.git.pushAllTags('origin')
+await io.gh.prCreate('main', head, title, body)
+await io.circleci.triggerPipelineForTag(slug, defId, tag)
+await io.shell.readFile(path)
+io.console.log('hello')
 ```
+
+Tests mock individual methods via the domain: `spyOn(io.npm, 'publish')`, `spyOn(io.git, 'tagAt')`, etc.

--- a/scripts/lib/constants.test.ts
+++ b/scripts/lib/constants.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+import { CIRCLECI_PROJECT_SLUG, CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID } from './constants'
+
+/**
+ * Guardrail for CircleCI API trigger constants.
+ *
+ * This test imports the REAL exported constants (not a mock) and validates
+ * their shape. Any future typo — including a stray character in a hand-copied
+ * UUID — fails `bun check` locally before it can reach CI.
+ *
+ * Context: an earlier 10-character-first-segment typo in
+ * CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID caused the release pipeline trigger
+ * to 400 in production. No existing test exercised the raw constant, only
+ * the mocked io helper, so the bad value passed check. Don't regress.
+ */
+describe('CircleCI constants', () => {
+  test('CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID is a valid UUID (8-4-4-4-12)', () => {
+    expect(CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    )
+  })
+
+  test('CIRCLECI_PROJECT_SLUG matches the gh/<org>/<repo> format', () => {
+    expect(CIRCLECI_PROJECT_SLUG).toMatch(/^gh\/[\w-]+\/[\w-]+$/)
+  })
+})

--- a/scripts/lib/constants.ts
+++ b/scripts/lib/constants.ts
@@ -48,4 +48,4 @@ export const PUBLISH_TAG = 'latest'
 export const CIRCLECI_PROJECT_SLUG = 'gh/agent-facets/facets'
 
 /** CircleCI pipeline definition ID for the release pipeline (.circleci/release.yml). */
-export const CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID = '229d2f5823-f2c9-4cba-918a-e7d0dc2f658a'
+export const CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID = '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a'

--- a/scripts/lib/io/circleci.test.ts
+++ b/scripts/lib/io/circleci.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { io } from './index'
+
+describe('io.circleci.triggerPipelineForTag', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restore()
+    delete process.env.CIRCLECI_API_TOKEN
+  })
+
+  test('throws when CIRCLECI_API_TOKEN is not set', async () => {
+    delete process.env.CIRCLECI_API_TOKEN
+
+    await expect(
+      io.circleci.triggerPipelineForTag('gh/x/y', '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a', 'some-tag'),
+    ).rejects.toThrow(/CIRCLECI_API_TOKEN not set/)
+  })
+
+  test('throws with actionable error when definitionId is not a valid UUID', async () => {
+    process.env.CIRCLECI_API_TOKEN = 'fake-token'
+    const fetchSpy = mock(() => Promise.resolve(new Response('', { status: 200 })))
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    // First segment is 10 chars instead of 8 — the exact bug that shipped to prod.
+    await expect(
+      io.circleci.triggerPipelineForTag('gh/x/y', '229d2f5823-f2c9-4cba-918a-e7d0dc2f658a', 'some-tag'),
+    ).rejects.toThrow(/not a valid UUID/)
+
+    // Critically: fetch must NOT have been called — we failed before hitting the API.
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test('rejects obviously-not-a-uuid values', async () => {
+    process.env.CIRCLECI_API_TOKEN = 'fake-token'
+    const fetchSpy = mock(() => Promise.resolve(new Response('', { status: 200 })))
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    await expect(io.circleci.triggerPipelineForTag('gh/x/y', 'not-a-uuid', 'some-tag')).rejects.toThrow(
+      /not a valid UUID/,
+    )
+    await expect(io.circleci.triggerPipelineForTag('gh/x/y', '', 'some-tag')).rejects.toThrow(/not a valid UUID/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test('posts to CircleCI API with expected body when inputs are valid', async () => {
+    process.env.CIRCLECI_API_TOKEN = 'fake-token'
+    const fetchSpy = mock((_url: string, _init?: RequestInit) =>
+      Promise.resolve(new Response(JSON.stringify({ id: 'abc', number: 42 }), { status: 200 })),
+    )
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    const result = await io.circleci.triggerPipelineForTag(
+      'gh/agent-facets/facets',
+      '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
+      '@agent-facets/core@1.0.0',
+    )
+
+    expect(result).toEqual({ id: 'abc', number: 42 })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchSpy.mock.calls[0] ?? []
+    expect(url).toBe('https://circleci.com/api/v2/project/gh/agent-facets/facets/pipeline/run')
+    const headers = (init as RequestInit | undefined)?.headers as Record<string, string>
+    expect(headers['Circle-Token']).toBe('fake-token')
+    expect(headers['Content-Type']).toBe('application/json')
+
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body).toEqual({
+      definition_id: '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
+      config: { tag: '@agent-facets/core@1.0.0' },
+      checkout: { tag: '@agent-facets/core@1.0.0' },
+    })
+  })
+
+  test('throws with CircleCI error body on non-2xx response', async () => {
+    process.env.CIRCLECI_API_TOKEN = 'fake-token'
+    const fetchSpy = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ message: "Field 'definition_id' must be a valid uuid." }), { status: 400 }),
+      ),
+    )
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    await expect(
+      io.circleci.triggerPipelineForTag(
+        'gh/agent-facets/facets',
+        '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
+        '@agent-facets/core@1.0.0',
+      ),
+    ).rejects.toThrow(/CircleCI pipeline trigger failed .* 400/)
+  })
+})

--- a/scripts/lib/io/circleci.ts
+++ b/scripts/lib/io/circleci.ts
@@ -9,6 +9,8 @@
  * docs/contributing/release-pipeline.mdx for the full story.
  */
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export const circleciIo = {
   /**
    * Trigger a pipeline run for a specific tag via CircleCI API v2.
@@ -32,6 +34,17 @@ export const circleciIo = {
       throw new Error(
         'CIRCLECI_API_TOKEN not set. Expected from the `bot-context` CircleCI context. ' +
           'See docs/contributing/release-pipeline.mdx for setup instructions.',
+      )
+    }
+
+    // Fail fast on a malformed UUID rather than getting a cryptic 400 from
+    // CircleCI ("Field 'definition_id' must be a valid uuid"). See the
+    // constants.test.ts guardrail which also validates the real constant
+    // at build time.
+    if (!UUID_REGEX.test(definitionId)) {
+      throw new Error(
+        `Invalid pipeline definition ID: "${definitionId}" is not a valid UUID (expected 8-4-4-4-12 format). ` +
+          'Check scripts/lib/constants.ts. Fetch the correct ID from CircleCI UI → Project Settings → Pipelines.',
       )
     }
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -5,31 +5,52 @@ Publishes `@agent-facets/core`, `@agent-facets/brand`, `@agent-facets/adapter`, 
 ## Flow
 
 ```
-Tag push: @agent-facets/core@X.Y.Z
+Version PR merged to main
   │
   ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  release/tag.ts (main-pipeline)                                    │
+│                                                                    │
+│  1. Detect version PR merge                                        │
+│  2. Create git tags for each unpublished package version           │
+│  3. git push --tags origin                                         │
+│  4. For each tag: POST to CircleCI API v2 /pipeline/run            │
+│     with {definition_id, config: {tag}, checkout: {tag}}           │
+│                                                                    │
+│  Why explicit API trigger? GitHub-to-CircleCI tag-push webhooks    │
+│  are unreliable when the bot GitHub App pushes tags — the CircleCI │
+│  App installation drops events from other bot actors. See          │
+│  docs/contributing/release-pipeline.mdx.                           │
+└────────────────────────────────────────────────────────────────────┘
+  │
+  ▼ (one release pipeline per tag)
 ┌──────────────────────────────────────────────┐
 │  release/publish.ts                          │
 │                                              │
 │  1. Parse package name + version from tag    │
 │  2. Find package in workspace                │
 │  3. Skip if private (guard)                  │
-│  4. Mint OIDC token (npm trusted publishing) │
-│  5. Build via turbo                          │
-│  6. npm publish --access public              │
-│  7. Create GitHub Release                    │
-│  8. Send Slack notification                  │
+│  4. Skip if version already on npm (guard)   │
+│  5. Mint OIDC token (npm trusted publishing) │
+│  6. Build via turbo                          │
+│  7. npm publish --access public              │
+│  8. Create GitHub Release                    │
+│  9. Send Slack notification                  │
 └──────────────────────────────────────────────┘
 ```
 
 ## Scripts
 
-| Script              | CircleCI Job    | Trigger                        | Purpose                                                       |
-|---------------------|-----------------|--------------------------------|---------------------------------------------------------------|
-| `version.ts`        | `main-pipeline` | Push to `main`                 | Run `changeset version`, create/update Version Packages PR    |
-| `tag.ts`            | `main-pipeline` | Push to `main`                 | Detect merged version PR, create git tags for bumped packages |
-| `publish.ts`        | `release`       | Tag push (`@agent-facets/*@*`) | Build and publish one library package to npm                  |
-| `seed-adapters.ts`  | (manual)        | One-time bootstrap             | Seed adapter/library package names on npm with v0.0.1         |
+| Script              | CircleCI Job    | Trigger                        | Purpose                                                                   |
+|---------------------|-----------------|--------------------------------|---------------------------------------------------------------------------|
+| `version.ts`        | `main-pipeline` | Push to `main`                 | Run `changeset version`, create/update Version Packages PR                |
+| `tag.ts`            | `main-pipeline` | Push to `main`                 | Detect merged version PR, create git tags, trigger release pipelines      |
+| `publish.ts`        | `release`       | API trigger (`@agent-facets/*@*`) | Build and publish one library package to npm                           |
+| `seed-adapters.ts`  | (manual)        | One-time bootstrap             | Seed adapter/library package names on npm with v0.0.1                     |
+
+## Required secrets
+
+`tag.ts` requires `CIRCLECI_API_TOKEN` in the `bot-context` CircleCI context. It's a personal API token with write access to the project, used to POST to `/api/v2/project/<slug>/pipeline/run`. See [CI Architecture docs](../../docs/contributing/ci-architecture.mdx) for context rotation steps.
 
 ## Private Package Guard
 


### PR DESCRIPTION
### Why

A stray leading character in `CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID` (`229d2f5823-...` instead of `9d2f5823-...`) caused the release pipeline trigger to return a 400 from CircleCI in production. The bad value passed all existing checks because tests only exercised the mocked IO helper, never the raw constant itself.

### Details

The UUID is corrected in both `scripts/lib/constants.ts` and the documentation snippet in `docs/contributing/release-pipeline.mdx`.

To prevent this class of regression, two guardrails are added:

- **`scripts/lib/constants.test.ts`** — imports the real (non-mocked) constants and asserts that `CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID` matches the standard `8-4-4-4-12` UUID format and that `CIRCLECI_PROJECT_SLUG` matches `gh/<org>/<repo>`. This runs as part of `bun check` locally and in CI before any release can proceed.
- **UUID validation in `io.circleci.triggerPipelineForTag`** — the function now validates `definitionId` against the UUID regex before making any network call, throwing an actionable error message (pointing to `constants.ts` and the CircleCI UI) rather than letting a cryptic 400 surface from the API.

The IO adapter is also restructured from a flat interface to nested namespaces (`io.npm`, `io.git`, `io.gh`, `io.circleci`, `io.shell`, `io.console`), and a dedicated `circleci.ts` domain file is introduced. Tests mock at the domain level (`spyOn(io.circleci, 'triggerPipelineForTag')`).

### Verification

`scripts/lib/io/circleci.test.ts` covers the following cases:
- Throws when `CIRCLECI_API_TOKEN` is unset
- Throws before calling `fetch` when `definitionId` is not a valid UUID (including the exact 10-character first-segment bug that shipped)
- Posts the correct URL, headers, and body on a valid call
- Throws with the CircleCI error body on a non-2xx response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the automated release trigger path (CircleCI pipeline dispatch) and IO adapter surface area; mistakes could prevent releases from running even though changes are small and well-tested.
> 
> **Overview**
> Fixes the CircleCI release pipeline trigger by correcting `CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID` (and the corresponding docs curl snippet) so tag-driven releases can be dispatched successfully.
> 
> Adds guardrails to prevent regressions: a new `scripts/lib/constants.test.ts` validates the exported CircleCI constants, and `io.circleci.triggerPipelineForTag` now fails fast with an actionable error if `definitionId` is not a valid UUID (before making the network call), with dedicated unit tests for success and error cases.
> 
> Includes a changeset to publish patch releases for the affected packages, and updates release-script docs to reflect the nested `io.<domain>` namespaces including the new `io.circleci` domain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b185aa6c3e6c47ec8ebe45dc0e32fc61a442e2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->