### PR TITLE
Cache the full .sst directory in CircleCI

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -63,17 +63,17 @@ jobs:
             - aws-oidc-setup
             - restore_cache:
                 keys:
-                    - v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
-                    - v1-sst-platform-{{ checksum "bun.lock" }}-
-                    - v1-sst-platform-
+                    - v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+                    - v2-sst-{{ checksum "bun.lock" }}-
+                    - v2-sst-
             - run:
                 command: bun scripts/deploy/site.ts
                 name: Deploy SST main stage
                 no_output_timeout: 30m
             - save_cache:
-                key: v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+                key: v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
                 paths:
-                    - .sst/platform
+                    - .sst
                 when: always
             - notify-failure
     finalize-cli:

--- a/.circleci/release/jobs/deploy-site.yml
+++ b/.circleci/release/jobs/deploy-site.yml
@@ -9,16 +9,16 @@ steps:
   - aws-oidc-setup
   - restore_cache:
       keys:
-        - v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
-        - v1-sst-platform-{{ checksum "bun.lock" }}-
-        - v1-sst-platform-
+        - v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+        - v2-sst-{{ checksum "bun.lock" }}-
+        - v2-sst-
   - run:
       name: Deploy SST main stage
       command: bun scripts/deploy/site.ts
       no_output_timeout: 30m
   - save_cache:
-      key: v1-sst-platform-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+      key: v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
       paths:
-        - .sst/platform
+        - .sst
       when: always
   - notify-failure

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,11 +7,18 @@ pre-commit:
     biome-format:
       priority: 2
       glob: "*.{ts,js,json}"
+      # Keep in sync with `files.includes` ignores in biome.json — passing an
+      # ignored file as the only argument makes biome exit 1 with
+      # "No files were processed".
+      exclude:
+        - "sst-env.d.ts"
       run: bun biome check --write --unsafe {staged_files}
       stage_fixed: true
     biome-lint:
       priority: 3
       glob: "*.{ts,js,json}"
+      exclude:
+        - "sst-env.d.ts"
       run: bun biome check --error-on-warnings {staged_files}
     circleci-pack:
       priority: 4

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -21,7 +21,6 @@ declare module "sst" {
     }
   }
 }
-/// <reference path="sst-env.d.ts" />
 
 import "sst"
 export {}


### PR DESCRIPTION
### Why

The SST deploy job was caching only `.sst/platform`, but SST also tracks state in sibling files (`provider-lock.json`, `outputs.json`, `esbuild.json`, `pulumi/`, `artifacts/`, `log/`, `stage`). Restoring just `.sst/platform` left SST without its supporting state, so it redid the install/build work on every deploy and the cache was effectively useless.

### Details

- Cache path widened from `.sst/platform` to `.sst`.
- Cache key prefix bumped from `v1-sst-platform-` to `v2-sst-` so the new entry doesn't get restored on top of the old layout.

Drive-by:

- `lefthook.yml` — exclude `sst-env.d.ts` from the biome format/lint hooks. It's already in `biome.json`'s `files.includes` ignore list, and when it was the only staged `.{ts,js,json}` file biome aborted with `No files were processed` and exit 1, blocking the commit.
- `sst-env.d.ts` — drop a redundant self `/// <reference path="sst-env.d.ts" />` line.

### Verification

CI — the next deploy job populates a fresh cache under the new key and path; subsequent deploys should restore the full `.sst` directory and skip SST's install step.