### PR TITLE
Migrate strategy references from local repo to Notion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .turbo/
-.strategy/
 lefthook-local.yml
 mise.local.toml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,9 +77,7 @@ See `packages/common/AGENTS.md` for the rule on what does and doesn't belong her
 
 ## Strategy
 
-Company-wide strategy decision records are located at `../strategy` (the sibling `strategy/` repository). This includes Strategic Decision Records (SDRs), initiatives, and roadmap phases organized by namespace.
-
-The `facets/` namespace within that repo (`../strategy/facets/`) contains strategy decisions specific to this project — including SDRs, initiatives, and roadmap entries. Consult these when you need strategic context for decisions affecting this project.
+Strategic Decision Records (SDRs) and Architectural Decision Records (ADRs) live in Notion. The authoritative databases and views are configured in `.opencode/notion.json` (keys: `sdrs`, `sdr_events`, `sdr_relationships`, `adrs`, `adr_events`). Consult these when you need strategic or architectural context for decisions affecting this project. See also Article III of `openspec/config.yaml` for ADR authority.
 
 ## Bun
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -77,7 +77,6 @@ rules:
     - MUST include a "Non-goals" section
     - Each capability in the Capabilities section MUST correspond to a product domain, not a feature within a domain. Use domain names (e.g., `execution`, `planning`) not domain-feature compounds (e.g., NOT `execution-loop`, `auth-login`, `user-auth`, `data-export`). Check `openspec/specs/` for existing domain names before inventing new ones.
     - MUST reference which ADRs in Notion informed the proposal. If no relevant ADRs exist, state so explicitly.
-    - If the proposed work corresponds to a roadmap phase in `../strategy/<namespace>/roadmap/`, the proposal MUST reference the phase file and note its current status. If the phase is `planned`, the proposal MUST note that the phase needs to be transitioned to `active` before implementation begins.
   design:
     - MUST identify any user-facing documentation in `docs/` and root `README.md` that would need updating based on the proposed changes
     - If the design changes observable behavior, CLI commands, APIs, or concepts covered in `docs/`, the design MUST note which doc files need updating
@@ -125,4 +124,3 @@ rules:
       - [ ] 4.4 Verify: <run checks for this block>
       ```
     - MUST check `docs/` and root `README.md` for content that references changed behavior, and SHOULD include documentation update tasks when affected docs are found
-    - If the work corresponds to a roadmap phase, the tasks MUST include a final step to check whether the phase's success criteria are fully met. If all criteria are satisfied, the step SHOULD transition the phase to `completed` and archive it. If criteria remain unmet, the step MUST note explicitly what remains.


### PR DESCRIPTION
### Why

The `strategy/` sibling repository is no longer the source of truth for strategic and architectural decisions. SDRs and ADRs have moved to Notion, making the local `strategy/` repo references stale and misleading.

### Details

- Removes `.strategy/` from `.gitignore` since the sibling repo is no longer in use.
- Updates `AGENTS.md` to point agents to Notion (via `.opencode/notion.json`) for SDR and ADR context instead of the `../strategy/` directory.
- Removes the two `openspec/config.yaml` rules that required proposals and task lists to cross-reference roadmap phase files in `../strategy/`, since those files no longer exist in the expected location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/config-only changes; primary risk is breaking internal contribution workflows that still rely on the old `../strategy` roadmap references.
> 
> **Overview**
> Updates contributor/agent guidance to treat Notion as the source of truth for SDRs/ADRs, pointing to `.opencode/notion.json` and `openspec/config.yaml` for authority.
> 
> Removes now-stale `../strategy` roadmap/phase cross-reference requirements from `openspec/config.yaml`, and drops `.strategy/` from `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243a58a5b2e9d351b5986830054a50ccc192b588. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->