### PR TITLE
Cache `.sst/platform` in CircleCI deploy-site job

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -61,10 +61,20 @@ jobs:
         steps:
             - setup-mise
             - aws-oidc-setup
+            - restore_cache:
+                keys:
+                    - v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+                    - v1-sst-platform-{{ checksum "bun.lock" }}-
+                    - v1-sst-platform-
             - run:
                 command: bun scripts/deploy/site.ts
                 name: Deploy SST main stage
                 no_output_timeout: 30m
+            - save_cache:
+                key: v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+                paths:
+                    - .sst/platform
+                when: always
             - notify-failure
     finalize-cli:
         docker:

--- a/.circleci/release/jobs/deploy-site.yml
+++ b/.circleci/release/jobs/deploy-site.yml
@@ -7,8 +7,18 @@ environment:
 steps:
   - setup-mise
   - aws-oidc-setup
+  - restore_cache:
+      keys:
+        - v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+        - v1-sst-platform-{{ checksum "bun.lock" }}-
+        - v1-sst-platform-
   - run:
       name: Deploy SST main stage
       command: bun scripts/deploy/site.ts
       no_output_timeout: 30m
+  - save_cache:
+      key: v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+      paths:
+        - .sst/platform
+      when: always
   - notify-failure


### PR DESCRIPTION
### Why

SST downloads platform dependencies during deployment, which adds unnecessary time to each deploy job. Caching the `.sst/platform` directory avoids redundant downloads on subsequent runs.

### Details

The cache key is based on checksums of `bun.lock` and `sst.config.ts`, so the cache is invalidated when dependencies or the SST config change. The cache is saved with `when: always` to ensure it is persisted even if the deploy step fails, maximizing cache reuse across runs. Fallback keys allow partial cache hits when only one of the two files has changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects build caching and could surface as slower deploys or stale cache behavior if keys are mis-specified.
> 
> **Overview**
> Speeds up CircleCI `deploy-site` by caching SST platform downloads: adds `restore_cache` before deploy and `save_cache` (with `when: always`) after deploy for `.sst/platform`.
> 
> Uses cache keys derived from `bun.lock` and `sst.config.ts` with fallback keys to allow partial hits when only one input changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731a3e6c17fd7135bee1dae1dd3d4661b1274608. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->