### PR TITLE
Authenticate mise GitHub API calls in CI

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -2,6 +2,60 @@
 - When creating new commands, write them to the development/commands directory, then make a symlink in release/commands
 - `release/@config.yml` is a symlink to `development/@config.yml` — edits to either land in both packed configs. The `parameters.package` block lives here for this reason; it's consumed only by the release workflow's `serial-group` but declared in both packed outputs, which is harmless (CircleCI ignores unused declared parameters).
 
+## Required contexts
+
+### `github` — required for every job that uses `setup-mise`
+
+Every job that runs the `setup-mise` command MUST attach the `github` org-level context. The
+context provides a single env var, `MISE_GITHUB_TOKEN`, which mise auto-discovers (priority 1
+in mise's [token resolution chain][mise-tokens]) and uses to authenticate against the GitHub
+REST API when resolving and downloading tool releases. Without it, mise falls back to
+unauthenticated requests, which CircleCI's shared IP pool burns through GitHub's 60-req/hour
+unauthenticated rate limit. With it, the limit is 5,000 req/hour per token.
+
+[mise-tokens]: https://mise.en.dev/dev-tools/github-tokens.html
+
+| Workflow      | Job                | Requires `github` context? |
+|---------------|--------------------|----------------------------|
+| `ci`          | `check`            | yes                        |
+| `ci`          | `main-pipeline`    | yes                        |
+| `release`     | `release`          | yes                        |
+| `release-cli` | `build-cli`        | yes                        |
+| `release-cli` | `publish-platform` | yes                        |
+| `release-cli` | `finalize-cli`     | yes                        |
+| `deploy`      | `deploy-site`      | yes                        |
+
+If a future job adds `setup-mise` without attaching the `github` context, it will fail loudly
+on the `Install tools` step with `mise WARN GitHub rate limit exceeded` once CircleCI's IP
+pool exhausts the unauthenticated budget. That failure is the documented detection mechanism
+— add `- github` to the job's `context:` list to fix.
+
+#### Token shape and rotation
+
+- **Type**: classic personal access token (PAT).
+- **Scopes**: **none** — every checkbox must be unchecked. Mise only reads public release
+  metadata; granting any scope is gratuitous attack surface.
+- **Owner**: a bot/machine GitHub account (or a designated human as fallback).
+- **Expiration**: Permanent (ok because of lack of permissions).
+- **Storage**: CircleCI org settings → Contexts → `github` → env var `MISE_GITHUB_TOKEN`.
+  Never as a project-level env var (would be ambient to every job).
+
+#### Why `MISE_GITHUB_TOKEN`, not `GITHUB_TOKEN`
+
+The release scripts in `scripts/lib/ci.ts` runtime-mint a **GitHub App installation token**
+and assign it to `process.env.GITHUB_TOKEN` and `process.env.GH_TOKEN` for `gh`-based release
+operations (npm publish, tag creation, release notes). That token has real scopes and is
+unrelated to the rate-limit fix above.
+
+We deliberately use `MISE_GITHUB_TOKEN` (not `GITHUB_TOKEN`) in the `github` context so the
+two paths cannot collide:
+
+- Mise reads `MISE_GITHUB_TOKEN` at priority 1 (mise-only).
+- `gh` and the release scripts read `GITHUB_TOKEN` (owned exclusively by the App-token mint).
+
+Renaming the context env var to `GITHUB_TOKEN` would risk silently poisoning `gh`/script
+operations with the scopeless PAT in any job where `mintGithubTokens()` hasn't yet run.
+
 ## Pipelines
 
 Two packed CircleCI configs, one per pipeline dir.

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -109,6 +109,7 @@ workflows:
             - check:
                 context:
                     - turbo-cache
+                    - github
                 filters:
                     branches:
                         ignore:
@@ -118,6 +119,7 @@ workflows:
                     - turbo-cache
                     - bot-context
                     - slack-secrets
+                    - github
                 filters:
                     branches:
                         only:

--- a/.circleci/development/workflows/ci.yml
+++ b/.circleci/development/workflows/ci.yml
@@ -2,6 +2,7 @@ jobs:
   - check:
       context:
         - turbo-cache
+        - github
       filters:
         branches:
           ignore:
@@ -12,6 +13,7 @@ jobs:
         - turbo-cache
         - bot-context
         - slack-secrets
+        - github
       filters:
         branches:
           only:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -137,6 +137,7 @@ workflows:
                     - bot-context
                     - slack-secrets
                     - sst
+                    - github
                 filters:
                     branches:
                         only:
@@ -149,6 +150,7 @@ workflows:
                     - turbo-cache
                     - bot-context
                     - slack-secrets
+                    - github
                 filters:
                     branches:
                         ignore:
@@ -164,6 +166,7 @@ workflows:
                     - turbo-cache
                     - bot-context
                     - slack-secrets
+                    - github
                 filters:
                     branches:
                         ignore:
@@ -177,6 +180,7 @@ workflows:
                     - turbo-cache
                     - bot-context
                     - slack-secrets
+                    - github
                 filters:
                     branches:
                         ignore:
@@ -206,6 +210,7 @@ workflows:
                     - turbo-cache
                     - bot-context
                     - slack-secrets
+                    - github
                 filters:
                     branches:
                         ignore:

--- a/.circleci/release/workflows/deploy.yml
+++ b/.circleci/release/workflows/deploy.yml
@@ -5,6 +5,7 @@ jobs:
         - bot-context
         - slack-secrets
         - sst
+        - github
       filters:
         branches:
           only:

--- a/.circleci/release/workflows/release-cli.yml
+++ b/.circleci/release/workflows/release-cli.yml
@@ -5,6 +5,7 @@ jobs:
         - turbo-cache
         - bot-context
         - slack-secrets
+        - github
       filters:
         tags:
           only:
@@ -32,6 +33,7 @@ jobs:
         - turbo-cache
         - bot-context
         - slack-secrets
+        - github
       requires:
         - build-cli
       filters:
@@ -47,6 +49,7 @@ jobs:
         - turbo-cache
         - bot-context
         - slack-secrets
+        - github
       requires:
         - publish-platform
       filters:

--- a/.circleci/release/workflows/release.yml
+++ b/.circleci/release/workflows/release.yml
@@ -5,6 +5,7 @@ jobs:
         - turbo-cache
         - bot-context
         - slack-secrets
+        - github
       filters:
         tags:
           only:


### PR DESCRIPTION
### Why

CircleCI's shared IP pool exhausts GitHub's 60-req/hour unauthenticated rate limit, causing the `Install tools` step (`mise install --yes`) to fail intermittently with `403 Forbidden` when resolving release tarballs. Authenticating raises the limit to 5,000/hr per token.

### Details

The `github` org-level context now provides `MISE_GITHUB_TOKEN` (a scopeless classic PAT) to every job that runs `setup-mise`. Mise picks it up at priority 1 in its [token resolution chain](https://mise.en.dev/dev-tools/github-tokens.html).

The non-obvious choice is the env var **name**: `MISE_GITHUB_TOKEN`, not `GITHUB_TOKEN`. The release scripts in `scripts/lib/ci.ts` runtime-mint a GitHub App installation token and assign it to `process.env.GITHUB_TOKEN` / `GH_TOKEN` for `gh`-based release operations. Putting a scopeless PAT under `GITHUB_TOKEN` in the ambient context would silently poison `gh` in any window where `mintGithubTokens()` hadn't yet run. `MISE_GITHUB_TOKEN` is mise-only by design — the `GITHUB_TOKEN` namespace stays exclusively owned by the App-token mint.

The PAT must be created with **zero scopes**. Mise only reads public release metadata; granting any scope is gratuitous attack surface. `.circleci/AGENTS.md` documents the rotation policy and which jobs require the context — if a future job adds `setup-mise` without attaching `github`, it fails loudly with the same rate-limit error.