### PR TITLE
Fix "MCP servers" spacing and reformat actors table alignment

### DIFF
--- a/docs/docs/learn/index.md
+++ b/docs/docs/learn/index.md
@@ -11,7 +11,7 @@ A **facet** is a versioned collection of [assets](#assets) defined by a facet ma
 
 ## Assets
 
-A discrete unit of content within a facet. Consisting of any combination of skills, agents, commands, and MCPservers.
+A discrete unit of content within a facet. Consisting of any combination of skills, agents, commands, and MCP servers.
 
 <Columns col={2}>
   <Card title='Skills' href='/docs/learn/skills'>
@@ -26,5 +26,4 @@ A discrete unit of content within a facet. Consisting of any combination of skil
   <Card title='Servers' href='/docs/learn/servers'>
     A reference to an MCP server that is compliant with the [Model Context Protocol](https://modelcontextprotocol.io/specification/latest)
   </Card>
-
 </Columns>

--- a/docs/specification/architecture.md
+++ b/docs/specification/architecture.md
@@ -7,13 +7,13 @@ The Facets system distributes AI assistant extensions through a registry-based m
 
 ## Actors
 
-| Actor              | Role                                                                                                              |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| **Author**         | Creates facets and/or MCP servers. Publishes to the registry.                                                     |
-| **Registry**       | Stores facet archives and source-mode server artifacts. Assembles archives with server-side composition. Computes and stores integrity hashes. |
-| **CLI**            | The consumer-facing tool. Installs facets, resolves server references, manages the lockfile, runs MCP servers.    |
-| **AI assistant**   | The host application that loads installed text assets and connects to running MCP servers.                         |
-| **OCI registry**   | External container registry (GHCR, Docker Hub, ECR, etc.) that hosts ref-mode server images.                      |
+| Actor            | Role                                                                                                                                           |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Author**       | Creates facets and/or MCP servers. Publishes to the registry.                                                                                  |
+| **Registry**     | Stores facet archives and source-mode server artifacts. Assembles archives with server-side composition. Computes and stores integrity hashes. |
+| **CLI**          | The consumer-facing tool. Installs facets, resolves server references, manages the lockfile, runs MCP servers.                                 |
+| **AI assistant** | The host application that loads installed text assets and connects to running MCP servers.                                                     |
+| **OCI registry** | External container registry (GHCR, Docker Hub, ECR, etc.) that hosts ref-mode server images.                                                   |
 
 ## Artifact Types
 


### PR DESCRIPTION
### Why

Fixes a missing space in "MCP servers" and removes a stray blank line before the closing `</Columns>` tag. Also reformats the Actors table in the architecture spec for consistent column alignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits (spacing/formatting) with no functional or behavioral impact.
> 
> **Overview**
> Fixes a typo in `docs/docs/learn/index.md` by changing `MCPservers` to `MCP servers` and removes an extra blank line before `</Columns>`.
> 
> Reformats the Actors table in `docs/specification/architecture.md` to use consistent column alignment and separator formatting without changing the described roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985e79dae1a33fe58ecb982d55f6a3493216e4fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->