### PR TITLE
Fix `var(--serif)` fallback syntax to `var(--serif, serif)`

### DIFF
--- a/.changeset/brave-donuts-buy.md
+++ b/.changeset/brave-donuts-buy.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/brand": minor
+---
+
+Brand now controls fonts and theming

--- a/packages/landing/src/components/Explainer.module.css
+++ b/packages/landing/src/components/Explainer.module.css
@@ -34,7 +34,7 @@
 }
 
 .title em {
-  font-family: var(--serif), serif;
+  font-family: var(--serif, serif);
   font-style: italic;
   font-weight: 400;
 }

--- a/packages/landing/src/components/FacetStage.module.css
+++ b/packages/landing/src/components/FacetStage.module.css
@@ -70,7 +70,7 @@
 }
 
 .step h3 em {
-  font-family: var(--serif), serif;
+  font-family: var(--serif, serif);
   font-style: italic;
   font-weight: 400;
   color: var(--accent-a);

--- a/packages/landing/src/components/Hero.module.css
+++ b/packages/landing/src/components/Hero.module.css
@@ -69,7 +69,7 @@
 }
 
 .accent {
-  font-family: var(--serif), serif;
+  font-family: var(--serif, serif);
   font-style: italic;
   font-weight: 400;
   background: linear-gradient(100deg, var(--accent-a) 0%, var(--accent-b) 45%, var(--accent-d) 100%);


### PR DESCRIPTION
### Why

The `--serif` CSS custom property was being used with incorrect fallback syntax (`var(--serif), serif`), which means `serif` was never actually used as a fallback if `--serif` was undefined. The correct CSS syntax for a fallback value inside `var()` is `var(--serif, serif)`.

### Details

CSS `var()` fallbacks must be specified as the second argument inside the function itself. The previous syntax `var(--serif), serif` would result in an empty value (or invalid property) rather than falling back to `serif` when `--serif` is not defined. This fix ensures the font stack degrades gracefully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that improves font fallback behavior; no runtime logic or data/auth paths affected.
> 
> **Overview**
> Fixes incorrect CSS custom property fallback usage by changing `font-family: var(--serif), serif` to `var(--serif, serif)` in several landing page components so `serif` is actually used when `--serif` is unset.
> 
> Adds a changeset bumping `@agent-facets/brand` with a note that brand now controls fonts and theming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3705adf93415d753b09fba4367c11885a44340ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->