### PR TITLE
Reformat scene label to stacked right-aligned layout and adjust vertical position

### DIFF
--- a/packages/landing/src/components/FacetStage.module.css
+++ b/packages/landing/src/components/FacetStage.module.css
@@ -232,7 +232,8 @@
 .sceneLabel {
   position: absolute;
   left: 50%;
-  bottom: 10%;
+  bottom: 24%;
+  text-align: right;
   transform: translateX(-50%);
   font-family: var(--mono), monospace;
   font-size: 11px;

--- a/packages/landing/src/components/FacetStage.tsx
+++ b/packages/landing/src/components/FacetStage.tsx
@@ -155,7 +155,11 @@ export function FacetStage() {
               )
             })}
             <div className={`${styles.sceneLabel}${step === 4 ? ` ${styles.active}` : ''}`} aria-hidden="true">
-              one facet · four primitives · zero setup
+              facet · &nbsp;one
+              <br />
+              primitives · four
+              <br />
+              setup · zero
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Why

The scene label text was displaying in a single line, which didn't read as well visually and wasn't positioned ideally within the stage.

### Details

The label text has been reformatted into three stacked lines — `facet · one`, `primitives · four`, `setup · zero` — right-aligned, to create a more intentional typographic layout. The vertical position has also been raised from `10%` to `24%` from the bottom to better fit the new multi-line presentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts label layout and positioning with no logic, data, or security impact.
> 
> **Overview**
> Reformats the `FacetStage` scene label from a single line into a stacked 3-line layout (using `<br />`), and right-aligns the text for a more deliberate typographic treatment.
> 
> Moves the label higher within the scene by changing `.sceneLabel` from `bottom: 10%` to `bottom: 24%`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffaeee01e84ec714f65bcfa133306fc26424adbe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->