### PR TITLE
Upload all build assets to S3 so fonts no longer 404

### DIFF
--- a/infra/site.ts
+++ b/infra/site.ts
@@ -43,11 +43,25 @@ const landing = new sst.aws.StaticSite('AgentFacetsLanding', {
     url: 'http://localhost:5173',
   },
   assets: {
+    // SST iterates `fileOptions` in reverse and uploads each matched file
+    // with the first rule that claims it (see
+    // .sst/platform/src/components/aws/static-site.ts, the
+    // `uploadAssets` -> `for (const fileOption of fileOptions.reverse())`
+    // loop). Files matching NO rule are silently dropped, so this list
+    // must be exhaustive — prefer a catch-all + specific overrides over
+    // an allowlist of extensions.
     fileOptions: [
+      // Listed first, runs LAST after SST's internal .reverse(). Sweeps
+      // every file the HTML rule didn't claim: JS, CSS, fonts, images,
+      // favicons, static data. Safe because Vite emits content-hashed
+      // filenames for everything under /assets/.
       {
-        files: ['**/*.css', '**/*.js', '**/*.webp', '**/*.svg', '**/*.ico', '**/*.json'],
+        files: '**',
         cacheControl: 'max-age=31536000,public,immutable',
       },
+      // Listed last, runs FIRST after .reverse() so the catch-all doesn't
+      // claim index.html with the wrong cache header. HTML is the single
+      // mutable URL whose content changes deploy-to-deploy.
       {
         files: '**/*.html',
         cacheControl: 'max-age=3600,public',


### PR DESCRIPTION
### Why

`agentfacets.io` has been serving Georgia/Times for the hero's Instrument Serif italics because every `.woff2` and `.woff` file returned **HTTP 403** — the font files never reached S3. The assets bucket held exactly 4 objects (`index.html`, `favicon.ico`, `assets/index-*.css`, `assets/index-*.js`); Vite's 10 woff2 + 4 woff outputs were silently dropped during deploy.

### Details

SST treats `assets.fileOptions` as an **upload allowlist**, not an annotation overlay. In `.sst/platform/src/components/aws/static-site.ts`, `uploadAssets` iterates the list (after `.reverse()`), uploads files matching the first rule that claims them, and skips anything that matches no rule. The previous `fileOptions` in `infra/site.ts` only listed `css/js/webp/svg/ico/json/html`, so fonts — and any future asset extension — were dropped before the PutObject call.

This PR replaces the extension allowlist with a `**` catch-all plus an HTML-specific override. Because SST reverses the array and uses first-match-wins, the HTML rule (listed last, iterated first) still claims `index.html` with the short `max-age=3600` header before the catch-all sweeps everything else with the immutable year cache. Inline comments make the reverse-iteration ordering visible so the next editor doesn't recreate the bug.

Immutable caching on non-HTML is safe because Vite emits content-hashed filenames for everything under `/assets/`.

### Verification

Deployed to `julian.agentfacets.io` and verified end-to-end:

- S3 bucket: 14 font files landed (10 woff2 + 4 woff), sizes match Vite's `dist/`.
- `curl -I` on a woff2: `HTTP/2 200`, `content-type: font/woff2`, `cache-control: max-age=31536000,public,immutable`.
- Browser: hero "AI agents." renders in Instrument Serif italic (flowing "g" descender, bracketed "A" serifs) instead of the Georgia/Times fallback — matches local dev exactly.
- `bun check` green (233 tests, lint, types across 32 tasks).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change limited to static-site S3 upload/caching behavior; main risk is unintended caching headers on non-HTML files or uploading extra artifacts, mitigated by keeping an explicit HTML override.
> 
> **Overview**
> Fixes missing StaticSite uploads by replacing the extension-based `assets.fileOptions` allowlist with a `**` catch-all, ensuring fonts and any future asset types are included in S3 deploys.
> 
> Adjusts caching so `**/*.html` is still uploaded with a short TTL while everything else gets long-lived immutable caching, and adds comments documenting SST’s reverse-iteration/first-match behavior to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518b1b4f218c5198d6067da1ae37d30d513e3b08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->