### PR TITLE
Add rotating verb/noun headline with scramble animation and `useRotation`/`useScrambleTo` hooks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,7 @@
       "enabled": true
     },
     "formatter": {
+      "lineWidth": 120,
       "quoteStyle": "single",
       "semicolons": "asNeeded"
     }

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build && tsc --noEmit",
     "types": "tsc --noEmit",
-    "test": "echo \"No tests specified\""
+    "test": "bun test"
   },
   "dependencies": {
     "@agent-facets/brand": "workspace:*",

--- a/packages/landing/public/agent-prompt.txt
+++ b/packages/landing/public/agent-prompt.txt
@@ -1,0 +1,155 @@
+You are helping a user install and use facets — a tool that manages
+capabilities (skills, sub-agents, slash commands, MCP servers) for AI
+coding tools like Claude Code, Codex, Cursor, OpenCode, and others.
+Think of facets as the "capability layer" the user installs into their
+project so their agent can do more.
+
+This prompt is the source of truth for how to onboard a user. It lives
+at https://agentfacets.io/agent-prompt.txt (in the agent-facets repo at
+packages/landing/public/agent-prompt.txt). If anything below is unclear,
+fetch the latest copy of this URL — it changes more often than the page
+that points to it.
+
+
+# Step 1 — install the facet CLI
+
+Run this in the user's shell. It is safe, idempotent, and short-circuits
+when the latest version is already installed:
+
+    curl -fsSL https://agentfacets.io/install | bash
+
+The script installs to ~/.facet/bin/facet and adds that directory to
+the user's shell PATH (zsh, bash, fish, or sh). After it finishes,
+either restart the shell or source the rc file the script reports as
+modified. Verify with:
+
+    facet --version
+
+Notes:
+- macOS and Linux only. On Windows native, instruct the user to run
+  `npm install -g agent-facets` instead. WSL is fine via the curl path.
+- If the user is in a fresh shell where ~/.facet/bin isn't on PATH yet,
+  invoke the binary as ~/.facet/bin/facet directly.
+
+
+# Step 2 — ask the user what they want
+
+Once `facet` is installed, ask the user:
+
+  "Want me to look for a facet for you, or do you already have one in
+   mind?"
+
+Two paths from there:
+
+  (a) "Look for one" → use the search API in Step 3.
+  (b) "I have one in mind" or they paste a URL → skip to Step 4.
+
+
+# Step 3 — search the registry
+
+The facet.cafe registry exposes a JSON API at https://api.facet.cafe/v0.
+All read endpoints are unauthenticated and CORS-open. You can curl
+directly from the user's session.
+
+List all published facets:
+
+    curl -fsSL https://api.facet.cafe/v0/packages
+
+Response shape:
+
+    {
+      "facets": [
+        {
+          "name": "owner/facet-name",
+          "latestVersion": "1.2.3",
+          "publishedAt": "2025-...",
+          "description": "...",     // optional
+          "author": "...",          // optional
+          "assetCounts": { "skills": 3, "agents": 1, "commands": 0, "servers": 0 }
+        },
+        ...
+      ]
+    }
+
+V0 has no server-side `?q=` filter — pull the list and filter
+client-side (substring match against name/description). The list is
+capped at 200 facets for now; expect that to grow.
+
+Get info about a specific facet (name may contain a `/`, URL-encode
+it as `%2F`):
+
+    curl -fsSL https://api.facet.cafe/v0/packages/<name>
+
+Get a specific version's metadata (use the literal `latest` for the
+LATEST pointer):
+
+    curl -fsSL https://api.facet.cafe/v0/packages/<name>/<version>
+
+Errors come back as JSON with a stable `code` and a `docsUrl`:
+
+    { "error": "...", "code": "E_FACET_NOT_FOUND",
+      "docsUrl": "https://agentfacets.io/errors/E_FACET_NOT_FOUND" }
+
+Heads up: the registry is in V0. The list may currently be small or
+empty. If nothing matches the user's request, fall back to suggesting
+they install a known github source directly (Step 4) or browse
+https://facet.cafe in the browser.
+
+When you find a candidate, summarize it for the user — name, what it
+provides (assetCounts), description if present — and confirm before
+installing.
+
+
+# Step 4 — install the facet
+
+Run from inside the user's project directory (where their facets.json
+lives, or where they want it created):
+
+    facet add <source>
+
+`<source>` accepts several forms:
+
+  Registry (once a facet is published):
+      facet add owner/facet-name
+      facet add owner/facet-name@1.2.3
+
+  GitHub (most common in the wild today):
+      facet add github:owner/repo
+      facet add github:owner/repo#branch-or-tag-or-sha
+      facet add github:owner/repo/subdir#ref
+
+  Generic git:
+      facet add git+https://example.com/repo.git#ref
+
+  Local (for development):
+      facet add file:../path/to/facet
+
+`facet add` writes the entry to facets.json, fetches the source,
+verifies integrity, and installs it into the user's adapter targets
+(Claude Code, Cursor, etc.). If no adapter is configured yet, facet
+will offer an interactive picker.
+
+Useful flags:
+  --verbose         show step-by-step output on stderr
+  facet --help      full command list
+  facet add --help  details on add
+
+
+# What to tell the user as you go
+
+- After install, show `facet --version` output.
+- After `facet add`, show what was installed (the CLI prints this).
+- If anything fails, the error has a `code` and `docsUrl` — surface
+  both to the user.
+
+Be conversational. The user shouldn't feel like they're being walked
+through a script. You're a knowledgeable peer helping them try a new
+tool.
+
+
+# Where to learn more
+
+  Docs:     https://docs.agentfacets.io
+  Browse:   https://facet.cafe
+  API spec: https://api.facet.cafe/v0/openapi.yaml
+  Source:   https://github.com/agent-facets/facets

--- a/packages/landing/src/components/AgentPromptButton.tsx
+++ b/packages/landing/src/components/AgentPromptButton.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AGENT_PROMPT_POINTER } from '../lib/agent-prompt'
+import { copyToClipboard } from '../lib/copy'
+import styles from './Hero.module.css'
+
+const AGENT_COPIED_RESET_MS = 2200
+
+export function AgentPromptButton() {
+  const [agentCopied, setAgentCopied] = useState(false)
+
+  const agentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (agentTimerRef.current) clearTimeout(agentTimerRef.current)
+    },
+    [],
+  )
+
+  const copyAgentPrompt = useCallback(async () => {
+    setAgentCopied(await copyToClipboard(AGENT_PROMPT_POINTER))
+    if (agentTimerRef.current) clearTimeout(agentTimerRef.current)
+    agentTimerRef.current = setTimeout(() => setAgentCopied(false), AGENT_COPIED_RESET_MS)
+  }, [])
+
+  return (
+    <button
+      type="button"
+      className={`${styles.agentBreakout}${agentCopied ? ` ${styles.copied}` : ''}`}
+      onClick={copyAgentPrompt}
+      aria-label="Copy agent prompt to clipboard"
+    >
+      <span className={styles.agentInner}>
+        <span className={`${styles.agentState} ${styles.agentIdle}`}>
+          <span className={styles.sparkle} aria-hidden="true" />
+          <span>or just hand this prompt to your agent</span>
+          <span className={styles.copyBadge}>Copy</span>
+        </span>
+        <span className={`${styles.agentState} ${styles.agentDone}`}>
+          <span className={styles.checkmark} aria-hidden="true">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 8.5l3.2 3.2L13 5" />
+            </svg>
+          </span>
+          <span>Copied — paste into your agent</span>
+          <span className={styles.copyBadge}>Copied</span>
+        </span>
+      </span>
+    </button>
+  )
+}

--- a/packages/landing/src/components/Closer.module.css
+++ b/packages/landing/src/components/Closer.module.css
@@ -64,6 +64,17 @@
   position: relative;
 }
 
+.buttons {
+  display: flex;
+  flex-flow: column;
+  row-gap: 2rem;
+  align-items: center;
+}
+
+.buttons * {
+  flex: 0 auto;
+}
+
 .mobileCta {
   /* Hidden on desktop; shown below bp-mobile. */
   display: none;

--- a/packages/landing/src/components/Closer.tsx
+++ b/packages/landing/src/components/Closer.tsx
@@ -1,3 +1,4 @@
+import { AgentPromptButton } from './AgentPromptButton'
 import styles from './Closer.module.css'
 import { Footer } from './Footer'
 import { InstallBlock } from './InstallBlock'
@@ -16,7 +17,10 @@ export function Closer() {
           request. Just like npm — but for agents.
         </p>
         <div className={styles.installWrap}>
-          <InstallBlock />
+          <div className={styles.buttons}>
+            <InstallBlock />
+            <AgentPromptButton />
+          </div>
         </div>
         <div className={styles.mobileCta}>
           <RegistryCta />

--- a/packages/landing/src/components/Eyebrow.module.css
+++ b/packages/landing/src/components/Eyebrow.module.css
@@ -2,32 +2,60 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  /* 16px = 10px ring spread + ~6px clearance, mirroring the gap
+     between the fully-expanded ring and the pill border on the left. */
+  gap: 16px;
   padding: 8px 16px;
   border: 1px solid var(--line-strong);
   border-radius: 999px;
   background: var(--card);
-  font-family: var(--mono);
+  font-family: var(--mono), monospace;
   font-size: 12px;
   color: var(--ink-dim);
 }
 
+/* Link variant — only applied when the Eyebrow is rendered as <a>. */
+.eyebrowLink {
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.eyebrowLink:hover {
+  color: var(--ink);
+  border-color: var(--ink-dim);
+  background: color-mix(in oklab, var(--card) 60%, var(--ink) 4%);
+}
+
+.eyebrowLink:focus-visible {
+  outline: 2px solid var(--accent-c);
+  outline-offset: 2px;
+}
+
+/* Radar-blip dot. The dot stays solid; an outward ring radiates from
+   it (via box-shadow spread) and fades. Don't replace this with an
+   opacity animation — the expanding ring is the whole point. */
 .dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background: var(--accent-c);
-  box-shadow: 0 0 10px var(--accent-c);
-  animation: pulse 2s ease-in-out infinite;
+  box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent-c) 60%, transparent);
+  animation: eyebrow-pulse 1.8s ease-out infinite;
 }
 
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
+@keyframes eyebrow-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent-c) 60%, transparent);
   }
-  50% {
-    opacity: 0.4;
+  70% {
+    box-shadow: 0 0 0 10px color-mix(in oklab, var(--accent-c) 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent-c) 0%, transparent);
   }
 }
 

--- a/packages/landing/src/components/Eyebrow.tsx
+++ b/packages/landing/src/components/Eyebrow.tsx
@@ -3,12 +3,28 @@ import styles from './Eyebrow.module.css'
 
 type EyebrowProps = {
   children: ReactNode
+  /**
+   * Optional href. When set, the eyebrow renders as an `<a>` and picks up
+   * the `.eyebrowLink` hover affordance. When omitted, it renders as a
+   * non-interactive `<div>` (preserves the original behavior).
+   */
+  href?: string
 }
 
 /**
  * Small status pill with a pulsing dot — used above the hero headline.
+ * Optionally a link when `href` is provided.
  */
-export function Eyebrow({ children }: EyebrowProps) {
+export function Eyebrow({ children, href }: EyebrowProps) {
+  if (href !== undefined) {
+    return (
+      <a className={`${styles.eyebrow} ${styles.eyebrowLink}`} href={href}>
+        <span className={styles.dot} aria-hidden="true" />
+        {children}
+      </a>
+    )
+  }
+
   return (
     <div className={styles.eyebrow}>
       <span className={styles.dot} aria-hidden="true" />

--- a/packages/landing/src/components/Hero.module.css
+++ b/packages/landing/src/components/Hero.module.css
@@ -1,3 +1,10 @@
+/* Hero. Headline-relative sizing flows from --headline-size on .hero;
+   bumping that one variable rescales preamble, verb, noun, sub, tool,
+   and caret in proportion. --supporting-ratio sizes .preamble/.sub
+   relative to the headline; --tool-ratio sizes the gradient tool
+   word. Mobile breakpoint overrides --headline-size + a couple of
+   readability floors. */
+
 .hero {
   position: relative;
   min-height: 100vh;
@@ -8,6 +15,12 @@
   justify-content: center;
   text-align: center;
   overflow: hidden;
+
+  /* rem floor/ceiling so user font-size preferences still scale the
+     hero; 7vw midpoint stays viewport-relative. */
+  --headline-size: clamp(3.5rem, 7vw, 6rem);
+  --supporting-ratio: 0.3;
+  --tool-ratio: 0.5;
 }
 
 .heroBg {
@@ -60,18 +73,60 @@
   z-index: 1;
   font-family: var(--sans), sans-serif;
   font-weight: 700;
-  font-size: clamp(48px, 9vw, 128px);
-  line-height: 0.92;
+  font-size: var(--headline-size);
+  line-height: 0.95;
   letter-spacing: -0.04em;
-  margin: 0 0 24px;
+  margin: 0 0 22px;
   max-width: 1100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.05em;
   overflow: visible;
 }
 
+/* Sized via calc(--headline-size) (not em) so this class can be
+   composed onto siblings of .title — see .subPrefix below. */
+.preamble {
+  display: inline-block;
+  font-family: var(--sans);
+  font-style: normal;
+  font-weight: 500;
+  font-size: calc(var(--headline-size) * var(--supporting-ratio));
+  letter-spacing: 0.01em;
+  color: var(--ink-dim);
+  line-height: 1.1;
+  margin-bottom: 0.5em;
+  text-transform: none;
+}
+
+/* min-width sized for the widest verb ("install" / "manage" at 7
+   chars). Bump if a longer verb joins the rotation. */
+.verbSlot {
+  display: inline-block;
+  position: relative;
+  min-width: 7.5ch;
+  text-align: center;
+}
+
+.verbWord {
+  display: inline-block;
+  font-family: var(--sans);
+  font-style: normal;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.04em;
+  animation: fadeBlur 0.6s ease-out both;
+}
+
+.scrambleSlot {
+  display: inline-block;
+}
+
+/* Gradient text-fill only — typography (family/style/weight) is set
+   by the consumer so each instance can pick mono vs. serif without a
+   specificity fight. Today the only consumer is .scrambleNoun. */
 .accent {
-  font-family: var(--serif, serif);
-  font-style: italic;
-  font-weight: 400;
   background: linear-gradient(100deg, var(--accent-a) 0%, var(--accent-b) 45%, var(--accent-d) 100%);
   -webkit-background-clip: text;
   background-clip: text;
@@ -79,47 +134,277 @@
   color: transparent;
   letter-spacing: -0.02em;
   display: inline-block;
-  padding: 0.2em 0.2em;
-  margin: -0.2em -0.2em;
+  padding: 0.05em 0.1em;
+  margin: -0.05em -0.1em;
+}
+
+/* Mono so random scramble glyphs have stable widths. */
+.scrambleNoun {
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  word-spacing: -0.2em;
+}
+
+@keyframes fadeBlur {
+  0% {
+    opacity: 0;
+    filter: blur(10px);
+    transform: scale(0.96);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
 }
 
 .sub {
   position: relative;
   z-index: 1;
   font-family: var(--sans);
-  font-size: clamp(16px, 1.5vw, 20px);
+  /* Same proportion as .preamble so "for" reads as a peer to the
+     preamble copy. */
+  font-size: calc(var(--headline-size) * 0.3);
   line-height: 1.5;
   color: var(--ink-dim);
-  max-width: 560px;
-  margin: 0 auto 48px;
+  margin: 0 auto 38px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.15em;
 }
 
-.installWrap {
-  position: relative;
-  z-index: 1;
-  margin-bottom: 20px;
+/* Composes .preamble in the JSX for typography. Resets the .preamble
+   bottom margin since .sub's flex gap handles spacing. */
+.subPrefix {
+  margin-bottom: 0;
+  white-space: nowrap;
+  text-align: center;
 }
 
-.mobileCta {
-  /* Hidden on desktop; shown below bp-mobile. */
-  display: none;
+.toolSlot {
+  display: inline-block;
+  position: relative;
+  text-align: center;
+  vertical-align: baseline;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+
+/* Sized via --headline-size directly (not em on .sub) so it doesn't
+   compound the supporting-ratio shrink. */
+.toolWord {
+  display: inline-block;
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: calc(var(--headline-size) * var(--tool-ratio));
+  letter-spacing: -0.005em;
+  background: linear-gradient(100deg, var(--accent-c) 0%, var(--accent-a) 50%, var(--accent-b) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  white-space: pre;
+  min-height: 1em;
+  vertical-align: baseline;
+}
+
+/* ZWSP keeps the baseline anchored when the word is mid-delete. */
+.toolWord:empty::before {
+  content: "\200B";
+}
+
+/* Caret scales with the tool word. 0.85 of tool size approximates
+   cap-to-baseline; width and margin-left are fractions of height so
+   they stay visually consistent across sizes. */
+.caret {
+  display: inline-block;
+  background: var(--accent-a);
+  height: calc(var(--headline-size) * var(--tool-ratio) * 0.85);
+  width: calc(var(--headline-size) * var(--tool-ratio) * 0.05);
+  margin-left: calc(var(--headline-size) * var(--tool-ratio) * 0.08);
+  vertical-align: baseline;
+  transform: translateY(0.18em);
+  animation: caretBlink 1s steps(2, end) infinite;
+  /* Fade target for the hidden state. Layout dimensions stay so the
+     final tool word doesn't reflow on hide. */
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+/* Stop the blink, fade to 0 — keeps the caret's width so the line
+   doesn't reflow when it disappears. */
+.caretHidden {
+  animation: none;
+  opacity: 0;
+}
+
+@keyframes caretBlink {
+  50% {
+    opacity: 0;
+  }
+}
+
+.ctaRegion {
   position: relative;
   z-index: 1;
-  margin-bottom: 12px;
-  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 28px;
+}
+
+.installPillWrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 6px;
 }
 
 .installNote {
-  position: relative;
-  z-index: 1;
   font-family: var(--mono), monospace;
   font-size: 12px;
   color: var(--ink-faint);
-  margin-bottom: 40px;
+  margin-bottom: 18px;
+}
+
+/* Dashed pill, accent-c (green) idle, accent-d (coral) when copied.
+   The two states swap via the same fade+slide pattern as InstallBlock
+   for cross-action consistency. */
+.agentBreakout {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 14px 10px 16px;
+  background: transparent;
+  border: 1px dashed color-mix(in oklab, var(--accent-c) 50%, var(--line-strong));
+  border-radius: 999px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  color: var(--ink-dim);
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease,
+    border-color 0.18s ease;
+  appearance: none;
+}
+
+.agentBreakout:hover {
+  background: color-mix(in oklab, var(--accent-c) 8%, transparent);
+  color: var(--ink);
+}
+
+.agentBreakout.copied {
+  border-color: color-mix(in oklab, var(--accent-d) 50%, var(--line-strong));
+  color: color-mix(in oklab, var(--accent-d) 90%, var(--ink));
+}
+
+.agentBreakout.copied:hover {
+  background: color-mix(in oklab, var(--accent-d) 8%, transparent);
+}
+
+/* min-width sized to fit the longer "Copied — paste into your agent"
+   label so the pill width never jumps between idle and copied. */
+.agentInner {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 320px;
+  height: 20px;
+}
+
+.agentState {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  white-space: nowrap;
+  transition:
+    opacity 0.22s ease,
+    transform 0.22s cubic-bezier(0.2, 0.9, 0.2, 1);
+}
+
+.agentIdle {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.agentDone {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+.agentBreakout.copied .agentIdle {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+.agentBreakout.copied .agentDone {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.sparkle {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  background: linear-gradient(135deg, var(--accent-c), var(--accent-d));
+  -webkit-mask:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2 L13.8 9.2 L21 11 L13.8 12.8 L12 20 L10.2 12.8 L3 11 L10.2 9.2 Z M19 2 L19.7 4.3 L22 5 L19.7 5.7 L19 8 L18.3 5.7 L16 5 L18.3 4.3 Z' fill='black'/></svg>")
+    center / contain no-repeat;
+  mask:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2 L13.8 9.2 L21 11 L13.8 12.8 L12 20 L10.2 12.8 L3 11 L10.2 9.2 Z M19 2 L19.7 4.3 L22 5 L19.7 5.7 L19 8 L18.3 5.7 L16 5 L18.3 4.3 Z' fill='black'/></svg>")
+    center / contain no-repeat;
+  display: inline-block;
+}
+
+/* Inner SVG uses currentColor so it picks up the .copied coral. */
+.checkmark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+}
+
+.copyBadge {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklab, var(--accent-c) 14%, transparent);
+  color: color-mix(in oklab, var(--accent-c) 90%, var(--ink));
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.agentBreakout.copied .copyBadge {
+  background: color-mix(in oklab, var(--accent-d) 14%, transparent);
+  color: color-mix(in oklab, var(--accent-d) 90%, var(--ink));
+}
+
+/* Hidden on desktop; shown below bp-mobile. */
+.mobileCta {
+  opacity: 0;
+  display: none;
+  position: relative;
+  z-index: 1;
+  height: 0;
+  width: 0;
 }
 
 .installNoteMobile {
-  /* Hidden on desktop; shown below bp-mobile. */
   display: none;
   position: relative;
   z-index: 1;
@@ -143,7 +428,6 @@
   font-family: var(--mono);
   font-size: 13px;
   color: var(--ink-dim);
-  margin-top: 12px;
 }
 
 .ctaRow .sep {
@@ -167,19 +451,26 @@
   transform: translateX(3px);
 }
 
-/* bp-mobile — swap InstallBlock for RegistryCta, shrink type + spacing,
-   and hide the OrbitFloaters (via their own module). */
+@media (prefers-reduced-motion: reduce) {
+  .verbWord {
+    animation: none;
+  }
+  .caret {
+    animation: none;
+    opacity: 0.5;
+    transition: none;
+  }
+  .agentState {
+    transition: none;
+  }
+}
+
 @media (max-width: 1024px) {
   .hero {
     min-height: auto;
-    /*
-     * Top padding clears the fixed nav (--nav-mobile-height, ~55px)
-     * plus breathing room for the eyebrow. Desktop uses 140px to
-     * clear a ~68px nav; 96px keeps the same proportion on mobile.
-     */
     padding: 96px 22px 56px;
-    display: flex;
     gap: 1em;
+    --headline-size: 2.75rem;
   }
 
   .eyebrowRow {
@@ -187,42 +478,53 @@
   }
 
   .title {
-    font-size: 44px;
     line-height: 0.95;
     letter-spacing: -0.035em;
     text-wrap: balance;
     margin: 0 0 18px;
   }
 
+  /* Override the desktop ratio: at 44px headline, 0.3 yields 13px
+     which is too tight. Floor at ~14px for readability. */
+  .preamble {
+    font-size: 0.875rem;
+    margin-bottom: 0.45em;
+  }
+
   .sub {
-    font-size: 15.5px;
+    font-size: 0.97rem;
     max-width: 340px;
     margin: 0 auto 28px;
     text-wrap: pretty;
   }
 
-  .installWrap {
+  /* Hidden on mobile: the agent prompt assumes the user's agent runs
+     facets natively, which today is desktop tools only (Claude Code /
+     Codex / Cursor / OpenCode / OpenClaw). ChatGPT.com and Claude.ai
+     don't support facets, so showing the breakout there would imply
+     something we can't deliver. Revisit if/when that changes. */
+  .installPillWrap,
+  .installNote,
+  .agentBreakout {
     display: none;
+  }
+
+  .ctaRegion {
+    margin-bottom: 0;
   }
 
   .mobileCta {
+    opacity: 1;
     display: flex;
-  }
-
-  .installNote {
-    display: none;
+    height: unset;
+    width: 100%;
+    margin-bottom: 12px;
   }
 
   .installNoteMobile {
     display: block;
   }
 
-  /*
-   * On mobile, the CTA links become proper finger-sized targets:
-   * full-width pills ~48px tall (comfortably above the 44px HIG
-   * minimum), subtle card background, centered text. Each link is
-   * the whole row, so any tap anywhere in the pill activates it.
-   */
   .ctaRow {
     flex-direction: column;
     gap: 10px;

--- a/packages/landing/src/components/Hero.tsx
+++ b/packages/landing/src/components/Hero.tsx
@@ -1,10 +1,86 @@
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react'
+import { useRotation } from '../hooks/useRotation'
+import { useScrambleTo } from '../hooks/useScrambleTo'
+import { useTypeRotation } from '../hooks/useTypeRotation'
+import { copyToClipboard } from '../lib/copy'
+import { AgentPromptButton } from './AgentPromptButton'
 import { Eyebrow } from './Eyebrow'
 import styles from './Hero.module.css'
 import { InstallBlock } from './InstallBlock'
 import { OrbitFloaters } from './OrbitFloaters'
 import { RegistryCta } from './RegistryCta'
 
+/* All three rotors land on their LAST entry, so the page settles on
+   the thesis "manage capabilities for any tool". Earlier entries open
+   with familiar concepts and widen toward the abstraction. */
+
+const VERBS = ['manage', 'find', 'install', 'share', 'manage'] as const
+const NOUNS = ['capabilities', 'agents', 'skills', 'mcp servers', 'commands', 'capabilities'] as const
+const TOOLS = ['any AI agent', 'Claude Code', 'Codex', 'Cursor', 'OpenCode', 'OpenClaw', 'any AI agent'] as const
+
+/* All three rotors START their final transition at TARGET_RUNTIME_MS.
+   They each then settle on their own natural animation duration (verb
+   instantly, noun after SCRAMBLE_MS, tool after L_final × typeMs) —
+   a ~700ms arrival cascade. Tune TARGET_RUNTIME_MS alone to dilate or
+   compress the whole hero landing; the per-rotor cadences below
+   re-derive automatically when content or feel knobs change.
+
+   Solving each rotor so its (N-1)th transition fires at TARGET:
+     verb interval = TARGET / (N-1)
+     noun interval = TARGET / (N-1)        (scramble happens after start)
+     tool hold     = (TARGET - typing_nonfinal - deleting_nonfinal) / (N-1)
+   where typing_nonfinal / deleting_nonfinal sum over items 0..N-2
+   (the final item's typing/hold happen after the start moment). */
+
+const TARGET_RUNTIME_MS = 20_000
+const TOOL_TYPE_MS = 70
+const TOOL_DELETE_MS = 35
+const SCRAMBLE_MS = 700
+
+const VERB_INTERVAL_MS = TARGET_RUNTIME_MS / Math.max(1, VERBS.length - 1)
+const NOUN_INTERVAL_MS = TARGET_RUNTIME_MS / Math.max(1, NOUNS.length - 1)
+
+const TOOL_NON_FINAL = TOOLS.slice(0, -1)
+const TOOL_TYPING_BUDGET_MS = TOOL_NON_FINAL.reduce((sum, w) => sum + w.length * TOOL_TYPE_MS, 0)
+const TOOL_DELETING_BUDGET_MS = TOOL_NON_FINAL.reduce((sum, w) => sum + w.length * TOOL_DELETE_MS, 0)
+const TOOL_HOLD_MS = Math.max(
+  0,
+  (TARGET_RUNTIME_MS - TOOL_TYPING_BUDGET_MS - TOOL_DELETING_BUDGET_MS) / Math.max(1, TOOLS.length - 1),
+)
+
+/**
+ * sr-only recipe — visible to assistive tech, invisible to sighted users.
+ * Inline because this is the only consumer in the package; if a second
+ * component needs it, lift to a shared utility.
+ *
+ * Used to give the rotating headline + sub a single stable accessible
+ * reading. The animated DOM is `aria-hidden`, so screen readers only see
+ * these static spans. The values mirror VERBS[0] / NOUNS[0] / TOOLS[0],
+ * which (by design) also equal the settled last entries — so AT users
+ * get the same content as `prefers-reduced-motion` users.
+ */
+const VISUALLY_HIDDEN_STYLE: CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  whiteSpace: 'nowrap',
+  borderWidth: 0,
+}
+
 export function Hero() {
+  const [verb] = useRotation(VERBS, VERB_INTERVAL_MS)
+  const [noun] = useRotation(NOUNS, NOUN_INTERVAL_MS)
+  const nounOut = useScrambleTo(noun, SCRAMBLE_MS)
+  const { shown: tool, done: toolDone } = useTypeRotation(TOOLS, {
+    typeMs: TOOL_TYPE_MS,
+    holdMs: TOOL_HOLD_MS,
+    deleteMs: TOOL_DELETE_MS,
+  })
+
   return (
     <section className={styles.hero}>
       <div className={styles.heroBg} />
@@ -13,31 +89,55 @@ export function Hero() {
       <OrbitFloaters />
 
       <div className={styles.eyebrowRow}>
-        <Eyebrow>v{__APP_VERSION__} · pre-release alpha</Eyebrow>
+        <Eyebrow href="https://docs.agentfacets.io/roadmap/alpha">v{__APP_VERSION__} · pre-release alpha</Eyebrow>
       </div>
 
       <h1 className={styles.title}>
-        The package manager
-        <br />
-        for <span className={styles.accent}>AI agents.</span>
+        {/*
+         * Single stable sentence for assistive tech. The animated DOM
+         * below is aria-hidden so screen readers don't hear the rotors
+         * cycle (which previously read scrambled glyphs and partial
+         * words at every interval).
+         */}
+        <span style={VISUALLY_HIDDEN_STYLE}>
+          The simple and safe way to {VERBS[0]} {NOUNS[0]}
+        </span>
+        <span className={styles.preamble} aria-hidden="true">
+          The simple and safe way to
+        </span>
+        <span className={styles.verbSlot} aria-hidden="true">
+          <span key={verb} className={styles.verbWord}>
+            {verb}
+          </span>
+        </span>
+        <span className={styles.scrambleSlot} aria-hidden="true">
+          <span className={`${styles.accent} ${styles.scrambleNoun}`}>{nounOut}</span>
+        </span>
       </h1>
 
       <p className={styles.sub}>
-        Skills, sub-agents, slash commands, and MCP servers — bundled, versioned, installed with one line.
+        <span style={VISUALLY_HIDDEN_STYLE}>for {TOOLS[0]}.</span>
+        <span className={`${styles.preamble} ${styles.subPrefix}`} aria-hidden="true">
+          for
+        </span>
+        <span className={styles.toolSlot} aria-hidden="true">
+          <span className={styles.toolWord}>{tool}</span>
+          <span className={`${styles.caret}${toolDone ? ` ${styles.caretHidden}` : ''}`} aria-hidden="true" />
+        </span>
       </p>
 
-      {/*
-       * On desktop the install pill is the primary CTA; on mobile the
-       * curl command isn't useful, so we show a Registry CTA card
-       * pointing at facet.cafe instead. Both are mounted and CSS
-       * toggles visibility at the bp-mobile breakpoint.
-       */}
-      <div className={styles.installWrap}>
-        <InstallBlock />
-      </div>
-      <RegistryCta className={styles.mobileCta} />
+      <div className={styles.ctaRegion}>
+        <div className={styles.installPillWrap}>
+          <InstallBlock />
+        </div>
 
-      <div className={styles.installNote}>one-liner · macOS · Linux · works with Claude, Cursor, Codex &amp; more</div>
+        <div className={styles.installNote}>
+          one-liner · macOS · Linux · works with Claude, Cursor, Codex &amp; more
+        </div>
+        <AgentPromptButton />
+      </div>
+
+      <RegistryCta className={styles.mobileCta} />
       <div className={styles.installNoteMobile}>Search 200+ facets · install from your desktop with one line</div>
 
       <div className={styles.ctaRow}>

--- a/packages/landing/src/components/InstallBlock.module.css
+++ b/packages/landing/src/components/InstallBlock.module.css
@@ -9,7 +9,7 @@
   padding: 0;
   font-family: var(--mono);
   font-size: 15px;
-  box-shadow: 0 20px 60px -20px color-mix(in oklab, var(--accent-a) 50%, transparent);
+  box-shadow: 0 20px 60px -20px color-mix(in oklab, var(--accent-b) 50%, transparent);
   margin: 0;
   max-width: 92vw;
   overflow: hidden;
@@ -33,7 +33,7 @@
 }
 
 .prompt {
-  color: var(--accent-c);
+  color: var(--accent-b);
   padding: 18px 0 18px 22px;
   display: flex;
   align-items: center;

--- a/packages/landing/src/components/InstallBlock.tsx
+++ b/packages/landing/src/components/InstallBlock.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { copyToClipboard } from '../lib/copy'
 import styles from './InstallBlock.module.css'
 
 /**
@@ -8,35 +9,6 @@ import styles from './InstallBlock.module.css'
 export const INSTALL_CMD = 'curl -fsSL https://agentfacets.io/install | bash'
 
 const COPIED_RESET_MS = 1800
-
-function fallbackCopy(text: string): boolean {
-  try {
-    const ta = document.createElement('textarea')
-    ta.value = text
-    ta.setAttribute('readonly', '')
-    ta.style.cssText = 'position:fixed;top:-9999px;left:-9999px;opacity:0;'
-    document.body.appendChild(ta)
-    ta.select()
-    ta.setSelectionRange(0, text.length)
-    const ok = document.execCommand('copy')
-    document.body.removeChild(ta)
-    return ok
-  } catch {
-    return false
-  }
-}
-
-async function copyToClipboard(text: string): Promise<boolean> {
-  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText && window.isSecureContext !== false) {
-    try {
-      await navigator.clipboard.writeText(text)
-      return true
-    } catch {
-      return fallbackCopy(text)
-    }
-  }
-  return fallbackCopy(text)
-}
 
 /**
  * Full-width click-to-copy install command. The entire pill is one button —

--- a/packages/landing/src/components/LinkCard.tsx
+++ b/packages/landing/src/components/LinkCard.tsx
@@ -44,7 +44,7 @@ type LinkCardProps = {
 export function LinkCard({ href, label, value, icon, iconColor, external = true, className }: LinkCardProps) {
   const externalProps = external ? { target: '_blank', rel: 'noreferrer noopener' as const } : {}
   return (
-    <a className={`${styles.card}${className ? ` ${className}` : ''}`} href={href} {...externalProps}>
+    <a className={`${styles.card} ${className ? `${className}` : ''}`} href={href} {...externalProps}>
       <span className={styles.icon} style={iconColor ? { color: iconColor } : undefined} aria-hidden="true">
         {icon}
       </span>

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -54,7 +54,7 @@ export function Nav() {
         <div className={styles.links}>
           <a href="#top">Home</a>
           <a href="#what">Learn</a>
-          <a href="#demo">CLI</a>
+          <a href="#demo">Demo</a>
           <a href="https://docs.agentfacets.io" target="_self">
             Docs
           </a>

--- a/packages/landing/src/hooks/useRotation.ts
+++ b/packages/landing/src/hooks/useRotation.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Cycle through `items` once on a fixed cadence, then stop on the
+ * last item. Returns the current item and its index.
+ *
+ * Reduced-motion users see the first item only — no cycling at all.
+ *
+ * One-shot semantics are deliberate: the landing-page rotors all
+ * settle on a final "thesis" word ("Manage", "capabilities") that
+ * the page is supposed to leave the visitor with. A rotor that
+ * loops forever is almost certainly a bug. If you ever need looping
+ * back, add it as an opt-in `{ loop: true }` option — don't change
+ * the default.
+ *
+ * @example
+ *   const [verb] = useRotation(['Find', 'Install', 'Manage'], 3500)
+ *   //=> 'Find' → (3.5s) → 'Install' → (3.5s) → 'Manage' (held forever)
+ */
+export function useRotation<T>(items: readonly T[], intervalMs: number): readonly [T, number] {
+  const [i, setI] = useState(0)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      if (reduce) return
+    }
+    // Already on the last item — nothing more to advance to. Skip
+    // the interval entirely so we don't waste a timer firing every
+    // intervalMs just to no-op.
+    if (i >= items.length - 1) return
+    const id = window.setTimeout(() => setI((n) => n + 1), intervalMs)
+    return () => window.clearTimeout(id)
+  }, [i, items, intervalMs])
+
+  return [items[i] as T, i] as const
+}

--- a/packages/landing/src/hooks/useScrambleTo.ts
+++ b/packages/landing/src/hooks/useScrambleTo.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+const SCRAMBLE_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ#$%&/<>{}+=*'
+
+/**
+ * Animate `target` text in by scrambling random glyphs and progressively
+ * revealing the real characters left-to-right over `ms`. Spaces are
+ * preserved so multi-word strings ("mcp servers") don't shift width.
+ *
+ * Honors `prefers-reduced-motion` — reduces to a static pass-through.
+ *
+ * @example
+ *   const out = useScrambleTo(noun, 700)  //=> 'a%X#3' → 'agents'
+ */
+export function useScrambleTo(target: string, ms = 700): string {
+  const [out, setOut] = useState(target)
+  const startedFor = useRef(target)
+
+  useEffect(() => {
+    startedFor.current = target
+
+    if (typeof window !== 'undefined') {
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      if (reduce) {
+        setOut(target)
+        return
+      }
+    }
+
+    const start = performance.now()
+    let raf = 0
+
+    const tick = (now: number) => {
+      // Bail if a newer target has superseded this animation.
+      if (startedFor.current !== target) return
+      const t = Math.min(1, (now - start) / ms)
+      const reveal = Math.floor(t * target.length)
+      let s = ''
+      for (let i = 0; i < target.length; i++) {
+        if (i < reveal || target[i] === ' ') s += target[i]
+        else s += SCRAMBLE_CHARS[Math.floor(Math.random() * SCRAMBLE_CHARS.length)]
+      }
+      setOut(s)
+      if (t < 1) raf = requestAnimationFrame(tick)
+      else setOut(target)
+    }
+
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [target, ms])
+
+  return out
+}

--- a/packages/landing/src/hooks/useTheme.ts
+++ b/packages/landing/src/hooks/useTheme.ts
@@ -2,47 +2,102 @@ import { useCallback, useEffect, useState } from 'react'
 
 export type Theme = 'dark' | 'light'
 
+/**
+ * Internal mode state. `'system'` means we're tracking the OS preference
+ * reactively; `'dark'` / `'light'` means the user has made an explicit
+ * choice that overrides the OS.
+ *
+ * The hook's public API still returns just `Theme` (the resolved value)
+ * — `'system'` never escapes the hook.
+ */
+type Mode = 'system' | Theme
+
 const STORAGE_KEY = 'agentfacets.theme'
 const DEFAULT_THEME = 'light' satisfies Theme
 
-function readInitialTheme(): Theme {
+function getSystemTheme(): Theme {
   if (typeof window === 'undefined') return DEFAULT_THEME
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function readInitialMode(): Mode {
+  if (typeof window === 'undefined') return 'system'
   try {
     const stored = window.localStorage.getItem(STORAGE_KEY)
-
     if (stored === 'dark' || stored === 'light') return stored
-
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    return 'system'
   } catch {
-    return DEFAULT_THEME
+    return 'system'
   }
 }
 
+function resolveTheme(mode: Mode): Theme {
+  return mode === 'system' ? getSystemTheme() : mode
+}
+
 /**
- * Read + toggle the landing page's theme. Persists to `localStorage` and
- * mirrors the value onto `document.documentElement.dataset.theme` so CSS
- * custom properties swap between the dark and light variable sets.
+ * Read + toggle the landing page's theme. Three internal modes:
+ *
+ *   - `'system'`  — track OS preference reactively (default on first visit)
+ *   - `'light'`   — explicit user choice, persisted to localStorage
+ *   - `'dark'`    — explicit user choice, persisted to localStorage
+ *
+ * Behavior:
+ *   - First visit (no localStorage entry): mode is `'system'`. Displayed
+ *     theme follows OS preference, including live OS-level changes.
+ *   - User clicks the toggle: mode flips between explicit `'light'` and
+ *     `'dark'`, persisted so refreshes are sticky.
+ *   - User has explicit choice AND OS preference changes mid-session:
+ *     we wipe the localStorage entry and snap back to `'system'`, on
+ *     the assumption that the OS change is a stronger signal than the
+ *     stale explicit choice.
+ *
+ * The hook returns the resolved `Theme` (never `'system'`) plus a toggle.
  */
 export function useTheme(): readonly [Theme, () => void] {
-  const [theme, setTheme] = useState<Theme>(readInitialTheme)
+  const [mode, setMode] = useState<Mode>(readInitialMode)
+  const [theme, setTheme] = useState<Theme>(() => resolveTheme(readInitialMode()))
 
+  // Mirror the resolved theme onto the DOM whenever it changes.
   useEffect(() => {
     document.documentElement.dataset.theme = theme
-    try {
-      window.localStorage.setItem(STORAGE_KEY, theme)
-    } catch {
-      // Storage may be unavailable (private mode, etc.) — non-fatal.
-    }
-
-    const darkQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    const handlePrefChange = (e: MediaQueryListEvent) => setTheme(e.matches ? 'dark' : 'light')
-
-    darkQuery.addEventListener('change', handlePrefChange)
-    return () => darkQuery.removeEventListener('change', handlePrefChange)
   }, [theme])
 
+  // Subscribe to OS-level theme changes. In `'system'` mode we just
+  // update the resolved theme; in explicit mode we treat the OS change
+  // as a signal to abandon the explicit choice (snap back to system).
+  useEffect(() => {
+    const darkQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handlePrefChange = (e: MediaQueryListEvent) => {
+      const next: Theme = e.matches ? 'dark' : 'light'
+      if (mode === 'system') {
+        setTheme(next)
+        return
+      }
+      // Explicit mode + OS changed: snap back to system.
+      try {
+        window.localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // Storage may be unavailable (private mode, etc.) — non-fatal.
+      }
+      setMode('system')
+      setTheme(next)
+    }
+    darkQuery.addEventListener('change', handlePrefChange)
+    return () => darkQuery.removeEventListener('change', handlePrefChange)
+  }, [mode])
+
   const toggle = useCallback(() => {
-    setTheme((current) => (current === 'dark' ? 'light' : 'dark'))
+    setTheme((current) => {
+      const next: Theme = current === 'dark' ? 'light' : 'dark'
+      setMode(next)
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next)
+      } catch {
+        // Storage may be unavailable (private mode, etc.) — non-fatal.
+      }
+      return next
+    })
   }, [])
 
   return [theme, toggle] as const

--- a/packages/landing/src/hooks/useTypeRotation.ts
+++ b/packages/landing/src/hooks/useTypeRotation.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Type-in / hold / type-out rotor. Cycles through `items` once by
+ * typing each one character at a time, holding briefly, deleting
+ * backward, and advancing. The final item types in, holds, and then
+ * stays visible forever — there's no perpetual loop. The current
+ * partial string is exposed as `shown`.
+ *
+ * Reduced-motion users see the first item, fully typed, with no
+ * cycling.
+ *
+ * Cadences (in ms) are tuned to feel like a confident terminal-style
+ * prompt — not too fast, not too slow:
+ *   - typeMs: time per character while typing in
+ *   - holdMs: pause once fully typed
+ *   - deleteMs: time per character while typing out (faster than typing in)
+ *
+ * One-shot semantics are deliberate. A rotor that loops forever is
+ * almost certainly a bug — the landing-page sub line is supposed to
+ * settle on a final "thesis" word ("any tool"). If you ever need
+ * looping back, add it as an opt-in `{ loop: true }` option —
+ * don't change the default.
+ *
+ * Caller is responsible for passing a stable `items` reference. If
+ * `items` is recreated on every render (e.g., as an inline literal),
+ * the effect will re-fire on every render and the typing will reset.
+ * The standard React contract: memoize at the call site.
+ *
+ * @example
+ *   const { shown } = useTypeRotation(['Claude', 'Codex', 'any tool'])
+ *   //=> cycles Claude → Codex → any tool, then holds "any tool" forever
+ */
+export function useTypeRotation(
+  items: readonly string[],
+  opts: { typeMs?: number; holdMs?: number; deleteMs?: number } = {},
+): { shown: string; index: number; done: boolean } {
+  const { typeMs = 70, holdMs = 1400, deleteMs = 35 } = opts
+  const [index, setIndex] = useState(0)
+  const [shown, setShown] = useState('')
+  const [phase, setPhase] = useState<'typing' | 'hold' | 'deleting' | 'done'>('typing')
+
+  useEffect(() => {
+    // Honor reduced motion: show the first item, fully typed, no cycle.
+    if (typeof window !== 'undefined') {
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      if (reduce) {
+        setShown(items[0] ?? '')
+        return
+      }
+    }
+
+    // Terminal state: the last item is fully typed and we've held.
+    // No timers, no further state transitions — the final word just
+    // stays on screen.
+    if (phase === 'done') return
+
+    const target = items[index] ?? ''
+    let timeoutId: number | undefined
+
+    if (phase === 'typing') {
+      if (shown.length < target.length) {
+        timeoutId = window.setTimeout(() => setShown(target.slice(0, shown.length + 1)), typeMs)
+      } else {
+        timeoutId = window.setTimeout(() => setPhase('hold'), 0)
+      }
+    } else if (phase === 'hold') {
+      // If we're on the final item, freeze here forever. Otherwise
+      // proceed to delete and advance.
+      const isLast = index === items.length - 1
+      if (isLast) {
+        timeoutId = window.setTimeout(() => setPhase('done'), holdMs)
+      } else {
+        timeoutId = window.setTimeout(() => setPhase('deleting'), holdMs)
+      }
+    } else {
+      // deleting
+      if (shown.length > 0) {
+        timeoutId = window.setTimeout(() => setShown(target.slice(0, shown.length - 1)), deleteMs)
+      } else {
+        // Advance to the next item and start typing it. We can't
+        // reach this branch on the last item — the hold branch
+        // above transitions straight to 'done' instead.
+        setIndex((i) => i + 1)
+        setPhase('typing')
+      }
+    }
+
+    return () => {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId)
+    }
+  }, [shown, phase, index, items, typeMs, holdMs, deleteMs])
+
+  return { shown, index, done: phase === 'done' }
+}

--- a/packages/landing/src/lib/__tests__/agent-prompt.test.ts
+++ b/packages/landing/src/lib/__tests__/agent-prompt.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Sanity check on the agent prompt asset.
+ *
+ * Why this test exists: the AgentPromptButton copies a short pointer
+ * to the clipboard that tells the agent to fetch
+ * https://agentfacets.io/agent-prompt.txt. That URL is served by the
+ * static-site upload of `packages/landing/public/agent-prompt.txt`.
+ * If the .txt file is accidentally deleted or moved, the button's
+ * pointer points at a 404 and the whole UX is broken.
+ *
+ * We don't snapshot the content (the prompt iterates) — we just
+ * assert the file exists, is non-empty, and starts with a recognizable
+ * header so a casual rename or truncation is caught.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { AGENT_PROMPT_POINTER, AGENT_PROMPT_URL } from '../agent-prompt'
+
+const PROMPT_FILE = join(import.meta.dir, '..', '..', '..', 'public', 'agent-prompt.txt')
+
+describe('agent-prompt.txt asset', () => {
+  test('exists at packages/landing/public/agent-prompt.txt', () => {
+    expect(existsSync(PROMPT_FILE)).toBe(true)
+  })
+
+  test('is non-empty', () => {
+    const size = statSync(PROMPT_FILE).size
+    expect(size).toBeGreaterThan(500)
+  })
+
+  test('starts with the recognizable header', () => {
+    const body = readFileSync(PROMPT_FILE, 'utf8')
+    // The header phrase is intentionally distinctive — if someone
+    // edits the file and removes this opening sentence, the test
+    // fails and forces a deliberate decision.
+    expect(body.startsWith('You are helping a user install and use facets')).toBe(true)
+  })
+})
+
+describe('agent-prompt pointer constants', () => {
+  test('AGENT_PROMPT_URL is the apex URL', () => {
+    expect(AGENT_PROMPT_URL).toBe('https://agentfacets.io/agent-prompt.txt')
+  })
+
+  test('AGENT_PROMPT_POINTER references the URL exactly once', () => {
+    expect(AGENT_PROMPT_POINTER).toContain(AGENT_PROMPT_URL)
+    // Guard against accidental duplication of the URL in the pointer.
+    const occurrences = AGENT_PROMPT_POINTER.split(AGENT_PROMPT_URL).length - 1
+    expect(occurrences).toBe(1)
+  })
+})

--- a/packages/landing/src/lib/agent-prompt.ts
+++ b/packages/landing/src/lib/agent-prompt.ts
@@ -1,0 +1,23 @@
+/**
+ * Single source of truth for the agent prompt URL and the pointer text
+ * the AgentPromptButton copies to the clipboard.
+ *
+ * The button does NOT copy the prompt body. It copies a short
+ * instruction pointing the agent at the canonical .txt URL. That keeps
+ * the UI stable while the prompt itself iterates — edits to the prompt
+ * mean editing one file (`packages/landing/public/agent-prompt.txt`)
+ * and re-deploying. No code change, no UI change.
+ *
+ * If you change `AGENT_PROMPT_URL` you also need to move the .txt file
+ * to the new path under `packages/landing/public/` so the static-site
+ * upload still serves it.
+ */
+
+export const AGENT_PROMPT_URL = 'https://agentfacets.io/agent-prompt.txt'
+
+/**
+ * Exact text the AgentPromptButton copies to the clipboard. Derived
+ * from `AGENT_PROMPT_URL` via template string so the URL is referenced
+ * once, not duplicated.
+ */
+export const AGENT_PROMPT_POINTER = `Please fetch and follow the instructions at ${AGENT_PROMPT_URL}`

--- a/packages/landing/src/lib/copy.ts
+++ b/packages/landing/src/lib/copy.ts
@@ -1,0 +1,53 @@
+/**
+ * Single source of truth for clipboard copying in the landing package.
+ *
+ * Consumers should NOT roll their own clipboard logic. Use
+ * `copyToClipboard` for the happy path; it handles the
+ * `navigator.clipboard` API when available and falls back to the
+ * legacy `document.execCommand('copy')` path for browsers without
+ * Clipboard API support or in non-secure contexts (e.g., http:// or
+ * file:// where the modern API is gated off).
+ */
+
+/**
+ * Legacy fallback that creates an off-screen `<textarea>`, selects its
+ * contents, and triggers `document.execCommand('copy')`. Returns
+ * `true` on success, `false` on any failure. Used when the modern
+ * Clipboard API isn't available.
+ */
+export function fallbackCopy(text: string): boolean {
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.cssText = 'position:fixed;top:-9999px;left:-9999px;opacity:0;'
+    document.body.appendChild(ta)
+    ta.select()
+    ta.setSelectionRange(0, text.length)
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Copy `text` to the clipboard. Tries `navigator.clipboard.writeText`
+ * first (only when `isSecureContext !== false`); falls back to
+ * `fallbackCopy` if the modern API is missing, blocked, or rejects.
+ *
+ * Always resolves — never throws. Returns `true` if the write
+ * succeeded by either mechanism, `false` if both failed.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText && window.isSecureContext !== false) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      return fallbackCopy(text)
+    }
+  }
+  return fallbackCopy(text)
+}

--- a/packages/landing/tsconfig.json
+++ b/packages/landing/tsconfig.json
@@ -11,7 +11,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["vite/client"]
+    "types": ["vite/client", "bun", "node"]
   },
   "include": ["src", "vite", "vite.config.ts"]
 }


### PR DESCRIPTION
### Why

The hero headline was static ("The package manager for AI agents.") and the eyebrow pill was non-interactive. This replaces the static headline with a rotating verb/noun pair to better communicate the breadth of what Facet does, and makes the eyebrow pill a clickable link to the alpha roadmap.

### Details

**Rotating headline**

The headline is split into two independently cycling slots:

- **Verb slot** (`Find` / `Install` / `Manage` / `Secure`) rotates every 3,500 ms via a new `useRotation` hook. A tiny monospace CLI hint (`facet search <name>`, etc.) cross-fades above the verb on the same beat, keyed to the same React `key` so the entrance animation fires on every cycle.
- **Noun slot** (`agents` / `skills` / `mcp servers` / `commands`) rotates every 2,000 ms. The displayed text is passed through a new `useScrambleTo` hook that animates each transition by scrambling random glyphs and progressively revealing the real characters left-to-right over 700 ms. Monospace is used for the noun so glyph-width variance during the scramble doesn't cause layout shift.

The two intervals are intentionally mismatched — LCM(3500, 2000) = 14,000 ms — so the slots drift rather than lock-step.

Both hooks short-circuit their intervals and animations when `prefers-reduced-motion: reduce` is set. The CSS `@media (prefers-reduced-motion: reduce)` block additionally disables the `fadeBlur` entrance animations so even the one-time mount doesn't animate.

**`useTheme` overhaul**

The hook now tracks a three-way internal `Mode` (`'system'` | `'light'` | `'dark'`). First-time visitors start in `'system'` mode and see live OS-preference tracking. An explicit toggle persists to `localStorage`. If the OS preference changes while the user has an explicit choice, the hook treats that as a stronger signal, wipes the stored value, and snaps back to `'system'`.

**Eyebrow link**

`Eyebrow` accepts an optional `href`. When provided it renders as an `<a>` with hover (color + background tint transition) and `focus-visible` (accent-colored outline) affordances. When omitted it renders as a `<div>`, preserving the original behavior.

### Verification

- Observe the verb and CLI hint cross-fading on their respective cadences; confirm the noun scrambles between values.
- Enable "Reduce Motion" in OS accessibility settings and confirm all animations freeze and the rotors stop cycling.
- Click the eyebrow pill and confirm navigation to the roadmap URL.
- Toggle the theme, then change the OS preference mid-session and confirm the explicit choice is cleared and the displayed theme follows the OS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly landing-page UI/animation changes, but `useTheme` behavior is materially altered (new `system` mode and auto-reset on OS theme changes) which could affect persisted user preferences and theme syncing across sessions.
> 
> **Overview**
> Updates the landing hero to a **rotating verb + noun headline**, with a new scramble animation for the noun and shared fade/blur transitions; adds `useRotation` and `useScrambleTo` hooks and honors `prefers-reduced-motion`.
> 
> Makes the hero `Eyebrow` pill optionally clickable via a new `href` prop (with hover/focus styles) and links it to the alpha roadmap.
> 
> Refactors `useTheme` to track an internal `system | light | dark` mode: first visit follows OS theme reactively, explicit toggles persist to `localStorage`, and OS theme changes can clear an explicit choice and revert back to system tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694fba74986892301097c64fdcc2d746c3712fe1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->