### PR TITLE
Use pack-then-publish to ensure packument and tarball contents match

### DIFF
--- a/.changeset/tough-days-check.md
+++ b/.changeset/tough-days-check.md
@@ -1,0 +1,9 @@
+---
+"@agent-facets/core": patch
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+---
+
+Use pack-then-publish mechanism to ensure no drift between packument and published tarballs

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -4,6 +4,7 @@
       <w>arktype</w>
       <w>lefthook</w>
       <w>lerp</w>
+      <w>packument</w>
       <w>postinstall</w>
     </words>
   </dictionary>

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "yaml": "2.8.3",
       },
       "devDependencies": {
+        "@agent-facets/common": "workspace:*",
         "tsdown": "^0.21.10",
         "typescript": "^6.0.3",
       },
@@ -93,6 +94,7 @@
         "@agent-facets/adapter": "workspace:*",
         "@agent-facets/adapter-opencode": "workspace:*",
         "@agent-facets/brand": "workspace:*",
+        "@agent-facets/common": "workspace:*",
         "@agent-facets/core": "workspace:*",
         "ink-testing-library": "4.0.0",
       },
@@ -114,6 +116,7 @@
         "yaml": "2.8.3",
       },
       "devDependencies": {
+        "@agent-facets/common": "workspace:*",
         "tsdown": "^0.21.10",
         "typescript": "^6.0.3",
       },

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -24,6 +24,7 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
+    "@agent-facets/common": "workspace:*",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@agent-facets/brand": "workspace:*",
+    "@agent-facets/common": "workspace:*",
     "@agent-facets/core": "workspace:*",
     "@agent-facets/adapter": "workspace:*",
     "@agent-facets/adapter-opencode": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
+    "@agent-facets/common": "workspace:*",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ scripts/
 ├── lib/                        # Shared utilities
 │   ├── io/                     # IO adapter (split by domain, nested namespaces)
 │   │   ├── index.ts            # Composes io = { npm, git, gh, circleci, shell, console }
-│   │   ├── npm.ts              # npm CLI commands
+│   │   ├── npm.ts              # npm CLI commands (pack, publishTarball, view, etc.)
 │   │   ├── git.ts              # git CLI commands
 │   │   ├── github.ts           # GitHub CLI commands
 │   │   ├── circleci.ts         # CircleCI API v2 calls
@@ -111,6 +111,13 @@ The contract for marking a package as "workspace-only, never release" has three 
 
 Together these keep workspace-only packages out of the release pipeline entirely — no tags, no npm publishes, no lingering "unpublished" state, and no prepack failures.
 
+## Why pack-then-upload?
+
+Both the library publish path and the CLI matrix path go through one helper —
+`packAndPublish` in `scripts/lib/npm.ts` — which does `bun pm pack --quiet` followed by `npm publish <filename>`. This avoids an npm lifecycle race: when `npm publish` builds its own tarball, the registry **packument** (the JSON metadata served by `npm view`) is derived from a different `package.json` snapshot than the **tarball contents**. Our `prepack`/`postpack` rewrite/restore dance leaves the packument with the original (un-rewritten) manifest, so installs fail with `ENOLOCAL` errors trying to resolve `workspace:*` deps the registry shouldn't have advertised.
+
+Pre-building the tarball with `bun pm pack` and uploading it with `npm publish <filename>` makes npm derive the packument from the `package.json` *inside* the tarball — tarball and packument match by construction. The exact filename is captured from `bun pm pack --quiet`'s stdout (which is just the filename) and passed to `npm publish` as a single arg, never a `*.tgz` glob — `npm publish` accepts exactly one `<package-spec>`, so a leftover tarball from a prior local pack would otherwise fail with EUSAGE.
+
 ## Per-package release queueing
 
 `release/tag.ts` parses the package name out of scoped tags
@@ -132,7 +139,7 @@ Import it as:
 ```ts
 import { io } from '../lib/io'
 
-await io.npm.publish(pkgDir)
+await io.npm.publishTarball(pkgDir, filename)
 await io.git.pushAllTags('origin')
 await io.gh.prCreate('main', head, title, body)
 await io.circleci.triggerPipelineForTag(slug, defId, tag, packageName)

--- a/scripts/lib/io/npm.ts
+++ b/scripts/lib/io/npm.ts
@@ -10,8 +10,19 @@ export const npmIo = {
   /** Check that a specific version of a package exists — returns the shell result. */
   checkVersion: (pkg: string, ver: string) => $`npm view ${pkg}@${ver} version`.quiet(),
   viewDistTag: (pkg: string, tag: string) => $`npm view ${pkg}@${tag} version`.quiet(),
-  /** Publish a pre-packed .tgz with an explicit dist-tag. */
-  publishTarball: (cwd: string, tag: string) => $`npm publish *.tgz --access public --tag ${tag}`.cwd(cwd),
+  /** Pack the workspace at `dir` into a tarball. Returns `bun pm pack --quiet` stdout, which is the filename. */
+  pack: (dir: string) => $`bun pm pack --quiet`.cwd(dir).text(),
+  /**
+   * Publish a pre-packed tarball by filename, optionally with a dist-tag.
+   *
+   * `npm publish` accepts a single `<package-spec>`. Pass the exact filename
+   * captured from `pack()` — never a glob — so a stale `*.tgz` left over from
+   * a prior local pack can't expand to multiple args and trip EUSAGE.
+   */
+  publishTarball: (dir: string, filename: string, tag?: string) =>
+    tag
+      ? $`npm publish ${filename} --access public --tag ${tag}`.cwd(dir)
+      : $`npm publish ${filename} --access public`.cwd(dir),
   /** Publish interactively with inherited stdio — used for OIDC bootstrap flows. */
   publishPlain: async (cwd: string) => {
     const proc = Bun.spawn(['npm', 'publish', '--access', 'public'], {
@@ -27,8 +38,6 @@ export const npmIo = {
       throw new Error(stderr || `Failed with exit code ${code}`)
     }
   },
-  /** Publish the package in `dir` using its own package.json dist-tag. */
-  publish: (dir: string) => $`npm publish --access public`.cwd(dir),
   /** Get the currently-published latest version of a package, or null if never published. */
   viewVersion: async (pkg: string): Promise<string | null> => {
     const result = await $`npm view ${pkg} version`.nothrow().quiet()

--- a/scripts/lib/io/shell.ts
+++ b/scripts/lib/io/shell.ts
@@ -7,7 +7,6 @@ import { mintGitHubAppToken as mintGitHubAppTokenImpl } from '../github-app'
 
 export const shellIo = {
   // Shell
-  pack: (cwd: string) => $`bun pm pack`.cwd(cwd),
   chmod: (cwd: string) => $`chmod -R 755 .`.cwd(cwd).nothrow(),
   rm: (path: string) => $`rm -rf ${path}`.nothrow(),
   mkdir: (path: string) => $`mkdir -p ${path}`,

--- a/scripts/lib/npm.test.ts
+++ b/scripts/lib/npm.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { io } from './io'
+import { packAndPublish } from './npm'
+import { shellResult } from './test-helpers'
+
+describe('packAndPublish', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('passes the trimmed pack stdout to publishTarball as the filename', async () => {
+    // `bun pm pack --quiet` prints a leading blank line + the filename.
+    // The helper must trim before forwarding, otherwise `npm publish`
+    // sees an empty arg and fails with EUSAGE.
+    spyOn(io.npm, 'pack').mockResolvedValue('\nagent-facets-core-0.6.4.tgz\n')
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+
+    await packAndPublish('packages/core')
+
+    expect(publishSpy).toHaveBeenCalledWith('packages/core', 'agent-facets-core-0.6.4.tgz', undefined)
+  })
+
+  test('forwards the dist-tag when provided', async () => {
+    spyOn(io.npm, 'pack').mockResolvedValue('agent-facets-cli-darwin-arm64-0.4.2.tgz\n')
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+
+    await packAndPublish('dist/@agent-facets/cli-darwin-arm64', 'latest')
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      'dist/@agent-facets/cli-darwin-arm64',
+      'agent-facets-cli-darwin-arm64-0.4.2.tgz',
+      'latest',
+    )
+  })
+
+  test('publishes exactly one filename argument — never a glob', async () => {
+    // Regression guard for the EUSAGE failure mode if a stale .tgz exists.
+    // `npm publish` accepts a single <package-spec>, so the captured filename
+    // must be a literal string, not a `*.tgz` glob.
+    spyOn(io.npm, 'pack').mockResolvedValue('pkg-1.0.0.tgz')
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+
+    await packAndPublish('dir')
+
+    const filename = publishSpy.mock.calls[0]?.[1]
+    expect(filename).toBe('pkg-1.0.0.tgz')
+    expect(filename).not.toContain('*')
+  })
+
+  test('propagates pack errors without invoking publishTarball', async () => {
+    spyOn(io.npm, 'pack').mockRejectedValue(new Error('bun pm pack failed'))
+    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+
+    await expect(packAndPublish('dir')).rejects.toThrow('bun pm pack failed')
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/lib/npm.ts
+++ b/scripts/lib/npm.ts
@@ -70,3 +70,22 @@ export async function publishPlaceholder(pkg: string): Promise<void> {
 export async function mintNpmToken(): Promise<void> {
   process.env.NPM_ID_TOKEN = (await io.shell.mintCircleOidcToken()).trim()
 }
+
+/**
+ * Pack a package and publish the resulting tarball.
+ *
+ * Pack-then-upload (two commands) avoids a lifecycle race for npm: when given
+ * a pre-built tarball, npm builds the registry packument from the
+ * `package.json` *inside* the tarball, so the packument and tarball match by
+ * construction. Captures the exact filename from `bun pm pack --quiet` so we
+ * never publish a glob — `npm publish` accepts a single <package-spec> and
+ * fails with EUSAGE on multiple matches.
+ *
+ * @param dir Path to the package directory containing `package.json`.
+ * @param tag Optional npm dist-tag (e.g., `latest`, `next`). When omitted,
+ *            npm uses `publishConfig.tag` from `package.json` if present.
+ */
+export async function packAndPublish(dir: string, tag?: string): Promise<void> {
+  const filename = (await io.npm.pack(dir)).trim()
+  await io.npm.publishTarball(dir, filename, tag)
+}

--- a/scripts/release-cli/publish-cli-package.test.ts
+++ b/scripts/release-cli/publish-cli-package.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:
 import { CLI_PACKAGE_NAME } from '../lib/constants'
 import { io } from '../lib/io'
 import * as npm from '../lib/npm'
-import { shellResult } from '../lib/test-helpers'
 import { publishCliPackage } from './publish-cli-package'
 
 describe('publish-cli-package.ts', () => {
@@ -36,12 +35,12 @@ describe('publish-cli-package.ts', () => {
       version: '1.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(true)
-    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     const code = await publishCliPackage()
 
     expect(code).toBe(0)
-    expect(packSpy).not.toHaveBeenCalled()
+    expect(publishSpy).not.toHaveBeenCalled()
   })
 
   test('synthesizes package.json with correct optionalDependencies', async () => {
@@ -57,8 +56,7 @@ describe('publish-cli-package.ts', () => {
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
     const writeSpy = spyOn(io.shell, 'writeFile').mockResolvedValue(0)
-    spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
-    spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+    spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     await publishCliPackage()
 
@@ -73,7 +71,7 @@ describe('publish-cli-package.ts', () => {
     expect(written.bin).toEqual({ facet: './bin/facet' })
   })
 
-  test('calls pack and publish with latest tag', async () => {
+  test('calls packAndPublish with latest tag', async () => {
     spyOn(Bun.Glob.prototype, 'scanSync').mockImplementation(function* () {
       yield '@agent-facets/cli-darwin-arm64/package.json'
     })
@@ -83,13 +81,11 @@ describe('publish-cli-package.ts', () => {
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
     spyOn(io.shell, 'writeFile').mockResolvedValue(0)
-    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     const code = await publishCliPackage()
 
     expect(code).toBe(0)
-    expect(packSpy).toHaveBeenCalledTimes(1)
     expect(publishSpy).toHaveBeenCalledTimes(1)
     expect(publishSpy.mock.calls[0]?.[1]).toBe('latest')
   })

--- a/scripts/release-cli/publish-cli-package.ts
+++ b/scripts/release-cli/publish-cli-package.ts
@@ -16,7 +16,7 @@ import path from 'node:path'
 import { $ } from 'bun'
 import { CLI_DIR, CLI_PACKAGE_NAME, DIST_DIR, PUBLISH_TAG } from '../lib/constants'
 import { io } from '../lib/io'
-import { mintNpmToken, versionExists } from '../lib/npm'
+import { mintNpmToken, packAndPublish, versionExists } from '../lib/npm'
 
 /** Discover platform packages from build output. */
 async function discoverPlatformPackages(): Promise<Record<string, string>> {
@@ -73,8 +73,7 @@ export async function publishCliPackage(): Promise<number> {
     ),
   )
 
-  await io.shell.pack(cliPkgDir)
-  await io.npm.publishTarball(cliPkgDir, PUBLISH_TAG)
+  await packAndPublish(cliPkgDir, PUBLISH_TAG)
 
   console.log(`+ ${CLI_PACKAGE_NAME}@${version} published (latest)`)
   return 0

--- a/scripts/release-cli/publish-platform.test.ts
+++ b/scripts/release-cli/publish-platform.test.ts
@@ -30,7 +30,7 @@ describe('publish-platform.ts', () => {
       version: '1.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(true)
-    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     const code = await publishSingle('cli-darwin-arm64')
 
@@ -38,21 +38,19 @@ describe('publish-platform.ts', () => {
     expect(publishSpy).not.toHaveBeenCalled()
   })
 
-  test('runs chmod, pack, publish when version is not yet on npm', async () => {
+  test('runs chmod and packAndPublish when version is not yet on npm', async () => {
     spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-linux-x64',
       version: '2.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
     const chmodSpy = spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
-    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     const code = await publishSingle('cli-linux-x64')
 
     expect(code).toBe(0)
     expect(chmodSpy).toHaveBeenCalledTimes(1)
-    expect(packSpy).toHaveBeenCalledTimes(1)
     expect(publishSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -63,28 +61,25 @@ describe('publish-platform.ts', () => {
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
     spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
-    spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     await publishSingle('cli-windows-x64')
 
     expect(publishSpy.mock.calls[0]?.[1]).toBe('latest')
   })
 
-  test('passes the correct package directory to pack and publish', async () => {
+  test('passes the correct package directory to packAndPublish', async () => {
     spyOn(io.shell, 'readJson').mockResolvedValue({
       name: '@agent-facets/cli-darwin-x64',
       version: '4.0.0',
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
     spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
-    const packSpy = spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
-    const publishSpy = spyOn(io.npm, 'publishTarball').mockResolvedValue(shellResult())
+    const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
     await publishSingle('cli-darwin-x64')
 
     const expectedDir = path.join(DIST_DIR, '@agent-facets', 'cli-darwin-x64')
-    expect(packSpy.mock.calls[0]?.[0]).toBe(expectedDir)
     expect(publishSpy.mock.calls[0]?.[0]).toBe(expectedDir)
   })
 
@@ -95,8 +90,7 @@ describe('publish-platform.ts', () => {
     })
     spyOn(npm, 'versionExists').mockResolvedValue(false)
     spyOn(io.shell, 'chmod').mockResolvedValue(shellResult())
-    spyOn(io.shell, 'pack').mockResolvedValue(shellResult())
-    spyOn(io.npm, 'publishTarball').mockRejectedValue(new Error('npm publish failed'))
+    spyOn(npm, 'packAndPublish').mockRejectedValue(new Error('npm publish failed'))
 
     await expect(publishSingle('cli-linux-arm64')).rejects.toThrow('npm publish failed')
   })

--- a/scripts/release-cli/publish-platform.ts
+++ b/scripts/release-cli/publish-platform.ts
@@ -16,7 +16,7 @@
 import path from 'node:path'
 import { DIST_DIR, PUBLISH_TAG } from '../lib/constants'
 import { io } from '../lib/io'
-import { mintNpmToken, versionExists } from '../lib/npm'
+import { mintNpmToken, packAndPublish, versionExists } from '../lib/npm'
 
 export async function publishSingle(target: string): Promise<number> {
   // Mint OIDC token for npm trusted publishing (each matrix job needs its own)
@@ -45,8 +45,7 @@ export async function publishSingle(target: string): Promise<number> {
   if (process.platform !== 'win32') {
     await io.shell.chmod(pkgDir)
   }
-  await io.shell.pack(pkgDir)
-  await io.npm.publishTarball(pkgDir, PUBLISH_TAG)
+  await packAndPublish(pkgDir, PUBLISH_TAG)
 
   console.log(`+ ${name}@${version} published (latest)`)
   return 0

--- a/scripts/release/publish.test.ts
+++ b/scripts/release/publish.test.ts
@@ -50,7 +50,7 @@ describe('publish.ts', () => {
       spyOn(io.shell, 'mintGitHubAppToken').mockResolvedValue('fake-gh-token')
       spyOn(io.shell, 'turboBuild').mockResolvedValue(shellResult())
       spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('fake-oidc-token\n')
-      spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
+      spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
       spyOn(announce, 'slackNotify').mockResolvedValue(undefined)
       spyOn(io.shell, 'readFile').mockResolvedValue(SAMPLE_CHANGELOG)
       spyOn(io.gh, 'releaseCreate').mockResolvedValue(
@@ -107,7 +107,7 @@ describe('publish.ts', () => {
       process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
       setupPublishPath()
 
-      const publishSpy = spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
+      const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
       const { release } = await import('./publish')
       const code = await release()
@@ -121,7 +121,7 @@ describe('publish.ts', () => {
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([
         { name: '@agent-facets/platform-opencode', version: '0.1.0', dir: 'packages/platform-opencode', private: true },
       ])
-      const publishSpy = spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
+      const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
 
       const { release } = await import('./publish')
       const code = await release()
@@ -217,7 +217,7 @@ describe('publish.ts', () => {
       // a tag is re-pushed to recover from a post-publish failure.
       spyOn(npm, 'versionExists').mockResolvedValue(true)
 
-      const publishSpy = spyOn(io.npm, 'publish').mockResolvedValue(shellResult())
+      const publishSpy = spyOn(npm, 'packAndPublish').mockResolvedValue(undefined)
       const buildSpy = spyOn(io.shell, 'turboBuild').mockResolvedValue(shellResult())
       const oidcSpy = spyOn(io.shell, 'mintCircleOidcToken').mockResolvedValue('oidc\n')
 

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -20,7 +20,7 @@
 import { announceRelease } from '../lib/announce'
 import { loadWorkspacePackages, mintGithubTokens } from '../lib/ci'
 import { io } from '../lib/io'
-import { mintNpmToken, versionExists } from '../lib/npm'
+import { mintNpmToken, packAndPublish, versionExists } from '../lib/npm'
 import { parseTag } from '../lib/tags'
 
 export async function release(): Promise<number> {
@@ -78,7 +78,7 @@ export async function release(): Promise<number> {
   if (!alreadyPublished) {
     await mintNpmToken()
     await io.shell.turboBuild()
-    await io.npm.publish(pkg.dir)
+    await packAndPublish(pkg.dir)
     io.console.log(`Published ${parsed.name}@${parsed.version} to npm`)
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
     "lib": ["ESNext"],
-    "paths": {
-      "@agent-facets/common": ["./packages/common/src/index.ts"]
-    },
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
### Why

Publishing packages with `npm publish` directly caused a lifecycle race: the registry packument (the JSON metadata served by `npm view`) was derived from a different `package.json` snapshot than the tarball contents. Our `prepack`/`postpack` rewrite/restore dance left the packument with the original un-rewritten manifest, so installs failed with `ENOLOCAL` errors trying to resolve `workspace:*` deps the registry shouldn't have advertised. Six packages on npm currently exhibit this drift and need patch republishes once this lands (tracked separately).

### Details

Unified all three publish paths — library packages, the 12 CLI platform binaries, and the synthesized CLI wrapper — through a single `packAndPublish(dir, tag?)` helper in `scripts/lib/npm.ts`. Pack-then-upload makes npm derive the packument from the `package.json` *inside* the tarball, so packument and tarball match by construction.

Two behaviors worth flagging:

1. **The captured filename is passed to `npm publish` as a literal arg, never `*.tgz`.** `bun pm pack --quiet` prints the produced filename on stdout; we trim it and forward exactly that. `npm publish` accepts a single `<package-spec>`, so a stale tarball from a prior local pack would otherwise expand the glob to multiple args and trip EUSAGE. The previous CLI matrix code had this latent bug too — fixed here.

2. **The IO adapter shrinks.** `io.npm.publish` (single-command flow) and `io.shell.pack` (misclassified — `bun pm pack` belongs with npm packaging) are gone. `io.npm.pack` and `io.npm.publishTarball(dir, filename, tag?)` are the remaining primitives. The trim+handoff logic lives in `packAndPublish` where it can be unit-tested without shelling out.

Also removes a stale `tsconfig.json` path alias for `@agent-facets/common` in favor of declaring it as a proper `workspace:*` `devDependency` in the packages that need it.

### Verification

CI. New `scripts/lib/npm.test.ts` covers the trim, dist-tag forwarding, and a regression guard asserting the published filename is never a glob. The first patch republish on `main` will be the live integration test.