### PR TITLE
Exclude `sst-env.d.ts` from Biome and normalize quotes in auto-generated SST files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,9 @@
     "clientKind": "git",
     "useIgnoreFile": true
   },
+  "files": {
+    "includes": ["**", "!**/sst-env.d.ts"]
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/packages/adapter/sst-env.d.ts
+++ b/packages/adapter/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/adapters/claude-code/sst-env.d.ts
+++ b/packages/adapters/claude-code/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/adapters/codex/sst-env.d.ts
+++ b/packages/adapters/codex/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/adapters/opencode/sst-env.d.ts
+++ b/packages/adapters/opencode/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/brand/sst-env.d.ts
+++ b/packages/brand/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/cli/bin/sst-env.d.ts
+++ b/packages/cli/bin/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/cli/sst-env.d.ts
+++ b/packages/cli/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/common/sst-env.d.ts
+++ b/packages/common/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/core/sst-env.d.ts
+++ b/packages/core/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/functions/sst-env.d.ts
+++ b/packages/functions/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/packages/landing/sst-env.d.ts
+++ b/packages/landing/sst-env.d.ts
@@ -6,5 +6,5 @@
 
 /// <reference path="../../sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -4,24 +4,24 @@
 /* deno-fmt-ignore-file */
 /* biome-ignore-all lint: auto-generated */
 
-declare module 'sst' {
+declare module "sst" {
   export interface Resource {
-    AgentFacetsLanding: {
-      type: 'sst.aws.StaticSite'
-      url: string
+    "AgentFacetsLanding": {
+      "type": "sst.aws.StaticSite"
+      "url": string
     }
-    AgentFacetsSite: {
-      type: 'sst.aws.Router'
-      url: string
+    "AgentFacetsSite": {
+      "type": "sst.aws.Router"
+      "url": string
     }
-    InstallScript: {
-      name: string
-      type: 'sst.aws.Function'
-      url: string
+    "InstallScript": {
+      "name": string
+      "type": "sst.aws.Function"
+      "url": string
     }
   }
 }
 /// <reference path="sst-env.d.ts" />
 
-import 'sst'
+import "sst"
 export {}


### PR DESCRIPTION
### Why

Biome was linting auto-generated `sst-env.d.ts` files, causing noise and unnecessary formatting changes on those generated files.

### Details

`sst-env.d.ts` files are excluded from Biome's linting and formatting via a new `files.includes` rule in `biome.json`. As a side effect of Biome no longer managing these files, the existing `sst-env.d.ts` files were reformatted to use double quotes (matching SST's own generation style) and had their trailing newlines removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Biome configuration and formatting-only updates in SST auto-generated `sst-env.d.ts` files, with no runtime logic impacted.
> 
> **Overview**
> Updates `biome.json` to exclude `**/sst-env.d.ts` from Biome’s file set so auto-generated SST env typings are no longer linted/formatted.
> 
> Reformats existing `sst-env.d.ts` files across packages to match SST’s generation style (double quotes / module name normalization), avoiding future formatter churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682dcd2abb3d8ec29b015431aaae3a5ffd048414. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->