### PR TITLE
Remove `@agent-facets/common` from all package deps in favor of always bundling it

### DIFF
--- a/.changeset/pink-hornets-accept.md
+++ b/.changeset/pink-hornets-accept.md
@@ -1,0 +1,7 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/core": patch
+"agent-facets": patch
+---
+
+Get @agent-facets/common out of all deps, it's always bundled

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,6 @@
         "yaml": "2.8.3",
       },
       "devDependencies": {
-        "@agent-facets/common": "workspace:*",
         "tsdown": "^0.21.10",
         "typescript": "^6.0.3",
       },
@@ -94,7 +93,6 @@
         "@agent-facets/adapter": "workspace:*",
         "@agent-facets/adapter-opencode": "workspace:*",
         "@agent-facets/brand": "workspace:*",
-        "@agent-facets/common": "workspace:*",
         "@agent-facets/core": "workspace:*",
         "ink-testing-library": "4.0.0",
       },
@@ -110,7 +108,6 @@
       "version": "0.6.2",
       "dependencies": {
         "@agent-facets/adapter": "workspace:*",
-        "@agent-facets/common": "workspace:*",
         "arktype": "2.2.0",
         "comment-json": "^5.0.0",
         "nanotar": "0.3.0",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -24,7 +24,6 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@agent-facets/common": "workspace:*",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@agent-facets/brand": "workspace:*",
-    "@agent-facets/common": "workspace:*",
     "@agent-facets/core": "workspace:*",
     "@agent-facets/adapter": "workspace:*",
     "@agent-facets/adapter-opencode": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@agent-facets/adapter": "workspace:*",
-    "@agent-facets/common": "workspace:*",
     "arktype": "2.2.0",
     "comment-json": "^5.0.0",
     "nanotar": "0.3.0",
@@ -32,9 +31,6 @@
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"
   },
-  "bundledDependencies": [
-    "@agent-facets/common"
-  ],
   "peerDependencies": {
     "typescript": "^5 || ^6"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "lib": ["ESNext"],
+    "paths": {
+      "@agent-facets/common": ["./packages/common/src/index.ts"]
+    },
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
### Why

`@agent-facets/common` is always bundled into the packages that use it, so it doesn't need to be listed as an explicit dependency. Having it in `dependencies` or `devDependencies` is misleading and creates unnecessary workspace links.

### Details

`@agent-facets/common` has been removed from the `dependencies` and `devDependencies` of `@agent-facets/core`, `@agent-facets/adapter`, and the CLI package. The `bundledDependencies` entry in `@agent-facets/core` has also been dropped since it's no longer declared as a dependency at all.

To keep TypeScript path resolution working during development without the explicit dependency declarations, a `paths` alias for `@agent-facets/common` pointing to the local source has been added to the root `tsconfig.json`.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes published dependency metadata and bundling expectations, which can break consumers or local builds if `@agent-facets/common` is no longer resolvable at runtime.
> 
> **Overview**
> Removes `@agent-facets/common` from `dependencies`/`devDependencies` across `@agent-facets/core`, `@agent-facets/adapter`, and the CLI package, and drops `@agent-facets/common` from `@agent-facets/core`'s `bundledDependencies` so it’s no longer declared for publishing.
> 
> Adds a root `tsconfig.json` `paths` mapping for `@agent-facets/common` to the local source to preserve TypeScript resolution during development, and includes a changeset + lockfile updates reflecting the dependency cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46167b9f4209af0167769d55aed1b996073dfee9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->