### PR TITLE
Add CD workflow to deploy SST `main` stage on push to `main`

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -1,2 +1,20 @@
 - The release/commands directory contains single-file symlinks to the development/commands/* files
 - When creating new commands, write them to the development/commands directory, then make a symlink in release/commands
+
+## Pipelines
+
+Two packed CircleCI configs, one per pipeline dir.
+
+### `development/` — CI
+
+PR-time checks. Workflows: `ci` (runs `check` on non-main branches, runs `main-pipeline` on main).
+
+### `release/` — CD
+
+Everything that ships. Three workflows:
+
+| Workflow      | Trigger                             | Purpose                                  |
+|---------------|-------------------------------------|------------------------------------------|
+| `release`     | `@agent-facets/<pkg>@<version>` tag | Publish one library/adapter package      |
+| `release-cli` | `agent-facets@<version>` tag        | Build + publish 12 CLI platform packages |
+| `deploy`      | push to `main`                      | `sst deploy --stage main`                |

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -1,4 +1,9 @@
 commands:
+    aws-oidc-setup:
+        steps:
+            - aws-cli/setup:
+                region: us-east-1
+                role_arn: ${AWS_ROLE_ARN}
     notify-failure:
         steps:
             - run:
@@ -91,6 +96,8 @@ jobs:
                 command: bun scripts/release/publish.ts
                 name: Publish
             - notify-failure
+orbs:
+    aws-cli: circleci/aws-cli@5.4.1
 version: 2.1
 workflows:
     ci:

--- a/.circleci/development/@config.yml
+++ b/.circleci/development/@config.yml
@@ -1,1 +1,3 @@
 version: 2.1
+orbs:
+  aws-cli: circleci/aws-cli@5.4.1

--- a/.circleci/development/commands/aws-oidc-setup.yml
+++ b/.circleci/development/commands/aws-oidc-setup.yml
@@ -1,0 +1,4 @@
+steps:
+  - aws-cli/setup:
+      role_arn: ${AWS_ROLE_ARN}
+      region: us-east-1

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -1,4 +1,9 @@
 commands:
+    aws-oidc-setup:
+        steps:
+            - aws-cli/setup:
+                region: us-east-1
+                role_arn: ${AWS_ROLE_ARN}
     notify-failure:
         steps:
             - run:
@@ -46,6 +51,21 @@ jobs:
                     - packages/cli/dist
                 root: .
             - notify-failure
+    deploy-site:
+        docker:
+            - image: cimg/base:current
+        environment:
+            LEFTHOOK: "0"
+            MISE_ENV: release
+        resource_class: small
+        steps:
+            - setup-mise
+            - aws-oidc-setup
+            - run:
+                command: bun scripts/deploy/site.ts
+                name: Deploy SST main stage
+                no_output_timeout: 30m
+            - notify-failure
     finalize-cli:
         docker:
             - image: cimg/base:current
@@ -92,8 +112,21 @@ jobs:
                 command: bun scripts/release/publish.ts
                 name: Publish
             - notify-failure
+orbs:
+    aws-cli: circleci/aws-cli@5.4.1
 version: 2.1
 workflows:
+    deploy:
+        jobs:
+            - deploy-site:
+                context:
+                    - bot-context
+                    - slack-secrets
+                    - sst
+                filters:
+                    branches:
+                        only:
+                            - main
     release:
         jobs:
             - release:

--- a/.circleci/release/commands/aws-oidc-setup.yml
+++ b/.circleci/release/commands/aws-oidc-setup.yml
@@ -1,0 +1,1 @@
+../../development/commands/aws-oidc-setup.yml

--- a/.circleci/release/jobs/deploy-site.yml
+++ b/.circleci/release/jobs/deploy-site.yml
@@ -1,0 +1,14 @@
+docker:
+  - image: cimg/base:current
+resource_class: small
+environment:
+  LEFTHOOK: "0"
+  MISE_ENV: release
+steps:
+  - setup-mise
+  - aws-oidc-setup
+  - run:
+      name: Deploy SST main stage
+      command: bun scripts/deploy/site.ts
+      no_output_timeout: 30m
+  - notify-failure

--- a/.circleci/release/workflows/deploy.yml
+++ b/.circleci/release/workflows/deploy.yml
@@ -1,0 +1,10 @@
+jobs:
+  - deploy-site:
+      context:
+        - bot-context
+        - slack-secrets
+        - sst
+      filters:
+        branches:
+          only:
+            - main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,17 @@ account is shared with the sibling `facet-cafe` repo.
 | `bun sst deploy --stage <stage>` | Deploy to a named stage               |
 | `bun sst remove --stage <stage>` | Tear down a non-main stage            |
 
-Manual deploys only for now. CircleCI wiring is a deferred follow-up.
+### Continuous deployment
+
+Every push to `main` runs `sst deploy --stage main` via the `deploy` workflow
+in `.circleci/release/workflows/deploy.yml`. Requires the `sst` CircleCI
+context with `AWS_ROLE_ARN`. See `scripts/deploy/README.md` for the pipeline
+flow and [CircleCI's AWS OIDC docs][oidc-aws] for the one-time IAM setup.
+
+[oidc-aws]: https://circleci.com/docs/guides/permissions-authentication/openid-connect-tokens/#set-up-aws
+
+Manual deploys are still supported for ad-hoc stages via the `bun sst deploy
+--stage <stage>` command.
 
 ### Layout
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,9 @@ scripts/
 │   ├── seed.ts                 # Seed platform package names on npm
 │   └── targets.ts              # Platform target matrix definitions
 │
+├── deploy/                     # SST main-stage CD pipeline
+│   └── site.ts                 # `sst install` + `sst deploy --stage main`
+│
 ├── lib/                        # Shared utilities
 │   ├── io/                     # IO adapter (split by domain, nested namespaces)
 │   │   ├── index.ts            # Composes io = { npm, git, gh, circleci, shell, console }
@@ -46,9 +49,10 @@ scripts/
 └── check-bun-version.ts        # Verify Bun version matches mise.toml
 ```
 
-## Two Pipelines
+## Three Pipelines
 
-There are two independent release pipelines, triggered by different git tag patterns:
+There are three independent release-pipeline workflows — two triggered by git tag
+patterns, one triggered by pushes to `main`:
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
@@ -71,15 +75,18 @@ There are two independent release pipelines, triggered by different git tag patt
 │    @agent-facets/brand@X.Y.Z  ─── library tag                    │
 │    agent-facets@X.Y.Z         ─── CLI tag                        │
 └──────────────────────────────────────────────────────────────────┘
-            │                                       │
-            ▼                                       ▼
-   ┌─────────────────┐                  ┌──────────────────────┐
-   │ Library Release │                  │ CLI Release          │
-   │ (release/ dir)  │                  │ (release-cli/ dir)   │
-   │                 │                  │                      │
-   │ See release/    │                  │ See release-cli/     │
-   │ README.md       │                  │ README.md            │
-   └─────────────────┘                  └──────────────────────┘
+             │                                       │
+             ▼                                       ▼
+    ┌─────────────────┐                  ┌──────────────────────┐
+    │ Library Release │                  │ CLI Release          │
+    │ (release/ dir)  │                  │ (release-cli/ dir)   │
+    │                 │                  │                      │
+    │ See release/    │                  │ See release-cli/     │
+    │ README.md       │                  │ README.md            │
+    └─────────────────┘                  └──────────────────────┘
+
+Independently, every push to `main` triggers the `deploy` workflow which
+runs `sst deploy --stage main` via `deploy/site.ts`. See `deploy/README.md`.
 ```
 
 ## Why is the CLI package private?

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -1,0 +1,69 @@
+# Deploy Pipeline
+
+Continuous deployment (CD) of the SST `main` stage on every push to `main`.
+
+## Flow
+
+```
+Push to main
+  │
+  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  deploy-site CircleCI job (deploy workflow, release pipeline)      │
+│                                                                    │
+│  1. setup-mise       — install Bun, node, deps                     │
+│  2. aws-oidc-setup   — assume AWS_ROLE_ARN via OIDC (aws-cli orb)  │
+│  3. bun scripts/deploy/site.ts                                     │
+│       a. Pre-flight: AWS_ACCESS_KEY_ID must be set                 │
+│       b. bun sst install   (CI's postinstall skips it)             │
+│       c. bun sst deploy --stage main                               │
+│  4. notify-failure   — Slack hook on failure                       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Defined in `.circleci/release/jobs/deploy-site.yml` and
+`.circleci/release/workflows/deploy.yml`. Lives in the release pipeline because
+deployment is part of the release lifecycle; the development pipeline is
+reserved for PR-time CI checks.
+
+## Scripts
+
+| Script    | CircleCI Job  | Purpose                                                    |
+|-----------|---------------|------------------------------------------------------------|
+| `site.ts` | `deploy-site` | Install SST platform files, then `sst deploy --stage main` |
+
+## Required CircleCI context
+
+`sst` context with one variable:
+
+| Variable       | Value                                                    |
+|----------------|----------------------------------------------------------|
+| `AWS_ROLE_ARN` | `arn:aws:iam::<account-id>:role/<ci-deploy-role>`        |
+
+The role must trust the CircleCI OIDC provider for the `agent-facets` org and
+be scoped to this project by `project-id`. For the one-time AWS-side setup see
+[CircleCI: Using OpenID Connect tokens in jobs — Set up AWS][oidc-aws].
+
+[oidc-aws]: https://circleci.com/docs/guides/permissions-authentication/openid-connect-tokens/#set-up-aws
+
+## Manual redeploy
+
+Re-run the `deploy-site` job from the CircleCI UI for the relevant `main`
+commit, or push an empty commit to `main`:
+
+```sh
+git commit --allow-empty -m "chore: redeploy"
+git push origin main
+```
+
+## Why CD sits in the release pipeline
+
+- **CI** (`.circleci/development/`) runs on PRs and handles automated checks
+  that gate merge.
+- **CD** (`.circleci/release/`) runs on `main` and on release tags, and handles
+  everything that actually ships to users — npm publishes, CLI binaries, and
+  the SST deploy of `agentfacets.io`.
+
+The `deploy` workflow runs in parallel with `main-pipeline` (which re-runs
+`check` on `main`). CI already passed on the PR pre-merge, so gating the
+deploy on a second `check` run is redundant.

--- a/scripts/deploy/site.test.ts
+++ b/scripts/deploy/site.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { io } from '../lib/io'
+import { shellPromise, silenceIO } from '../lib/test-helpers'
+import { deploySite } from './site'
+
+describe('site.ts', () => {
+  beforeEach(() => {
+    silenceIO()
+  })
+
+  afterEach(() => {
+    mock.restore()
+    delete process.env.AWS_ACCESS_KEY_ID
+  })
+
+  test('returns 1 when AWS_ACCESS_KEY_ID is not set', async () => {
+    delete process.env.AWS_ACCESS_KEY_ID
+    const code = await deploySite()
+    expect(code).toBe(1)
+  })
+
+  test('runs sst install, then sst deploy, then returns 0', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAFAKE'
+    const callOrder: string[] = []
+
+    const installSpy = spyOn(io.shell, 'sstInstall').mockImplementation(() => {
+      callOrder.push('install')
+      return shellPromise()
+    })
+    const deploySpy = spyOn(io.shell, 'sstDeployMain').mockImplementation(() => {
+      callOrder.push('deploy')
+      return shellPromise()
+    })
+
+    const code = await deploySite()
+
+    expect(code).toBe(0)
+    expect(installSpy).toHaveBeenCalledTimes(1)
+    expect(deploySpy).toHaveBeenCalledTimes(1)
+    expect(callOrder).toEqual(['install', 'deploy'])
+  })
+
+  test('does not run sst deploy if AWS credentials are missing', async () => {
+    delete process.env.AWS_ACCESS_KEY_ID
+
+    const installSpy = spyOn(io.shell, 'sstInstall').mockImplementation(() => shellPromise())
+    const deploySpy = spyOn(io.shell, 'sstDeployMain').mockImplementation(() => shellPromise())
+
+    await deploySite()
+
+    expect(installSpy).not.toHaveBeenCalled()
+    expect(deploySpy).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/deploy/site.ts
+++ b/scripts/deploy/site.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env bun
+
+/**
+ * Deploy the SST `main` stage. Runs in the CD workflow on merges to main.
+ *
+ * Pipeline:
+ *   1. Pre-flight: verify AWS credentials have been assumed (the aws-cli
+ *      orb's `aws-cli/setup` step must have run before this script).
+ *   2. `bun sst install` — populate `.sst/platform/` (CI's `postinstall`
+ *      skips this via the `[ -n "$CI" ]` guard in `package.json`).
+ *   3. `bun sst deploy --stage main` — deploy the `main` stage.
+ *
+ * Invoked by the `deploy-site` job in the `deploy` CircleCI workflow.
+ */
+
+import { io } from '../lib/io'
+
+export async function deploySite(): Promise<number> {
+  if (!process.env.AWS_ACCESS_KEY_ID) {
+    io.console.error('AWS credentials not set. aws-cli orb setup must run before this script.')
+    return 1
+  }
+
+  io.console.log('Installing SST platform files...')
+  await io.shell.sstInstall()
+
+  io.console.log('Deploying SST `main` stage...')
+  await io.shell.sstDeployMain()
+
+  io.console.log('Done.')
+  return 0
+}
+
+if (import.meta.main) {
+  const code = await deploySite()
+  process.exit(code)
+}

--- a/scripts/lib/io/shell.ts
+++ b/scripts/lib/io/shell.ts
@@ -25,6 +25,10 @@ export const shellIo = {
   verifyPackages: (packages: string[], version: string) =>
     $`bun scripts/release-cli/verify.ts ${version} ${packages.join(',')}`,
 
+  // SST deploy
+  sstInstall: () => $`bun sst install`,
+  sstDeployMain: () => $`bun sst deploy --stage main`,
+
   // Filesystem
   readFile: (path: string) => Bun.file(path).text(),
   readJson: (path: string) => Bun.file(path).json(),


### PR DESCRIPTION
### Why

Manual deploys to the SST `main` stage were the only option. This wires up continuous deployment so every push to `main` automatically runs `sst deploy --stage main` via CircleCI.

### Details

A new `deploy` workflow is added to the release pipeline (`.circleci/release/`) that triggers on pushes to `main` and runs a `deploy-site` job. The job uses the `circleci/aws-cli` orb to assume an AWS role via OIDC before invoking `scripts/deploy/site.ts`, which runs `bun sst install` followed by `bun sst deploy --stage main`.

The deploy script guards against missing AWS credentials as a pre-flight check — if `AWS_ACCESS_KEY_ID` is not set (i.e., the OIDC setup step didn't run), it exits early with a non-zero code rather than attempting a deploy with no credentials.

CD lives in the release pipeline rather than the development pipeline because the development pipeline is reserved for PR-time CI checks. The `deploy` workflow runs in parallel with `main-pipeline` on `main` — gating the deploy on a redundant re-run of `check` after it already passed on the PR would be unnecessary.

Two new `shellIo` methods (`sstInstall`, `sstDeployMain`) are added to keep shell invocations mockable in tests.

The `sst` CircleCI context must exist with `AWS_ROLE_ARN` set to a role that trusts the CircleCI OIDC provider scoped to this project. See `scripts/deploy/README.md` for the full flow and the one-time IAM setup reference.

### Verification

Unit tests in `scripts/deploy/site.test.ts` cover the credential pre-flight guard, the happy-path ordering of `sst install` → `sst deploy`, and the case where deploy commands are not called when credentials are absent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automatic production deployment path that assumes AWS credentials via OIDC and runs `sst deploy` on every `main` push; misconfiguration could trigger failed or unintended deployments. Changes are localized to CircleCI config and a small deploy script with basic preflight checks and tests.
> 
> **Overview**
> Adds a new CircleCI **CD `deploy` workflow** in the release pipeline that runs on pushes to `main` and executes a new `deploy-site` job to deploy the SST `main` stage.
> 
> Introduces `scripts/deploy/site.ts` (with unit tests) to perform a credential preflight and then run `sst install` followed by `sst deploy --stage main`, and wires in AWS role assumption via a reusable `aws-oidc-setup` command (CircleCI `aws-cli` orb). Documentation is updated to describe the new pipeline and required `sst` context (`AWS_ROLE_ARN`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e778a45fee36e27a57d0a7a5e11237dfd3f3e826. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->