### PR TITLE
Remove `@agent-facets/common` from changeset

### DIFF
--- a/.changeset/frank-eagles-return.md
+++ b/.changeset/frank-eagles-return.md
@@ -5,7 +5,6 @@
 "@agent-facets/adapter-opencode": patch
 "@agent-facets/brand": patch
 "agent-facets": patch
-"@agent-facets/common": patch
 "@agent-facets/core": patch
 
 ---


### PR DESCRIPTION
### Why

Removes `@agent-facets/common` from the changeset so it is not included in the next release bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts a Changesets release manifest to exclude a package from the next version bump; no runtime or build logic changes.
> 
> **Overview**
> Removes `@agent-facets/common` from `.changeset/frank-eagles-return.md`, so the next release will bump patch versions for the remaining listed packages but **not** `@agent-facets/common`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16cda90f371f527c858d20a1c64428072b768093. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->