### PR TITLE
Mark `@agent-facets/common` as a `bundledDependency` in `@agent-facets/core`

### DIFF
--- a/.changeset/deep-buttons-brush.md
+++ b/.changeset/deep-buttons-brush.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/core": patch
+---
+
+Properly mark @agent-facets/common as a bundled dep (via package.json)

--- a/bun.lock
+++ b/bun.lock
@@ -109,14 +109,14 @@
       "name": "@agent-facets/core",
       "version": "0.6.2",
       "dependencies": {
+        "@agent-facets/adapter": "workspace:*",
+        "@agent-facets/common": "workspace:*",
         "arktype": "2.2.0",
         "comment-json": "^5.0.0",
         "nanotar": "0.3.0",
         "yaml": "2.8.3",
       },
       "devDependencies": {
-        "@agent-facets/adapter": "workspace:*",
-        "@agent-facets/common": "workspace:*",
         "tsdown": "^0.21.10",
         "typescript": "^6.0.3",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,17 +21,20 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@agent-facets/adapter": "workspace:*",
+    "@agent-facets/common": "workspace:*",
     "arktype": "2.2.0",
     "comment-json": "^5.0.0",
     "nanotar": "0.3.0",
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@agent-facets/common": "workspace:*",
-    "@agent-facets/adapter": "workspace:*",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"
   },
+  "bundledDependencies": [
+    "@agent-facets/common"
+  ],
   "peerDependencies": {
     "typescript": "^5 || ^6"
   },


### PR DESCRIPTION
### Why

`@agent-facets/common` was listed as a `devDependency` in `@agent-facets/core`, but it is actually bundled into the package at build time. This mismatch meant the dependency relationship was not accurately reflected in the published package metadata.

### Details

`@agent-facets/common` has been moved out of `devDependencies` and into `bundledDependencies`, which correctly signals to package managers that it is included in the distributed bundle rather than being an external peer or dev-only dependency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: updates `@agent-facets/core` dependency classification to reflect bundling, with no runtime logic changes; main risk is incorrect packaging if bundling expectations differ.
> 
> **Overview**
> Updates `@agent-facets/core` package metadata to treat `@agent-facets/common` as a `bundledDependencies` entry instead of a `devDependency`, so consumers see it as included in the published bundle.
> 
> Adds a changeset for a patch release and updates `bun.lock` to reflect the dependency metadata change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95ee79038b086123b9967e969cfefaf83554ae0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->