### PR TITLE
Poll GitHub commit→PR index before tagging to handle indexing lag

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "docs:validate": "bun --cwd docs mint validate",
     "docs:broken-links": "bun --cwd docs mint broken-links",
     "postinstall": "mise exec -- lefthook install",
-    "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify"
+    "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify",
+    "nuke": "bun run clean && bun install && bun check"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.12",

--- a/scripts/lib/io/shell.ts
+++ b/scripts/lib/io/shell.ts
@@ -11,6 +11,7 @@ export const shellIo = {
   chmod: (cwd: string) => $`chmod -R 755 .`.cwd(cwd).nothrow(),
   rm: (path: string) => $`rm -rf ${path}`.nothrow(),
   mkdir: (path: string) => $`mkdir -p ${path}`,
+  sleep: (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)),
 
   // CI tokens
   mintGitHubAppToken: () => mintGitHubAppTokenImpl(),

--- a/scripts/release/tag.test.ts
+++ b/scripts/release/tag.test.ts
@@ -8,6 +8,7 @@ describe('tag.ts', () => {
   beforeEach(() => {
     silenceIO()
     spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
+    spyOn(io.shell, 'sleep').mockResolvedValue(undefined)
     spyOn(io.gh, 'authSetupGit').mockResolvedValue(shellResult())
   })
 
@@ -27,15 +28,44 @@ describe('tag.ts', () => {
       expect(code).toBe(1)
     })
 
-    test('exits early when commit has no associated PRs', async () => {
+    test('polls and exits when commit has no associated PRs after full window', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([])
+      // GitHub's commit→PR index never catches up — endpoint keeps returning [].
+      const prSpy = spyOn(io.gh, 'getPrForCommit').mockResolvedValue([])
       const fetchSpy = spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
 
       const code = await tagRelease()
 
       expect(code).toBe(0)
+      // Polled the full window (30 attempts) before giving up.
+      expect(prSpy).toHaveBeenCalledTimes(30)
       expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    test('polls getPrForCommit until the PR appears, then proceeds with tagging', async () => {
+      process.env.CIRCLE_SHA1 = 'abc123'
+      // Simulate GitHub's commit→PR index catching up on the 4th poll.
+      const prSpy = spyOn(io.gh, 'getPrForCommit')
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValue([{ number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' }])
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
+      ])
+      spyOn(io.npm, 'viewVersion').mockResolvedValue('1.0.0')
+      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
+
+      const code = await tagRelease()
+
+      expect(code).toBe(0)
+      expect(prSpy).toHaveBeenCalledTimes(4)
+      // Proceeded with tagging — did not bail out on the empty responses.
+      expect(tagSpy).toHaveBeenCalledWith('@agent-facets/core@1.1.0', 'original-sha')
     })
 
     test('exits early when commit is not a version PR merge', async () => {

--- a/scripts/release/tag.ts
+++ b/scripts/release/tag.ts
@@ -28,6 +28,23 @@ import {
 } from '../lib/constants'
 import { io } from '../lib/io'
 
+/**
+ * Poll parameters for GitHub's commit→PR index catching up after a squash merge.
+ *
+ * GitHub's `repos/{owner}/{repo}/commits/{sha}/pulls` endpoint is backed by a
+ * search index that lags behind the merge event by ~60 seconds in observed
+ * cases. If tag.ts runs before the index catches up, `getPrForCommit` returns
+ * an empty array and we'd silently skip tagging — which broke the 0.5.3
+ * release (pipeline 196).
+ *
+ * We poll at a fixed 10-second interval for up to 5 minutes. If the endpoint
+ * still returns empty after the full window, we fall through to the existing
+ * "nothing to do" exit path — a legitimate non-version-PR merge with no
+ * associated PRs in the API.
+ */
+const PR_POLL_INTERVAL_MS = 10_000
+const PR_POLL_MAX_ATTEMPTS = 30
+
 export async function tagRelease(): Promise<number> {
   const sha = process.env.CIRCLE_SHA1
   if (!sha) {
@@ -38,7 +55,15 @@ export async function tagRelease(): Promise<number> {
   await mintGithubTokens()
   await io.gh.authSetupGit()
 
-  const prs = await io.gh.getPrForCommit(sha)
+  let prs = await io.gh.getPrForCommit(sha)
+  for (let attempt = 1; attempt < PR_POLL_MAX_ATTEMPTS && prs.length === 0; attempt++) {
+    io.console.log(
+      `PR not yet indexed for ${sha}, retrying in ${PR_POLL_INTERVAL_MS / 1000}s (attempt ${attempt + 1}/${PR_POLL_MAX_ATTEMPTS})...`,
+    )
+    await io.shell.sleep(PR_POLL_INTERVAL_MS)
+    prs = await io.gh.getPrForCommit(sha)
+  }
+
   const versionPr = prs.find((p) => p.headRefName === CHANGESET_RELEASE_BRANCH)
 
   if (!versionPr) {


### PR DESCRIPTION
### Why

GitHub's `commits/{sha}/pulls` endpoint is backed by a search index that lags behind a squash merge event by ~60 seconds in observed cases. When `tag.ts` ran before the index caught up, `getPrForCommit` returned an empty array and tagging was silently skipped. This broke the 0.5.3 release (pipeline 196).

### Details

Rather than treating an empty PR response as an immediate "nothing to do" signal, `tagRelease` now polls the endpoint at a 10-second interval for up to 5 minutes (30 attempts). If the PR appears before the window expires, execution continues normally with tagging. If the endpoint still returns empty after all 30 attempts, the existing "no associated PR" exit path is taken — which remains the correct behavior for non-version-PR merges.

A `sleep` utility was added to `shellIo` so it can be mocked in tests. The existing test for the "no PRs" case was updated to assert that all 30 poll attempts are made before giving up, and a new test covers the happy path where the PR appears on the 4th poll and tagging proceeds correctly.

A `nuke` script was also added as a convenience command to clean, reinstall, and type-check in one step.

### Verification

New and updated unit tests cover both the polling-exhausted and polling-succeeded paths. CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI release tagging flow to wait up to 5 minutes for GitHub’s commit→PR association to appear; mistakes here could delay or skip tag creation and downstream release pipelines.
> 
> **Overview**
> Prevents silent release-tagging skips by **polling GitHub’s commit→PR endpoint** in `tagRelease` when it initially returns no PRs (10s interval, up to 30 attempts), then proceeding with tagging once the version PR is observed.
> 
> Adds a mockable `io.shell.sleep` helper and expands `tag.test.ts` to cover both the “poll window exhausted” path and the “PR appears after a few polls” path. Also adds a convenience `nuke` script (`clean` + reinstall + `check`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182352524940fed3be15c20c5e33ad95606815dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->