### PR TITLE
Exclude `.turbo` folders for `common`, `functions`, and `landing` packages in IDE

### DIFF
--- a/.idea/facets.iml
+++ b/.idea/facets.iml
@@ -17,6 +17,9 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/core/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/.sst" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/common/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/functions/.turbo" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/landing/.turbo" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
### Why

Turbo build cache directories for `common`, `functions`, and `landing` packages were being indexed by the IDE, causing unnecessary noise and slowdowns.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates an IDE project configuration file to exclude more build-cache directories; no runtime or production code changes.
> 
> **Overview**
> Expands `.idea/facets.iml` exclusions to ignore `.turbo` cache directories for the `common`, `functions`, and `landing` packages, reducing IDE indexing noise and overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b457b2ef31cdb9b06400fe91cb0caaab5f115c03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->