### PR TITLE
Add namespaced registry name support to `parseSource`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": ["@changesets/changelog-github", { "repo": "agent-facets/facets" }],
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [["agent-facets", "@agent-facets/adapter", "@agent-facets/core"]],
   "ignore": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/odd-squids-play.md
+++ b/.changeset/odd-squids-play.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/core": patch
+---
+
+Add namespaced registry name support to `parseSource`

--- a/.changeset/quiet-vans-type.md
+++ b/.changeset/quiet-vans-type.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/core": patch
+---
+
+Linked core, adapter SDK, and CLI package versions

--- a/packages/core/src/sources/facet/__tests__/parse-source.test.ts
+++ b/packages/core/src/sources/facet/__tests__/parse-source.test.ts
@@ -1,85 +1,52 @@
 import { describe, expect, test } from 'bun:test'
 import { parseFacetSource as parseSource } from '../parse-source.ts'
+import type { Source } from '../types.ts'
 
 describe('parseSource — registry forms', () => {
-  test('bare name resolves to latest', () => {
-    const result = parseSource('viper-plans')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.value).toEqual({
-        kind: 'registry',
-        name: 'viper-plans',
-        version: { kind: 'latest' },
-      })
-    }
-  })
-
-  test('name@latest resolves to latest', () => {
-    const result = parseSource('viper-plans@latest')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.value).toEqual({
-        kind: 'registry',
-        name: 'viper-plans',
-        version: { kind: 'latest' },
-      })
-    }
-  })
-
-  test('name@* resolves to wildcard', () => {
-    const result = parseSource('viper-plans@*')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.value).toEqual({
-        kind: 'registry',
-        name: 'viper-plans',
-        version: { kind: 'wildcard' },
-      })
-    }
-  })
-
-  test('name@exact pins to exact version', () => {
-    const result = parseSource('viper-plans@1.2.3')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.value).toEqual({
-        kind: 'registry',
-        name: 'viper-plans',
-        version: { kind: 'exact', major: 1, minor: 2, patch: 3 },
-      })
-    }
-  })
-
-  test('name@major.* pins to major', () => {
-    const result = parseSource('viper-plans@1.*')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.value).toEqual({
-        kind: 'registry',
-        name: 'viper-plans',
-        version: { kind: 'majorWildcard', major: 1 },
-      })
-    }
-  })
-
-  test('name@major.minor.* pins to minor', () => {
-    const result = parseSource('viper-plans@1.2.*')
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.value).toEqual({
-        kind: 'registry',
-        name: 'viper-plans',
-        version: { kind: 'minorWildcard', major: 1, minor: 2 },
-      })
-    }
+  const cases: ReadonlyArray<readonly [string, string, Source]> = [
+    ['bare name', 'viper-plans', { kind: 'registry', name: 'viper-plans', version: { kind: 'latest' } }],
+    ['name@latest', 'viper-plans@latest', { kind: 'registry', name: 'viper-plans', version: { kind: 'latest' } }],
+    ['name@*', 'viper-plans@*', { kind: 'registry', name: 'viper-plans', version: { kind: 'wildcard' } }],
+    [
+      'name@exact',
+      'viper-plans@1.2.3',
+      { kind: 'registry', name: 'viper-plans', version: { kind: 'exact', major: 1, minor: 2, patch: 3 } },
+    ],
+    [
+      'name@major.*',
+      'viper-plans@1.*',
+      { kind: 'registry', name: 'viper-plans', version: { kind: 'majorWildcard', major: 1 } },
+    ],
+    [
+      'name@major.minor.*',
+      'viper-plans@1.2.*',
+      { kind: 'registry', name: 'viper-plans', version: { kind: 'minorWildcard', major: 1, minor: 2 } },
+    ],
+    ['namespaced bare name', 'acme/cowsay', { kind: 'registry', name: 'acme/cowsay', version: { kind: 'latest' } }],
+    [
+      'namespaced name@exact',
+      'acme/cowsay@1.2.3',
+      { kind: 'registry', name: 'acme/cowsay', version: { kind: 'exact', major: 1, minor: 2, patch: 3 } },
+    ],
+    [
+      'namespaced name@latest',
+      'acme/cowsay@latest',
+      { kind: 'registry', name: 'acme/cowsay', version: { kind: 'latest' } },
+    ],
+  ]
+  test.each(cases)('parses %s as registry source', (_label, input, expected) => {
+    const result = parseSource(input)
+    if (!result.ok) expect.unreachable()
+    expect(result.value).toEqual(expected)
   })
 
   test('latest equivalence: bare, @latest, and @* are semantically identical', () => {
     const bareResult = parseSource('viper-plans')
     const latestResult = parseSource('viper-plans@latest')
     const wildcardResult = parseSource('viper-plans@*')
-    expect(bareResult.ok && latestResult.ok && wildcardResult.ok).toBe(true)
-    if (!bareResult.ok || !latestResult.ok || !wildcardResult.ok) return
+    if (!bareResult.ok) expect.unreachable()
+    if (!latestResult.ok) expect.unreachable()
+    if (!wildcardResult.ok) expect.unreachable()
     // All three are registry sources for the same name. The version surface
     // form is preserved (bare and latest both produce kind:'latest', * produces
     // kind:'wildcard') but resolvesToLatest collapses all three to the same
@@ -227,6 +194,15 @@ describe('parseSource — local forms', () => {
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.value).toEqual({ kind: 'local', path: '.' })
   })
+
+  // PATH_RE intercepts anything starting with `/` before REGISTRY_RE runs,
+  // so a leading slash is always a local path — even when it looks like
+  // a malformed namespaced name.
+  test('leading-slash name is a local path, not a registry error', () => {
+    const result = parseSource('/cowsay')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toEqual({ kind: 'local', path: '/cowsay' })
+  })
 })
 
 describe('parseSource — rejected forms', () => {
@@ -278,6 +254,18 @@ describe('parseSource — rejected forms', () => {
 
   test('completely unrecognized specifier', () => {
     const result = parseSource('!!@@##')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.code).toBe('INVALID_REGISTRY_NAME')
+  })
+
+  test('multi-slash registry name is rejected', () => {
+    const result = parseSource('acme/foo/bar')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.code).toBe('INVALID_REGISTRY_NAME')
+  })
+
+  test('trailing-slash registry name is rejected', () => {
+    const result = parseSource('cowsay/')
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error.code).toBe('INVALID_REGISTRY_NAME')
   })

--- a/packages/core/src/sources/facet/parse-source.ts
+++ b/packages/core/src/sources/facet/parse-source.ts
@@ -40,9 +40,12 @@ const GIT_SCHEMES = new Set(['https', 'http', 'ssh', 'git'])
 
 /**
  * Registry name regex. Lowercase letters, digits, hyphens; must start
- * with a letter. Optional `@<version-spec>` tail.
+ * with a letter. A name segment may optionally be followed by `/<segment>`
+ * to form a namespaced name (`<namespace>/<name>`), where the second
+ * segment matches the same character class. Group 1 captures the canonical
+ * full name (with the slash if present). Optional `@<version-spec>` tail.
  */
-const REGISTRY_RE = /^([a-z][a-z0-9-]*)(?:@(.+))?$/
+const REGISTRY_RE = /^([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)(?:@(.+))?$/
 
 /**
  * Parse a facet source string into a `Source`.


### PR DESCRIPTION
### Why

Registry package names currently only support a flat `name` format. This adds support for namespaced names in the form `namespace/name` (e.g. `acme/cowsay`), allowing packages to be scoped under an organization or owner.

### Details

`REGISTRY_RE` now accepts an optional `namespace/` prefix, where each segment (namespace and name) must independently match the existing character class (`[a-z][a-z0-9-]*`). Only a single slash is permitted — names like `acme/foo/bar` are rejected with `INVALID_REGISTRY_NAME`, as are trailing-slash forms like `cowsay/`. Paths beginning with `/` are still intercepted by `PATH_RE` before `REGISTRY_RE` runs, so they remain local paths rather than triggering a registry error.

### Verification

New test cases cover the following scenarios:
- `acme/cowsay` resolves to `latest`
- `acme/cowsay@1.2.3` pins to an exact version
- `acme/cowsay@latest` resolves to `latest`
- `/cowsay` is treated as a local path
- `acme/foo/bar` and `cowsay/` are both rejected with `INVALID_REGISTRY_NAME`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to broadening the registry-name regex in `parseFacetSource`, with added tests covering new accepted/rejected forms and no changes to git/local parsing logic.
> 
> **Overview**
> `parseFacetSource` now accepts **namespaced registry package names** in the form `namespace/name` (optionally with `@<version>`), while still rejecting invalid multi-slash or trailing-slash names.
> 
> Tests were expanded to cover parsing of namespaced names (bare/`@latest`/exact), ensure `/...` continues to be treated as a local path, and validate rejection of `acme/foo/bar` and `cowsay/` as `INVALID_REGISTRY_NAME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7112f658c680a91eb4a34c42c618f530c02039c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->