### PR TITLE
Migrate install URL from facet.cafe to install.agentfacets.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Full documentation is available at [agentfacets.io](https://agentfacets.io).
 ## Quickstart
 
 ```shell
-# Install the CLI
+# Install the CLI (macOS/Linux)
+curl -fsSL https://install.agentfacets.io | bash
+
+# Or via npm (all platforms, including Windows)
 npm install -g agent-facets
 
 # For closed-alpha partners: see docs/alpha/partner-onboarding.md

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -129,7 +129,7 @@
         "type": "button",
         "icon": "download",
         "label": "Download CLI",
-        "href": "https://facet.cafe/install"
+        "href": "https://install.agentfacets.io"
       }
     ]
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ references that extend AI coding assistants.
 <CodeGroup>
 
 ```shell curl
-curl -fsSL https://facet.cafe/install | bash
+curl -fsSL https://install.agentfacets.io | bash
 ```
 
 ```shell npm


### PR DESCRIPTION
### Why

The CLI install URL has moved from `facet.cafe/install` to `install.agentfacets.io`. All references need to point to the new domain.

### Details

The README quickstart section now also clarifies that the `curl` install method is for macOS/Linux only, and positions `npm install -g agent-facets` as the cross-platform alternative (including Windows).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates install URLs and clarifies platform support; no runtime or security-sensitive code is affected.
> 
> **Overview**
> Updates all user-facing CLI install references from `facet.cafe/install` to `https://install.agentfacets.io` across the README and docs site.
> 
> Clarifies in `README.md` that the `curl | bash` installer is for macOS/Linux and positions `npm install -g agent-facets` as the cross-platform (Windows-inclusive) alternative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab52a11df9d6d158bf651b3776dd7c9eab24c4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->