### PR TITLE
Add per-package `serial-group` queueing to CircleCI release workflows

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "ignore": ["@agent-facets/landing"],
+  "ignore": ["@agent-facets/common", "@agent-facets/functions", "@agent-facets/landing"],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/frank-eagles-return.md
+++ b/.changeset/frank-eagles-return.md
@@ -1,0 +1,13 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/common": patch
+"@agent-facets/core": patch
+
+---
+
+Serial deploys via CI to ensure tag and release ordering

--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -1,5 +1,6 @@
 - The release/commands directory contains single-file symlinks to the development/commands/* files
 - When creating new commands, write them to the development/commands directory, then make a symlink in release/commands
+- `release/@config.yml` is a symlink to `development/@config.yml` — edits to either land in both packed configs. The `parameters.package` block lives here for this reason; it's consumed only by the release workflow's `serial-group` but declared in both packed outputs, which is harmless (CircleCI ignores unused declared parameters).
 
 ## Pipelines
 
@@ -18,3 +19,22 @@ Everything that ships. Three workflows:
 | `release`     | `@agent-facets/<pkg>@<version>` tag | Publish one library/adapter package      |
 | `release-cli` | `agent-facets@<version>` tag        | Build + publish 12 CLI platform packages |
 | `deploy`      | push to `main`                      | `sst deploy --stage main`                |
+
+## Serial groups
+
+The main-branch / deploy / release top-level jobs that must queue are assigned a `serial-group` so they queue against their own kind. PR-time work such as `ci`'s `check` job is not serialized. Same-kind runs serialize; different kinds do not interfere. All groups are scoped with `<< pipeline.project.slug >>` so they stay per-project inside the org.
+
+| Workflow      | Job             | serial-group                                                            |
+|---------------|-----------------|-------------------------------------------------------------------------|
+| `ci`          | `main-pipeline` | `<< pipeline.project.slug >>/main-pipeline`                             |
+| `deploy`      | `deploy-site`   | `<< pipeline.project.slug >>/deploy-site`                               |
+| `release`     | `release`       | `<< pipeline.project.slug >>/release/<< pipeline.parameters.package >>` |
+| `release-cli` | `build-cli`     | `<< pipeline.project.slug >>/release-cli-build`                         |
+| `release-cli` | `finalize-cli`  | `<< pipeline.project.slug >>/release-cli-finalize`                      |
+
+Notes:
+
+- The `release` group keys on the `package` pipeline parameter so different packages (`core`, `adapter`, …) can release in parallel while repeat releases of the same package serialize. `scripts/release/tag.ts` parses the package name out of the tag and forwards it via the CircleCI API v2 trigger. The parameter is declared in `release/@config.yml` with a default of `""` — which applies to the `release-cli` trigger path that doesn't set it. Required because the serial-group charset (`[A-Za-z0-9._\-/]`) excludes `@`, so we can't embed the raw tag string.
+- `release-cli` uses **two distinct** group names (`release-cli-build` and `release-cli-finalize`). CircleCI's docs explicitly warn against reusing  the same `serial-group` value on multiple jobs in a single workflow.
+- `publish-platform` intentionally has no `serial-group`. Each matrix variant publishes a distinct platform package, so parallel runs are safe, and adding it would spawn 12 separate queues.
+- Pipeline-number priority: if a newer pipeline enters a serial group while an older one is still waiting, the older one is skipped. This matches the behavior we want for deploys and releases — newer always wins.

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -98,6 +98,10 @@ jobs:
             - notify-failure
 orbs:
     aws-cli: circleci/aws-cli@5.4.1
+parameters:
+    package:
+        default: ""
+        type: string
 version: 2.1
 workflows:
     ci:
@@ -118,4 +122,5 @@ workflows:
                     branches:
                         only:
                             - main
+                serial-group: << pipeline.project.slug >>/main-pipeline
 

--- a/.circleci/development/@config.yml
+++ b/.circleci/development/@config.yml
@@ -1,3 +1,13 @@
 version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@5.4.1
+parameters:
+  # Package name parsed from the release tag (`@agent-facets/<pkg>@<version>`) by
+  # scripts/release/tag.ts, forwarded via the CircleCI API v2 trigger. Consumed
+  # only by the `release` workflow's `serial-group` to key the queue per-package
+  # (so `@agent-facets/core@x` and `@agent-facets/adapter@y` releases can run
+  # concurrently). The `release-cli` workflow does not set or reference it; the
+  # empty default keeps the parameter satisfied for that trigger path.
+  package:
+    type: string
+    default: ""

--- a/.circleci/development/workflows/ci.yml
+++ b/.circleci/development/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
           ignore:
             - main
   - main-pipeline:
+      serial-group: << pipeline.project.slug >>/main-pipeline
       context:
         - turbo-cache
         - bot-context

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -114,6 +114,10 @@ jobs:
             - notify-failure
 orbs:
     aws-cli: circleci/aws-cli@5.4.1
+parameters:
+    package:
+        default: ""
+        type: string
 version: 2.1
 workflows:
     deploy:
@@ -127,6 +131,7 @@ workflows:
                     branches:
                         only:
                             - main
+                serial-group: << pipeline.project.slug >>/deploy-site
     release:
         jobs:
             - release:
@@ -141,6 +146,7 @@ workflows:
                     tags:
                         only:
                             - /^@agent-facets\/.+@\d+\..+/
+                serial-group: << pipeline.project.slug >>/release/<< pipeline.parameters.package >>
     release-cli:
         jobs:
             - build-cli:
@@ -155,6 +161,7 @@ workflows:
                     tags:
                         only:
                             - /^agent-facets@\d+\..+/
+                serial-group: << pipeline.project.slug >>/release-cli-build
             - publish-platform:
                 context:
                     - turbo-cache
@@ -198,4 +205,5 @@ workflows:
                             - /^agent-facets@\d+\..+/
                 requires:
                     - publish-platform
+                serial-group: << pipeline.project.slug >>/release-cli-finalize
 

--- a/.circleci/release/workflows/deploy.yml
+++ b/.circleci/release/workflows/deploy.yml
@@ -1,5 +1,6 @@
 jobs:
   - deploy-site:
+      serial-group: << pipeline.project.slug >>/deploy-site
       context:
         - bot-context
         - slack-secrets

--- a/.circleci/release/workflows/release-cli.yml
+++ b/.circleci/release/workflows/release-cli.yml
@@ -1,5 +1,6 @@
 jobs:
   - build-cli:
+      serial-group: << pipeline.project.slug >>/release-cli-build
       context:
         - turbo-cache
         - bot-context
@@ -41,6 +42,7 @@ jobs:
           ignore:
             - /.*/
   - finalize-cli:
+      serial-group: << pipeline.project.slug >>/release-cli-finalize
       context:
         - turbo-cache
         - bot-context

--- a/.circleci/release/workflows/release.yml
+++ b/.circleci/release/workflows/release.yml
@@ -1,5 +1,6 @@
 jobs:
   - release:
+      serial-group: << pipeline.project.slug >>/release/<< pipeline.parameters.package >>
       context:
         - turbo-cache
         - bot-context

--- a/docs/docs/contributing/release-pipeline.md
+++ b/docs/docs/contributing/release-pipeline.md
@@ -21,6 +21,8 @@ Releases are fully automated. Merging a PR with changesets triggers a pipeline t
   </Step>
   <Step title="Release pipeline triggered per tag">
     After pushing tags, the `tag.ts` script also calls CircleCI's API v2 `pipeline/run` endpoint once per tag to explicitly trigger the release pipeline. We do not rely on GitHub-to-CircleCI tag-push webhooks because they are unreliable when the bot GitHub App pushes tags — CircleCI appears to filter events from other bot actors. The pipeline's workflow filters (tag regex in `.circleci/release.yml`) still apply, so scoped tags (`@agent-facets/*@*`) run the `release` workflow and unscoped tags (`agent-facets@*`) run `release-cli`.
+
+    For scoped tags, `tag.ts` also parses the package name (`@agent-facets/core@1.0.0` → `core`) and forwards it as the `package` pipeline parameter. The `release` workflow uses that parameter in its `serial-group` key, which queues releases per-package — so two different packages can release in parallel while repeat releases of the same package serialize. The CLI tag path does not use the parameter.
   </Step>
   <Step title="Publish to npm">
     The publish path depends on the package type:
@@ -78,16 +80,20 @@ The [changeset bot](https://github.com/apps/changeset-bot) comments on every PR 
 To manually trigger a release pipeline for a tag that's already pushed, POST to the API directly:
 
 ```bash
-for tag in \
-  '@agent-facets/core@0.4.0' \
-  'agent-facets@0.5.0' \
-  ; do
-  curl -X POST \
-    "https://circleci.com/api/v2/project/gh/agent-facets/facets/pipeline/run" \
-    -H "Circle-Token: $CIRCLECI_API_TOKEN" \
-    -H "content-type: application/json" \
-    --data "{\"definition_id\":\"9d2f5823-f2c9-4cba-918a-e7d0dc2f658a\",\"config\":{\"tag\":\"$tag\"},\"checkout\":{\"tag\":\"$tag\"}}"
-done
+# Scoped tag — forward the parsed package name so the `release` workflow's
+# per-package serial-group queues correctly.
+curl -X POST \
+  "https://circleci.com/api/v2/project/gh/agent-facets/facets/pipeline/run" \
+  -H "Circle-Token: $CIRCLECI_API_TOKEN" \
+  -H "content-type: application/json" \
+  --data '{"definition_id":"9d2f5823-f2c9-4cba-918a-e7d0dc2f658a","config":{"tag":"@agent-facets/core@0.4.0"},"checkout":{"tag":"@agent-facets/core@0.4.0"},"parameters":{"package":"core"}}'
+
+# CLI tag — no `package` parameter needed; release-cli doesn't use it.
+curl -X POST \
+  "https://circleci.com/api/v2/project/gh/agent-facets/facets/pipeline/run" \
+  -H "Circle-Token: $CIRCLECI_API_TOKEN" \
+  -H "content-type: application/json" \
+  --data '{"definition_id":"9d2f5823-f2c9-4cba-918a-e7d0dc2f658a","config":{"tag":"agent-facets@0.5.0"},"checkout":{"tag":"agent-facets@0.5.0"}}'
 ```
 
 The idempotency checks in `scripts/release/publish.ts`, `publish-platform.ts`, and `publish-cli-package.ts` mean re-triggering for an already-published version will skip the npm publish and only re-run the GitHub Release + notification steps.

--- a/packages/common/AGENTS.md
+++ b/packages/common/AGENTS.md
@@ -44,14 +44,17 @@ Before adding a file here, ask: "Would the adapter SDK want to call this
 at runtime?" If no, it probably belongs in `core`. If yes, and it has no
 heavy dependencies, `common` is the right home.
 
-## Release marker
+## Workspace-only — no release
 
-This package carries `"agentFacets": { "release": "skip" }` in its
-`package.json`. That tells `scripts/release/tag.ts` (and
-`scripts/lib/changesets.ts#hasUnpublishedVersions`) to never create a git
-tag for this package. `common` is workspace-only — it's bundled into the
-adapter SDK at build time and imported directly by `core` and `cli`, so
-there's no npm release path for it and no companion pipeline to trigger.
+This package is workspace-only: it's bundled into the adapter SDK at
+build time and imported directly by `core` and `cli`, so there's no npm
+release path for it. It's kept out of the release pipeline by two
+mechanisms:
 
-See `scripts/README.md` ("Opting a workspace package out of releases")
-for the full rationale.
+1. Listed in `.changeset/config.json` `ignore` — changesets never bumps
+   its version.
+2. Intentionally has no `version` field in `package.json` — `tag.ts` and
+   `hasUnpublishedVersions` defensively skip versionless packages.
+
+See `scripts/README.md` ("Workspace-only packages") for the full
+rationale.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,11 +1,7 @@
 {
   "name": "@agent-facets/common",
   "private": true,
-  "version": "0.2.0",
   "type": "module",
-  "agentFacets": {
-    "release": "skip"
-  },
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@agent-facets/functions",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,23 +99,28 @@ The CLI package (`agent-facets`) is marked `"private": true` in its `package.jso
 4. This custom flow cannot use `changeset publish` or standard `npm publish` from the source directory
 5. Marking it `private` prevents `changeset publish` from attempting to publish the raw source package — the custom `release-cli/` pipeline handles it instead
 
-## Opting a workspace package out of releases
+## Workspace-only packages
 
-Some workspace packages — like `@agent-facets/common` — are private helpers that are never published and have no companion release pipeline. `"private": true` alone isn't enough to skip them: the CLI package is also private but MUST be tagged (its tag triggers the binary release pipeline).
+Some workspace packages — `@agent-facets/common`, `@agent-facets/landing`, `@agent-facets/functions` — are private helpers that are never published and have no companion release pipeline. `"private": true` alone isn't enough to skip them: the CLI package is also private but MUST be tagged (its tag triggers the binary release pipeline).
 
-To mark a package as "workspace-only, never release", add this to its `package.json`:
+The contract for marking a package as "workspace-only, never release" has two parts, both required:
 
-```jsonc
-{
-  "name": "@agent-facets/something-internal",
-  "private": true,
-  "agentFacets": {
-    "release": "skip"
-  }
-}
-```
+1. **Listed in `.changeset/config.json` `ignore`** — changesets never bumps the package's version or includes it in the Version Packages PR. This is the authoritative mechanism.
+2. **No `version` field in `package.json`** — `release/tag.ts` and `lib/changesets.ts#hasUnpublishedVersions` defensively skip any package without a version. Without this fallback, an accidental removal from the `ignore` list would cause `tag.ts` to try creating `@pkg@undefined` tags, and `hasUnpublishedVersions` would perpetually report the package as "unpublished" (since `null !== undefined`).
 
-`release/tag.ts` and `lib/changesets.ts#hasUnpublishedVersions` both honor this marker. Without it, `io.npm.viewVersion` returns `null` for unpublished private packages, so `tag.ts` would perpetually try to re-tag them each release cycle — and fail the second time with "tag already exists".
+Together these keep workspace-only packages out of the release pipeline entirely — no tags, no npm publishes, no lingering "unpublished" state.
+
+## Per-package release queueing
+
+`release/tag.ts` parses the package name out of scoped tags
+(`@agent-facets/<pkg>@<version>` → `<pkg>`) and forwards it as the `package`
+pipeline parameter when triggering CircleCI. The `release` workflow uses that
+parameter in its `serial-group` key so releases of different packages
+(`core`, `adapter`, etc.) can run in parallel while repeat releases of the
+same package serialize. The CLI tag (`agent-facets@<version>`) routes to the
+`release-cli` workflow, which doesn't use the parameter — we pass `undefined`
+there and the pipeline default (`""`) applies. See `.circleci/AGENTS.md` for
+the full serial-group layout across workflows.
 
 ## IO Adapter
 
@@ -129,7 +134,7 @@ import { io } from '../lib/io'
 await io.npm.publish(pkgDir)
 await io.git.pushAllTags('origin')
 await io.gh.prCreate('main', head, title, body)
-await io.circleci.triggerPipelineForTag(slug, defId, tag)
+await io.circleci.triggerPipelineForTag(slug, defId, tag, packageName)
 await io.shell.readFile(path)
 io.console.log('hello')
 ```

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -2,17 +2,9 @@ import { getChangelogEntry } from '@changesets/release-utils'
 
 export interface WorkspacePackage {
   name: string
-  version: string
+  version?: string
   dir: string
   private?: boolean
-  /**
-   * Internal release marker, read from `agentFacets.release` in package.json.
-   * `"skip"` means the package is workspace-only — never tagged, never
-   * published. Used by `tag.ts` and `hasUnpublishedVersions` to exclude
-   * packages that have no publish path (unlike the private CLI package,
-   * which IS tagged because the tag triggers its binary release pipeline).
-   */
-  releaseMode?: 'skip'
 }
 
 /**
@@ -35,18 +27,20 @@ export function shouldPublish(pendingChangesets: string[]): boolean {
  * Check whether any workspace package has a local version
  * that doesn't yet exist on the npm registry.
  *
- * Packages marked `agentFacets.release: "skip"` are excluded — they're
- * workspace-only and have no npm registry to compare against. Without
- * this skip, `npmViewFn` would return `null` for them and they'd
- * perpetually report as "unpublished", causing tag.ts to keep firing
- * even when only skipped packages have bumps.
+ * Packages without a `version` field in `package.json` are excluded —
+ * they are workspace-only helpers (e.g. `@agent-facets/common`) whose
+ * release is suppressed upstream by the changesets `ignore` list in
+ * `.changeset/config.json`. This defensive filter prevents `npmViewFn`
+ * from being called with a versionless package (which would return
+ * `null`, mismatch `undefined`, and perpetually report as "unpublished",
+ * causing tag.ts to keep firing every main-pipeline run).
  */
 export async function hasUnpublishedVersions(
   packages: WorkspacePackage[],
   npmViewFn: (pkg: string) => Promise<string | null>,
 ): Promise<boolean> {
   for (const pkg of packages) {
-    if (pkg.releaseMode === 'skip') continue
+    if (!pkg.version) continue
     const npmVersion = await npmViewFn(pkg.name)
     if (npmVersion !== pkg.version) return true
   }

--- a/scripts/lib/ci.ts
+++ b/scripts/lib/ci.ts
@@ -31,7 +31,6 @@ export async function loadWorkspacePackages(): Promise<WorkspacePackage[]> {
           version: pkg.version,
           dir,
           private: pkg.private,
-          releaseMode: pkg.agentFacets?.release === 'skip' ? 'skip' : undefined,
         })
       }
     }

--- a/scripts/lib/io/circleci.test.ts
+++ b/scripts/lib/io/circleci.test.ts
@@ -48,7 +48,7 @@ describe('io.circleci.triggerPipelineForTag', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  test('posts to CircleCI API with expected body when inputs are valid', async () => {
+  test('posts to CircleCI API with expected body when inputs are valid (no package param)', async () => {
     process.env.CIRCLECI_API_TOKEN = 'fake-token'
     const fetchSpy = mock((_url: string, _init?: RequestInit) =>
       Promise.resolve(new Response(JSON.stringify({ id: 'abc', number: 42 }), { status: 200 })),
@@ -58,7 +58,7 @@ describe('io.circleci.triggerPipelineForTag', () => {
     const result = await io.circleci.triggerPipelineForTag(
       'gh/agent-facets/facets',
       '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
-      '@agent-facets/core@1.0.0',
+      'agent-facets@1.0.0',
     )
 
     expect(result).toEqual({ id: 'abc', number: 42 })
@@ -71,10 +71,40 @@ describe('io.circleci.triggerPipelineForTag', () => {
     expect(headers['Content-Type']).toBe('application/json')
 
     const body = JSON.parse((init as RequestInit).body as string)
+    // When no package name is supplied (release-cli trigger path), the
+    // `parameters` key is omitted so the release-cli workflow doesn't
+    // receive a stray parameter it doesn't declare.
+    expect(body).toEqual({
+      definition_id: '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
+      config: { tag: 'agent-facets@1.0.0' },
+      checkout: { tag: 'agent-facets@1.0.0' },
+    })
+  })
+
+  test('forwards packageName as `parameters.package` when provided', async () => {
+    // Per-package `serial-group` keying on the `release` workflow depends on
+    // this parameter being present in the API body. Without it, all scoped
+    // package releases would serialize through the same queue.
+    process.env.CIRCLECI_API_TOKEN = 'fake-token'
+    const fetchSpy = mock((_url: string, _init?: RequestInit) =>
+      Promise.resolve(new Response(JSON.stringify({ id: 'abc', number: 42 }), { status: 200 })),
+    )
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    await io.circleci.triggerPipelineForTag(
+      'gh/agent-facets/facets',
+      '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
+      '@agent-facets/core@1.0.0',
+      'core',
+    )
+
+    const [, init] = fetchSpy.mock.calls[0] ?? []
+    const body = JSON.parse((init as RequestInit).body as string)
     expect(body).toEqual({
       definition_id: '9d2f5823-f2c9-4cba-918a-e7d0dc2f658a',
       config: { tag: '@agent-facets/core@1.0.0' },
       checkout: { tag: '@agent-facets/core@1.0.0' },
+      parameters: { package: 'core' },
     })
   })
 

--- a/scripts/lib/io/circleci.ts
+++ b/scripts/lib/io/circleci.ts
@@ -21,6 +21,13 @@ export const circleciIo = {
    * `@agent-facets/core@1.0.0` fires only the `release` workflow. The
    * caller does not need to select which one.
    *
+   * When `packageName` is provided, it is forwarded as the `package`
+   * pipeline parameter. This is used by the `release` workflow's
+   * `serial-group` key to queue package publishes per-package — so
+   * releases of `@agent-facets/core` and `@agent-facets/adapter` can
+   * run in parallel while repeat releases of the same package still
+   * serialize. `release-cli` does not read this parameter.
+   *
    * Requires the CIRCLECI_API_TOKEN env var (provisioned via the
    * `bot-context` CircleCI context).
    */
@@ -28,6 +35,7 @@ export const circleciIo = {
     projectSlug: string,
     definitionId: string,
     tag: string,
+    packageName?: string,
   ): Promise<{ id: string; number: number }> => {
     const token = process.env.CIRCLECI_API_TOKEN
     if (!token) {
@@ -48,22 +56,32 @@ export const circleciIo = {
       )
     }
 
+    const body: {
+      definition_id: string
+      config: { tag: string }
+      checkout: { tag: string }
+      parameters?: { package: string }
+    } = {
+      definition_id: definitionId,
+      config: { tag },
+      checkout: { tag },
+    }
+    if (packageName) {
+      body.parameters = { package: packageName }
+    }
+
     const resp = await fetch(`https://circleci.com/api/v2/project/${projectSlug}/pipeline/run`, {
       method: 'POST',
       headers: {
         'Circle-Token': token,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        definition_id: definitionId,
-        config: { tag },
-        checkout: { tag },
-      }),
+      body: JSON.stringify(body),
     })
 
     if (!resp.ok) {
-      const body = await resp.text()
-      throw new Error(`CircleCI pipeline trigger failed for tag ${tag}: ${resp.status} ${body}`)
+      const errBody = await resp.text()
+      throw new Error(`CircleCI pipeline trigger failed for tag ${tag}: ${resp.status} ${errBody}`)
     }
 
     return (await resp.json()) as { id: string; number: number }

--- a/scripts/release/tag.test.ts
+++ b/scripts/release/tag.test.ts
@@ -160,72 +160,6 @@ describe('tag.ts', () => {
       expect(pushSpy).toHaveBeenCalledWith('origin')
     })
 
-    test('skips packages with releaseMode:"skip" when tagging', async () => {
-      // @agent-facets/common is workspace-only — marked agentFacets.release:"skip"
-      // in its package.json. It must not be tagged even when it has a version
-      // bump, because no release pipeline would do anything useful with the tag
-      // and the tag would collide on subsequent release cycles.
-      process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
-        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
-      ])
-      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
-      spyOn(io.git, 'config').mockResolvedValue(shellResult())
-      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
-        { name: '@agent-facets/core', version: '1.1.0', dir: 'packages/core' },
-        { name: 'agent-facets', version: '0.4.0', dir: 'packages/cli', private: true },
-        { name: '@agent-facets/common', version: '0.1.4', dir: 'packages/common', private: true, releaseMode: 'skip' },
-      ])
-      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
-        if (pkg === '@agent-facets/core') return '1.0.0' // bumped
-        if (pkg === 'agent-facets') return '0.3.0' // bumped
-        return null // common is never published
-      })
-      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
-      spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
-      const triggerSpy = spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
-
-      const code = await tagRelease()
-
-      expect(code).toBe(0)
-      expect(tagSpy).toHaveBeenCalledWith('@agent-facets/core@1.1.0', 'original-sha')
-      expect(tagSpy).toHaveBeenCalledWith('agent-facets@0.4.0', 'original-sha')
-      expect(tagSpy).not.toHaveBeenCalledWith('@agent-facets/common@0.1.4', 'original-sha')
-      // Only the two non-skipped packages should trigger pipelines.
-      expect(triggerSpy).toHaveBeenCalledTimes(2)
-    })
-
-    test('returns early when only releaseMode:"skip" packages have bumps', async () => {
-      // If every bumped package is release-skipped, there's nothing to tag.
-      // Without this handling, hasUnpublishedVersions would return true
-      // forever (npm view always returns null for skipped packages) and
-      // tag.ts would attempt tagging on every main-pipeline run.
-      process.env.CIRCLE_SHA1 = 'abc123'
-      spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
-        { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
-      ])
-      spyOn(io.git, 'fetchSha').mockResolvedValue(shellResult())
-      spyOn(io.git, 'config').mockResolvedValue(shellResult())
-      spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
-        { name: '@agent-facets/core', version: '1.0.0', dir: 'packages/core' },
-        { name: '@agent-facets/common', version: '0.1.4', dir: 'packages/common', private: true, releaseMode: 'skip' },
-      ])
-      spyOn(io.npm, 'viewVersion').mockImplementation(async (pkg: string) => {
-        if (pkg === '@agent-facets/core') return '1.0.0' // unchanged
-        return null // common is never published
-      })
-      const tagSpy = spyOn(io.git, 'tagAt').mockResolvedValue(shellResult())
-      const pushSpy = spyOn(io.git, 'pushAllTags').mockResolvedValue(shellResult())
-      const triggerSpy = spyOn(io.circleci, 'triggerPipelineForTag').mockResolvedValue({ id: 'p1', number: 1 })
-
-      const code = await tagRelease()
-
-      expect(code).toBe(0)
-      expect(tagSpy).not.toHaveBeenCalled()
-      expect(pushSpy).not.toHaveBeenCalled()
-      expect(triggerSpy).not.toHaveBeenCalled()
-    })
-
     test('fetches the original branch commit SHA', async () => {
       process.env.CIRCLE_SHA1 = 'abc123'
       spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
@@ -263,7 +197,12 @@ describe('tag.ts', () => {
       expect(configSpy).toHaveBeenCalledWith('user.email', '272408671+the-faceter[bot]@users.noreply.github.com')
     })
 
-    test('triggers CircleCI pipeline for each pushed tag', async () => {
+    test('triggers CircleCI pipeline for each pushed tag, forwarding package name for scoped tags', async () => {
+      // The `release` workflow queues per-package via `serial-group`. To make
+      // that work, scoped-package tags must trigger the pipeline with the
+      // parsed package name as the `package` parameter. The CLI tag
+      // (`agent-facets@x.y.z`) routes to `release-cli`, which ignores the
+      // parameter — so we pass undefined for that one.
       process.env.CIRCLE_SHA1 = 'abc123'
       spyOn(io.gh, 'getPrForCommit').mockResolvedValue([
         { number: 52, headRefName: 'changeset-release/main', headRefOid: 'original-sha' },
@@ -291,11 +230,13 @@ describe('tag.ts', () => {
         CIRCLECI_PROJECT_SLUG,
         CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
         '@agent-facets/core@1.1.0',
+        'core',
       )
       expect(triggerSpy).toHaveBeenCalledWith(
         CIRCLECI_PROJECT_SLUG,
         CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
         'agent-facets@0.4.0',
+        undefined,
       )
     })
 

--- a/scripts/release/tag.ts
+++ b/scripts/release/tag.ts
@@ -45,6 +45,20 @@ import { io } from '../lib/io'
 const PR_POLL_INTERVAL_MS = 10_000
 const PR_POLL_MAX_ATTEMPTS = 30
 
+/**
+ * Match scoped package tags — `@agent-facets/<pkg>@<version>` — and capture
+ * `<pkg>`. Unscoped tags (`agent-facets@<version>`, the CLI) do not match,
+ * so the triggering code skips the `package` parameter for them. The
+ * package name is forwarded as a pipeline parameter so the `release`
+ * workflow's `serial-group` can queue per-package.
+ */
+const SCOPED_TAG_PACKAGE_REGEX = /^@agent-facets\/([a-z0-9-]+)@/
+
+function extractPackageName(tag: string): string | undefined {
+  const match = SCOPED_TAG_PACKAGE_REGEX.exec(tag)
+  return match?.[1]
+}
+
 export async function tagRelease(): Promise<number> {
   const sha = process.env.CIRCLE_SHA1
   if (!sha) {
@@ -89,13 +103,12 @@ export async function tagRelease(): Promise<number> {
 
   const pushedTags: string[] = []
   for (const pkg of packages) {
-    // Packages marked `agentFacets.release: "skip"` in their package.json
-    // are workspace-only (e.g., @agent-facets/common) and must not be tagged.
-    // Without this guard, io.npm.viewVersion returns null for these (never
-    // published), so `npmVersion !== pkg.version` is always true and every
-    // release cycle re-attempts the same tag — which fails with "tag already
-    // exists" once the first attempt has pushed.
-    if (pkg.releaseMode === 'skip') continue
+    // Workspace-only packages (e.g. @agent-facets/common) have no `version`
+    // field in their package.json — they're bundled into consumers at build
+    // time and never published to npm. Upstream, `.changeset/config.json`
+    // `ignore` keeps them out of version-bump PRs entirely. This guard is
+    // the defensive fallback: without it we'd try to tag `@pkg@undefined`.
+    if (!pkg.version) continue
     const npmVersion = await io.npm.viewVersion(pkg.name)
     if (npmVersion !== pkg.version) {
       const tag = `${pkg.name}@${pkg.version}`
@@ -110,12 +123,19 @@ export async function tagRelease(): Promise<number> {
 
   // Explicitly trigger the release pipeline for each tag. See module docblock
   // for why we don't rely on GitHub-to-CircleCI webhooks for this.
+  //
+  // For scoped package tags (`@agent-facets/<pkg>@<version>`), we forward
+  // the package name as a pipeline parameter so the `release` workflow's
+  // `serial-group` queues per-package. The CLI tag (`agent-facets@<version>`)
+  // goes through `release-cli`, which doesn't use the parameter.
   for (const tag of pushedTags) {
+    const packageName = extractPackageName(tag)
     io.console.log(`Triggering CircleCI release pipeline for ${tag}`)
     const result = await io.circleci.triggerPipelineForTag(
       CIRCLECI_PROJECT_SLUG,
       CIRCLECI_RELEASE_PIPELINE_DEFINITION_ID,
       tag,
+      packageName,
     )
     io.console.log(`  → pipeline #${result.number} (${result.id})`)
   }

--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -41,7 +41,14 @@ export async function buildChangesets(): Promise<number> {
   }
 
   const packagesAfter = await loadWorkspacePackages()
-  const changedPackages = packagesAfter.filter((p) => versionsBefore.get(p.name) !== p.version)
+  // Filter to versioned packages whose version changed. Versionless packages
+  // (workspace-only helpers like @agent-facets/common, listed in
+  // `.changeset/config.json` `ignore`) never bump, so they're naturally
+  // excluded; the explicit `p.version` check also narrows the type for
+  // buildVersionPrBody, which requires `version: string`.
+  const changedPackages = packagesAfter
+    .filter((p): p is typeof p & { version: string } => Boolean(p.version))
+    .filter((p) => versionsBefore.get(p.name) !== p.version)
   const { body: prBody, entries } = await buildVersionPrBody(changedPackages, io.shell.readFile)
 
   for (const entry of entries) {


### PR DESCRIPTION
### Why

Concurrent releases of different packages (e.g. `@agent-facets/core` and `@agent-facets/adapter`) were unnecessarily serialized because there was no per-job queueing in place. At the same time, repeat releases of the same package had no protection against running in parallel, which could cause race conditions.

### Details

`serial-group` is added to every top-level CircleCI job, scoped with `<< pipeline.project.slug >>` to stay per-project within the org:

- `ci` / `main-pipeline` → `<project>/main-pipeline`
- `deploy` / `deploy-site` → `<project>/deploy-site`
- `release` / `release` → `<project>/release/<< pipeline.parameters.package >>`
- `release-cli` / `build-cli` → `<project>/release-cli-build`
- `release-cli` / `finalize-cli` → `<project>/release-cli-finalize`

The `release` workflow keys its group on a new `package` pipeline parameter so different packages can release in parallel while repeat releases of the same package serialize. `scripts/release/tag.ts` now parses the package name out of scoped tags (`@agent-facets/core@1.0.0` → `core`) and forwards it via the CircleCI API v2 trigger. The CLI tag path (`agent-facets@<version>`) passes `undefined`, leaving the parameter at its declared default of `""`.

The raw tag string can't be embedded directly in a `serial-group` value because CircleCI restricts the charset to `[A-Za-z0-9._\-/]`, which excludes `@`.

`publish-platform` intentionally has no `serial-group` — each matrix variant publishes a distinct platform package, so parallel runs are safe.

`release-cli` uses two distinct group names (`release-cli-build` and `release-cli-finalize`) because CircleCI explicitly warns against reusing the same `serial-group` on multiple jobs within a single workflow.

The `parameters.package` block is declared in `@config.yml` (shared between both packed configs via symlink), which is harmless — CircleCI ignores unused declared parameters.

### Verification

CI, plus updated and new unit tests covering the no-package and with-package trigger paths in `circleci.test.ts` and the scoped/unscoped tag forwarding logic in `tag.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CircleCI workflow scheduling/serialization for `ci`, `deploy`, and release pipelines; misconfiguration could cause unintended concurrency or blocked/skipped deploys/releases.
> 
> **Overview**
> Adds **`serial-group` queueing across CircleCI workflows** so runs serialize per job type and per project slug, preventing parallel `main-pipeline`/deploy collisions and avoiding duplicate concurrent releases.
> 
> Introduces a new `package` pipeline parameter and updates `scripts/release/tag.ts` + `io.circleci.triggerPipelineForTag` to **parse scoped release tags** (`@agent-facets/<pkg>@<ver>`) and forward `parameters.package`, enabling **per-package release serialization** while keeping CLI releases (`agent-facets@<ver>`) parameter-free. Documentation and unit tests are updated to cover both trigger paths and the new queueing model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78a4feedbc3fddf187d4e4c401e48623364a9fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->