### PR TITLE
Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/
 lefthook-local.yml
 mise.local.toml
+.DS_Store
 
 *.bun-build
 bun.lockb


### PR DESCRIPTION
### Why

`.DS_Store` files generated by macOS were not being ignored by Git, risking accidental commits of these system files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates `.gitignore` only to prevent accidental commits of macOS `.DS_Store` files; no runtime or build behavior changes.
> 
> **Overview**
> Adds `.DS_Store` to `.gitignore` so macOS Finder metadata files are not tracked or accidentally committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e12366f51f34da7c012bebdaa172f0794c7540. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->