### PR TITLE
Use facet CLI in CI

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -4,9 +4,9 @@
 
 ## Required contexts
 
-### `github` — required for every job that uses `setup-mise`
+### `github` — required for every job that uses `setup-env`
 
-Every job that runs the `setup-mise` command MUST attach the `github` org-level context. The
+Every job that runs the `setup-env` command MUST attach the `github` org-level context. The
 context provides a single env var, `MISE_GITHUB_TOKEN`, which mise auto-discovers (priority 1
 in mise's [token resolution chain][mise-tokens]) and uses to authenticate against the GitHub
 REST API when resolving and downloading tool releases. Without it, mise falls back to
@@ -25,7 +25,7 @@ unauthenticated rate limit. With it, the limit is 5,000 req/hour per token.
 | `release-cli` | `finalize-cli`     | yes                        |
 | `deploy`      | `deploy-site`      | yes                        |
 
-If a future job adds `setup-mise` without attaching the `github` context, it will fail loudly
+If a future job adds `setup-env` without attaching the `github` context, it will fail loudly
 on the `Install tools` step with `mise WARN GitHub rate limit exceeded` once CircleCI's IP
 pool exhausts the unauthenticated budget. That failure is the documented detection mechanism
 — add `- github` to the job's `context:` list to fix.

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -17,7 +17,7 @@ commands:
                 environment:
                     TURBO_CONCURRENCY: "1"
                 name: Check
-    setup-mise:
+    setup-env:
         steps:
             - checkout
             - run:
@@ -28,6 +28,14 @@ commands:
             - run:
                 command: mise install --yes
                 name: Install tools
+            - run:
+                command: |
+                    curl -fsSL https://agentfacets.io/install | bash
+                    echo 'export PATH="$HOME/.facet/bin:$PATH"' >> "$BASH_ENV"
+                name: Install facet CLI
+            - run:
+                command: facet adapter install opencode
+                name: Install OpenCode adapter
             - restore_cache:
                 keys:
                     - v1-deps-{{ checksum "bun.lock" }}
@@ -46,7 +54,7 @@ jobs:
             - image: cimg/base:current
         resource_class: medium
         steps:
-            - setup-mise
+            - setup-env
             - run:
                 command: cp packages/cli/turbo.ci.json packages/cli/turbo.json
                 name: Disable CLI build cache
@@ -72,7 +80,7 @@ jobs:
             LEFTHOOK: "0"
         resource_class: medium
         steps:
-            - setup-mise
+            - setup-env
             - run-check
             - store_test_results:
                 path: test-results
@@ -91,7 +99,7 @@ jobs:
             MISE_ENV: release
         resource_class: small
         steps:
-            - setup-mise
+            - setup-env
             - run:
                 command: bun scripts/release/publish.ts
                 name: Publish

--- a/.circleci/development/commands/setup-env.yml
+++ b/.circleci/development/commands/setup-env.yml
@@ -8,6 +8,14 @@ steps:
   - run:
       name: Install tools
       command: mise install --yes
+  - run:
+      name: Install facet CLI
+      command: |
+        curl -fsSL https://agentfacets.io/install | bash
+        echo 'export PATH="$HOME/.facet/bin:$PATH"' >> "$BASH_ENV"
+  - run:
+      name: Install OpenCode adapter
+      command: facet adapter install opencode
   - restore_cache:
       keys:
         - v1-deps-{{ checksum "bun.lock" }}

--- a/.circleci/development/jobs/check.yml
+++ b/.circleci/development/jobs/check.yml
@@ -2,7 +2,7 @@ docker:
   - image: cimg/base:current
 resource_class: medium
 steps:
-  - setup-mise
+  - setup-env
   - run:
       name: Disable CLI build cache
       command: cp packages/cli/turbo.ci.json packages/cli/turbo.json

--- a/.circleci/development/jobs/main-pipeline.yml
+++ b/.circleci/development/jobs/main-pipeline.yml
@@ -4,7 +4,7 @@ resource_class: medium
 environment:
   LEFTHOOK: "0"
 steps:
-  - setup-mise
+  - setup-env
   - run-check
   - store_test_results:
       path: test-results

--- a/.circleci/development/jobs/release.yml
+++ b/.circleci/development/jobs/release.yml
@@ -5,7 +5,7 @@ environment:
   LEFTHOOK: "0"
   MISE_ENV: release
 steps:
-  - setup-mise
+  - setup-env
   - run:
       name: Publish
       command: bun scripts/release/publish.ts

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -10,7 +10,7 @@ commands:
                 command: bun scripts/lib/notify-failure.ts
                 name: Notify failure
                 when: on_fail
-    setup-mise:
+    setup-env:
         steps:
             - checkout
             - run:
@@ -21,6 +21,14 @@ commands:
             - run:
                 command: mise install --yes
                 name: Install tools
+            - run:
+                command: |
+                    curl -fsSL https://agentfacets.io/install | bash
+                    echo 'export PATH="$HOME/.facet/bin:$PATH"' >> "$BASH_ENV"
+                name: Install facet CLI
+            - run:
+                command: facet adapter install opencode
+                name: Install OpenCode adapter
             - restore_cache:
                 keys:
                     - v1-deps-{{ checksum "bun.lock" }}
@@ -42,7 +50,7 @@ jobs:
             MISE_ENV: release
         resource_class: small
         steps:
-            - setup-mise
+            - setup-env
             - run:
                 command: bun scripts/release-cli/build.ts
                 name: Build CLI binaries
@@ -59,7 +67,7 @@ jobs:
             MISE_ENV: release
         resource_class: small
         steps:
-            - setup-mise
+            - setup-env
             - aws-oidc-setup
             - restore_cache:
                 keys:
@@ -84,7 +92,7 @@ jobs:
             MISE_ENV: release
         resource_class: small
         steps:
-            - setup-mise
+            - setup-env
             - attach_workspace:
                 at: .
             - run:
@@ -102,7 +110,7 @@ jobs:
                 type: string
         resource_class: small
         steps:
-            - setup-mise
+            - setup-env
             - attach_workspace:
                 at: .
             - run:
@@ -117,7 +125,7 @@ jobs:
             MISE_ENV: release
         resource_class: small
         steps:
-            - setup-mise
+            - setup-env
             - run:
                 command: bun scripts/release/publish.ts
                 name: Publish

--- a/.circleci/release/commands/setup-env.yml
+++ b/.circleci/release/commands/setup-env.yml
@@ -1,0 +1,1 @@
+../../development/commands/setup-env.yml

--- a/.circleci/release/commands/setup-mise.yml
+++ b/.circleci/release/commands/setup-mise.yml
@@ -1,1 +1,0 @@
-../../development/commands/setup-mise.yml

--- a/.circleci/release/jobs/build-cli.yml
+++ b/.circleci/release/jobs/build-cli.yml
@@ -5,7 +5,7 @@ environment:
   LEFTHOOK: "0"
   MISE_ENV: release
 steps:
-  - setup-mise
+  - setup-env
   - run:
       name: Build CLI binaries
       command: bun scripts/release-cli/build.ts

--- a/.circleci/release/jobs/deploy-site.yml
+++ b/.circleci/release/jobs/deploy-site.yml
@@ -5,7 +5,7 @@ environment:
   LEFTHOOK: "0"
   MISE_ENV: release
 steps:
-  - setup-mise
+  - setup-env
   - aws-oidc-setup
   - restore_cache:
       keys:

--- a/.circleci/release/jobs/finalize-cli.yml
+++ b/.circleci/release/jobs/finalize-cli.yml
@@ -5,7 +5,7 @@ environment:
   LEFTHOOK: "0"
   MISE_ENV: release
 steps:
-  - setup-mise
+  - setup-env
   - attach_workspace:
       at: .
   - run:

--- a/.circleci/release/jobs/publish-platform.yml
+++ b/.circleci/release/jobs/publish-platform.yml
@@ -8,7 +8,7 @@ environment:
   LEFTHOOK: "0"
   MISE_ENV: release
 steps:
-  - setup-mise
+  - setup-env
   - attach_workspace:
       at: .
   - run:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "docs": "bun --cwd docs mint dev",
     "docs:validate": "bun --cwd docs mint validate",
     "docs:broken-links": "bun --cwd docs mint broken-links",
-    "postinstall": "mise exec -- lefthook install && bun dev install && { [ -n \"$CI\" ] || sst install; }",
+    "postinstall": "mise exec -- lefthook install && facet install && { [ -n \"$CI\" ] || sst install; }",
     "clean": "rm -rf .turbo .sst node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify",
     "nuke": "bun run clean && bun install && bun check"
   },

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -11,7 +11,7 @@ Push to main
 ┌────────────────────────────────────────────────────────────────────┐
 │  deploy-site CircleCI job (deploy workflow, release pipeline)      │
 │                                                                    │
-│  1. setup-mise       — install Bun, node, deps                     │
+│  1. setup-env        — install mise, facet CLI, Bun, node, deps    │
 │  2. aws-oidc-setup   — assume AWS_ROLE_ARN via OIDC (aws-cli orb)  │
 │  3. bun scripts/deploy/site.ts                                     │
 │       a. Pre-flight: AWS_ACCESS_KEY_ID must be set                 │


### PR DESCRIPTION
### Why

<!-- Why does this change exist? Link an issue or describe the motivation. Remove this section for trivial changes where the title says it all. -->

### Details

<!-- What should the reviewer know that isn't obvious from the diff? Approach, trade-offs, edge cases. Remove this section if the change is self-explanatory. -->

### Verification

<!-- How do you know it works? Manual test steps, deployment notes, or just "CI". Remove this section if CI covers it. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies shared CircleCI setup used by all CI/release/deploy jobs and introduces an additional externally-downloaded install script (`agentfacets.io/install`), which could break pipelines if the installer or PATH changes.
> 
> **Overview**
> Switches CircleCI’s shared setup command from `setup-mise` to `setup-env` and extends it to install the `facet` CLI (via `curl ... | bash`) before installing dependencies.
> 
> Updates both packed and source CircleCI configs (including release symlinks) and adjusts docs to reflect the new setup step and required `github` context.
> 
> Replaces the repo `postinstall` step from `bun dev install` to `facet install` so local installs use the facet workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c525bce5bdb0bd90b16665a49f331f4ad5ef4919. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->