### PR TITLE
Exclude `@agent-facets/common` from release tagging and CI

### DIFF
--- a/.changeset/dry-clouds-pick.md
+++ b/.changeset/dry-clouds-pick.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/common": patch
+---
+
+Ignore common for tags and CI

--- a/packages/common/AGENTS.md
+++ b/packages/common/AGENTS.md
@@ -43,3 +43,15 @@ here so there's one definition, not two.
 Before adding a file here, ask: "Would the adapter SDK want to call this
 at runtime?" If no, it probably belongs in `core`. If yes, and it has no
 heavy dependencies, `common` is the right home.
+
+## Release marker
+
+This package carries `"agentFacets": { "release": "skip" }` in its
+`package.json`. That tells `scripts/release/tag.ts` (and
+`scripts/lib/changesets.ts#hasUnpublishedVersions`) to never create a git
+tag for this package. `common` is workspace-only — it's bundled into the
+adapter SDK at build time and imported directly by `core` and `cli`, so
+there's no npm release path for it and no companion pipeline to trigger.
+
+See `scripts/README.md` ("Opting a workspace package out of releases")
+for the full rationale.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.3",
   "type": "module",
+  "agentFacets": {
+    "release": "skip"
+  },
   "exports": {
     ".": "./src/index.ts"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,6 +92,24 @@ The CLI package (`agent-facets`) is marked `"private": true` in its `package.jso
 4. This custom flow cannot use `changeset publish` or standard `npm publish` from the source directory
 5. Marking it `private` prevents `changeset publish` from attempting to publish the raw source package — the custom `release-cli/` pipeline handles it instead
 
+## Opting a workspace package out of releases
+
+Some workspace packages — like `@agent-facets/common` — are private helpers that are never published and have no companion release pipeline. `"private": true` alone isn't enough to skip them: the CLI package is also private but MUST be tagged (its tag triggers the binary release pipeline).
+
+To mark a package as "workspace-only, never release", add this to its `package.json`:
+
+```jsonc
+{
+  "name": "@agent-facets/something-internal",
+  "private": true,
+  "agentFacets": {
+    "release": "skip"
+  }
+}
+```
+
+`release/tag.ts` and `lib/changesets.ts#hasUnpublishedVersions` both honor this marker. Without it, `io.npm.viewVersion` returns `null` for unpublished private packages, so `tag.ts` would perpetually try to re-tag them each release cycle — and fail the second time with "tag already exists".
+
 ## IO Adapter
 
 All external side effects (shell commands, file operations, network calls) go through the `io` object exported from `lib/io/`. The adapter is split into domain files and exposed as **nested namespaces** — one per domain.

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -5,6 +5,14 @@ export interface WorkspacePackage {
   version: string
   dir: string
   private?: boolean
+  /**
+   * Internal release marker, read from `agentFacets.release` in package.json.
+   * `"skip"` means the package is workspace-only — never tagged, never
+   * published. Used by `tag.ts` and `hasUnpublishedVersions` to exclude
+   * packages that have no publish path (unlike the private CLI package,
+   * which IS tagged because the tag triggers its binary release pipeline).
+   */
+  releaseMode?: 'skip'
 }
 
 /**
@@ -26,12 +34,19 @@ export function shouldPublish(pendingChangesets: string[]): boolean {
 /**
  * Check whether any workspace package has a local version
  * that doesn't yet exist on the npm registry.
+ *
+ * Packages marked `agentFacets.release: "skip"` are excluded — they're
+ * workspace-only and have no npm registry to compare against. Without
+ * this skip, `npmViewFn` would return `null` for them and they'd
+ * perpetually report as "unpublished", causing tag.ts to keep firing
+ * even when only skipped packages have bumps.
  */
 export async function hasUnpublishedVersions(
   packages: WorkspacePackage[],
   npmViewFn: (pkg: string) => Promise<string | null>,
 ): Promise<boolean> {
   for (const pkg of packages) {
+    if (pkg.releaseMode === 'skip') continue
     const npmVersion = await npmViewFn(pkg.name)
     if (npmVersion !== pkg.version) return true
   }

--- a/scripts/lib/ci.ts
+++ b/scripts/lib/ci.ts
@@ -26,7 +26,13 @@ export async function loadWorkspacePackages(): Promise<WorkspacePackage[]> {
     for (const dir of dirs) {
       if (await io.shell.fileExists(`${dir}/package.json`)) {
         const pkg = await io.shell.readJson(`${dir}/package.json`)
-        results.push({ name: pkg.name, version: pkg.version, dir, private: pkg.private })
+        results.push({
+          name: pkg.name,
+          version: pkg.version,
+          dir,
+          private: pkg.private,
+          releaseMode: pkg.agentFacets?.release === 'skip' ? 'skip' : undefined,
+        })
       }
     }
   }

--- a/scripts/release/tag.test.ts
+++ b/scripts/release/tag.test.ts
@@ -160,6 +160,72 @@ describe('tag.ts', () => {
       expect(pushSpy).toHaveBeenCalledWith('origin')
     })
 
+    test('skips packages with releaseMode:"skip" when tagging', async () => {
+      // @agent-facets/common is workspace-only — marked agentFacets.release:"skip"
+      // in its package.json. It must not be tagged even when it has a version
+      // bump, because no release pipeline would do anything useful with the tag
+      // and the tag would collide on subsequent release cycles.
+      process.env.CIRCLE_SHA1 = 'abc123'
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
+        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
+      ])
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
+        { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli', private: true },
+        { name: '@agent-facets/common', version: '0.1.4', dir: 'packages/common', private: true, releaseMode: 'skip' },
+      ])
+      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
+        if (pkg === '@agent-facets/core') return '1.0.0' // bumped
+        if (pkg === 'agent-facets') return '0.3.0' // bumped
+        return null // common is never published
+      })
+      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      const triggerSpy = spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
+
+      const code = await tagRelease()
+
+      expect(code).toBe(0)
+      expect(tagSpy).toHaveBeenCalledWith('@agent-facets/core@1.1.0', 'original-sha')
+      expect(tagSpy).toHaveBeenCalledWith('agent-facets@0.4.0', 'original-sha')
+      expect(tagSpy).not.toHaveBeenCalledWith('@agent-facets/common@0.1.4', 'original-sha')
+      // Only the two non-skipped packages should trigger pipelines.
+      expect(triggerSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('returns early when only releaseMode:"skip" packages have bumps', async () => {
+      // If every bumped package is release-skipped, there's nothing to tag.
+      // Without this handling, hasUnpublishedVersions would return true
+      // forever (npm view always returns null for skipped packages) and
+      // tag.ts would attempt tagging on every main-pipeline run.
+      process.env.CIRCLE_SHA1 = 'abc123'
+      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
+        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
+      ])
+      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
+      spyOn(io.git, 'config').mockResolvedValue(shellResult())
+      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
+        { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
+        { name: '@agent-facets/common', version: '0.1.4', dir: 'packages/common', private: true, releaseMode: 'skip' },
+      ])
+      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
+        if (pkg === '@agent-facets/core') return '1.0.0' // unchanged
+        return null // common is never published
+      })
+      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
+      const pushSpy = spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
+      const triggerSpy = spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
+
+      const code = await tagRelease()
+
+      expect(code).toBe(0)
+      expect(tagSpy).not.toHaveBeenCalled()
+      expect(pushSpy).not.toHaveBeenCalled()
+      expect(triggerSpy).not.toHaveBeenCalled()
+    })
+
     test('fetches the original branch commit SHA', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
       spyOn(io.gh, 'getPrForCommit').mockResolvedValue([

--- a/scripts/release/tag.ts
+++ b/scripts/release/tag.ts
@@ -89,6 +89,13 @@ export async function tagRelease(): Promise<number> {
 
   const pushedTags: string[] = []
   for (const pkg of packages) {
+    // Packages marked `agentFacets.release: "skip"` in their package.json
+    // are workspace-only (e.g., @agent-facets/common) and must not be tagged.
+    // Without this guard, io.npm.viewVersion returns null for these (never
+    // published), so `npmVersion !== pkg.version` is always true and every
+    // release cycle re-attempts the same tag — which fails with "tag already
+    // exists" once the first attempt has pushed.
+    if (pkg.releaseMode === 'skip') continue
     const npmVersion = await io.npm.viewVersion(pkg.name)
     if (npmVersion !== pkg.version) {
       const tag = `${pkg.name}@${pkg.version}`


### PR DESCRIPTION
### Why

`@agent-facets/common` is a workspace-only package — it's bundled into the adapter SDK at build time and imported directly by `core` and `cli`, so it has no npm publish path and no companion release pipeline. However, `"private": true` alone isn't sufficient to exclude it from the release process, because the CLI package is also private but *must* be tagged (its tag triggers the binary release pipeline). Without an explicit opt-out mechanism, `io.npm.viewVersion` returns `null` for `common` (since it's never published), causing `tag.ts` to perpetually attempt re-tagging it on every release cycle — and fail with "tag already exists" after the first run.

### Details

A new `agentFacets.release: "skip"` marker in `package.json` signals that a package should be excluded from all release automation. Both `tag.ts` and `hasUnpublishedVersions` in `lib/changesets.ts` check for this marker and skip the package entirely. `loadWorkspacePackages` in `lib/ci.ts` reads the marker and surfaces it as `releaseMode: "skip"` on the `WorkspacePackage` type.

This is distinct from the `"private": true` flag, which only prevents `changeset publish` from publishing the raw source — it doesn't prevent tagging. The new marker covers the case where a package is private *and* has no release path of any kind.

Two new tests cover the key scenarios: one verifies that skipped packages are excluded from tagging and pipeline triggers even when they have a version bump, and another verifies that the release process exits cleanly (no tags, no pushes, no pipeline triggers) when the only bumped packages are release-skipped.

### Verification

New tests in `scripts/release/tag.test.ts` cover both scenarios. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation used to create git tags and trigger CI pipelines; a mistake could skip needed tags or keep pipelines from running. Scope is contained and covered by new unit tests.
> 
> **Overview**
> Prevents workspace-only packages from participating in release tagging by introducing an `agentFacets.release: "skip"` marker (added to `@agent-facets/common`) and threading it through CI package discovery as `releaseMode: 'skip'`.
> 
> Updates `hasUnpublishedVersions` and `release/tag.ts` to ignore skipped packages so `npm view` returning `null` no longer causes perpetual “unpublished”/re-tagging attempts, and adds tests to verify skipped packages neither get tagged nor trigger CircleCI pipelines (including the “only skipped bumps” no-op case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71331858615339bfec1ffa61e86494b1680fd484. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->