### PR TITLE
Add Turbo configs and disable build cache in CI for adapter packages

### DIFF
--- a/.changeset/whole-carrots-live.md
+++ b/.changeset/whole-carrots-live.md
@@ -1,0 +1,12 @@
+---
+"@agent-facets/adapter-claude-code": minor
+"@agent-facets/adapter-opencode": minor
+"@agent-facets/adapter-codex": minor
+"@agent-facets/adapter": minor
+"@agent-facets/brand": minor
+"agent-facets": minor
+"@agent-facets/common": minor
+"@agent-facets/core": minor
+---
+
+Clean up publish failures

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -43,10 +43,19 @@ jobs:
             - run:
                 command: cp packages/cli/turbo.ci.json packages/cli/turbo.json
                 name: Disable CLI build cache
+            - run:
+                command: cp packages/adapters/opencode/turbo.ci.json packages/adapters/opencode/turbo.json
+                name: Disable OpenCode adapter build cache
+            - run:
+                command: cp packages/adapters/claude-code/turbo.ci.json packages/adapters/claude-code/turbo.json
+                name: Disable Claude Code adapter build cache
+            - run:
+                command: cp packages/adapters/codex/turbo.ci.json packages/adapters/codex/turbo.json
+                name: Disable Codex adapter build cache
             - run-check
             - run:
-                command: git checkout packages/cli/turbo.json
-                name: Restore CLI turbo config
+                command: git checkout packages
+                name: Restore Turbo configs
             - store_test_results:
                 path: test-results
     main-pipeline:

--- a/.circleci/development/jobs/check.yml
+++ b/.circleci/development/jobs/check.yml
@@ -6,10 +6,19 @@ steps:
   - run:
       name: Disable CLI build cache
       command: cp packages/cli/turbo.ci.json packages/cli/turbo.json
+  - run:
+      name: Disable OpenCode adapter build cache
+      command: cp packages/adapters/opencode/turbo.ci.json packages/adapters/opencode/turbo.json
+  - run:
+      name: Disable Claude Code adapter build cache
+      command: cp packages/adapters/claude-code/turbo.ci.json packages/adapters/claude-code/turbo.json
+  - run:
+      name: Disable Codex adapter build cache
+      command: cp packages/adapters/codex/turbo.ci.json packages/adapters/codex/turbo.json
   - run-check
   - run:
-      name: Restore CLI turbo config
-      command: git checkout packages/cli/turbo.json
+      name: Restore Turbo configs
+      command: git checkout packages
   - store_test_results:
       path: test-results
 

--- a/packages/adapters/claude-code/turbo.ci.json
+++ b/packages/adapters/claude-code/turbo.ci.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}

--- a/packages/adapters/claude-code/turbo.json
+++ b/packages/adapters/claude-code/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {},
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}

--- a/packages/adapters/codex/turbo.ci.json
+++ b/packages/adapters/codex/turbo.ci.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}

--- a/packages/adapters/codex/turbo.json
+++ b/packages/adapters/codex/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {},
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}

--- a/packages/adapters/opencode/turbo.ci.json
+++ b/packages/adapters/opencode/turbo.ci.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}

--- a/packages/adapters/opencode/turbo.json
+++ b/packages/adapters/opencode/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {},
+    "test": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
+}


### PR DESCRIPTION
### Why

The OpenCode, Claude Code, and Codex adapters were missing Turbo configurations, meaning their build caches were not being disabled during CI runs the way the CLI package's was.

### Details

Each adapter now has a `turbo.json` (standard local config) and a `turbo.ci.json` (CI-specific config with `cache: false` on the `build` task). The CI pipeline steps copy the `.ci.json` variant over `turbo.json` before running checks, then restore all configs in the `packages/` directory at once via `git checkout packages` rather than restoring only the CLI config.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI configuration and Turborepo task settings, with no runtime application logic changes.
> 
> **Overview**
> **Improves CI determinism for adapter packages** by adding per-adapter `turbo.json` plus CI-specific `turbo.ci.json` files (with `build.cache: false`) for `opencode`, `claude-code`, and `codex`.
> 
> Updates CircleCI `check` jobs to copy each adapter’s `turbo.ci.json` over `turbo.json` before running `bun turbo check`, and simplifies cleanup by restoring all modified configs via `git checkout packages`.
> 
> Adds a Changeset bumping multiple packages (minor) to ship the CI/publish cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9ee69ad276f3e1a95cee9380d8fbc565da3d5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->