### PR TITLE
Add mobile-responsive layout with `MobileMenu`, `MobileFacetStack`, `RegistryCta`, and `LinkCard` components

### DIFF
--- a/packages/landing/src/components/CliDemo.module.css
+++ b/packages/landing/src/components/CliDemo.module.css
@@ -1,5 +1,6 @@
+/** biome-ignore-all lint/correctness/noUnknownPseudoClass: it works, for reasons */
 .section {
-  padding: 160px 32px 160px;
+  padding: 0 32px 4em;
   position: relative;
 }
 
@@ -14,7 +15,7 @@
 }
 
 .label {
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 12px;
   color: var(--ink-faint);
   letter-spacing: 0.2em;
@@ -28,7 +29,7 @@
 }
 
 .title {
-  font-family: var(--sans);
+  font-family: var(--sans), sans-serif;
   font-weight: 700;
   font-size: clamp(36px, 5.5vw, 64px);
   letter-spacing: -0.03em;
@@ -37,7 +38,7 @@
 }
 
 .title em {
-  font-family: var(--serif);
+  font-family: var(--serif), serif;
   font-style: italic;
   font-weight: 400;
 }
@@ -64,7 +65,7 @@
   gap: 12px;
   padding: 12px 16px;
   border-bottom: 1px solid var(--line);
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 12px;
   color: var(--ink-faint);
 }
@@ -99,7 +100,7 @@
 }
 
 .body {
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 14px;
   line-height: 1.65;
   padding: 28px 32px;
@@ -170,7 +171,7 @@
   gap: 8px;
   justify-content: center;
   margin-top: 24px;
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 12px;
   color: var(--ink-faint);
 }
@@ -179,7 +180,7 @@
   background: var(--card);
   border: 1px solid var(--line-strong);
   color: var(--ink-dim);
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 12px;
   padding: 6px 12px;
   border-radius: 6px;
@@ -195,5 +196,76 @@
 @media (prefers-reduced-motion: reduce) {
   .blink {
     animation: none;
+  }
+}
+
+/* bp-mobile — tighter terminal on small viewports. */
+@media (max-width: 1024px) {
+  .section {
+    padding: 64px 22px 20px;
+  }
+
+  .wrap {
+    max-width: 400px;
+  }
+
+  .head {
+    margin-bottom: 32px;
+  }
+
+  .label {
+    font-size: 10.5px;
+    margin-bottom: 14px;
+  }
+
+  .title {
+    font-size: 36px;
+    letter-spacing: -0.028em;
+    line-height: 1;
+    margin-bottom: 14px;
+    text-wrap: balance;
+  }
+
+  .sub {
+    font-size: 15px;
+    line-height: 1.55;
+    max-width: 340px;
+    text-wrap: pretty;
+  }
+
+  .window {
+    border-radius: 12px;
+  }
+
+  .titlebar {
+    padding: 10px 14px;
+    font-size: 10.5px;
+  }
+
+  .dots span {
+    width: 9px;
+    height: 9px;
+  }
+
+  .body {
+    font-size: 11.5px;
+    line-height: 1.7;
+    padding: 16px 16px 18px;
+    min-height: auto;
+  }
+
+  .controls {
+    margin-top: 14px;
+  }
+
+  .controls button {
+    font-size: 11px;
+    padding: 6px 12px;
+  }
+
+  /* The output bar from the install progress line — narrower on mobile. */
+  .body :global(.bar) {
+    width: 120px;
+    height: 5px;
   }
 }

--- a/packages/landing/src/components/CliDemo.tsx
+++ b/packages/landing/src/components/CliDemo.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
+import { useIsMobile } from '../hooks/useIsMobile'
 import styles from './CliDemo.module.css'
 
 type PromptEntry = { kind: 'prompt'; text: string; cursor?: boolean }
@@ -6,41 +7,75 @@ type OutEntry = { kind: 'out'; delay?: number; html: string }
 type Entry = PromptEntry | OutEntry
 
 /**
- * The CLI demo script. Content is copied verbatim from the mockup — the
- * HTML inside `out` entries is static source we control (no user input),
- * so `dangerouslySetInnerHTML` is safe here.
+ * The full CLI demo script shown on desktop. Starts with a registry
+ * search, adds `viper-plans`, then lists installed facets. Structure
+ * reflects reality: facets install INTO adapters (claude-code, opencode)
+ * rather than into a standalone ~/.facets/... directory.
+ *
+ * The HTML inside `out` entries is static source we control (no user
+ * input), so `dangerouslySetInnerHTML` via `innerHTML` is safe here.
  */
-const CLI_SCRIPT: readonly Entry[] = [
+const FULL_CLI_SCRIPT: readonly Entry[] = [
   { kind: 'prompt', text: 'facet search viper' },
   {
     kind: 'out',
     delay: 300,
-    html: '<span class="dim">Searching registry… found 3 matches.</span>\n<span class="violet">viper-plans</span>        <span class="dim">v1.4.0 · by @acme · 12.4k installs · 4 skills, 2 agents, 3 cmds, 1 mcp</span>\n<span class="violet">viper-reviews</span>      <span class="dim">v0.8.1 · by @acme · 3.1k installs  · 3 skills, 1 agent, 2 cmds</span>\n<span class="violet">viper-shipit</span>       <span class="dim">v2.0.0 · by @acme · 9.7k installs  · 5 skills, 1 agent, 4 cmds, 2 mcp</span>\n',
+    html:
+      '<span class="dim">Searching registry… found 3 matches.</span>\n' +
+      '<span class="violet">viper-plans</span>    <span class="dim">v1.4.0 · by @acme · 12.4k installs · 2 skills, 2 agents, 2 cmds, 2 mcps</span>\n' +
+      '<span class="violet">viper-reviews</span>  <span class="dim">v0.8.1 · by @acme · 3.1k installs  · 3 skills, 1 agent, 2 cmds</span>\n' +
+      '<span class="violet">viper-shipit</span>   <span class="dim">v2.0.0 · by @acme · 9.7k installs  · 5 skills, 1 agent, 4 cmds, 2 mcp</span>\n',
   },
   { kind: 'prompt', text: 'facet add viper-plans' },
   {
     kind: 'out',
     delay: 400,
-    html: '<span class="dim">Resolving viper-plans@latest…</span>\n<span class="ok">✓</span> viper-plans@1.4.0 <span class="dim">(42 KB)</span>\n<span class="dim">Bundle contains:</span>\n  <span class="violet">skills/</span>     4 files   <span class="dim">plan-writer, risk-scan, scope-trim, delta-log</span>\n  <span class="pink">agents/</span>     2 files   <span class="dim">planner, skeptic</span>\n  <span class="ok">commands/</span>   3 files   <span class="dim">/plan /risk /ship</span>\n  <span class="warn">mcp/</span>        1 server  <span class="dim">linear (oauth required)</span>\n',
+    html:
+      '<span class="dim">Resolving viper-plans@latest…</span>\n' +
+      '<span class="ok">✓</span> viper-plans@1.4.0 <span class="dim">(42 KB)</span>\n' +
+      '<span class="dim">Bundle contains:</span>\n' +
+      '  <span class="violet">skills/</span>    2 files    <span class="dim">viper-plans, viper-runs</span>\n' +
+      '  <span class="pink">agents/</span>    2 files    <span class="dim">planner, executor</span>\n' +
+      '  <span class="ok">commands/</span>  2 files    <span class="dim">/viper-plan, /viper-run</span>\n' +
+      '  <span class="warn">mcp/</span>       2 servers  <span class="dim">viper-plan-manager, linear (oauth required)</span>\n',
   },
   {
     kind: 'out',
     delay: 200,
-    html: '<span class="dim">Installing to ~/.facets/viper-plans …</span>  <span class="bar"><i style="width:100%"></i></span> <span class="ok">done</span>\n<span class="dim">Authenticating linear MCP…</span>  <span class="ok">✓</span>\n<span class="dim">Registering slash commands with 3 editors…</span>  <span class="ok">✓</span>\n',
+    html:
+      '<span class="dim">Installing to adapters:</span>\n' +
+      '  <span class="violet">claude-code</span>    <span class="dim">v2.1.0</span>  <span class="ok">✓</span>\n' +
+      '  <span class="violet">opencode</span>       <span class="dim">v1.8.3</span>  <span class="ok">✓</span>\n' +
+      '<span class="bar"><i style="width:100%"></i></span> <span class="ok">done</span>\n' +
+      '<span class="dim">Authenticating Linear MCP…</span>  <span class="ok">✓</span>\n' +
+      '<span class="dim">Registered facet with 2 adapters</span>  <span class="ok">✓</span>\n',
   },
   {
     kind: 'out',
     delay: 300,
-    html: '<span class="ok">✓ viper-plans installed.</span>  <span class="dim">Try </span><span class="violet">/viper-plan "Q2 migration"</span><span class="dim"> in your editor.</span>\n\n',
+    html:
+      '<span class="ok">✓ viper-plans installed.</span>\n' +
+      '<span class="dim">Now </span><span class="violet">/viper-plan</span><span class="dim"> is available to your agents.</span>\n\n',
   },
   { kind: 'prompt', text: 'facet list' },
   {
     kind: 'out',
     delay: 200,
-    html: '<span class="violet">viper-plans</span>       <span class="dim">1.4.0</span>\n<span class="violet">ship-it</span>           <span class="dim">2.0.0</span>\n<span class="violet">designer-kit</span>      <span class="dim">0.9.3</span>  <span class="warn">(update: 1.0.0)</span>\n',
+    html:
+      '<span class="violet">viper-plans</span>     <span class="dim">1.4.0</span>\n' +
+      '<span class="violet">typescript-pro</span>  <span class="dim">2.0.0</span>\n' +
+      '<span class="violet">designer-kit</span>    <span class="dim">0.9.3</span>  <span class="warn">(update: 1.0.0)</span>\n',
   },
   { kind: 'prompt', text: '', cursor: true },
 ]
+
+/**
+ * The mobile variant skips the initial `facet search viper` step (the
+ * search listing is too wide for a phone screen) and jumps straight
+ * to the install flow. Everything from `facet add` onward is shared
+ * with the desktop script.
+ */
+const MOBILE_CLI_SCRIPT: readonly Entry[] = FULL_CLI_SCRIPT.slice(2)
 
 /**
  * Cancellable sleep — resolves after `ms` ms or when the consumer sets the
@@ -61,6 +96,19 @@ function sleep(ms: number, isAborted: () => boolean): Promise<void> {
 }
 
 export function CliDemo() {
+  const isMobile = useIsMobile()
+  /*
+   * Viewport-change behavior: whichever script was chosen when the
+   * section first entered the viewport is the one that plays. We
+   * deliberately do NOT re-run the demo on resize — re-playing would
+   * surprise users in the middle of a read. Replay/skip buttons use
+   * the current viewport value, so manual control always reflects the
+   * latest viewport.
+   */
+  const script = isMobile ? MOBILE_CLI_SCRIPT : FULL_CLI_SCRIPT
+  const scriptRef = useRef(script)
+  scriptRef.current = script
+
   const bodyRef = useRef<HTMLDivElement>(null)
   const abortRef = useRef(false)
   const hasRunRef = useRef(false)
@@ -69,7 +117,7 @@ export function CliDemo() {
     const body = bodyRef.current
     if (!body) return
     body.innerHTML = ''
-    for (const entry of CLI_SCRIPT) {
+    for (const entry of scriptRef.current) {
       if (entry.kind === 'prompt') {
         const line = document.createElement('div')
         const cursorHtml = entry.cursor ? `<span class="${styles.blink}"></span>` : ''
@@ -97,7 +145,7 @@ export function CliDemo() {
       }
     }
 
-    for (const entry of CLI_SCRIPT) {
+    for (const entry of scriptRef.current) {
       if (abortRef.current) return
       if (entry.kind === 'prompt') {
         const line = document.createElement('div')
@@ -174,9 +222,9 @@ export function CliDemo() {
   )
 
   return (
-    <section id="demo" className={styles.section}>
+    <section className={styles.section}>
       <div className={styles.wrap}>
-        <div className={styles.head}>
+        <div id="demo" className={styles.head}>
           <div className={styles.label}>Like npm, but for agents</div>
           <h2 className={styles.title}>
             Install a facet in <em>six seconds.</em>

--- a/packages/landing/src/components/Closer.module.css
+++ b/packages/landing/src/components/Closer.module.css
@@ -1,5 +1,5 @@
 .closer {
-  padding: 120px 32px 60px;
+  padding: 120px 32px 0;
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -62,4 +62,42 @@
   justify-content: center;
   margin-top: 30px;
   position: relative;
+}
+
+.mobileCta {
+  /* Hidden on desktop; shown below bp-mobile. */
+  display: none;
+  margin: 30px auto 0;
+}
+
+/* bp-mobile — swap InstallBlock for RegistryCta, shrink type + spacing. */
+@media (max-width: 1024px) {
+  .closer {
+    padding: 70px 22px 30px;
+  }
+
+  .title {
+    font-size: 42px;
+    letter-spacing: -0.03em;
+    line-height: 0.95;
+    margin-bottom: 16px;
+    text-wrap: balance;
+  }
+
+  .sub {
+    font-size: 14.5px;
+    line-height: 1.55;
+    max-width: 340px;
+    text-wrap: pretty;
+    padding-bottom: 2em;
+  }
+
+  .installWrap {
+    display: none;
+  }
+
+  .mobileCta {
+    display: flex;
+    margin-top: 22px;
+  }
 }

--- a/packages/landing/src/components/Closer.tsx
+++ b/packages/landing/src/components/Closer.tsx
@@ -18,7 +18,9 @@ export function Closer() {
         <div className={styles.installWrap}>
           <InstallBlock />
         </div>
-        <RegistryCta className={styles.mobileCta} />
+        <div className={styles.mobileCta}>
+          <RegistryCta />
+        </div>
       </div>
       <Footer />
     </section>

--- a/packages/landing/src/components/Closer.tsx
+++ b/packages/landing/src/components/Closer.tsx
@@ -1,11 +1,9 @@
-import { useIsMobile } from '../hooks/useIsMobile'
 import styles from './Closer.module.css'
 import { Footer } from './Footer'
 import { InstallBlock } from './InstallBlock'
 import { RegistryCta } from './RegistryCta'
 
 export function Closer() {
-  const isMobile = useIsMobile()
   return (
     <section className={styles.closer}>
       <div className={styles.glow} />
@@ -20,7 +18,7 @@ export function Closer() {
         <div className={styles.installWrap}>
           <InstallBlock />
         </div>
-        {isMobile && <RegistryCta className={styles.mobileCta} />}
+        <RegistryCta className={styles.mobileCta} />
       </div>
       <Footer />
     </section>

--- a/packages/landing/src/components/Closer.tsx
+++ b/packages/landing/src/components/Closer.tsx
@@ -1,8 +1,11 @@
+import { useIsMobile } from '../hooks/useIsMobile'
 import styles from './Closer.module.css'
 import { Footer } from './Footer'
 import { InstallBlock } from './InstallBlock'
+import { RegistryCta } from './RegistryCta'
 
 export function Closer() {
+  const isMobile = useIsMobile()
   return (
     <section className={styles.closer}>
       <div className={styles.glow} />
@@ -17,6 +20,7 @@ export function Closer() {
         <div className={styles.installWrap}>
           <InstallBlock />
         </div>
+        {isMobile && <RegistryCta className={styles.mobileCta} />}
       </div>
       <Footer />
     </section>

--- a/packages/landing/src/components/Explainer.module.css
+++ b/packages/landing/src/components/Explainer.module.css
@@ -1,11 +1,17 @@
 .explainer {
   position: relative;
-  padding: 120px 0 0;
+  padding: 80px 0 0;
 }
 
 .intro {
   max-width: 900px;
-  margin: 0 auto 60px;
+  /*
+   * Intro sits visually close to the top of the first FacetStage
+   * step. The stage's sticky inner is aligned to the top (see
+   * FacetStage.module.css .sticky) so there's no viewport-height
+   * void between "The Idea" and "Skills".
+   */
+  margin: 0 auto 0;
   padding: 0 32px;
   text-align: center;
 }
@@ -45,4 +51,60 @@
   color: var(--ink-dim);
   max-width: 620px;
   margin: 0 auto;
+}
+
+.learnCard {
+  margin-top: 32px;
+}
+
+.desktopStage {
+  display: block;
+}
+
+.mobileStack {
+  display: none;
+}
+
+/* bp-mobile — swap desktop scroll-stage for the static stack. */
+@media (max-width: 1024px) {
+  .explainer {
+    padding: 64px 0 20px;
+  }
+
+  .intro {
+    padding: 0 22px;
+    margin-bottom: 32px;
+  }
+
+  .label {
+    font-size: 10.5px;
+    margin-bottom: 14px;
+  }
+
+  .title {
+    font-size: 36px;
+    letter-spacing: -0.028em;
+    line-height: 1;
+    margin-bottom: 14px;
+    text-wrap: balance;
+  }
+
+  .sub {
+    font-size: 15px;
+    line-height: 1.55;
+    max-width: 340px;
+    text-wrap: pretty;
+  }
+
+  .learnCard {
+    margin-top: 24px;
+  }
+
+  .desktopStage {
+    display: none;
+  }
+
+  .mobileStack {
+    display: block;
+  }
 }

--- a/packages/landing/src/components/Explainer.tsx
+++ b/packages/landing/src/components/Explainer.tsx
@@ -1,10 +1,29 @@
 import styles from './Explainer.module.css'
 import { FacetStage } from './FacetStage'
+import { LinkCard } from './LinkCard'
+import { MobileFacetStack } from './MobileFacetStack'
+
+const BOOK_ICON = (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <title>book</title>
+    <path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H20v17H6.5a2.5 2.5 0 0 0 0 5H20" />
+    <path d="M4 4.5v15A2.5 2.5 0 0 0 6.5 22" />
+  </svg>
+)
 
 export function Explainer() {
   return (
-    <section id="what" className={styles.explainer}>
-      <div className={styles.intro}>
+    <section className={styles.explainer}>
+      <div id="what" className={styles.intro}>
         <div className={styles.label}>The Idea</div>
         <h2 className={styles.title}>
           So what&apos;s a <em>facet</em>?
@@ -12,8 +31,26 @@ export function Explainer() {
         <p className={styles.sub}>
           Think npm, but the packages are the things that make your agents useful. Four primitives, one bundle.
         </p>
+        <LinkCard
+          className={styles.learnCard}
+          href="https://docs.agentfacets.io"
+          label="Learn about facets"
+          value="docs.agentfacets.io"
+          icon={BOOK_ICON}
+        />
       </div>
-      <FacetStage />
+      {/*
+       * Desktop: the scroll-linked 3D choreography of FacetStage.
+       * Mobile: a static stack of primitive cards. The two are
+       * toggled via CSS at the bp-mobile breakpoint; both sit in
+       * the DOM but only one lays out at a time.
+       */}
+      <div className={styles.desktopStage}>
+        <FacetStage />
+      </div>
+      <div className={styles.mobileStack}>
+        <MobileFacetStack />
+      </div>
     </section>
   )
 }

--- a/packages/landing/src/components/FacetStage.module.css
+++ b/packages/landing/src/components/FacetStage.module.css
@@ -3,6 +3,16 @@
   height: 400vh;
 }
 
+/* bp-mobile — belt-and-braces: the Explainer wrapper already toggles
+   the whole stage off on mobile, but if that wrapper is ever
+   bypassed (e.g. the component is used in isolation), don't render
+   the 400vh scroll stage on small viewports. */
+@media (max-width: 1024px) {
+  .stage {
+    display: none;
+  }
+}
+
 .sticky {
   position: sticky;
   top: 0;
@@ -11,7 +21,13 @@
   grid-template-columns: 1fr 1fr;
   gap: 40px;
   align-items: center;
-  padding: 0 64px;
+  /*
+   * Top padding pushes the scene/copy toward the upper half of the
+   * sticky viewport so the first primitive feels bolted right under
+   * the intro rather than floating in the middle of a 100vh void.
+   * Bottom padding is less — the step copy + scene sit high.
+   */
+  padding: 60px 64px 160px;
   overflow: hidden;
 }
 
@@ -27,7 +43,12 @@
   position: relative;
   max-width: 440px;
   width: 100%;
-  min-height: 70vh;
+  /*
+   * Enough height to absolute-position all 5 steps on top of each
+   * other without the tallest clipping, but not so much that empty
+   * space pushes the sticky content away from the intro above.
+   */
+  min-height: 440px;
 }
 
 .step {
@@ -35,7 +56,7 @@
   left: 0;
   right: 0;
   top: 50%;
-  transform: translateY(-50%) translateY(30px);
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
   opacity: 0;

--- a/packages/landing/src/components/FacetStage.tsx
+++ b/packages/landing/src/components/FacetStage.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode, useRef } from 'react'
+import { useRef } from 'react'
 import { useScrollProgress } from '../hooks/useScrollProgress'
+import { STEPS } from './explainer-content'
 import styles from './FacetStage.module.css'
 
 type BoxDef = {
@@ -57,71 +58,6 @@ const STACK_LAYOUTS: readonly (readonly string[])[] = [
     'translate(-50%,-50%) translateY(12px) scale(0.6) rotateX(0)',
     'translate(-50%,-50%) translateY(36px) scale(0.6) rotateX(0)',
   ],
-]
-
-type StepCopy = {
-  idx: string
-  title: ReactNode
-  body: ReactNode
-  tags: readonly string[]
-}
-
-const STEPS: readonly StepCopy[] = [
-  {
-    idx: '01 / Skills',
-    title: (
-      <>
-        Procedural <em>know-how.</em>
-      </>
-    ),
-    body: 'Structured recipes your agent can follow — from "write a PR description" to "run a TPM standup." Curated, tested, versioned.',
-    tags: ['markdown', 'deterministic', 'composable'],
-  },
-  {
-    idx: '02 / Agents',
-    title: (
-      <>
-        Specialists on <em>call.</em>
-      </>
-    ),
-    body: 'Sub-agents with their own system prompts, tool budgets, and personalities. Spawn them when you need a second opinion, a reviewer, or a planner.',
-    tags: ['sub-agent', 'scoped tools', 'memory'],
-  },
-  {
-    idx: '03 / Commands',
-    title: (
-      <>
-        Slash <em>shortcuts.</em>
-      </>
-    ),
-    body: '/review-pr, /triage, /changelog. Commands get pinned to your workspace the moment you install — no config file surgery.',
-    tags: ['/slash', 'one-key', 'hotkeys'],
-  },
-  {
-    idx: '04 / MCP Servers',
-    title: (
-      <>
-        Real <em>tools,</em> real APIs.
-      </>
-    ),
-    body: 'MCP servers bring the outside world in: Linear, Postgres, internal dashboards, your Figma library. Bundled, auth-handled, ready.',
-    tags: ['MCP', 'OAuth', 'sandboxed'],
-  },
-  {
-    idx: '05 / The Facet',
-    title: (
-      <>
-        All four, <em>packed</em> into one.
-      </>
-    ),
-    body: (
-      <>
-        A facet is the bundle. Publish one, <code>facet add viper-plans</code>, and every primitive lands at once — no
-        glue, no drift.
-      </>
-    ),
-    tags: ['one install', 'semver', 'reproducible'],
-  },
 ]
 
 /**

--- a/packages/landing/src/components/Footer.module.css
+++ b/packages/landing/src/components/Footer.module.css
@@ -1,14 +1,14 @@
 .footer {
-  padding: 60px 32px 40px;
+  padding: 5em 32px 5em;
   display: flex;
   justify-content: space-between;
   gap: 20px;
   flex-wrap: wrap;
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 12px;
   color: var(--ink-faint);
   border-top: 1px solid var(--line);
-  margin-top: 60px;
+  margin-top: 10em;
 }
 
 .footer a {
@@ -22,4 +22,21 @@
 .links {
   display: flex;
   gap: 24px;
+}
+
+/* bp-mobile — stack + center, match the mockup's compact footer. */
+@media (max-width: 1024px) {
+  .footer {
+    flex-direction: column-reverse;
+    justify-content: center;
+    align-items: center;
+    gap: 14px;
+    padding: 30px 22px 36px;
+    margin-top: 40px;
+    font-size: 11px;
+  }
+
+  .links {
+    gap: 18px;
+  }
 }

--- a/packages/landing/src/components/Hero.module.css
+++ b/packages/landing/src/components/Hero.module.css
@@ -100,6 +100,15 @@
   margin-bottom: 20px;
 }
 
+.mobileCta {
+  /* Hidden on desktop; shown below bp-mobile. */
+  display: none;
+  position: relative;
+  z-index: 1;
+  margin-bottom: 12px;
+  width: 100%;
+}
+
 .installNote {
   position: relative;
   z-index: 1;
@@ -107,6 +116,20 @@
   font-size: 12px;
   color: var(--ink-faint);
   margin-bottom: 40px;
+}
+
+.installNoteMobile {
+  /* Hidden on desktop; shown below bp-mobile. */
+  display: none;
+  position: relative;
+  z-index: 1;
+  font-family: var(--mono), monospace;
+  font-size: 10.5px;
+  color: var(--ink-faint);
+  line-height: 1.5;
+  text-align: center;
+  max-width: 320px;
+  margin: 0 auto 24px;
 }
 
 .ctaRow {
@@ -142,4 +165,95 @@
 
 .ctaRow a:hover .arrow {
   transform: translateX(3px);
+}
+
+/* bp-mobile — swap InstallBlock for RegistryCta, shrink type + spacing,
+   and hide the OrbitFloaters (via their own module). */
+@media (max-width: 1024px) {
+  .hero {
+    min-height: auto;
+    /*
+     * Top padding clears the fixed nav (--nav-mobile-height, ~55px)
+     * plus breathing room for the eyebrow. Desktop uses 140px to
+     * clear a ~68px nav; 96px keeps the same proportion on mobile.
+     */
+    padding: 96px 22px 56px;
+    display: flex;
+    gap: 1em;
+  }
+
+  .eyebrowRow {
+    margin-bottom: 22px;
+  }
+
+  .title {
+    font-size: 44px;
+    line-height: 0.95;
+    letter-spacing: -0.035em;
+    text-wrap: balance;
+    margin: 0 0 18px;
+  }
+
+  .sub {
+    font-size: 15.5px;
+    max-width: 340px;
+    margin: 0 auto 28px;
+    text-wrap: pretty;
+  }
+
+  .installWrap {
+    display: none;
+  }
+
+  .mobileCta {
+    display: flex;
+  }
+
+  .installNote {
+    display: none;
+  }
+
+  .installNoteMobile {
+    display: block;
+  }
+
+  /*
+   * On mobile, the CTA links become proper finger-sized targets:
+   * full-width pills ~48px tall (comfortably above the 44px HIG
+   * minimum), subtle card background, centered text. Each link is
+   * the whole row, so any tap anywhere in the pill activates it.
+   */
+  .ctaRow {
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 22px;
+    font-size: 14px;
+    width: 100%;
+    max-width: 320px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .ctaRow a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    min-height: 48px;
+    padding: 12px 18px;
+    background: var(--card);
+    border: 1px solid var(--line-strong);
+    border-radius: 10px;
+    color: var(--ink);
+  }
+
+  .ctaRow a:active {
+    background: color-mix(in oklab, var(--ink) 8%, transparent);
+    transform: translateY(1px);
+  }
+
+  .ctaRow .sep {
+    display: none;
+  }
 }

--- a/packages/landing/src/components/Hero.tsx
+++ b/packages/landing/src/components/Hero.tsx
@@ -2,6 +2,7 @@ import { Eyebrow } from './Eyebrow'
 import styles from './Hero.module.css'
 import { InstallBlock } from './InstallBlock'
 import { OrbitFloaters } from './OrbitFloaters'
+import { RegistryCta } from './RegistryCta'
 
 export function Hero() {
   return (
@@ -25,10 +26,19 @@ export function Hero() {
         Skills, sub-agents, slash commands, and MCP servers — bundled, versioned, installed with one line.
       </p>
 
+      {/*
+       * On desktop the install pill is the primary CTA; on mobile the
+       * curl command isn't useful, so we show a Registry CTA card
+       * pointing at facet.cafe instead. Both are mounted and CSS
+       * toggles visibility at the bp-mobile breakpoint.
+       */}
       <div className={styles.installWrap}>
         <InstallBlock />
       </div>
+      <RegistryCta className={styles.mobileCta} />
+
       <div className={styles.installNote}>one-liner · macOS · Linux · works with Claude, Cursor, Codex &amp; more</div>
+      <div className={styles.installNoteMobile}>Search 200+ facets · install from your desktop with one line</div>
 
       <div className={styles.ctaRow}>
         <a href="#demo">
@@ -39,8 +49,8 @@ export function Hero() {
           Browse the registry <span className={styles.arrow}>↗</span>
         </a>
         <span className={styles.sep}>·</span>
-        <a href="https://docs.agentfacets.io" target="_blank" rel="noreferrer noopener">
-          Publish a facet <span className={styles.arrow}>↗</span>
+        <a href="https://docs.agentfacets.io">
+          Learn more about facets <span className={styles.arrow}>↗</span>
         </a>
       </div>
     </section>

--- a/packages/landing/src/components/LinkCard.module.css
+++ b/packages/landing/src/components/LinkCard.module.css
@@ -1,0 +1,100 @@
+.card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--bg-elev);
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin: 0 auto;
+  max-width: 360px;
+  text-align: left;
+  box-shadow: 0 14px 40px -14px color-mix(in oklab, var(--accent-a) 55%, transparent);
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.1s ease;
+}
+
+.card:active {
+  transform: translateY(1px);
+}
+
+/*
+ * Decorative gradient wash. The content sits on top via position:relative
+ * + z-index on the children below.
+ */
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    color-mix(in oklab, var(--accent-a) 22%, transparent),
+    color-mix(in oklab, var(--accent-b) 22%, transparent)
+  );
+  opacity: 0.9;
+  z-index: 0;
+}
+
+.icon,
+.text,
+.arrow {
+  position: relative;
+  z-index: 1;
+}
+
+.icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  background: var(--bg-elev);
+  border: 1px solid var(--line-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-b);
+}
+
+.text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink);
+  opacity: 0.85;
+  margin-bottom: 2px;
+  font-weight: 600;
+}
+
+.value {
+  font-family: var(--mono), monospace;
+  font-size: 14px;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.arrow {
+  color: var(--ink);
+  opacity: 0.75;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.card:active .arrow {
+  transform: translateX(3px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .arrow {
+    transition: none;
+  }
+}

--- a/packages/landing/src/components/LinkCard.tsx
+++ b/packages/landing/src/components/LinkCard.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react'
+import styles from './LinkCard.module.css'
+
+type LinkCardProps = {
+  href: string
+  /**
+   * Small uppercase eyebrow label above the value. E.g. "Browse the
+   * registry", "Learn about facets".
+   */
+  label: string
+  /**
+   * The primary text of the card — usually the destination host or
+   * page title. E.g. "facet.cafe", "docs.agentfacets.io".
+   */
+  value: string
+  /**
+   * Icon content for the left-hand square. Pass an inline SVG. The
+   * icon inherits `currentColor` from the square's `color` prop; use
+   * `iconColor` to set that per-card.
+   */
+  icon: ReactNode
+  /**
+   * CSS color applied to the icon square's `color` property so inline
+   * SVGs using `currentColor` pick it up. Defaults to `var(--accent-b)`.
+   */
+  iconColor?: string
+  /**
+   * When true, opens in a new tab with rel="noreferrer noopener" and
+   * shows the external-link arrow. Defaults to true since every use
+   * of this card today points at an off-site destination; in-page
+   * anchors should use the plainer Hero CTA pills.
+   */
+  external?: boolean
+  className?: string
+}
+
+/**
+ * Gradient-washed card with a square icon slot, a small label, a
+ * primary value line, and an arrow. Used in Hero, Explainer, and
+ * Closer for prominent off-site CTAs. Originally introduced as
+ * `RegistryCta` for facet.cafe on mobile; generalized so the same
+ * visual language can advertise any destination.
+ */
+export function LinkCard({ href, label, value, icon, iconColor, external = true, className }: LinkCardProps) {
+  const externalProps = external ? { target: '_blank', rel: 'noreferrer noopener' as const } : {}
+  return (
+    <a className={`${styles.card}${className ? ` ${className}` : ''}`} href={href} {...externalProps}>
+      <span className={styles.icon} style={iconColor ? { color: iconColor } : undefined} aria-hidden="true">
+        {icon}
+      </span>
+      <span className={styles.text}>
+        <span className={styles.label}>{label}</span>
+        <span className={styles.value}>{value}</span>
+      </span>
+      <svg
+        className={styles.arrow}
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {external ? (
+          <>
+            <path d="M7 17 17 7" />
+            <path d="M7 7h10v10" />
+          </>
+        ) : (
+          <path d="M5 12h14M13 5l7 7-7 7" />
+        )}
+      </svg>
+    </a>
+  )
+}

--- a/packages/landing/src/components/MobileFacetStack.module.css
+++ b/packages/landing/src/components/MobileFacetStack.module.css
@@ -1,0 +1,321 @@
+/* ---------- Facet hero: diamond + stacked mini-boxes ---------- */
+
+.facetHero {
+  position: relative;
+  height: 240px;
+  margin: 0 auto 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.diamond {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 200px;
+  height: 200px;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border: 1.5px solid;
+  border-image: linear-gradient(135deg, var(--accent-a), var(--accent-b), var(--accent-d)) 1;
+  box-shadow: 0 0 50px color-mix(in oklab, var(--accent-a) 30%, transparent);
+  opacity: 0.55;
+}
+
+.diamond::before {
+  content: "";
+  position: absolute;
+  inset: 16px;
+  border: 1px solid color-mix(in oklab, var(--accent-b) 40%, transparent);
+}
+
+.stack {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.miniBox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1.5px solid;
+  font-family: var(--mono);
+  font-size: 12px;
+  backdrop-filter: blur(6px);
+  width: 200px;
+  animation: miniFloat 4s ease-in-out infinite;
+}
+
+.miniBox:nth-child(1) {
+  animation-delay: 0s;
+}
+.miniBox:nth-child(2) {
+  animation-delay: 0.5s;
+}
+.miniBox:nth-child(3) {
+  animation-delay: 1s;
+}
+.miniBox:nth-child(4) {
+  animation-delay: 1.5s;
+}
+
+@keyframes miniFloat {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(-3px);
+  }
+}
+
+.miniIcon {
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.miniLabel {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.mb-skills {
+  border-color: var(--accent-a);
+  background: color-mix(in oklab, var(--accent-a) 14%, var(--bg-elev));
+}
+.mb-skills .miniIcon {
+  background: color-mix(in oklab, var(--accent-a) 28%, transparent);
+  color: var(--accent-a);
+}
+
+.mb-agents {
+  border-color: var(--accent-b);
+  background: color-mix(in oklab, var(--accent-b) 14%, var(--bg-elev));
+}
+.mb-agents .miniIcon {
+  background: color-mix(in oklab, var(--accent-b) 28%, transparent);
+  color: var(--accent-b);
+}
+
+.mb-cmds {
+  border-color: var(--accent-c);
+  background: color-mix(in oklab, var(--accent-c) 14%, var(--bg-elev));
+}
+.mb-cmds .miniIcon {
+  background: color-mix(in oklab, var(--accent-c) 28%, transparent);
+  color: var(--accent-c);
+}
+
+.mb-mcp {
+  border-color: var(--accent-d);
+  background: color-mix(in oklab, var(--accent-d) 14%, var(--bg-elev));
+}
+.mb-mcp .miniIcon {
+  background: color-mix(in oklab, var(--accent-d) 32%, transparent);
+  color: var(--accent-d);
+}
+
+/* ---------- Primitive cards ---------- */
+
+.primitives {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 10px 22px 20px;
+}
+
+.primCard {
+  background: var(--bg-elev);
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  padding: 20px;
+  position: relative;
+  overflow: hidden;
+}
+
+.primCard::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+}
+
+.p-skills::before {
+  background: var(--accent-a);
+}
+.p-agents::before {
+  background: var(--accent-b);
+}
+.p-cmds::before {
+  background: var(--accent-c);
+}
+.p-mcp::before {
+  background: var(--accent-d);
+}
+
+.primHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.primNum {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  letter-spacing: 0.12em;
+}
+
+.primBadge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 4px 8px;
+  border-radius: 5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.p-skills .primBadge {
+  background: color-mix(in oklab, var(--accent-a) 20%, transparent);
+  color: var(--accent-a);
+}
+.p-agents .primBadge {
+  background: color-mix(in oklab, var(--accent-b) 20%, transparent);
+  color: var(--accent-b);
+}
+.p-cmds .primBadge {
+  background: color-mix(in oklab, var(--accent-c) 20%, transparent);
+  color: var(--accent-c);
+}
+.p-mcp .primBadge {
+  background: color-mix(in oklab, var(--accent-d) 25%, transparent);
+  color: var(--accent-d);
+}
+
+.primTitle {
+  font-family: var(--sans);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  margin: 0 0 8px;
+}
+
+.primTitle em {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent-a);
+}
+
+.primBody {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.primTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 14px;
+}
+
+.primTag {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 4px 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--ink-dim);
+  background: var(--card);
+}
+
+/* ---------- Packed-into-facet reveal ---------- */
+
+.packed {
+  text-align: center;
+  margin: 36px auto 0;
+  padding: 28px 22px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 14px;
+  max-width: 400px;
+  background: radial-gradient(ellipse at center, color-mix(in oklab, var(--accent-a) 8%, transparent), transparent 70%);
+}
+
+.packedLabel {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 10px;
+}
+
+.packedTitle {
+  font-family: var(--sans);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  margin: 0 0 8px;
+  line-height: 1.05;
+  text-wrap: balance;
+}
+
+.packedTitle em {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  background: linear-gradient(100deg, var(--accent-a), var(--accent-b), var(--accent-d));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: inline-block;
+  padding: 0.08em 0.18em;
+  margin: -0.08em -0.18em;
+}
+
+.packedBody {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0 0 14px;
+}
+
+.packedCode {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 8px 14px;
+  background: var(--bg-elev);
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  color: var(--accent-b);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .miniBox {
+    animation: none;
+  }
+}

--- a/packages/landing/src/components/MobileFacetStack.tsx
+++ b/packages/landing/src/components/MobileFacetStack.tsx
@@ -1,0 +1,63 @@
+import { PACKED_COPY, PRIMITIVE_CARDS } from './explainer-content'
+import styles from './MobileFacetStack.module.css'
+
+const MINI_BOXES: ReadonlyArray<{ slug: 'skills' | 'agents' | 'cmds' | 'mcp'; icon: string; label: string }> = [
+  { slug: 'skills', icon: 'S', label: 'skills/' },
+  { slug: 'agents', icon: 'A', label: 'agents/' },
+  { slug: 'cmds', icon: '/', label: 'commands/' },
+  { slug: 'mcp', icon: 'M', label: 'mcp/' },
+]
+
+/**
+ * The mobile counterpart to `FacetStage`. Static (no scroll-linked 3D
+ * choreography) — instead, renders a single diamond visual with the 4
+ * primitives stacked inside, followed by 4 primitive cards, followed
+ * by the "packed" reveal.
+ *
+ * Shares copy with `FacetStage` via `explainer-content.tsx` so the two
+ * components stay in sync.
+ */
+export function MobileFacetStack() {
+  return (
+    <>
+      <div className={styles.facetHero} aria-hidden="true">
+        <div className={styles.diamond} />
+        <div className={styles.stack}>
+          {MINI_BOXES.map((box) => (
+            <div key={box.slug} className={`${styles.miniBox} ${styles[`mb-${box.slug}`]}`}>
+              <div className={styles.miniIcon}>{box.icon}</div>
+              <div className={styles.miniLabel}>{box.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.primitives}>
+        {PRIMITIVE_CARDS.map((card) => (
+          <article key={card.slug} className={`${styles.primCard} ${styles[`p-${card.slug}`]}`}>
+            <div className={styles.primHead}>
+              <span className={styles.primNum}>{card.num}</span>
+              <span className={styles.primBadge}>{card.badge}</span>
+            </div>
+            <h3 className={styles.primTitle}>{card.title}</h3>
+            <p className={styles.primBody}>{card.body}</p>
+            <div className={styles.primTags}>
+              {card.tags.map((tag) => (
+                <span key={tag} className={styles.primTag}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <div className={styles.packed}>
+        <div className={styles.packedLabel}>{PACKED_COPY.label}</div>
+        <h3 className={styles.packedTitle}>{PACKED_COPY.title}</h3>
+        <p className={styles.packedBody}>{PACKED_COPY.body}</p>
+        <code className={styles.packedCode}>{PACKED_COPY.code}</code>
+      </div>
+    </>
+  )
+}

--- a/packages/landing/src/components/MobileMenu.module.css
+++ b/packages/landing/src/components/MobileMenu.module.css
@@ -1,0 +1,98 @@
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.root.open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  appearance: none;
+  background: color-mix(in oklab, var(--bg) 60%, transparent);
+  backdrop-filter: blur(4px) saturate(1.2);
+  -webkit-backdrop-filter: blur(4px) saturate(1.2);
+  border: none;
+  cursor: default;
+}
+
+.panel {
+  position: absolute;
+  /*
+   * Start flush below the fixed nav (raised to z-index: 70). The
+   * nav stays visible as a crisp bar on top; the menu sheet slides
+   * down underneath it. --nav-mobile-height is defined in global.css.
+   */
+  top: var(--nav-mobile-height);
+  left: 0;
+  right: 0;
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  backdrop-filter: blur(14px) saturate(1.4);
+  -webkit-backdrop-filter: blur(14px) saturate(1.4);
+  border-bottom: 1px solid var(--line-strong);
+  padding: 20px 22px 28px;
+  transform: translateY(-100%);
+  transition: transform 0.25s cubic-bezier(0.2, 0.9, 0.2, 1);
+  box-shadow: 0 20px 50px -20px rgba(0, 0, 0, 0.5);
+}
+
+.root.open .panel {
+  transform: translateY(0);
+}
+
+.links {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 8px;
+  font-family: var(--mono);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ink);
+  border-bottom: 1px solid var(--line);
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+  border-radius: 6px;
+}
+
+.link:last-child {
+  border-bottom: none;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: var(--ink);
+  background: var(--card);
+}
+
+.link:active {
+  background: color-mix(in oklab, var(--ink) 6%, transparent);
+}
+
+.extArrow {
+  color: var(--ink-faint);
+  font-size: 0.9em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .root,
+  .panel {
+    transition: none;
+  }
+}

--- a/packages/landing/src/components/MobileMenu.tsx
+++ b/packages/landing/src/components/MobileMenu.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from 'react'
+import styles from './MobileMenu.module.css'
+
+type MenuLink = {
+  label: string
+  href: string
+  external?: boolean
+}
+
+/**
+ * Mobile menu entries in display order. In-page anchors first (Home,
+ * Facets, CLI), then external destinations (Docs, Registry, GitHub).
+ * Theme toggle is deliberately kept in the nav bar itself so users
+ * don't have to open the menu to change themes.
+ */
+const LINKS: readonly MenuLink[] = [
+  { label: 'Home', href: '#top' },
+  { label: 'Learn', href: '#what' },
+  { label: 'CLI', href: '#demo' },
+  { label: 'Docs', href: 'https://docs.agentfacets.io' },
+  { label: 'Reference', href: 'https://docs.agentfacets.io/cli' },
+  { label: 'Registry', href: 'https://facet.cafe/', external: true },
+  { label: 'GitHub', href: 'https://github.com/agent-facets/facets', external: true },
+]
+
+type MobileMenuProps = {
+  open: boolean
+  onClose: () => void
+}
+
+/**
+ * Full-width slide-down menu for mobile viewports. Triggered by the
+ * brand mark in the nav bar. Closes on link tap, backdrop tap, or
+ * Escape key. Body scroll is locked while open. Focus moves to the
+ * first link on open; the parent component is responsible for
+ * returning focus to the trigger on close.
+ *
+ * The panel is always mounted (not conditionally rendered) so its
+ * slide-in transition has something to animate; the `open` prop
+ * toggles a class that drives the transform/opacity.
+ */
+export function MobileMenu({ open, onClose }: MobileMenuProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const firstLinkRef = useRef<HTMLAnchorElement>(null)
+
+  // Lock body scroll while the menu is open.
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => {
+      document.removeEventListener('keydown', handler)
+    }
+  }, [open, onClose])
+
+  // Move focus to the first link on open.
+  useEffect(() => {
+    if (!open) return
+    // Defer a tick so the browser has flipped the `aria-hidden` state.
+    const id = window.requestAnimationFrame(() => {
+      firstLinkRef.current?.focus()
+    })
+    return () => {
+      window.cancelAnimationFrame(id)
+    }
+  }, [open])
+
+  return (
+    <div
+      className={`${styles.root}${open ? ` ${styles.open}` : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Main menu"
+      aria-hidden={!open}
+    >
+      {/* Backdrop: sits behind the panel so tapping outside closes. */}
+      <button
+        type="button"
+        className={styles.backdrop}
+        aria-label="Close menu"
+        onClick={onClose}
+        tabIndex={open ? 0 : -1}
+      />
+      <div ref={panelRef} className={styles.panel} id="mobile-menu">
+        <nav className={styles.links} aria-label="Mobile navigation">
+          {LINKS.map((link, i) => {
+            const externalProps = link.external ? { target: '_blank', rel: 'noreferrer noopener' } : {}
+            return (
+              <a
+                key={link.label}
+                ref={i === 0 ? firstLinkRef : undefined}
+                href={link.href}
+                onClick={onClose}
+                tabIndex={open ? 0 : -1}
+                className={styles.link}
+                {...externalProps}
+              >
+                <span>{link.label}</span>
+                {link.external ? (
+                  <span className={styles.extArrow} aria-hidden="true">
+                    ↗
+                  </span>
+                ) : null}
+              </a>
+            )
+          })}
+        </nav>
+      </div>
+    </div>
+  )
+}

--- a/packages/landing/src/components/Nav.module.css
+++ b/packages/landing/src/components/Nav.module.css
@@ -3,7 +3,13 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 50;
+  /*
+   * Sits above the MobileMenu overlay (z-index: 60) so the brand mark
+   * and theme toggle remain visible and interactive while the menu
+   * sheet is open. The menu's .panel starts at top: var(--nav-mobile-height)
+   * to avoid visual overlap.
+   */
+  z-index: 70;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -27,10 +33,23 @@
   text-decoration: none;
   cursor: pointer;
   transition: opacity 0.15s ease;
+
+  /* Button-as-brand on mobile — strip default button chrome. */
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
 }
 
 .brand:hover {
   opacity: 0.8;
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--accent-c);
+  outline-offset: 4px;
+  border-radius: 6px;
 }
 
 .links {
@@ -92,8 +111,25 @@
   border-color: var(--ink-dim);
 }
 
-@media (max-width: 900px) {
-  .links {
+/* bp-mobile — mobile nav: brand + theme toggle only. Links + GitHub
+   button live inside the MobileMenu sheet instead. */
+@media (max-width: 1024px) {
+  .nav {
+    padding: 14px 18px;
+  }
+
+  .brand {
+    min-width: 0;
+    gap: 9px;
+    font-size: 15px;
+  }
+
+  .links,
+  .ghbtn {
     display: none;
+  }
+
+  .right {
+    min-width: 0;
   }
 }

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -1,25 +1,71 @@
+import { useCallback, useRef, useState } from 'react'
+import { useIsMobile } from '../hooks/useIsMobile'
 import { BrandMark } from './BrandMark'
+import { MobileMenu } from './MobileMenu'
 import styles from './Nav.module.css'
 import { ThemeToggle } from './ThemeToggle'
 
+/**
+ * Top nav bar. On desktop the brand mark links back to top (href="#top"),
+ * matching the existing behavior. On mobile the brand mark becomes a
+ * hamburger trigger — tapping it opens the `MobileMenu` slide-down sheet.
+ * The dual role is rendered conditionally via `useIsMobile()` so there's
+ * only ever one landmark in the DOM at a time.
+ */
 export function Nav() {
+  const isMobile = useIsMobile()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false)
+    // Return focus to the brand-mark trigger on close.
+    triggerRef.current?.focus()
+  }, [])
+
+  const toggleMenu = useCallback(() => {
+    setMenuOpen((v) => !v)
+  }, [])
+
   return (
     <>
       <div id="top" />
       <nav className={styles.nav}>
-        <a className={styles.brand} href="#top" aria-label="Agent Facets — back to top">
-          <BrandMark />
-          Agent Facets
-        </a>
+        {isMobile ? (
+          <button
+            ref={triggerRef}
+            type="button"
+            className={styles.brand}
+            onClick={toggleMenu}
+            aria-expanded={menuOpen}
+            aria-controls="mobile-menu"
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          >
+            <BrandMark />
+            Agent Facets
+          </button>
+        ) : (
+          <a className={styles.brand} href="#top" aria-label="Agent Facets — back to top">
+            <BrandMark />
+            Agent Facets
+          </a>
+        )}
+
         <div className={styles.links}>
           <a href="#top">Home</a>
-          <a href="#what">Facets</a>
+          <a href="#what">Learn</a>
           <a href="#demo">CLI</a>
-          <a href="https://docs.agentfacets.io">Docs</a>
+          <a href="https://docs.agentfacets.io" target="_self">
+            Docs
+          </a>
+          <a href="https://docs.agentfacets.io/cli" target="_self">
+            Reference
+          </a>
           <a href="https://facet.cafe/" target="_blank" rel="noreferrer noopener">
             Registry <span className={styles.extArrow}>↗</span>
           </a>
         </div>
+
         <div className={styles.right}>
           <ThemeToggle />
           <a
@@ -35,6 +81,7 @@ export function Nav() {
           </a>
         </div>
       </nav>
+      {isMobile ? <MobileMenu open={menuOpen} onClose={closeMenu} /> : null}
     </>
   )
 }

--- a/packages/landing/src/components/OrbitFloaters.module.css
+++ b/packages/landing/src/components/OrbitFloaters.module.css
@@ -43,8 +43,10 @@
   }
 }
 
-@media (max-width: 900px) {
-  .box {
+/* bp-mobile — hide floaters entirely on small viewports; they add
+   visual noise in a narrow hero and collide with the CTA + title. */
+@media (max-width: 1024px) {
+  .orbits {
     display: none;
   }
 }

--- a/packages/landing/src/components/OrbitFloaters.tsx
+++ b/packages/landing/src/components/OrbitFloaters.tsx
@@ -10,14 +10,14 @@ type Floater = {
 
 const FLOATERS: readonly Floater[] = [
   { label: 'skills/', accent: 'var(--accent-a)', style: { top: '22%', left: '10%' }, delay: '0s' },
-  { label: 'agents/', accent: 'var(--accent-b)', style: { top: '35%', right: '12%' }, delay: '1.5s' },
+  { label: 'agents/', accent: 'var(--accent-b)', style: { top: '15%', right: '12%' }, delay: '1.5s' },
   {
     label: 'commands/',
     accent: 'var(--accent-c)',
-    style: { bottom: '30%', left: '19%' },
+    style: { bottom: '30%', left: '3%' },
     delay: '3s',
   },
-  { label: 'mcp/', accent: 'var(--accent-d)', style: { bottom: '38%', right: '20%' }, delay: '4.5s' },
+  { label: 'mcp/', accent: 'var(--accent-d)', style: { bottom: '38%', right: '10%' }, delay: '4.5s' },
 ]
 
 /**

--- a/packages/landing/src/components/RegistryCta.tsx
+++ b/packages/landing/src/components/RegistryCta.tsx
@@ -1,0 +1,40 @@
+import { LinkCard } from './LinkCard'
+
+type RegistryCtaProps = {
+  className?: string
+}
+
+const MAGNIFYING_GLASS = (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <title>magnifying glass</title>
+    <circle cx="11" cy="11" r="7" />
+    <path d="m20 20-3.5-3.5" />
+  </svg>
+)
+
+/**
+ * Specific `LinkCard` that advertises the facet.cafe registry. Kept
+ * as a convenience wrapper so call sites stay readable (`<RegistryCta />`
+ * vs a wall of props) and so the registry URL + icon live in one place.
+ * Used on mobile hero + closer where the install one-liner is hidden.
+ */
+export function RegistryCta({ className }: RegistryCtaProps) {
+  return (
+    <LinkCard
+      href="https://facet.cafe/"
+      label="Browse the registry"
+      value="facet.cafe"
+      icon={MAGNIFYING_GLASS}
+      className={className}
+    />
+  )
+}

--- a/packages/landing/src/components/explainer-content.tsx
+++ b/packages/landing/src/components/explainer-content.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Single source of truth for the "So what's a facet?" primitive copy.
+ * Shared between the desktop `FacetStage` (scroll-linked) and the
+ * mobile `MobileFacetStack` (static).
+ *
+ * STEPS describes the 5 scroll-choreographed steps on desktop. The
+ * final step (`05 / The Facet`) is the "packed" summary, which on
+ * mobile is rendered separately in the `.packed` card and uses the
+ * copy from PACKED_COPY below.
+ */
+export type StepCopy = {
+  readonly idx: string
+  readonly title: ReactNode
+  readonly body: ReactNode
+  readonly tags: readonly string[]
+}
+
+/**
+ * Mobile primitive-card metadata — the 4 colored cards shown in
+ * `MobileFacetStack`. Derived from the same source as STEPS but
+ * adds an `accent` slot so the card can style its top border
+ * without introspecting className conventions.
+ */
+export type PrimitiveCardCopy = {
+  readonly num: string
+  readonly slug: 'skills' | 'agents' | 'cmds' | 'mcp'
+  readonly badge: string
+  readonly title: ReactNode
+  readonly body: string
+  readonly tags: readonly string[]
+}
+
+export const STEPS: readonly StepCopy[] = [
+  {
+    idx: '01 / Skills',
+    title: (
+      <>
+        Procedural <em>know-how.</em>
+      </>
+    ),
+    body: 'Structured recipes your agent can follow — from "write a PR description" to "run a TPM standup." Curated, tested, versioned.',
+    tags: ['markdown', 'deterministic', 'composable'],
+  },
+  {
+    idx: '02 / Agents',
+    title: (
+      <>
+        Specialists on <em>call.</em>
+      </>
+    ),
+    body: 'Sub-agents with their own system prompts, tool budgets, and personalities. Spawn them when you need a second opinion, a reviewer, or a planner.',
+    tags: ['sub-agent', 'scoped tools', 'memory'],
+  },
+  {
+    idx: '03 / Commands',
+    title: (
+      <>
+        Slash <em>shortcuts.</em>
+      </>
+    ),
+    body: '/review-pr, /triage, /changelog. Commands get pinned to your workspace the moment you install — no config file surgery.',
+    tags: ['/slash', 'one-key', 'hotkeys'],
+  },
+  {
+    idx: '04 / MCP Servers',
+    title: (
+      <>
+        Real <em>tools,</em> real APIs.
+      </>
+    ),
+    body: 'MCP servers bring the outside world in: Linear, Postgres, internal dashboards, your Figma library. Bundled, auth-handled, ready.',
+    tags: ['MCP', 'OAuth', 'sandboxed'],
+  },
+  {
+    idx: '05 / The Facet',
+    title: (
+      <>
+        All four, <em>packed</em> into one.
+      </>
+    ),
+    body: (
+      <>
+        A facet is the bundle. Publish one, <code>facet add viper-plans</code>, and every primitive lands at once — no
+        glue, no drift.
+      </>
+    ),
+    tags: ['one install', 'semver', 'reproducible'],
+  },
+]
+
+export const PRIMITIVE_CARDS: readonly PrimitiveCardCopy[] = [
+  {
+    num: '01',
+    slug: 'skills',
+    badge: 'skills/',
+    title: (
+      <>
+        Procedural <em>know-how.</em>
+      </>
+    ),
+    body: 'Structured recipes your agent can follow — from "write a PR description" to "run a TPM standup."',
+    tags: ['markdown', 'deterministic', 'composable'],
+  },
+  {
+    num: '02',
+    slug: 'agents',
+    badge: 'agents/',
+    title: (
+      <>
+        Specialists on <em>call.</em>
+      </>
+    ),
+    body: 'Sub-agents with their own prompts, tools, and personalities. Spawn for a second opinion, a reviewer, a planner.',
+    tags: ['sub-agent', 'scoped tools', 'memory'],
+  },
+  {
+    num: '03',
+    slug: 'cmds',
+    badge: 'commands/',
+    title: (
+      <>
+        Slash <em>shortcuts.</em>
+      </>
+    ),
+    body: '/review-pr, /triage, /changelog. Pinned to your workspace the moment you install. No config surgery.',
+    tags: ['/slash', 'one-key', 'hotkeys'],
+  },
+  {
+    num: '04',
+    slug: 'mcp',
+    badge: 'mcp/',
+    title: (
+      <>
+        Real <em>tools,</em> real APIs.
+      </>
+    ),
+    body: 'MCP servers bring the outside world in: Linear, Postgres, internal dashboards, Figma — bundled, auth-handled.',
+    tags: ['MCP', 'OAuth', 'sandboxed'],
+  },
+]
+
+export const PACKED_COPY = {
+  label: 'The Facet',
+  title: (
+    <>
+      All four, <em>packed</em> into one.
+    </>
+  ),
+  body: 'Publish once. Install once. Every primitive lands together — no glue, no drift.',
+  code: 'facet add viper-plans',
+} as const

--- a/packages/landing/src/hooks/useIsMobile.ts
+++ b/packages/landing/src/hooks/useIsMobile.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * The source of truth for the mobile breakpoint for TypeScript, in pixels.
+ *
+ * Keep this synced with the `--mobile-width` value in `global.css`.
+ */
+export const MOBILE_BREAKPOINT_PX = 1024
+
+const MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX}px)`
+
+/**
+ * Returns `true` when the viewport is at or below the mobile breakpoint.
+ *
+ * SSR-safe: the initial render always returns `false` (desktop) to
+ * avoid hydration mismatch. The real value is computed in `useEffect`
+ * after mount. Consumers that render differently on mobile vs desktop
+ * will briefly show the desktop variant, then swap on the next frame —
+ * acceptable for this landing site, where the initial HTML is generic.
+ *
+ * Listens for viewport changes via `matchMedia.addEventListener` so
+ * resizes across the breakpoint update the result live.
+ */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+
+    const mq = window.matchMedia(MEDIA_QUERY)
+    setIsMobile(mq.matches)
+
+    const handler = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches)
+    }
+
+    mq.addEventListener('change', handler)
+    return () => {
+      mq.removeEventListener('change', handler)
+    }
+  }, [])
+
+  return isMobile
+}

--- a/packages/landing/src/styles/global.css
+++ b/packages/landing/src/styles/global.css
@@ -8,6 +8,7 @@
 *::before,
 *::after {
   box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
 }
 
 html {
@@ -16,6 +17,17 @@ html {
    * browser-chosen and can't be tuned from CSS.
    */
   scroll-behavior: smooth;
+}
+
+/*
+ * Mobile nav height. Derived from `.nav` mobile padding (14px × 2) +
+ * BrandMark SVG (26px) + bottom border (1px) = 55px. Referenced by
+ * `MobileMenu.module.css` so the slide-down panel starts flush below
+ * the nav rather than overlapping it. If you change the mobile nav
+ * padding or brand-mark size, update this value.
+ */
+:root {
+  --nav-mobile-height: 55px;
 }
 
 html,
@@ -34,14 +46,26 @@ body {
 }
 
 /*
- * Offset the top of each anchored section so the fixed nav (~68px tall)
- * doesn't overlap the section heading when the browser scrolls the anchor
- * into view.
+ * Offset the top of each anchored section so the fixed nav (~68px tall
+ * on desktop, ~52px on mobile) doesn't overlap the section heading when
+ * the browser scrolls the anchor into view.
+ *
+ * Mobile breakpoint: see /* bp-mobile *​/ convention. The hook counterpart
+ * lives in `src/hooks/useIsMobile.ts`.
  */
 :target,
 [id="what"],
 [id="demo"] {
   scroll-margin-top: 88px;
+}
+
+/* bp-mobile */
+@media (max-width: 1024px) {
+  :target,
+  [id="what"],
+  [id="demo"] {
+    scroll-margin-top: 60px;
+  }
 }
 
 a {


### PR DESCRIPTION
### Why

The landing page had no mobile layout — on viewports ≤ 1024 px the desktop-only scroll-linked `FacetStage`, the `InstallBlock` curl command, and the orbit floaters all rendered as-is, producing a broken experience on phones.

### Details

**Breakpoint convention:** A single `1024px` breakpoint (`bp-mobile`) is used throughout. The TypeScript counterpart is `useIsMobile()` — an SSR-safe `matchMedia` hook that initialises to `false` (desktop) to avoid hydration mismatches, then corrects on mount.

**Nav:** On mobile the brand mark becomes a `<button>` that opens `MobileMenu`, a slide-down sheet with all nav links. The nav bar itself only shows the brand mark and theme toggle. `z-index` was raised to 70 so the nav stays above the menu overlay (60). A `--nav-mobile-height` CSS custom property (55 px) is defined in `global.css` and referenced by the menu panel so it starts flush below the nav.

**Hero:** The `InstallBlock` curl pill is hidden on mobile and replaced by a `RegistryCta` card pointing at `facet.cafe`. A separate `installNoteMobile` note replaces the desktop one-liner note. CTA links become full-width 48 px pill targets. `OrbitFloaters` are hidden entirely via their own module.

**Explainer / FacetStage:** The 400 vh scroll-linked `FacetStage` is hidden on mobile and replaced by `MobileFacetStack` — a static layout with a diamond visual, four animated mini-boxes, four primitive cards, and a "packed" reveal card. Both components share copy from a new `explainer-content.tsx` module so they stay in sync. A `LinkCard` pointing at `docs.agentfacets.io` is added below the intro text.

**CLI Demo:** The `facet search viper` step (too wide for a phone) is skipped on mobile via `MOBILE_CLI_SCRIPT = FULL_CLI_SCRIPT.slice(2)`. The active script is read through a ref so in-flight animations aren't interrupted by a resize. Section padding is tightened and font sizes are reduced.

**Closer / Footer:** `InstallBlock` is hidden on mobile and replaced by a `RegistryCta`. The footer stacks and centres. Padding and margin values are reduced across all sections.

**`LinkCard`:** A new generic gradient-washed card component with an icon slot, label, value, and arrow. `RegistryCta` and the Explainer docs link are both thin wrappers around it.

**Font-family fallbacks:** All `var(--mono)` / `var(--sans)` / `var(--serif)` declarations now include a generic fallback (`monospace`, `sans-serif`, `serif`) so text renders correctly if the custom font fails to load.

**Anchor scroll offsets:** `scroll-margin-top` is reduced to 60 px on mobile to match the shorter nav.

### Verification

Resize the browser to ≤ 1024 px and verify: the mobile menu opens and closes, all section CTAs are tappable, the CLI demo skips the search step, `MobileFacetStack` renders in place of `FacetStage`, and the footer stacks vertically. Resize back above 1024 px and confirm the desktop layout is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/CSS and client-side interaction changes on the landing page (mobile breakpoint behavior, new menu overlay, and responsive content swaps) with low impact beyond layout and UX.
> 
> **Overview**
> Adds a consistent `bp-mobile` (≤1024px) responsive experience across the landing page, including a new SSR-safe `useIsMobile()` hook and updated section spacing/typography.
> 
> Introduces mobile-specific UX components: a slide-down `MobileMenu` (brand becomes a menu trigger, scroll-lock + focus handling), a generic `LinkCard` plus `RegistryCta`, and a static `MobileFacetStack` that replaces the scroll-linked `FacetStage` on small viewports while sharing copy via new `explainer-content.tsx`.
> 
> Updates key sections for mobile: Hero/Closer swap the desktop `InstallBlock` for registry/docs CTAs, `OrbitFloaters` are hidden, and the `CliDemo` uses a narrower mobile script + tightened terminal styles; anchor scroll offsets are adjusted in `global.css` for the shorter mobile nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe7f07b595ab8ade9f6a9de0af1dd43436972c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->