### PR TITLE
Promote `add`, `install`, and `remove` to available and update roadmap copy for alpha/beta

### DIFF
--- a/docs/roadmap/alpha.md
+++ b/docs/roadmap/alpha.md
@@ -3,26 +3,28 @@ title: Pre-Release Alpha
 sidebarTitle: Alpha
 ---
 
+The pre-release alpha is a work in progress, but is available for enterprising users to try out.
+
 ## Available Now
 
 These commands are implemented and ready to use:
 
-| Command        | Description                                                                         |
-| -------------- | ----------------------------------------------------------------------------------- |
-| `facet create` | Scaffold a new **facet** project with an interactive wizard                         |
-| `facet edit`   | Full authoring workbench — edit identity, manage assets, reconcile disk vs manifest |
-| `facet build`  | Validate and package a **facet** into a distributable archive                       |
+| Command         | Description                                                                         |
+|-----------------|-------------------------------------------------------------------------------------|
+| `facet create`  | Scaffold a new **facet** project with an interactive wizard                         |
+| `facet edit`    | Full authoring workbench — edit identity, manage assets, reconcile disk vs manifest |
+| `facet build`   | Validate and package a **facet** into a distributable archive                       |
+| `facet add`     | Add a **facet** to the project — resolve from registry, download, and install       |
+| `facet install` | Install all **facets** from the lockfile                                            |
+| `facet remove`  | Remove a **facet** from the project and update the lockfile                         |
 
 ## Planned
 
 These commands are registered in the CLI but not yet implemented:
 
-| Command         | Description                                                                  |
-| --------------- | ---------------------------------------------------------------------------- |
-| `facet add`     | Add a **facet** to the project — resolve from registry, download, and install |
-| `facet install` | Install all **facets** from the lockfile                                     |
-| `facet remove`  | Remove a **facet** from the project and update the lockfile                  |
-| `facet upgrade` | Interactive upgrade wizard for installed **facets**                          |
-| `facet publish` | Publish a built **facet** to the registry                                   |
-| `facet info`    | Show information about a **facet** from the registry                        |
-| `facet list`    | List installed **facets**                                                   |
+| Command         | Description                                          |
+|-----------------|------------------------------------------------------|
+| `facet upgrade` | Interactive upgrade wizard for installed **facets**  |
+| `facet publish` | Publish a built **facet** to the registry            |
+| `facet info`    | Show information about a **facet** from the registry |
+| `facet list`    | List installed **facets**                            |

--- a/docs/roadmap/beta.md
+++ b/docs/roadmap/beta.md
@@ -3,6 +3,8 @@ title: Open Beta
 sidebarTitle: Beta
 ---
 
+The beta will be available when all the planned features are implemented.
+
 ## Available Now
 
 These commands are implemented and ready to use:

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -23,7 +23,7 @@ icon: "map"
   arrow="true"
   cta="See the goals for the beta"
 >
-  A public beta release. The alpha will run until we feel confident for a public beta release.
+  A public beta release. The beta will run until we are ready to release a stable version for general use.
 </Card>
 </Columns>
 

--- a/packages/landing/src/components/Hero.tsx
+++ b/packages/landing/src/components/Hero.tsx
@@ -12,7 +12,7 @@ export function Hero() {
       <OrbitFloaters />
 
       <div className={styles.eyebrowRow}>
-        <Eyebrow>v{__APP_VERSION__} · public beta</Eyebrow>
+        <Eyebrow>v{__APP_VERSION__} · pre-release alpha</Eyebrow>
       </div>
 
       <h1 className={styles.title}>

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -13,11 +13,9 @@ export function Nav() {
         </a>
         <div className={styles.links}>
           <a href="#top">Home</a>
-          <a href="#what">What</a>
+          <a href="#what">Facets</a>
           <a href="#demo">CLI</a>
-          <a href="https://docs.agentfacets.io" target="_blank" rel="noreferrer noopener">
-            Docs <span className={styles.extArrow}>↗</span>
-          </a>
+          <a href="https://docs.agentfacets.io">Docs</a>
           <a href="https://facet.cafe/" target="_blank" rel="noreferrer noopener">
             Registry <span className={styles.extArrow}>↗</span>
           </a>


### PR DESCRIPTION
### Why

The roadmap docs and landing page hero were inaccurate — `facet add`, `facet install`, and `facet remove` have been implemented and should no longer be listed as planned, and the release stage label on the landing page was incorrect.

### Details

- `facet add`, `facet install`, and `facet remove` are moved from the "Planned" table to the "Available Now" table in the alpha roadmap.
- A note is added to the alpha page clarifying it is a work in progress but available for early users.
- A note is added to the beta page clarifying it will be available once all planned features are implemented.
- The beta card description on the roadmap index is updated to better reflect the purpose of the beta phase.
- The landing page hero label is corrected from "public beta" to "pre-release alpha".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation and marketing copy updates only; no runtime logic changes beyond minor link attribute adjustments.
> 
> **Overview**
> Updates roadmap documentation to reflect current release stages: adds clarifying intro copy on `alpha`/`beta`, moves `facet add`/`facet install`/`facet remove` into **Available Now** for the alpha roadmap, and revises the beta card description on the roadmap index.
> 
> Adjusts landing page copy by changing the hero stage label to *pre-release alpha*, renaming the nav anchor from “What” to “Facets”, and simplifying the Docs link (removing new-tab attributes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ac4f53db5d86d00e202f4291530d7bb82e83eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->