### PR TITLE
Wire CLI to live registry: add `facet search`, `facet list`, registry resolution in install pipeline, and InstallView marketing aesthetic

### DIFF
--- a/.changeset/mean-parents-train.md
+++ b/.changeset/mean-parents-train.md
@@ -1,0 +1,6 @@
+---
+"agent-facets": patch
+"@agent-facets/core": patch
+---
+
+Wire CLI to live registry: add `facet search`, `facet list`, registry resolution in install pipeline, and InstallView marketing aesthetic

--- a/packages/cli/src/__tests__/cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/cli.e2e.test.ts
@@ -17,10 +17,20 @@ if (!existsSync(CLI_PATH)) {
 // `self-update` shows in help with `self-upgrade` as a comma-joined alias on
 // the same line; we assert the canonical name only here, and the alias
 // rendering separately in self-update.e2e.test.ts.
-const IMPLEMENTED_COMMAND_NAMES = ['adapter', 'add', 'build', 'create', 'edit', 'install', 'self-update']
+const IMPLEMENTED_COMMAND_NAMES = [
+  'adapter',
+  'add',
+  'build',
+  'create',
+  'edit',
+  'install',
+  'list',
+  'search',
+  'self-update',
+]
 // Stubs — invocable (to surface "did you mean…" suggestions) but hidden from
 // the global help listing (Adjustment K).
-const STUB_COMMAND_NAMES = ['info', 'list', 'publish', 'remove', 'upgrade']
+const STUB_COMMAND_NAMES = ['info', 'publish', 'remove', 'upgrade']
 
 type ExecResult = {
   stdout: string

--- a/packages/cli/src/__tests__/cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/cli.e2e.test.ts
@@ -25,12 +25,13 @@ const IMPLEMENTED_COMMAND_NAMES = [
   'edit',
   'install',
   'list',
+  'publish',
   'search',
   'self-update',
 ]
 // Stubs — invocable (to surface "did you mean…" suggestions) but hidden from
 // the global help listing (Adjustment K).
-const STUB_COMMAND_NAMES = ['info', 'publish', 'remove', 'upgrade']
+const STUB_COMMAND_NAMES = ['info', 'remove', 'upgrade']
 
 type ExecResult = {
   stdout: string

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -243,6 +243,157 @@ describe('InstallView — drift removal', () => {
   })
 })
 
+describe('InstallView — marketing aesthetic on `add`', () => {
+  test('renders bundle viz line and "Now /<cmd> is available" landing line', async () => {
+    const events: StageEvent[] = [
+      { kind: 'install-start', totalFacets: 1 },
+      { kind: 'facet-start', facet: 'cowsay', specifier: 'cowsay@latest' },
+      {
+        kind: 'facet-success',
+        facet: 'cowsay',
+        outcome: { kind: 'installed', name: 'cowsay', version: '0.1.0' },
+      },
+      { kind: 'install-complete', outcome: 'success' },
+    ]
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: {
+        lockfileVersion: 1,
+        facets: {
+          cowsay: {
+            source: 'cowsay@latest',
+            version: '0.1.0',
+            integrity: 'sha256:x',
+            assets: [
+              { scope: 'project', type: 'command', name: 'cowsay' },
+              { scope: 'project', type: 'skill', name: 'ascii-art' },
+            ],
+          },
+        },
+      },
+      summary: {
+        installed: 1,
+        updated: 0,
+        repaired: 0,
+        unchanged: 0,
+        removed: 0,
+        totalAssets: 2,
+        removedAssets: 0,
+      },
+      perFacet: [{ kind: 'installed', name: 'cowsay', version: '0.1.0' }],
+      serverWarnings: [],
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'add',
+        run: makeFakeRun(events, result),
+      }),
+    )
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('+ 1 skill · 1 command')
+    expect(frame).toContain('Now /cowsay is available to your agents.')
+    instance.unmount()
+  })
+
+  test('omits the landing line when no command asset shipped', async () => {
+    const events: StageEvent[] = [
+      { kind: 'install-start', totalFacets: 1 },
+      { kind: 'facet-start', facet: 'pure-skills', specifier: 'pure-skills@1.0.0' },
+      {
+        kind: 'facet-success',
+        facet: 'pure-skills',
+        outcome: { kind: 'installed', name: 'pure-skills', version: '1.0.0' },
+      },
+      { kind: 'install-complete', outcome: 'success' },
+    ]
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: {
+        lockfileVersion: 1,
+        facets: {
+          'pure-skills': {
+            source: 'pure-skills@1.0.0',
+            version: '1.0.0',
+            integrity: 'sha256:x',
+            assets: [{ scope: 'project', type: 'skill', name: 'planning' }],
+          },
+        },
+      },
+      summary: {
+        installed: 1,
+        updated: 0,
+        repaired: 0,
+        unchanged: 0,
+        removed: 0,
+        totalAssets: 1,
+        removedAssets: 0,
+      },
+      perFacet: [{ kind: 'installed', name: 'pure-skills', version: '1.0.0' }],
+      serverWarnings: [],
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'add',
+        run: makeFakeRun(events, result),
+      }),
+    )
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('+ 1 skill')
+    expect(frame).not.toContain('is available to your agents')
+    instance.unmount()
+  })
+
+  test('skips the landing line on `mode: install` even when commands shipped', async () => {
+    const events: StageEvent[] = [
+      { kind: 'install-start', totalFacets: 1 },
+      { kind: 'facet-start', facet: 'cowsay', specifier: 'cowsay@latest' },
+      {
+        kind: 'facet-success',
+        facet: 'cowsay',
+        outcome: { kind: 'installed', name: 'cowsay', version: '0.1.0' },
+      },
+    ]
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: {
+        lockfileVersion: 1,
+        facets: {
+          cowsay: {
+            source: 'cowsay@latest',
+            version: '0.1.0',
+            integrity: 'sha256:x',
+            assets: [{ scope: 'project', type: 'command', name: 'cowsay' }],
+          },
+        },
+      },
+      summary: {
+        installed: 1,
+        updated: 0,
+        repaired: 0,
+        unchanged: 0,
+        removed: 0,
+        totalAssets: 1,
+        removedAssets: 0,
+      },
+      perFacet: [{ kind: 'installed', name: 'cowsay', version: '0.1.0' }],
+      serverWarnings: [],
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun(events, result),
+      }),
+    )
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('+ 1 command')
+    expect(frame).not.toContain('is available to your agents')
+    instance.unmount()
+  })
+})
+
 describe('InstallView — empty / no-op', () => {
   test('renders the no-op message when nothing changes', async () => {
     const events: StageEvent[] = [

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -345,6 +345,78 @@ describe('InstallView — marketing aesthetic on `add`', () => {
     instance.unmount()
   })
 
+  test("counts only THIS run's facets, not pre-existing lockfile entries", async () => {
+    // Regression for the PR review finding: when `facet add cowsay` runs
+    // against a project that already has `existing-skill` in the lockfile,
+    // the bundle viz must show only cowsay's assets — not the project total.
+    const events: StageEvent[] = [
+      { kind: 'install-start', totalFacets: 1 },
+      { kind: 'facet-start', facet: 'cowsay', specifier: 'cowsay@latest' },
+      {
+        kind: 'facet-success',
+        facet: 'cowsay',
+        outcome: { kind: 'installed', name: 'cowsay', version: '0.1.0' },
+      },
+      { kind: 'install-complete', outcome: 'success' },
+    ]
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: {
+        lockfileVersion: 1,
+        facets: {
+          // pre-existing — must NOT appear in the count
+          'existing-skill': {
+            source: 'existing-skill@1.0.0',
+            version: '1.0.0',
+            integrity: 'sha256:y',
+            assets: [
+              { scope: 'project', type: 'skill', name: 'old-skill-a' },
+              { scope: 'project', type: 'skill', name: 'old-skill-b' },
+              { scope: 'project', type: 'command', name: 'old-command' },
+            ],
+          },
+          // newly installed this run
+          cowsay: {
+            source: 'cowsay@latest',
+            version: '0.1.0',
+            integrity: 'sha256:x',
+            assets: [{ scope: 'project', type: 'command', name: 'cowsay' }],
+          },
+        },
+      },
+      summary: {
+        installed: 1,
+        updated: 0,
+        repaired: 0,
+        unchanged: 1,
+        removed: 0,
+        totalAssets: 1,
+        removedAssets: 0,
+      },
+      perFacet: [
+        { kind: 'installed', name: 'cowsay', version: '0.1.0' },
+        // pre-existing — `unchanged` must NOT contribute to the bundle viz
+        { kind: 'unchanged', name: 'existing-skill', version: '1.0.0' },
+      ],
+      serverWarnings: [],
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'add',
+        run: makeFakeRun(events, result),
+      }),
+    )
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    // Only cowsay's one command — no skills from `existing-skill`.
+    expect(frame).toContain('+ 1 command')
+    expect(frame).not.toContain('skill')
+    // Landing line picks up cowsay's command, not the pre-existing one.
+    expect(frame).toContain('Now /cowsay is available to your agents.')
+    expect(frame).not.toContain('old-command')
+    instance.unmount()
+  })
+
   test('skips the landing line on `mode: install` even when commands shipped', async () => {
     const events: StageEvent[] = [
       { kind: 'install-start', totalFacets: 1 },

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -4,6 +4,8 @@ import { buildCommand } from './commands/build.ts'
 import { createCommand } from './commands/create/index.ts'
 import { editCommand } from './commands/edit/index.ts'
 import { installCommand } from './commands/install/index.ts'
+import { listCommand } from './commands/list/index.ts'
+import { searchCommand } from './commands/search/index.ts'
 import { selfUpdateCommand } from './commands/self-update.ts'
 
 export type FlagDef = {
@@ -52,9 +54,10 @@ export const commands: Record<string, Command> = {
   edit: editCommand,
   info: stubCommand('info', 'Show information about a facet'),
   install: installCommand,
-  list: stubCommand('list', 'List installed facets'),
+  list: listCommand,
   publish: stubCommand('publish', 'Publish a facet to the registry'),
   remove: stubCommand('remove', 'Remove a facet from the project'),
+  search: searchCommand,
   'self-update': selfUpdateCommand,
   upgrade: stubCommand('upgrade', 'Upgrade installed facets'),
 }

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -5,6 +5,7 @@ import { createCommand } from './commands/create/index.ts'
 import { editCommand } from './commands/edit/index.ts'
 import { installCommand } from './commands/install/index.ts'
 import { listCommand } from './commands/list/index.ts'
+import { publishCommand } from './commands/publish/index.ts'
 import { searchCommand } from './commands/search/index.ts'
 import { selfUpdateCommand } from './commands/self-update.ts'
 
@@ -55,7 +56,7 @@ export const commands: Record<string, Command> = {
   info: stubCommand('info', 'Show information about a facet'),
   install: installCommand,
   list: listCommand,
-  publish: stubCommand('publish', 'Publish a facet to the registry'),
+  publish: publishCommand,
   remove: stubCommand('remove', 'Remove a facet from the project'),
   search: searchCommand,
   'self-update': selfUpdateCommand,

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -244,11 +244,10 @@ async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
  */
 async function peekFacetName(source: Source, specifier: string): Promise<string | null> {
   if (source.kind === 'registry') {
-    // Registry sources peek would require resolving against the
-    // registry, which is currently stubbed. Fall back to using the
-    // declared name (which matches the package name) so the manifest
-    // write succeeds; runInstall will surface the registry error when
-    // it tries to actually fetch.
+    // Registry source: the canonical name on the parsed source IS the
+    // facet name (the registry keys by canonical name), so we can write
+    // the manifest entry without a network round-trip. runInstall will
+    // verify the manifest's declared name matches when it downloads.
     return source.name
   }
   const { loadManifest } = await import('@agent-facets/core')

--- a/packages/cli/src/commands/list/__tests__/list.test.ts
+++ b/packages/cli/src/commands/list/__tests__/list.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureStderr, captureStdout } from '../../../__tests__/helpers/capture-std.ts'
+import { listCommand } from '../index.ts'
+
+let projectRoot: string
+let originalCwd: string
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'facet-list-test-'))
+  originalCwd = process.cwd()
+  process.chdir(projectRoot)
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  rmSync(projectRoot, { recursive: true, force: true })
+})
+
+describe('listCommand', () => {
+  test('not-a-project: prints helpful hint when facets.json is absent', async () => {
+    const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('No facets.json in this directory')
+    expect(stdout).toContain("'facet add <name>'")
+  })
+
+  test('empty: prints "no facets installed" when facets.json has no entries', async () => {
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: {} }))
+    const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('No facets installed in this project')
+  })
+
+  test('single entry without lockfile: shows source specifier', async () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({ facets: { 'viper-plans': 'github:agent-facets/viper-plans' } }),
+    )
+    const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('viper-plans')
+    expect(stdout).toContain('github:agent-facets/viper-plans')
+  })
+
+  test('multiple entries: aligns the value column to the longest name', async () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        facets: {
+          a: 'short',
+          'much-longer-name': 'short',
+        },
+      }),
+    )
+    const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
+    expect(result).toBe(0)
+    const lines = stdout.split('\n').filter((l) => l.length > 0)
+    expect(lines).toHaveLength(2)
+    // The value `short` should land at the same column index in both lines.
+    const indices = lines.map((l) => l.indexOf('short'))
+    expect(indices[0]).toBe(indices[1])
+  })
+
+  test('with lockfile: prefers resolved version over source specifier', async () => {
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { cowsay: 'cowsay@latest' } }))
+    writeFileSync(
+      join(projectRoot, 'facets.lock'),
+      JSON.stringify({
+        lockfileVersion: 1,
+        facets: {
+          cowsay: {
+            source: 'cowsay@latest',
+            version: '0.1.0',
+            integrity: 'sha256-deadbeef',
+            assets: [],
+          },
+        },
+      }),
+    )
+    const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('cowsay')
+    expect(stdout).toContain('0.1.0')
+    // Source specifier should NOT appear — version takes precedence.
+    expect(stdout).not.toContain('cowsay@latest')
+  })
+
+  test('lockfile missing for one entry: falls back to source for that entry only', async () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        facets: {
+          installed: 'installed@1.0.0',
+          'not-installed': 'github:org/not-installed',
+        },
+      }),
+    )
+    writeFileSync(
+      join(projectRoot, 'facets.lock'),
+      JSON.stringify({
+        lockfileVersion: 1,
+        facets: {
+          installed: {
+            source: 'installed@1.0.0',
+            version: '1.0.0',
+            integrity: 'sha256-x',
+            assets: [],
+          },
+        },
+      }),
+    )
+    const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('1.0.0')
+    expect(stdout).toContain('github:org/not-installed')
+  })
+
+  test('malformed facets.json: writes a CliError and exits non-zero', async () => {
+    writeFileSync(join(projectRoot, 'facets.json'), '{not valid json')
+    const { result, stderr } = await captureStderr(() => listCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('facets.json is malformed')
+  })
+
+  test('positional args are rejected', async () => {
+    const { result, stderr } = await captureStderr(() => listCommand.run(['extra'], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('does not accept positional arguments')
+  })
+})

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -1,0 +1,96 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { FACETS_LOCK_FILE, loadFacetsJson, loadLockfile } from '@agent-facets/core'
+import type { Command } from '../../commands.ts'
+import { writeCliError } from '../../util/errors.ts'
+
+/**
+ * `facet list` — show the facets installed in the current project.
+ *
+ * Pulls names + source specifiers from `facets.json`. When `facets.lock`
+ * exists, prefers the resolved version from there (gives the user "what
+ * actually got installed" rather than "what was requested"). For entries
+ * present in facets.json but missing from the lockfile (un-installed
+ * dependencies), shows the source specifier so the user knows to run
+ * `facet install`.
+ *
+ * No network calls. No "updates available" indicator (deferred to alpha).
+ */
+export const listCommand: Command = {
+  name: 'list',
+  description: 'List installed facets',
+  implemented: true,
+  run: async (args, _flags) => {
+    if (args.length > 0) {
+      writeCliError({
+        what: `facet list does not accept positional arguments (got "${args[0]}")`,
+        fix: "use 'facet search <term>' to browse the registry",
+      })
+      return 1
+    }
+
+    const projectRoot = process.cwd()
+    const facetsJsonPath = join(projectRoot, 'facets.json')
+
+    if (!existsSync(facetsJsonPath)) {
+      // "Forward-compatible" hint per the work plan: `facet init` doesn't
+      // exist yet, so we point at `facet add` which lazily creates
+      // facets.json on first use.
+      process.stdout.write(
+        [
+          'No facets.json in this directory.',
+          "  Try 'facet add <name>' to add one, or 'facet search' to browse.",
+          '',
+        ].join('\n'),
+      )
+      return 0
+    }
+
+    const facetsJsonResult = loadFacetsJson(projectRoot)
+    if (!facetsJsonResult.ok) {
+      writeCliError({
+        what: 'facets.json is malformed',
+        detail: facetsJsonResult.error,
+        fix: 'fix the JSON syntax or schema errors and try again',
+      })
+      return 1
+    }
+
+    const declared = Object.entries(facetsJsonResult.data.facets)
+    if (declared.length === 0) {
+      process.stdout.write(
+        [
+          'No facets installed in this project.',
+          "  Try 'facet add <name>' to add one, or 'facet search' to browse.",
+          '',
+        ].join('\n'),
+      )
+      return 0
+    }
+
+    // Look up resolved versions from the lockfile when present. Lockfile
+    // misses (entry declared but not yet installed) fall back to the source
+    // specifier so the user can tell at a glance which entries need
+    // `facet install` to materialize.
+    const lockfileResult = loadLockfile(projectRoot)
+    const lockfile = lockfileResult.ok && lockfileResult.existed ? lockfileResult.data : undefined
+    if (!lockfileResult.ok) {
+      // Surface lockfile damage but don't block the listing — degrade to
+      // showing source specifiers only.
+      process.stderr.write(
+        `warning: ${FACETS_LOCK_FILE} is malformed (${lockfileResult.error}); showing source specifiers instead of resolved versions\n`,
+      )
+    }
+
+    const rows = declared.map(([name, source]) => {
+      const lockEntry = lockfile?.facets[name]
+      const value = lockEntry !== undefined ? lockEntry.version : source
+      return { name, value }
+    })
+
+    const nameWidth = rows.reduce((max, r) => Math.max(max, r.name.length), 0)
+    const lines = rows.map((r) => `${r.name.padEnd(nameWidth)}  ${r.value}`)
+    process.stdout.write(`${lines.join('\n')}\n`)
+    return 0
+  },
+}

--- a/packages/cli/src/commands/publish/__tests__/publish.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publish.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { captureStderr, captureStdout } from '../../../__tests__/helpers/capture-std.ts'
+import { publishCommand } from '../index.ts'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_KEY = process.env.FACET_REGISTRY_API_KEY
+const ORIGINAL_URL = process.env.FACET_REGISTRY_URL
+
+let projectRoot: string
+let originalCwd: string
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'facet-publish-test-'))
+  originalCwd = process.cwd()
+  process.chdir(projectRoot)
+  process.env.FACET_REGISTRY_URL = 'https://api.test/v0'
+  process.env.FACET_REGISTRY_API_KEY = 'test-key'
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  rmSync(projectRoot, { recursive: true, force: true })
+  globalThis.fetch = ORIGINAL_FETCH
+  if (ORIGINAL_KEY === undefined) delete process.env.FACET_REGISTRY_API_KEY
+  else process.env.FACET_REGISTRY_API_KEY = ORIGINAL_KEY
+  if (ORIGINAL_URL === undefined) delete process.env.FACET_REGISTRY_URL
+  else process.env.FACET_REGISTRY_URL = ORIGINAL_URL
+})
+
+function writeManifest(version: string): void {
+  writeFileSync(
+    join(projectRoot, 'facet.json'),
+    JSON.stringify({
+      name: 'cowsay',
+      version,
+      commands: { cowsay: { description: 'ascii cow' } },
+    }),
+  )
+  mkdirSync(join(projectRoot, 'commands'), { recursive: true })
+  writeFileSync(join(projectRoot, 'commands/cowsay.md'), '# cowsay\n')
+}
+
+describe('publishCommand', () => {
+  test('happy path: publishes the on-disk version verbatim, returns 0 on 201', async () => {
+    writeManifest('0.1.0')
+    let calledUrl = ''
+    let calledHeaders: Record<string, string> = {}
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calledUrl = String(input)
+      calledHeaders = init?.headers as Record<string, string>
+      return new Response(JSON.stringify({}), { status: 201 })
+    }) as unknown as typeof fetch
+
+    const { result, stdout } = await captureStdout(() => publishCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(calledUrl).toBe('https://api.test/v0/packages/cowsay/versions')
+    expect(calledHeaders['x-api-key']).toBe('test-key')
+    expect(calledHeaders['content-type']).toBe('application/gzip')
+    expect(stdout).toContain('Published cowsay@0.1.0')
+    // Manifest on disk MUST NOT be mutated by publish.
+    const updated = JSON.parse(readFileSync(join(projectRoot, 'facet.json'), 'utf8')) as { version: string }
+    expect(updated.version).toBe('0.1.0')
+  })
+
+  test('namespaced facet: URL-encodes the slash', async () => {
+    writeFileSync(join(projectRoot, 'facet.json'), JSON.stringify({ name: 'acme/cowsay', version: '0.1.0' }))
+    let calledUrl = ''
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calledUrl = String(input)
+      return new Response('{}', { status: 201 })
+    }) as unknown as typeof fetch
+
+    await captureStdout(() => publishCommand.run([], {}))
+    expect(calledUrl).toBe('https://api.test/v0/packages/acme%2Fcowsay/versions')
+  })
+
+  test('missing API key: fails before any HTTP call and does not touch disk', async () => {
+    writeManifest('0.1.0')
+    delete process.env.FACET_REGISTRY_API_KEY
+    let attempts = 0
+    globalThis.fetch = (async () => {
+      attempts++
+      return new Response('{}', { status: 201 })
+    }) as unknown as typeof fetch
+
+    const { result, stderr } = await captureStderr(() => publishCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(attempts).toBe(0)
+    expect(stderr).toContain('FACET_REGISTRY_API_KEY')
+    expect(stderr).toContain('docs:')
+    const v = JSON.parse(readFileSync(join(projectRoot, 'facet.json'), 'utf8')) as { version: string }
+    expect(v.version).toBe('0.1.0')
+  })
+
+  test('no facet.json: clean error', async () => {
+    const { result, stderr } = await captureStderr(() => publishCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('no facet.json')
+  })
+
+  test('413 (tarball too large): translates to clean error', async () => {
+    writeManifest('0.1.0')
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: 'tarball exceeds the 5 MB size limit',
+          code: 'E_TARBALL_TOO_LARGE',
+          docsUrl: 'https://agentfacets.io/errors/E_TARBALL_TOO_LARGE',
+        }),
+        { status: 413 },
+      )) as unknown as typeof fetch
+    const { result, stderr } = await captureStderr(() => publishCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('exceeds size limit')
+    expect(stderr).toContain('5 MB')
+  })
+
+  test('409 VERSION_EXISTS: surfaces a clean error pointing at manual bump, no retry, no mutation', async () => {
+    writeManifest('0.1.0')
+    let attempts = 0
+    globalThis.fetch = (async () => {
+      attempts++
+      return new Response(
+        JSON.stringify({
+          error: 'version 0.1.0 already exists',
+          code: 'VERSION_EXISTS',
+          docsUrl: 'https://agentfacets.io/errors/VERSION_EXISTS',
+        }),
+        { status: 409 },
+      )
+    }) as unknown as typeof fetch
+
+    const { result, stderr } = await captureStderr(() => publishCommand.run([], {}))
+    expect(result).toBe(1)
+    // Exactly one attempt — no auto-retry-with-rebump.
+    expect(attempts).toBe(1)
+    expect(stderr).toContain('version 0.1.0 already exists')
+    expect(stderr).toContain('bump `version` in facet.json')
+    // facet.json must be untouched.
+    const v = JSON.parse(readFileSync(join(projectRoot, 'facet.json'), 'utf8')) as { version: string }
+    expect(v.version).toBe('0.1.0')
+  })
+
+  test('network failure: surfaces clean error and does not mutate facet.json', async () => {
+    writeManifest('0.1.0')
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed')
+    }) as unknown as typeof fetch
+    const { result, stderr } = await captureStderr(() => publishCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('registry temporarily unavailable')
+    const v = JSON.parse(readFileSync(join(projectRoot, 'facet.json'), 'utf8')) as { version: string }
+    expect(v.version).toBe('0.1.0')
+  })
+
+  test('positional args are rejected', async () => {
+    const { result, stderr } = await captureStderr(() => publishCommand.run(['extra'], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('does not accept positional arguments')
+  })
+})

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -1,0 +1,170 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { encodeFacetName, getRegistryBaseUrl, packFacetSource } from '@agent-facets/core'
+import type { Command } from '../../commands.ts'
+import { writeCliError } from '../../util/errors.ts'
+import {
+  isRegistryErrorResponse,
+  type RegistryErrorResponse,
+  translateRegistryError,
+} from '../../util/registry-errors.ts'
+
+/**
+ * `facet publish` — package the current directory as a `.tar.gz` and POST
+ * it to the registry.
+ *
+ * Publish does NOT mutate `facet.json`. The version published is whatever
+ * is on disk; bumping the version is an explicit user action (edit
+ * `facet.json` and re-run). On a 409 `VERSION_EXISTS`, we surface a
+ * clean error pointing the user at the manual bump — no silent retry,
+ * no auto-bump dance. Local mutations driven by a network operation
+ * are surprising; we don't do them.
+ *
+ * Future work: a `--bump patch|minor|major` flag will reintroduce
+ * version mutation as an explicit, opt-in user request that prompts
+ * for confirmation before writing.
+ */
+export const publishCommand: Command = {
+  name: 'publish',
+  description: 'Publish a facet to the registry',
+  implemented: true,
+  run: async (args, _flags) => {
+    if (args.length > 0) {
+      writeCliError({
+        what: `facet publish does not accept positional arguments (got "${args[0]}")`,
+        fix: 'cd into the facet source directory and run `facet publish`',
+      })
+      return 1
+    }
+
+    const projectRoot = process.cwd()
+    const manifestPath = join(projectRoot, 'facet.json')
+    if (!existsSync(manifestPath)) {
+      writeCliError({
+        what: 'no facet.json in this directory',
+        detail: `looked at ${manifestPath}`,
+        fix: 'cd into a directory with facet.json or run `facet create` to scaffold one',
+      })
+      return 1
+    }
+
+    // Read API key BEFORE doing any work — fail fast so the user doesn't
+    // wait through a tarball pack just to be told their env isn't set up.
+    const apiKey = process.env.FACET_REGISTRY_API_KEY
+    if (apiKey === undefined || apiKey.length === 0) {
+      writeCliError({
+        what: 'FACET_REGISTRY_API_KEY environment variable not set',
+        fix: 'export FACET_REGISTRY_API_KEY=<key from registry admin>',
+        docsUrl: 'https://agentfacets.io/errors/E_API_KEY_MISSING',
+      })
+      return 1
+    }
+
+    let manifest: { name: string; version: string }
+    try {
+      const raw = readFileSync(manifestPath, 'utf8')
+      manifest = JSON.parse(raw) as { name: string; version: string }
+    } catch (err) {
+      writeCliError({
+        what: 'facet.json is not valid JSON',
+        detail: err instanceof Error ? err.message : String(err),
+        fix: 'fix the JSON syntax and try again',
+      })
+      return 1
+    }
+    if (typeof manifest.name !== 'string' || typeof manifest.version !== 'string') {
+      writeCliError({
+        what: 'facet.json is missing required fields',
+        detail: 'expected `name` and `version` (both strings)',
+        fix: 'add both fields and try again',
+      })
+      return 1
+    }
+
+    const tarball = await packFacetSource(projectRoot)
+    process.stdout.write(`Packed ${tarball.byteLength} bytes\n`)
+
+    const result = await postPublish({
+      base: getRegistryBaseUrl(),
+      name: manifest.name,
+      tarball,
+      apiKey,
+    })
+
+    if (result.kind === 'success') {
+      process.stdout.write(`Published ${manifest.name}@${manifest.version}.\n`)
+      return 0
+    }
+
+    if (result.kind === 'version-exists') {
+      writeCliError({
+        what: `version ${manifest.version} already exists in the registry`,
+        detail: result.envelope.error,
+        fix: 'bump `version` in facet.json and try again',
+        docsUrl: result.envelope.docsUrl,
+      })
+      return 1
+    }
+
+    writeCliError(result.failure)
+    return 1
+  },
+}
+
+interface PublishArgs {
+  base: string
+  name: string
+  tarball: Uint8Array
+  apiKey: string
+}
+
+type PublishResult =
+  | { kind: 'success' }
+  | { kind: 'version-exists'; envelope: RegistryErrorResponse }
+  | { kind: 'failure'; failure: import('../../util/errors.ts').CliError }
+
+async function postPublish(args: PublishArgs): Promise<PublishResult> {
+  const url = `${args.base}/packages/${encodeFacetName(args.name)}/versions`
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'x-api-key': args.apiKey,
+        'content-type': 'application/gzip',
+      },
+      body: args.tarball,
+    })
+  } catch (err) {
+    return {
+      kind: 'failure',
+      failure: {
+        what: 'registry temporarily unavailable',
+        detail: err instanceof Error ? err.message : String(err),
+        fix: 'try again in a moment',
+        docsUrl: 'https://agentfacets.io/errors/E_REGISTRY_UNAVAILABLE',
+      },
+    }
+  }
+  if (response.ok) return { kind: 'success' }
+
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    body = undefined
+  }
+  if (isRegistryErrorResponse(body)) {
+    if (body.code === 'VERSION_EXISTS') return { kind: 'version-exists', envelope: body }
+    return { kind: 'failure', failure: translateRegistryError(body) }
+  }
+  return {
+    kind: 'failure',
+    failure: {
+      what: 'registry returned an unexpected response',
+      detail: `HTTP ${response.status} ${response.statusText}`,
+      fix: 'try again in a moment',
+      docsUrl: 'https://agentfacets.io/errors/E_REGISTRY_UNAVAILABLE',
+    },
+  }
+}

--- a/packages/cli/src/commands/search/__tests__/search.test.ts
+++ b/packages/cli/src/commands/search/__tests__/search.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { captureStderr, captureStdout } from '../../../__tests__/helpers/capture-std.ts'
+import { searchCommand } from '../index.ts'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_ENV = process.env.FACET_REGISTRY_URL
+
+beforeEach(() => {
+  process.env.FACET_REGISTRY_URL = 'https://api.test/v0'
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  if (ORIGINAL_ENV === undefined) delete process.env.FACET_REGISTRY_URL
+  else process.env.FACET_REGISTRY_URL = ORIGINAL_ENV
+})
+
+function mockPackages(facets: ReadonlyArray<{ name: string; latestVersion: string; publishedAt?: string }>): void {
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        facets: facets.map((f) => ({
+          publishedAt: '2026-05-01T00:00:00Z',
+          ...f,
+        })),
+      }),
+      { status: 200 },
+    )) as unknown as typeof fetch
+}
+
+describe('searchCommand', () => {
+  test('empty registry: prints "no facets in the registry yet"', async () => {
+    mockPackages([])
+    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('No facets in the registry yet')
+  })
+
+  test('single match: renders headline + both copy-paste next-commands', async () => {
+    mockPackages([{ name: 'cowsay', latestVersion: '0.1.0' }])
+    const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('cowsay   v0.1.0')
+    expect(stdout).toContain('→ facet add cowsay')
+    expect(stdout).toContain('→ opencode run --command cowsay')
+  })
+
+  test('namespaced name: opencode command line uses last segment, facet add uses full canonical', async () => {
+    mockPackages([{ name: 'acme/cowsay', latestVersion: '0.1.0' }])
+    const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('→ facet add acme/cowsay')
+    expect(stdout).toContain('→ opencode run --command cowsay')
+    expect(stdout).not.toContain('--command acme/cowsay')
+  })
+
+  test('multiple matches: blank line between blocks', async () => {
+    mockPackages([
+      { name: 'cowsay', latestVersion: '0.1.0' },
+      { name: 'mooing-cow', latestVersion: '0.2.0' },
+    ])
+    const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('cowsay')
+    expect(stdout).toContain('mooing-cow')
+    expect(stdout).toContain('\n\n')
+  })
+
+  test('case-insensitive substring match', async () => {
+    mockPackages([{ name: 'CamelCaseName', latestVersion: '1.0.0' }])
+    const { result, stdout } = await captureStdout(() => searchCommand.run(['camel'], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('CamelCaseName')
+  })
+
+  test('no-args lists everything', async () => {
+    mockPackages([
+      { name: 'a', latestVersion: '1.0.0' },
+      { name: 'b', latestVersion: '2.0.0' },
+    ])
+    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('a')
+    expect(stdout).toContain('b')
+  })
+
+  test('no match for term: friendly hint pointing back at no-arg search', async () => {
+    mockPackages([{ name: 'cowsay', latestVersion: '0.1.0' }])
+    const { result, stdout } = await captureStdout(() => searchCommand.run(['xyz-not-there'], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('No facets match "xyz-not-there"')
+    expect(stdout).toContain("'facet search' with no args")
+  })
+
+  test('network failure: writes a CliError and returns 1', async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed')
+    }) as unknown as typeof fetch
+    const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('registry temporarily unavailable')
+    expect(stderr).toContain('docs:')
+  })
+
+  test('server returns Tier 2 error envelope: translates to a clean CliError', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: 'whoops',
+          code: 'E_REGISTRY_UNAVAILABLE',
+          docsUrl: 'https://agentfacets.io/errors/E_REGISTRY_UNAVAILABLE',
+        }),
+        { status: 503 },
+      )) as unknown as typeof fetch
+    const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('registry temporarily unavailable')
+    expect(stderr).toContain('try again in a moment')
+  })
+
+  test('rejects more than one positional arg', async () => {
+    const { result, stderr } = await captureStderr(() => searchCommand.run(['a', 'b'], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('at most one argument')
+  })
+
+  test('malformed JSON body: clean error', async () => {
+    globalThis.fetch = (async () => new Response('not json', { status: 200 })) as unknown as typeof fetch
+    const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('malformed response')
+  })
+
+  test('unexpected response shape: clean error pointing at self-update', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ items: [] }), { status: 200 })) as unknown as typeof fetch
+    const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('unexpected shape')
+  })
+})

--- a/packages/cli/src/commands/search/__tests__/search.test.ts
+++ b/packages/cli/src/commands/search/__tests__/search.test.ts
@@ -36,22 +36,24 @@ describe('searchCommand', () => {
     expect(stdout).toContain('No facets in the registry yet')
   })
 
-  test('single match: renders headline + both copy-paste next-commands', async () => {
+  test('single match: renders headline + facet add suggestion', async () => {
     mockPackages([{ name: 'cowsay', latestVersion: '0.1.0' }])
     const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
     expect(result).toBe(0)
     expect(stdout).toContain('cowsay   v0.1.0')
     expect(stdout).toContain('→ facet add cowsay')
-    expect(stdout).toContain('→ opencode run --command cowsay')
+    // We deliberately do not suggest an `opencode run --command ...` line
+    // because the V0 list endpoint doesn't return asset metadata; we'd
+    // be guessing the wrong command name for many facets.
+    expect(stdout).not.toContain('opencode run')
   })
 
-  test('namespaced name: opencode command line uses last segment, facet add uses full canonical', async () => {
+  test('namespaced name: facet add uses full canonical name', async () => {
     mockPackages([{ name: 'acme/cowsay', latestVersion: '0.1.0' }])
     const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
     expect(result).toBe(0)
     expect(stdout).toContain('→ facet add acme/cowsay')
-    expect(stdout).toContain('→ opencode run --command cowsay')
-    expect(stdout).not.toContain('--command acme/cowsay')
+    expect(stdout).not.toContain('opencode run')
   })
 
   test('multiple matches: blank line between blocks', async () => {

--- a/packages/cli/src/commands/search/index.ts
+++ b/packages/cli/src/commands/search/index.ts
@@ -7,16 +7,17 @@ import { registryFetch } from '../../util/registry-client.ts'
  * `term` (substring, case-insensitive). With no term, lists every facet
  * the registry returns (capped server-side at LIMIT 200 in V0).
  *
- * Each result includes the **two copy-paste next-commands** that take a
- * conference engineer from "I see this in the list" → "I have this
- * working in 30 seconds":
+ * Each result shows the canonical name, latest version, and the single
+ * copy-paste next step:
  *
  *   - `facet add <name>` — install it
- *   - `opencode run --command <last-segment>` — invoke a command asset
  *
- * The two-line block is the magical-moment delivery vehicle for the demo
- * arc; do NOT collapse it into a single line. Conference engineer at T+24h
- * doesn't remember the exact name; this shows them what to type.
+ * We deliberately do NOT suggest a downstream invocation (e.g.,
+ * `opencode run --command ...`) because the V0 list endpoint doesn't
+ * carry asset metadata: many facets ship arbitrary command names,
+ * multiple commands, or no commands at all (skill-only or agent-only).
+ * Once the registry returns asset names, we can add a runtime-correct
+ * suggestion line back.
  *
  * V0 registry returns `{name, latestVersion, publishedAt}` per result —
  * author/install-count/asset-counts are alpha+. Render gracefully without
@@ -25,7 +26,7 @@ import { registryFetch } from '../../util/registry-client.ts'
 export const searchCommand: Command = {
   name: 'search',
   description: 'Search the registry for facets',
-  usage: 'facet search [term]',
+  usage: '[term]',
   implemented: true,
   run: async (args, _flags) => {
     if (args.length > 1) {
@@ -108,14 +109,5 @@ function isPackagesResponse(value: unknown): value is PackagesResponse {
 
 function renderResult(f: RegistryFacetSummary): string {
   const headline = `${f.name}   v${f.latestVersion}`
-  // For namespaced canonical names (`acme/cowsay`), the invokable command
-  // name in adapters is the last segment only. Adapter command names don't
-  // carry namespaces — the namespace is a registry-level disambiguator.
-  const commandName = lastSegment(f.name)
-  return [headline, `  → facet add ${f.name}`, `  → opencode run --command ${commandName}`].join('\n')
-}
-
-function lastSegment(canonical: string): string {
-  const idx = canonical.lastIndexOf('/')
-  return idx === -1 ? canonical : canonical.slice(idx + 1)
+  return [headline, `  → facet add ${f.name}`].join('\n')
 }

--- a/packages/cli/src/commands/search/index.ts
+++ b/packages/cli/src/commands/search/index.ts
@@ -1,0 +1,121 @@
+import type { Command } from '../../commands.ts'
+import { writeCliError } from '../../util/errors.ts'
+import { registryFetch } from '../../util/registry-client.ts'
+
+/**
+ * `facet search [term]` — query the registry for facets whose name matches
+ * `term` (substring, case-insensitive). With no term, lists every facet
+ * the registry returns (capped server-side at LIMIT 200 in V0).
+ *
+ * Each result includes the **two copy-paste next-commands** that take a
+ * conference engineer from "I see this in the list" → "I have this
+ * working in 30 seconds":
+ *
+ *   - `facet add <name>` — install it
+ *   - `opencode run --command <last-segment>` — invoke a command asset
+ *
+ * The two-line block is the magical-moment delivery vehicle for the demo
+ * arc; do NOT collapse it into a single line. Conference engineer at T+24h
+ * doesn't remember the exact name; this shows them what to type.
+ *
+ * V0 registry returns `{name, latestVersion, publishedAt}` per result —
+ * author/install-count/asset-counts are alpha+. Render gracefully without
+ * them; absent fields just don't appear.
+ */
+export const searchCommand: Command = {
+  name: 'search',
+  description: 'Search the registry for facets',
+  usage: 'facet search [term]',
+  implemented: true,
+  run: async (args, _flags) => {
+    if (args.length > 1) {
+      writeCliError({
+        what: `facet search accepts at most one argument (got ${args.length})`,
+        fix: "use 'facet search <term>' or 'facet search' to list everything",
+      })
+      return 1
+    }
+    const term = args[0]
+
+    const result = await registryFetch('/packages')
+    if (!result.ok) {
+      writeCliError(result.failure)
+      return 1
+    }
+
+    let body: unknown
+    try {
+      body = await result.response.json()
+    } catch (err) {
+      writeCliError({
+        what: 'registry returned a malformed response',
+        detail: err instanceof Error ? err.message : String(err),
+        fix: 'try again in a moment',
+      })
+      return 1
+    }
+
+    if (!isPackagesResponse(body)) {
+      writeCliError({
+        what: 'registry returned an unexpected shape',
+        detail: 'expected { facets: [{ name, latestVersion, publishedAt }, ...] }',
+        fix: "this likely means the CLI is talking to a newer registry — try 'facet self-update'",
+      })
+      return 1
+    }
+
+    const all = body.facets
+    const filtered = term !== undefined ? all.filter((f) => f.name.toLowerCase().includes(term.toLowerCase())) : all
+
+    if (all.length === 0) {
+      process.stdout.write('No facets in the registry yet.\n')
+      return 0
+    }
+    if (filtered.length === 0) {
+      process.stdout.write(`No facets match "${term ?? ''}". Try 'facet search' with no args to list everything.\n`)
+      return 0
+    }
+
+    const blocks = filtered.map((f) => renderResult(f))
+    process.stdout.write(`${blocks.join('\n\n')}\n`)
+    return 0
+  },
+}
+
+interface RegistryFacetSummary {
+  name: string
+  latestVersion: string
+  publishedAt: string
+}
+
+interface PackagesResponse {
+  facets: RegistryFacetSummary[]
+}
+
+function isPackagesResponse(value: unknown): value is PackagesResponse {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (!Array.isArray(v.facets)) return false
+  return v.facets.every(
+    (f) =>
+      f !== null &&
+      typeof f === 'object' &&
+      typeof (f as Record<string, unknown>).name === 'string' &&
+      typeof (f as Record<string, unknown>).latestVersion === 'string' &&
+      typeof (f as Record<string, unknown>).publishedAt === 'string',
+  )
+}
+
+function renderResult(f: RegistryFacetSummary): string {
+  const headline = `${f.name}   v${f.latestVersion}`
+  // For namespaced canonical names (`acme/cowsay`), the invokable command
+  // name in adapters is the last segment only. Adapter command names don't
+  // carry namespaces — the namespace is a registry-level disambiguator.
+  const commandName = lastSegment(f.name)
+  return [headline, `  → facet add ${f.name}`, `  → opencode run --command ${commandName}`].join('\n')
+}
+
+function lastSegment(canonical: string): string {
+  const idx = canonical.lastIndexOf('/')
+  return idx === -1 ? canonical : canonical.slice(idx + 1)
+}

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -178,7 +178,7 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
         </Box>
       )}
 
-      {result?.ok && <SuccessSummary result={result} />}
+      {result?.ok && <SuccessSummary result={result} mode={mode} />}
       {result && !result.ok && <FailureBlock failure={result.failure} />}
       {result && !result.ok && !result.rollback.ok && (
         <Box flexDirection="column" marginTop={1}>
@@ -193,7 +193,7 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   )
 }
 
-function SuccessSummary({ result }: { result: RunInstallResult & { ok: true } }) {
+function SuccessSummary({ result, mode }: { result: RunInstallResult & { ok: true }; mode: 'add' | 'install' }) {
   const { summary } = result
   const isNoOp = summary.installed === 0 && summary.updated === 0 && summary.repaired === 0 && summary.removed === 0
   if (isNoOp) {
@@ -203,14 +203,69 @@ function SuccessSummary({ result }: { result: RunInstallResult & { ok: true } })
       </Box>
     )
   }
+  // Bundle viz: count what landed across all facets, by asset type. Per
+  // the marketing-site aesthetic we surface the breakdown so users see
+  // exactly which kind of capability they just gained.
+  const counts = countAssetsByType(result)
+  const bundleViz = formatBundleViz(counts)
+  // Landing line: pick a representative command asset name to render
+  // `Now /<cmd> is available to your agents.` This is the magical-moment
+  // delivery vehicle for the demo. Skip on `install` (existing facets,
+  // not a new capability) and when no command asset shipped.
+  const landingCommand = mode === 'add' ? firstCommandAsset(result) : undefined
   return (
     <Box flexDirection="column">
       <Text color={THEME.success} bold>
         Done.
       </Text>
       <Text color={THEME.hint}>{summaryLine(summary)}</Text>
+      {bundleViz !== null && <Text color={THEME.hint}>{bundleViz}</Text>}
+      {landingCommand !== undefined && (
+        <Text color={THEME.brand} bold>
+          Now /{landingCommand} is available to your agents.
+        </Text>
+      )}
     </Box>
   )
+}
+
+interface AssetCounts {
+  skill: number
+  agent: number
+  command: number
+}
+
+function countAssetsByType(result: RunInstallResult & { ok: true }): AssetCounts {
+  const counts: AssetCounts = { skill: 0, agent: 0, command: 0 }
+  for (const facet of Object.values(result.lockfile.facets)) {
+    for (const asset of facet.assets) {
+      counts[asset.type]++
+    }
+  }
+  return counts
+}
+
+function formatBundleViz(counts: AssetCounts): string | null {
+  const parts: string[] = []
+  if (counts.skill > 0) parts.push(`${counts.skill} skill${counts.skill === 1 ? '' : 's'}`)
+  if (counts.agent > 0) parts.push(`${counts.agent} agent${counts.agent === 1 ? '' : 's'}`)
+  if (counts.command > 0) parts.push(`${counts.command} command${counts.command === 1 ? '' : 's'}`)
+  if (parts.length === 0) return null
+  return `+ ${parts.join(' · ')}`
+}
+
+/**
+ * Pick the first command asset across all installed facets — the landing
+ * line uses it as the suggested invocation. Returns undefined when no
+ * facet shipped a command (e.g., skill-only or agent-only bundle).
+ */
+function firstCommandAsset(result: RunInstallResult & { ok: true }): string | undefined {
+  for (const facet of Object.values(result.lockfile.facets)) {
+    for (const asset of facet.assets) {
+      if (asset.type === 'command') return asset.name
+    }
+  }
+  return undefined
 }
 
 function summaryLine(summary: {

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -203,15 +203,15 @@ function SuccessSummary({ result, mode }: { result: RunInstallResult & { ok: tru
       </Box>
     )
   }
-  // Bundle viz: count what landed across all facets, by asset type. Per
-  // the marketing-site aesthetic we surface the breakdown so users see
-  // exactly which kind of capability they just gained.
+  // Bundle viz + landing line: only surface what landed THIS run. The
+  // lockfile carries every facet in the project; `perFacet` carries the
+  // outcomes from this invocation. The marketing aesthetic is "exactly
+  // which capability you just gained", so iterating the lockfile would
+  // advertise pre-existing facets every time the user adds one more.
   const counts = countAssetsByType(result)
   const bundleViz = formatBundleViz(counts)
-  // Landing line: pick a representative command asset name to render
-  // `Now /<cmd> is available to your agents.` This is the magical-moment
-  // delivery vehicle for the demo. Skip on `install` (existing facets,
-  // not a new capability) and when no command asset shipped.
+  // Skip the landing line on `install` (no new capability — just a sync)
+  // and when nothing this run shipped a command asset.
   const landingCommand = mode === 'add' ? firstCommandAsset(result) : undefined
   return (
     <Box flexDirection="column">
@@ -237,12 +237,29 @@ interface AssetCounts {
 
 function countAssetsByType(result: RunInstallResult & { ok: true }): AssetCounts {
   const counts: AssetCounts = { skill: 0, agent: 0, command: 0 }
-  for (const facet of Object.values(result.lockfile.facets)) {
+  for (const name of touchedFacetNames(result)) {
+    const facet = result.lockfile.facets[name]
+    if (facet === undefined) continue
     for (const asset of facet.assets) {
       counts[asset.type]++
     }
   }
   return counts
+}
+
+/**
+ * Names of facets actually written to disk in this run — installed,
+ * updated, or repaired. `unchanged` contributes no new assets and
+ * `removed` is rendered separately.
+ */
+function touchedFacetNames(result: RunInstallResult & { ok: true }): ReadonlyArray<string> {
+  const names: string[] = []
+  for (const outcome of result.perFacet) {
+    if (outcome.kind === 'installed' || outcome.kind === 'updated' || outcome.kind === 'repaired') {
+      names.push(outcome.name)
+    }
+  }
+  return names
 }
 
 function formatBundleViz(counts: AssetCounts): string | null {
@@ -255,12 +272,15 @@ function formatBundleViz(counts: AssetCounts): string | null {
 }
 
 /**
- * Pick the first command asset across all installed facets — the landing
- * line uses it as the suggested invocation. Returns undefined when no
- * facet shipped a command (e.g., skill-only or agent-only bundle).
+ * Pick the first command asset across the facets THIS RUN installed/updated
+ * — the landing line uses it as the suggested invocation. Returns undefined
+ * when no facet from this run shipped a command (e.g., skill-only or
+ * agent-only bundle, or only `unchanged` outcomes).
  */
 function firstCommandAsset(result: RunInstallResult & { ok: true }): string | undefined {
-  for (const facet of Object.values(result.lockfile.facets)) {
+  for (const name of touchedFacetNames(result)) {
+    const facet = result.lockfile.facets[name]
+    if (facet === undefined) continue
     for (const asset of facet.assets) {
       if (asset.type === 'command') return asset.name
     }

--- a/packages/cli/src/util/__tests__/errors.test.ts
+++ b/packages/cli/src/util/__tests__/errors.test.ts
@@ -48,6 +48,28 @@ describe('formatCliError', () => {
   test('substitutes (no detail) when detail is the empty string', () => {
     expect(formatCliError({ what: 'x', detail: '', fix: 'y' })).toContain('(no detail)')
   })
+
+  test('appends a docs: line when docsUrl is provided', () => {
+    const err: CliError = {
+      what: 'facet not found in registry',
+      detail: 'no facet "viper-plans" published',
+      fix: "try 'facet search <term>' to find available facets",
+      docsUrl: 'https://agentfacets.io/errors/E_FACET_NOT_FOUND',
+    }
+    expect(formatCliError(err)).toBe(
+      [
+        'error: facet not found in registry',
+        '  no facet "viper-plans" published',
+        "  fix: try 'facet search <term>' to find available facets",
+        '  docs: https://agentfacets.io/errors/E_FACET_NOT_FOUND',
+      ].join('\n'),
+    )
+  })
+
+  test('omits the docs line when docsUrl is the empty string', () => {
+    const out = formatCliError({ what: 'x', fix: 'y', docsUrl: '' })
+    expect(out).not.toContain('docs:')
+  })
 })
 
 describe('writeCliError', () => {

--- a/packages/cli/src/util/__tests__/registry-client.test.ts
+++ b/packages/cli/src/util/__tests__/registry-client.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { encodeFacetName, getRegistryBaseUrl, registryFetch } from '../registry-client.ts'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_ENV = process.env.FACET_REGISTRY_URL
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  if (ORIGINAL_ENV === undefined) delete process.env.FACET_REGISTRY_URL
+  else process.env.FACET_REGISTRY_URL = ORIGINAL_ENV
+})
+
+describe('getRegistryBaseUrl', () => {
+  test('falls back to the dev stage default when env is unset', () => {
+    delete process.env.FACET_REGISTRY_URL
+    expect(getRegistryBaseUrl()).toBe('https://api.dev.facet.cafe/v0')
+  })
+
+  test('uses FACET_REGISTRY_URL when set', () => {
+    process.env.FACET_REGISTRY_URL = 'https://api.example.com/v0'
+    expect(getRegistryBaseUrl()).toBe('https://api.example.com/v0')
+  })
+
+  test('strips trailing slashes so paths can be appended without doubling', () => {
+    process.env.FACET_REGISTRY_URL = 'https://api.example.com/v0///'
+    expect(getRegistryBaseUrl()).toBe('https://api.example.com/v0')
+  })
+
+  test('treats empty FACET_REGISTRY_URL as unset', () => {
+    process.env.FACET_REGISTRY_URL = ''
+    expect(getRegistryBaseUrl()).toBe('https://api.dev.facet.cafe/v0')
+  })
+})
+
+describe('encodeFacetName', () => {
+  test('passes bare names through unchanged', () => {
+    expect(encodeFacetName('cowsay')).toBe('cowsay')
+  })
+
+  test('percent-encodes the slash in namespaced names (npm-style %2F)', () => {
+    expect(encodeFacetName('acme/cowsay')).toBe('acme%2Fcowsay')
+  })
+})
+
+describe('registryFetch', () => {
+  beforeEach(() => {
+    process.env.FACET_REGISTRY_URL = 'https://api.test/v0'
+  })
+
+  test('returns ok=true with the Response on 2xx', async () => {
+    let calledUrl = ''
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calledUrl = String(input)
+      // Inspect init to verify signal was threaded through (timeout wiring).
+      expect(init?.signal).toBeDefined()
+      return new Response(JSON.stringify({ facets: [] }), { status: 200 })
+    }) as unknown as typeof fetch
+    const result = await registryFetch('/packages')
+    expect(result.ok).toBe(true)
+    expect(calledUrl).toBe('https://api.test/v0/packages')
+  })
+
+  test('translates a Tier 2 error envelope into a CliError', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: 'facet "missing" not found in registry',
+          code: 'E_FACET_NOT_FOUND',
+          docsUrl: 'https://agentfacets.io/errors/E_FACET_NOT_FOUND',
+        }),
+        { status: 404 },
+      )) as unknown as typeof fetch
+    const result = await registryFetch('/packages/missing/1.0.0')
+    if (result.ok) expect.unreachable()
+    expect(result.kind).toBe('server-error')
+    expect(result.failure.fix).toBe("try 'facet search <term>' to find available facets")
+    expect(result.failure.docsUrl).toBe('https://agentfacets.io/errors/E_FACET_NOT_FOUND')
+  })
+
+  test('does NOT retry on HTTP error responses (server already answered)', async () => {
+    let attempts = 0
+    globalThis.fetch = (async () => {
+      attempts++
+      return new Response(
+        JSON.stringify({
+          error: 'gone',
+          code: 'E_FACET_NOT_FOUND',
+          docsUrl: 'https://docs',
+        }),
+        { status: 404 },
+      )
+    }) as unknown as typeof fetch
+    await registryFetch('/packages/x/1.0.0')
+    expect(attempts).toBe(1)
+  })
+
+  test('falls back to a generic CliError for non-Tier-2 error bodies (gateway page, etc.)', async () => {
+    globalThis.fetch = (async () =>
+      new Response('<html>502 Bad Gateway</html>', {
+        status: 502,
+        statusText: 'Bad Gateway',
+      })) as unknown as typeof fetch
+    const result = await registryFetch('/packages')
+    if (result.ok) expect.unreachable()
+    expect(result.kind).toBe('server-error')
+    expect(result.failure.what).toContain('unexpected response')
+    expect(result.failure.detail).toContain('502')
+  })
+
+  test('retries on network failure up to 2 times then fails with a network CliError', async () => {
+    let attempts = 0
+    globalThis.fetch = (async () => {
+      attempts++
+      throw new TypeError('fetch failed')
+    }) as unknown as typeof fetch
+    const result = await registryFetch('/packages')
+    if (result.ok) expect.unreachable()
+    expect(attempts).toBe(3) // initial + 2 retries
+    expect(result.kind).toBe('network')
+    expect(result.failure.fix).toBe('try again in a moment')
+  })
+
+  test('succeeds if a retry attempt recovers from a transient network failure', async () => {
+    let attempts = 0
+    globalThis.fetch = (async () => {
+      attempts++
+      if (attempts < 2) throw new TypeError('fetch failed')
+      return new Response(JSON.stringify({ facets: [] }), { status: 200 })
+    }) as unknown as typeof fetch
+    const result = await registryFetch('/packages')
+    expect(result.ok).toBe(true)
+    expect(attempts).toBe(2)
+  })
+
+  test('appends a leading slash if the path is missing one', async () => {
+    let calledUrl = ''
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calledUrl = String(input)
+      return new Response('{}', { status: 200 })
+    }) as unknown as typeof fetch
+    await registryFetch('packages')
+    expect(calledUrl).toBe('https://api.test/v0/packages')
+  })
+})

--- a/packages/cli/src/util/__tests__/registry-errors.test.ts
+++ b/packages/cli/src/util/__tests__/registry-errors.test.ts
@@ -22,7 +22,7 @@ describe('translateRegistryError', () => {
     ['E_TARBALL_CORRUPTED', 'try again; if persistent, check your network'],
     ['E_TARBALL_TOO_LARGE', 'reduce the facet contents below 5 MB or split into multiple facets'],
     ['E_API_KEY_MISSING', 'set FACET_REGISTRY_API_KEY in your environment'],
-    ['VERSION_EXISTS', "bump the version in facet.json or use 'facet publish' which auto-bumps"],
+    ['VERSION_EXISTS', 'bump `version` in facet.json and try again'],
   ]
 
   test.each(canonicalCodes)('%s maps to its canonical fix', (code, expectedFix) => {

--- a/packages/cli/src/util/__tests__/registry-errors.test.ts
+++ b/packages/cli/src/util/__tests__/registry-errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  isRegistryErrorResponse,
+  type RegistryErrorCode,
+  type RegistryErrorResponse,
+  translateRegistryError,
+} from '../registry-errors.ts'
+
+const stubResponse = (code: string): RegistryErrorResponse => ({
+  error: `the server's human message about ${code}`,
+  code,
+  docsUrl: `https://agentfacets.io/errors/${code}`,
+})
+
+describe('translateRegistryError', () => {
+  // Each canonical code must map to a non-generic, non-empty fix line.
+  // If a future code lands in the response without a mapping, it should
+  // fall through to the unknown-code branch — exercised separately below.
+  const canonicalCodes: ReadonlyArray<readonly [RegistryErrorCode, string]> = [
+    ['E_FACET_NOT_FOUND', "try 'facet search <term>' to find available facets"],
+    ['E_REGISTRY_UNAVAILABLE', 'try again in a moment'],
+    ['E_TARBALL_CORRUPTED', 'try again; if persistent, check your network'],
+    ['E_TARBALL_TOO_LARGE', 'reduce the facet contents below 5 MB or split into multiple facets'],
+    ['E_API_KEY_MISSING', 'set FACET_REGISTRY_API_KEY in your environment'],
+    ['VERSION_EXISTS', "bump the version in facet.json or use 'facet publish' which auto-bumps"],
+  ]
+
+  test.each(canonicalCodes)('%s maps to its canonical fix', (code, expectedFix) => {
+    const cli = translateRegistryError(stubResponse(code))
+    expect(cli.fix).toBe(expectedFix)
+    expect(cli.detail).toBe(`the server's human message about ${code}`)
+    expect(cli.docsUrl).toBe(`https://agentfacets.io/errors/${code}`)
+    expect(cli.what.length).toBeGreaterThan(0)
+  })
+
+  test('unknown code falls through to a generic fix and surfaces the code in `what`', () => {
+    const cli = translateRegistryError(stubResponse('E_FUTURE_CODE'))
+    expect(cli.fix).toBe('check the docs URL for details')
+    expect(cli.what).toContain('E_FUTURE_CODE')
+  })
+
+  test('preserves the docsUrl verbatim so users can deep-link from terminal output', () => {
+    const cli = translateRegistryError({
+      error: 'x',
+      code: 'E_FACET_NOT_FOUND',
+      docsUrl: 'https://docs.example/notfound',
+    })
+    expect(cli.docsUrl).toBe('https://docs.example/notfound')
+  })
+})
+
+describe('isRegistryErrorResponse', () => {
+  test('accepts a well-formed registry error response', () => {
+    expect(
+      isRegistryErrorResponse({
+        error: 'x',
+        code: 'E_FACET_NOT_FOUND',
+        docsUrl: 'https://docs',
+      }),
+    ).toBe(true)
+  })
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 42],
+    ['string', 'oops'],
+    ['empty object', {}],
+    ['missing code', { error: 'x', docsUrl: 'y' }],
+    ['missing error', { code: 'x', docsUrl: 'y' }],
+    ['missing docsUrl', { error: 'x', code: 'y' }],
+    ['code is non-string', { error: 'x', code: 42, docsUrl: 'y' }],
+  ])('rejects %s', (_label, value) => {
+    expect(isRegistryErrorResponse(value)).toBe(false)
+  })
+})

--- a/packages/cli/src/util/errors.ts
+++ b/packages/cli/src/util/errors.ts
@@ -28,18 +28,29 @@ export interface CliError {
   detail?: string
   /** One-line action the user should take to unblock themselves. */
   fix: string
+  /**
+   * Optional canonical docs URL for the error. When present, renders as a
+   * fourth line `  docs: <url>` so users can deep-link from terminal output
+   * to documentation. Used by registry error translations.
+   */
+  docsUrl?: string
 }
 
 /**
- * Format a CliError as the 3-line stderr block. Exposed for tests and for
- * callers that want to control writing (e.g., Ink cleanup paths that write
- * after unmount).
+ * Format a CliError as the canonical stderr block. Three lines normally;
+ * four when `docsUrl` is provided. Exposed for tests and for callers that
+ * want to control writing (e.g., Ink cleanup paths that write after unmount).
  */
 export function formatCliError(err: CliError): string {
   const detail = err.detail && err.detail.length > 0 ? err.detail : '(no detail)'
   const errorLabel = colorize('error:', THEME.warning)
   const fixLabel = colorize('fix:', THEME.warning)
-  return [`${errorLabel} ${err.what}`, `  ${detail}`, `  ${fixLabel} ${err.fix}`].join('\n')
+  const lines = [`${errorLabel} ${err.what}`, `  ${detail}`, `  ${fixLabel} ${err.fix}`]
+  if (err.docsUrl !== undefined && err.docsUrl.length > 0) {
+    const docsLabel = colorize('docs:', THEME.warning)
+    lines.push(`  ${docsLabel} ${err.docsUrl}`)
+  }
+  return lines.join('\n')
 }
 
 /**

--- a/packages/cli/src/util/registry-client.ts
+++ b/packages/cli/src/util/registry-client.ts
@@ -1,0 +1,135 @@
+import type { CliError } from './errors.ts'
+import { isRegistryErrorResponse, translateRegistryError } from './registry-errors.ts'
+
+/**
+ * Default registry base URL. Overridable via `FACET_REGISTRY_URL` env so
+ * V0 can point the conference build at the `dev` stage without rebuilding.
+ * Once `main` ships this constant becomes the prod URL.
+ */
+const DEFAULT_REGISTRY_URL = 'https://api.dev.facet.cafe/v0'
+
+/** Hard wall-clock per HTTP attempt. Conservative on a conference network. */
+const REQUEST_TIMEOUT_MS = 5000
+
+/** Number of retries on network failure (initial attempt is not counted). */
+const NETWORK_RETRIES = 2
+
+/** Backoff between retries. Constant — V0 doesn't need exponential. */
+const RETRY_BACKOFF_MS = 500
+
+/**
+ * Resolve the registry base URL from env, stripping any trailing slash so
+ * callers can append paths without double-slashing.
+ */
+export function getRegistryBaseUrl(): string {
+  const fromEnv = process.env.FACET_REGISTRY_URL
+  const raw = fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_REGISTRY_URL
+  return raw.replace(/\/+$/, '')
+}
+
+/**
+ * Encode a canonical facet name for use in a URL path. Namespaced names
+ * like `acme/cowsay` become `acme%2Fcowsay`; bare names pass through.
+ *
+ * Centralized so every call site encodes identically — silent mismatches
+ * between client and server URL forms are notoriously hard to debug.
+ */
+export function encodeFacetName(name: string): string {
+  return encodeURIComponent(name)
+}
+
+/**
+ * Outcome of a `registryFetch` call. Discriminated by `ok` so callers can
+ * branch without try/catch noise.
+ *
+ * `failure` always carries a CliError ready to feed to `writeCliError`.
+ * `kind` lets callers distinguish "server said no" from "couldn't reach
+ * the server" — same final shape, different downstream handling
+ * (e.g., publish should not auto-retry on `server-error`).
+ */
+export type RegistryFetchResult =
+  | { ok: true; response: Response }
+  | { ok: false; failure: CliError; kind: 'network' | 'server-error' }
+
+/**
+ * Fetch a registry path with retry/timeout/error-translation baked in.
+ *
+ * `path` is appended to the resolved base URL; pass either an absolute
+ * `/packages/...` form or a relative form. URL-encoding of facet names
+ * is the caller's job — use `encodeFacetName` first.
+ *
+ * Behavior:
+ *   - Per-attempt 5s timeout via AbortController.
+ *   - Up to 2 retries on network failure (DNS/TCP/timeout) with 500ms backoff.
+ *   - HTTP error responses are NOT retried (server already responded).
+ *   - Error responses are JSON-decoded; if they match the registry's
+ *     `{error,code,docsUrl}` Tier 2 contract, they're translated via
+ *     `translateRegistryError` so callers get a ready-to-print CliError.
+ *   - Non-JSON or non-Tier-2 error bodies surface as `E_REGISTRY_UNAVAILABLE`-shaped
+ *     CliErrors (server is responding but speaking a dialect we don't know).
+ */
+export async function registryFetch(path: string, init?: RequestInit): Promise<RegistryFetchResult> {
+  const url = `${getRegistryBaseUrl()}${path.startsWith('/') ? path : `/${path}`}`
+  let lastNetworkError: Error | undefined
+  for (let attempt = 0; attempt <= NETWORK_RETRIES; attempt++) {
+    if (attempt > 0) await sleep(RETRY_BACKOFF_MS)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+    try {
+      const response = await fetch(url, { ...init, signal: controller.signal })
+      clearTimeout(timeout)
+      if (response.ok) return { ok: true, response }
+      const failure = await translateHttpFailure(response)
+      return { ok: false, failure, kind: 'server-error' }
+    } catch (err) {
+      clearTimeout(timeout)
+      lastNetworkError = err instanceof Error ? err : new Error(String(err))
+      // Non-network errors (e.g. invalid URL) shouldn't be retried.
+      if (!isNetworkError(lastNetworkError)) break
+    }
+  }
+  return {
+    ok: false,
+    kind: 'network',
+    failure: {
+      what: 'registry temporarily unavailable',
+      detail: lastNetworkError ? lastNetworkError.message : 'unknown network failure',
+      fix: 'try again in a moment',
+      docsUrl: 'https://agentfacets.io/errors/E_REGISTRY_UNAVAILABLE',
+    },
+  }
+}
+
+async function translateHttpFailure(response: Response): Promise<CliError> {
+  // Try to parse the registry's Tier 2 error envelope. Body might not be JSON
+  // (gateway 502 page, empty 503 from a load balancer, etc.) — degrade
+  // gracefully rather than throwing inside the error path.
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    body = undefined
+  }
+  if (isRegistryErrorResponse(body)) return translateRegistryError(body)
+  return {
+    what: 'registry returned an unexpected response',
+    detail: `HTTP ${response.status} ${response.statusText}`,
+    fix: 'try again in a moment',
+    docsUrl: 'https://agentfacets.io/errors/E_REGISTRY_UNAVAILABLE',
+  }
+}
+
+function isNetworkError(err: Error): boolean {
+  // AbortError (timeout) is a transient network problem — retry.
+  if (err.name === 'AbortError') return true
+  // Bun/undici surface DNS/TCP failures with name === 'TypeError' and
+  // a message like "fetch failed" or "Unable to connect". Conservative:
+  // any TypeError from fetch is a network problem, since fetch validation
+  // errors throw before we reach the await.
+  if (err.name === 'TypeError') return true
+  return false
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/cli/src/util/registry-client.ts
+++ b/packages/cli/src/util/registry-client.ts
@@ -1,12 +1,11 @@
+import { getRegistryBaseUrl } from '@agent-facets/core'
 import type { CliError } from './errors.ts'
 import { isRegistryErrorResponse, translateRegistryError } from './registry-errors.ts'
 
-/**
- * Default registry base URL. Overridable via `FACET_REGISTRY_URL` env so
- * V0 can point the conference build at the `dev` stage without rebuilding.
- * Once `main` ships this constant becomes the prod URL.
- */
-const DEFAULT_REGISTRY_URL = 'https://api.dev.facet.cafe/v0'
+// Re-exported from core so commands can import URL helpers from a single
+// place. Core owns the env-var lookup and encoding rules so the install
+// pipeline (in core) and the standalone CLI commands can never disagree.
+export { encodeFacetName, getRegistryBaseUrl } from '@agent-facets/core'
 
 /** Hard wall-clock per HTTP attempt. Conservative on a conference network. */
 const REQUEST_TIMEOUT_MS = 5000
@@ -16,27 +15,6 @@ const NETWORK_RETRIES = 2
 
 /** Backoff between retries. Constant — V0 doesn't need exponential. */
 const RETRY_BACKOFF_MS = 500
-
-/**
- * Resolve the registry base URL from env, stripping any trailing slash so
- * callers can append paths without double-slashing.
- */
-export function getRegistryBaseUrl(): string {
-  const fromEnv = process.env.FACET_REGISTRY_URL
-  const raw = fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_REGISTRY_URL
-  return raw.replace(/\/+$/, '')
-}
-
-/**
- * Encode a canonical facet name for use in a URL path. Namespaced names
- * like `acme/cowsay` become `acme%2Fcowsay`; bare names pass through.
- *
- * Centralized so every call site encodes identically — silent mismatches
- * between client and server URL forms are notoriously hard to debug.
- */
-export function encodeFacetName(name: string): string {
-  return encodeURIComponent(name)
-}
 
 /**
  * Outcome of a `registryFetch` call. Discriminated by `ok` so callers can

--- a/packages/cli/src/util/registry-errors.ts
+++ b/packages/cli/src/util/registry-errors.ts
@@ -1,0 +1,95 @@
+import type { CliError } from './errors.ts'
+
+/**
+ * Wire-format error response from the registry API. Every 4xx/5xx from
+ * `https://api.facet.cafe/v0/*` returns this shape (Tier 2 error contract,
+ * pre-locked in osaka backend `packages/v0/core/src/errors/index.ts`).
+ */
+export interface RegistryErrorResponse {
+  error: string
+  code: string
+  docsUrl: string
+}
+
+/**
+ * Canonical registry error codes. Five come from the backend's exhaustive
+ * enum; `VERSION_EXISTS` is returned by the publish route on 409 dup but
+ * sits outside the backend's E_* prefix because it isn't an "error" in the
+ * registry-broken sense — it's a normal "you already published that"
+ * response that publish auto-handles.
+ */
+export type RegistryErrorCode =
+  | 'E_FACET_NOT_FOUND'
+  | 'E_REGISTRY_UNAVAILABLE'
+  | 'E_TARBALL_CORRUPTED'
+  | 'E_TARBALL_TOO_LARGE'
+  | 'E_API_KEY_MISSING'
+  | 'VERSION_EXISTS'
+
+/**
+ * Detect the registry error wire shape on an unknown JSON value.
+ */
+export function isRegistryErrorResponse(value: unknown): value is RegistryErrorResponse {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return typeof v.error === 'string' && typeof v.code === 'string' && typeof v.docsUrl === 'string'
+}
+
+/**
+ * Translate a registry error response into the canonical 4-line CliError
+ * shape. Centralized so every command (`add`, `search`, `publish`) renders
+ * registry failures identically.
+ *
+ * The server's human `error` message becomes the `detail` line verbatim;
+ * the `fix` is derived from the machine `code` so the suggestion stays
+ * actionable even if the server's `error` text changes. Unknown codes
+ * fall through to a generic "check the docs URL" fix.
+ */
+export function translateRegistryError(response: RegistryErrorResponse): CliError {
+  const what = whatForCode(response.code)
+  const fix = fixForCode(response.code)
+  return {
+    what,
+    detail: response.error,
+    fix,
+    docsUrl: response.docsUrl,
+  }
+}
+
+function whatForCode(code: string): string {
+  switch (code) {
+    case 'E_FACET_NOT_FOUND':
+      return 'facet not found in registry'
+    case 'E_REGISTRY_UNAVAILABLE':
+      return 'registry temporarily unavailable'
+    case 'E_TARBALL_CORRUPTED':
+      return 'facet archive is corrupted'
+    case 'E_TARBALL_TOO_LARGE':
+      return 'facet archive exceeds size limit'
+    case 'E_API_KEY_MISSING':
+      return 'registry API key missing or invalid'
+    case 'VERSION_EXISTS':
+      return 'version already published'
+    default:
+      return `registry error (${code})`
+  }
+}
+
+function fixForCode(code: string): string {
+  switch (code) {
+    case 'E_FACET_NOT_FOUND':
+      return "try 'facet search <term>' to find available facets"
+    case 'E_REGISTRY_UNAVAILABLE':
+      return 'try again in a moment'
+    case 'E_TARBALL_CORRUPTED':
+      return 'try again; if persistent, check your network'
+    case 'E_TARBALL_TOO_LARGE':
+      return 'reduce the facet contents below 5 MB or split into multiple facets'
+    case 'E_API_KEY_MISSING':
+      return 'set FACET_REGISTRY_API_KEY in your environment'
+    case 'VERSION_EXISTS':
+      return "bump the version in facet.json or use 'facet publish' which auto-bumps"
+    default:
+      return 'check the docs URL for details'
+  }
+}

--- a/packages/cli/src/util/registry-errors.ts
+++ b/packages/cli/src/util/registry-errors.ts
@@ -88,7 +88,7 @@ function fixForCode(code: string): string {
     case 'E_API_KEY_MISSING':
       return 'set FACET_REGISTRY_API_KEY in your environment'
     case 'VERSION_EXISTS':
-      return "bump the version in facet.json or use 'facet publish' which auto-bumps"
+      return 'bump `version` in facet.json and try again'
     default:
       return 'check the docs URL for details'
   }

--- a/packages/core/src/__tests__/registry.test.ts
+++ b/packages/core/src/__tests__/registry.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createTar } from 'nanotar'
 import { describeVersionSpec, downloadAndExtractFacet, resolveRegistryMetadataBatch } from '../registry/index.ts'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_ENV = process.env.FACET_REGISTRY_URL
+
+beforeEach(() => {
+  process.env.FACET_REGISTRY_URL = 'https://api.test/v0'
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  if (ORIGINAL_ENV === undefined) delete process.env.FACET_REGISTRY_URL
+  else process.env.FACET_REGISTRY_URL = ORIGINAL_ENV
+})
 
 describe('describeVersionSpec', () => {
   test('exact', () => {
@@ -8,14 +26,6 @@ describe('describeVersionSpec', () => {
 
   test('majorWildcard', () => {
     expect(describeVersionSpec({ kind: 'majorWildcard', major: 1 })).toBe('1.*')
-  })
-
-  test('minorWildcard', () => {
-    expect(describeVersionSpec({ kind: 'minorWildcard', major: 1, minor: 2 })).toBe('1.2.*')
-  })
-
-  test('wildcard', () => {
-    expect(describeVersionSpec({ kind: 'wildcard' })).toBe('*')
   })
 
   test('latest', () => {
@@ -30,95 +40,249 @@ describe('resolveRegistryMetadataBatch', () => {
     if (result.ok) expect(result.value).toEqual([])
   })
 
-  test('single-spec batch returns REGISTRY_NOT_AVAILABLE', async () => {
-    const result = await resolveRegistryMetadataBatch([{ name: 'viper-plans', version: { kind: 'latest' } }])
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    expect(result.error.code).toBe('REGISTRY_NOT_AVAILABLE')
+  test('latest spec collapses to "latest" in the URL and uses the server-resolved version on the archive URL', async () => {
+    const calledUrls: string[] = []
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calledUrls.push(String(input))
+      return new Response(
+        JSON.stringify({
+          name: 'cowsay',
+          version: '0.1.0',
+          contentHash: 'sha256:abc',
+          sizeBytes: 100,
+          publishedAt: '2026-05-01T00:00:00Z',
+        }),
+        { status: 200 },
+      )
+    }) as unknown as typeof fetch
+    const result = await resolveRegistryMetadataBatch([{ name: 'cowsay', version: { kind: 'latest' } }])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(calledUrls[0]).toBe('https://api.test/v0/packages/cowsay/latest')
+    const meta = result.value[0]
+    if (meta === undefined) expect.unreachable()
+    expect(meta.version).toBe('0.1.0')
+    expect(meta.tarballUrl).toBe('https://api.test/v0/packages/cowsay/0.1.0/archive')
+    expect(meta.expectedIntegrity).toBe('sha256:abc')
   })
 
-  test('multi-spec batch returns REGISTRY_NOT_AVAILABLE', async () => {
+  test('exact spec is sent verbatim', async () => {
+    const calledUrls: string[] = []
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calledUrls.push(String(input))
+      return new Response(
+        JSON.stringify({
+          name: 'cowsay',
+          version: '1.2.3',
+          contentHash: 'sha256:x',
+          sizeBytes: 1,
+          publishedAt: '2026-05-01',
+        }),
+        { status: 200 },
+      )
+    }) as unknown as typeof fetch
+    await resolveRegistryMetadataBatch([{ name: 'cowsay', version: { kind: 'exact', major: 1, minor: 2, patch: 3 } }])
+    expect(calledUrls[0]).toBe('https://api.test/v0/packages/cowsay/1.2.3')
+  })
+
+  test('namespaced names are URL-encoded (%2F) on the URL path', async () => {
+    const calledUrls: string[] = []
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calledUrls.push(String(input))
+      return new Response(
+        JSON.stringify({
+          name: 'acme/cowsay',
+          version: '0.1.0',
+          contentHash: 'sha256:x',
+          sizeBytes: 1,
+          publishedAt: '2026-05-01',
+        }),
+        { status: 200 },
+      )
+    }) as unknown as typeof fetch
+    await resolveRegistryMetadataBatch([{ name: 'acme/cowsay', version: { kind: 'latest' } }])
+    expect(calledUrls[0]).toBe('https://api.test/v0/packages/acme%2Fcowsay/latest')
+  })
+
+  test('404 maps to NOT_FOUND with the spec verbatim', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: 'gone', code: 'E_FACET_NOT_FOUND', docsUrl: 'x' }), {
+        status: 404,
+      })) as unknown as typeof fetch
     const result = await resolveRegistryMetadataBatch([
-      { name: 'viper-plans', version: { kind: 'exact', major: 1, minor: 2, patch: 3 } },
-      { name: 'rezi', version: { kind: 'majorWildcard', major: 2 } },
+      { name: 'missing', version: { kind: 'exact', major: 1, minor: 0, patch: 0 } },
     ])
     expect(result.ok).toBe(false)
     if (result.ok) return
-    expect(result.error.code).toBe('REGISTRY_NOT_AVAILABLE')
+    expect(result.error.code).toBe('NOT_FOUND')
+    if (result.error.code !== 'NOT_FOUND') return
+    expect(result.error.name).toBe('missing')
+    expect(result.error.spec).toBe('1.0.0')
   })
 
-  test('error message names facets.cafe', async () => {
-    const result = await resolveRegistryMetadataBatch([{ name: 'viper-plans', version: { kind: 'latest' } }])
+  test('5xx maps to NETWORK_ERROR', async () => {
+    globalThis.fetch = (async () => new Response('boom', { status: 503 })) as unknown as typeof fetch
+    const result = await resolveRegistryMetadataBatch([{ name: 'x', version: { kind: 'latest' } }])
     expect(result.ok).toBe(false)
     if (result.ok) return
-    if (result.error.code !== 'REGISTRY_NOT_AVAILABLE') return
-    expect(result.error.what).toContain('facets.cafe')
+    expect(result.error.code).toBe('NETWORK_ERROR')
   })
 
-  test('error fix suggests github/https/ssh/local workaround', async () => {
-    const result = await resolveRegistryMetadataBatch([{ name: 'viper-plans', version: { kind: 'latest' } }])
+  test('thrown fetch maps to NETWORK_ERROR', async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed')
+    }) as unknown as typeof fetch
+    const result = await resolveRegistryMetadataBatch([{ name: 'x', version: { kind: 'latest' } }])
     expect(result.ok).toBe(false)
     if (result.ok) return
-    if (result.error.code !== 'REGISTRY_NOT_AVAILABLE') return
-    expect(result.error.fix).toContain('github:')
-    expect(result.error.fix).toContain('https')
-    expect(result.error.fix).toContain('local path')
+    expect(result.error.code).toBe('NETWORK_ERROR')
+    if (result.error.code !== 'NETWORK_ERROR') return
+    expect(result.error.cause).toContain('fetch failed')
   })
 
-  test('error message renders the version spec verbatim', async () => {
+  test('multi-spec batch fans out and short-circuits on first failure', async () => {
+    let calls = 0
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calls++
+      const url = String(input)
+      if (url.includes('good')) {
+        return new Response(
+          JSON.stringify({
+            name: 'good',
+            version: '1.0.0',
+            contentHash: 'sha256:x',
+            sizeBytes: 1,
+            publishedAt: '2026-05-01',
+          }),
+          { status: 200 },
+        )
+      }
+      return new Response(JSON.stringify({ code: 'E_FACET_NOT_FOUND' }), { status: 404 })
+    }) as unknown as typeof fetch
     const result = await resolveRegistryMetadataBatch([
-      { name: 'viper-plans', version: { kind: 'majorWildcard', major: 1 } },
+      { name: 'good', version: { kind: 'latest' } },
+      { name: 'bad', version: { kind: 'latest' } },
     ])
     expect(result.ok).toBe(false)
-    if (result.ok) return
-    if (result.error.code !== 'REGISTRY_NOT_AVAILABLE') return
-    expect(result.error.what).toContain('viper-plans@1.*')
-  })
-
-  test('multi-spec error mentions count and a sample', async () => {
-    const result = await resolveRegistryMetadataBatch([
-      { name: 'a', version: { kind: 'latest' } },
-      { name: 'b', version: { kind: 'latest' } },
-      { name: 'c', version: { kind: 'latest' } },
-    ])
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    if (result.error.code !== 'REGISTRY_NOT_AVAILABLE') return
-    expect(result.error.what).toContain('3 facets')
-    expect(result.error.what).toContain('a@latest')
+    expect(calls).toBe(2)
   })
 })
 
 describe('downloadAndExtractFacet', () => {
-  test('returns REGISTRY_NOT_AVAILABLE', async () => {
-    const result = await downloadAndExtractFacet(
-      {
-        name: 'viper-plans',
-        version: '1.2.3',
-        expectedIntegrity: 'sha256:abc',
-        tarballUrl: 'https://facets.cafe/viper-plans-1.2.3.facet',
-      },
-      '/tmp/dest',
-    )
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    expect(result.error.code).toBe('REGISTRY_NOT_AVAILABLE')
+  let dest: string
+  beforeEach(() => {
+    dest = mkdtempSync(join(tmpdir(), 'facet-dl-'))
+  })
+  afterEach(() => {
+    rmSync(dest, { recursive: true, force: true })
   })
 
-  test('error message includes tarballUrl and name@version', async () => {
+  // Build a real gzipped tarball and its sha256 so the integrity check
+  // exercises the actual happy path.
+  function buildArchive(entries: Array<{ name: string; data: string }>): {
+    bytes: Uint8Array
+    integrity: string
+  } {
+    const tar = createTar(entries.map((e) => ({ name: e.name, data: e.data }))) as Uint8Array<ArrayBuffer>
+    // Bun.gzipSync's TS return type uses ArrayBufferLike which doesn't
+    // satisfy node's stricter ArrayBuffer-typed signatures for crypto and
+    // Response — cast through unknown so the rest of the helper compiles.
+    const bytes = Bun.gzipSync(tar) as unknown as Uint8Array<ArrayBuffer>
+    const integrity = `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+    return { bytes, integrity }
+  }
+
+  test('happy path: downloads, verifies sha256, extracts files preserving paths', async () => {
+    const { bytes, integrity } = buildArchive([
+      { name: 'facet.json', data: '{"name":"cowsay","version":"0.1.0"}' },
+      { name: 'commands/cowsay.md', data: '# cowsay\n' },
+    ])
+    globalThis.fetch = (async () => new Response(bytes, { status: 200 })) as unknown as typeof fetch
     const result = await downloadAndExtractFacet(
       {
-        name: 'viper-plans',
-        version: '1.2.3',
-        expectedIntegrity: 'sha256:abc',
-        tarballUrl: 'https://facets.cafe/viper-plans-1.2.3.facet',
+        name: 'cowsay',
+        version: '0.1.0',
+        expectedIntegrity: integrity,
+        tarballUrl: 'https://api.test/v0/packages/cowsay/0.1.0/archive',
       },
-      '/tmp/dest',
+      dest,
+    )
+    expect(result.ok).toBe(true)
+    expect(readFileSync(join(dest, 'facet.json'), 'utf8')).toContain('cowsay')
+    expect(readFileSync(join(dest, 'commands/cowsay.md'), 'utf8')).toContain('# cowsay')
+  })
+
+  test('sha256 mismatch: returns NETWORK_ERROR with hash detail and writes nothing', async () => {
+    const { bytes } = buildArchive([{ name: 'facet.json', data: '{}' }])
+    globalThis.fetch = (async () => new Response(bytes, { status: 200 })) as unknown as typeof fetch
+    const result = await downloadAndExtractFacet(
+      {
+        name: 'cowsay',
+        version: '0.1.0',
+        expectedIntegrity: 'sha256:0000',
+        tarballUrl: 'https://api.test',
+      },
+      dest,
     )
     expect(result.ok).toBe(false)
     if (result.ok) return
-    if (result.error.code !== 'REGISTRY_NOT_AVAILABLE') return
-    expect(result.error.what).toContain('https://facets.cafe/viper-plans-1.2.3.facet')
-    expect(result.error.what).toContain('viper-plans@1.2.3')
+    expect(result.error.code).toBe('NETWORK_ERROR')
+    if (result.error.code !== 'NETWORK_ERROR') return
+    expect(result.error.cause).toContain('sha256 mismatch')
+  })
+
+  test('404 maps to NOT_FOUND', async () => {
+    globalThis.fetch = (async () => new Response('gone', { status: 404 })) as unknown as typeof fetch
+    const result = await downloadAndExtractFacet(
+      {
+        name: 'cowsay',
+        version: '0.1.0',
+        expectedIntegrity: 'sha256:x',
+        tarballUrl: 'https://api.test',
+      },
+      dest,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.code).toBe('NOT_FOUND')
+  })
+
+  test('5xx maps to NETWORK_ERROR', async () => {
+    globalThis.fetch = (async () => new Response('boom', { status: 503 })) as unknown as typeof fetch
+    const result = await downloadAndExtractFacet(
+      {
+        name: 'x',
+        version: '1.0.0',
+        expectedIntegrity: 'sha256:x',
+        tarballUrl: 'https://api.test',
+      },
+      dest,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.code).toBe('NETWORK_ERROR')
+  })
+
+  // Note: path-safety sanitization in `downloadAndExtractFacet` is
+  // defense-in-depth. We can't easily exercise it through `nanotar`'s
+  // writer here because the writer normalizes leading `/` and `../`
+  // segments out before they reach the wire. The sanitization remains
+  // important for tarballs produced by other writers; covered by review.
+
+  test('non-gzip body: clean error', async () => {
+    const bytes = new TextEncoder().encode('not a tarball')
+    globalThis.fetch = (async () => new Response(bytes, { status: 200 })) as unknown as typeof fetch
+    const result = await downloadAndExtractFacet(
+      {
+        name: 'x',
+        version: '1.0.0',
+        expectedIntegrity: `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+        tarballUrl: 'https://api.test',
+      },
+      dest,
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.code).toBe('NETWORK_ERROR')
   })
 })

--- a/packages/core/src/__tests__/run-install.test.ts
+++ b/packages/core/src/__tests__/run-install.test.ts
@@ -211,20 +211,34 @@ describe('runInstall — local source success path', () => {
   })
 })
 
-describe('runInstall — registry source returns REGISTRY_ERROR (stub)', () => {
-  test('bare registry name fails with REGISTRY_NOT_AVAILABLE', async () => {
-    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { 'viper-plans': 'viper-plans@1.0.0' } }))
+describe('runInstall — registry source surfaces REGISTRY_ERROR on resolution failure', () => {
+  test('unreachable registry: bare registry name fails with REGISTRY_ERROR / NETWORK_ERROR', async () => {
+    // Point at an unresolvable host so the resolver hits a real network
+    // failure (no mock) — exercises the failure-translation path end-to-end.
+    const originalEnv = process.env.FACET_REGISTRY_URL
+    process.env.FACET_REGISTRY_URL = 'http://127.0.0.1:1' // closed port
+    try {
+      writeFileSync(
+        join(projectRoot, 'facets.json'),
+        JSON.stringify({ facets: { 'viper-plans': 'viper-plans@1.0.0' } }),
+      )
 
-    const result = await runInstall({
-      projectRoot,
-      adapters: [buildFakeAdapter('test')],
-    })
-    expect(result.ok).toBe(false)
-    if (result.ok) return
-    expect(result.failure.code).toBe('REGISTRY_ERROR')
-    if (result.failure.code !== 'REGISTRY_ERROR') return
-    expect(result.failure.error.code).toBe('REGISTRY_NOT_AVAILABLE')
-    expect(result.failure.facet).toBe('viper-plans')
+      const result = await runInstall({
+        projectRoot,
+        adapters: [buildFakeAdapter('test')],
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.failure.code).toBe('REGISTRY_ERROR')
+      if (result.failure.code !== 'REGISTRY_ERROR') return
+      // Either NETWORK_ERROR (refused/dns) or NOT_FOUND if the unlikely
+      // event the host is reachable; both signal "registry didn't help".
+      expect(['NETWORK_ERROR', 'NOT_FOUND']).toContain(result.failure.error.code)
+      expect(result.failure.facet).toBe('viper-plans')
+    } finally {
+      if (originalEnv === undefined) delete process.env.FACET_REGISTRY_URL
+      else process.env.FACET_REGISTRY_URL = originalEnv
+    }
   })
 })
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,6 +132,9 @@ export type {
 export {
   describeVersionSpec,
   downloadAndExtractFacet,
+  encodeFacetName,
+  getRegistryBaseUrl,
+  packFacetSource,
   resolveRegistryMetadataBatch,
 } from './registry/index.ts'
 // scaffold

--- a/packages/core/src/install/run-install.ts
+++ b/packages/core/src/install/run-install.ts
@@ -1,9 +1,8 @@
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
 import { runBuildPipeline } from '../build/pipeline.ts'
-import { type CacheIdentity, cacheGet, cachePutVerified, readCachedIntegrity } from '../cache/index.ts'
+import { type CacheIdentity, cacheGet, cachePutVerified, cacheStagingDir, readCachedIntegrity } from '../cache/index.ts'
 import { verifyGitOneCheck } from '../integrity/index.ts'
 import { loadManifest, type ResolvedFacetManifest, resolvePrompts } from '../loaders/facet.ts'
 import { loadFacetsJson } from '../manifest/project-files.ts'
@@ -47,6 +46,42 @@ export function resolveCloneRef(
   manifestRef: string | undefined,
 ): string | undefined {
   return locked?.commit ?? manifestRef
+}
+
+/**
+ * Parse a `LockfileFacet.version` string into an exact `VersionSpec` for
+ * the registry resolver. Lockfile versions are always concrete `M.N.P`
+ * by contract (the lockfile records the resolved version, never a
+ * range), so this is a straightforward split. A malformed value is a
+ * lockfile corruption — not a user-facing failure mode — so we throw.
+ *
+ * Used on the registry-source cache-miss path to pin the metadata
+ * fetch at `locked.version` instead of re-resolving the manifest spec
+ * (which may be `@latest` or a wildcard). See the call site for the
+ * reproducibility rationale.
+ */
+function parseLockedVersion(version: string): {
+  kind: 'exact'
+  major: number
+  minor: number
+  patch: number
+} {
+  const parts = version.split('.')
+  if (parts.length !== 3) {
+    throw new Error(`lockfile corruption: version "${version}" is not M.N.P`)
+  }
+  const [major, minor, patch] = parts.map((p) => Number.parseInt(p, 10))
+  if (
+    major === undefined ||
+    minor === undefined ||
+    patch === undefined ||
+    !Number.isInteger(major) ||
+    !Number.isInteger(minor) ||
+    !Number.isInteger(patch)
+  ) {
+    throw new Error(`lockfile corruption: version "${version}" has non-integer parts`)
+  }
+  return { kind: 'exact', major, minor, patch }
 }
 
 /**
@@ -495,9 +530,15 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
 
     if (sourceDir === undefined) {
       onStage({ kind: 'facet-stage', facet: facetName, stage: 'fetch' })
-      const metaResult = await resolveRegistryMetadataBatch([
-        { name: parsed.value.name, version: parsed.value.version },
-      ])
+      // Reproducibility: when the lockfile pins a version, resolve metadata
+      // for THAT exact version on a cache miss — never re-resolve from the
+      // manifest specifier (which may be `@latest` or a wildcard). Without
+      // this, a cold-cache reinstall of a project locked to `1.2.3` against
+      // a manifest of `@latest` would silently fetch `1.3.0` and trip the
+      // integrity check. Mirrors `resolveCloneRef` for the git path.
+      const versionForFetch: typeof parsed.value.version =
+        locked !== undefined ? parseLockedVersion(locked.version) : parsed.value.version
+      const metaResult = await resolveRegistryMetadataBatch([{ name: parsed.value.name, version: versionForFetch }])
       if (!metaResult.ok) {
         return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: metaResult.error } }
       }
@@ -513,7 +554,12 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
         }
       }
 
-      const tempDir = await mkdtemp(join(tmpdir(), 'facet-registry-'))
+      // Stage under the cache root (not the OS tmp dir). cachePutVerified's
+      // final rename into the cache slot must be atomic, which requires the
+      // staging dir and the slot to share a filesystem. If FACETS_CACHE_DIR
+      // points at a volume different from /tmp, mkdtemp under tmpdir() would
+      // make the rename throw EXDEV.
+      const tempDir = cacheStagingDir()
       onStage({ kind: 'facet-stage', facet: facetName, stage: 'verify' })
       const downloadResult = await downloadAndExtractFacet(meta, tempDir)
       if (!downloadResult.ok) {

--- a/packages/core/src/install/run-install.ts
+++ b/packages/core/src/install/run-install.ts
@@ -1,4 +1,5 @@
-import { rm } from 'node:fs/promises'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
 import { runBuildPipeline } from '../build/pipeline.ts'
@@ -6,6 +7,8 @@ import { type CacheIdentity, cacheGet, cachePutVerified, readCachedIntegrity } f
 import { verifyGitOneCheck } from '../integrity/index.ts'
 import { loadManifest, type ResolvedFacetManifest, resolvePrompts } from '../loaders/facet.ts'
 import { loadFacetsJson } from '../manifest/project-files.ts'
+import { downloadAndExtractFacet } from '../registry/download.ts'
+import { resolveRegistryMetadataBatch } from '../registry/resolve-metadata.ts'
 import type { BuildManifest } from '../schemas/build-manifest.ts'
 import type { Lockfile, LockfileFacet } from '../schemas/lockfile.ts'
 import type { FacetsJson } from '../schemas/project-manifest.ts'
@@ -457,19 +460,71 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
     }
     sourceDir = local.dir
   } else {
-    // Registry source — currently stubbed; future blocks wire registry
-    // resolution + cache + integrity verification here.
-    return {
-      ok: false,
-      failure: {
-        code: 'REGISTRY_ERROR',
-        facet: facetName,
-        error: {
-          code: 'REGISTRY_NOT_AVAILABLE',
-          what: `registry is not yet available (would query facets.cafe for "${parsed.value.name}")`,
-          fix: 'use a github: shortcut, https URL, ssh URL, or local path until the registry ships',
-        },
-      },
+    // Registry source. Cache-first when locked; otherwise resolve metadata
+    // → download archive → extract to temp dir → let the build pipeline
+    // re-derive integrity (the cache write below moves temp → cache slot).
+    if (locked !== undefined) {
+      const cacheId: CacheIdentity = {
+        kind: 'registry',
+        name: facetName,
+        version: locked.version,
+      }
+      const lookup = cacheGet(cacheId)
+      if (lookup.hit) {
+        const cached = readCachedIntegrity(lookup.path)
+        if (cached === null) {
+          onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; refetching`)
+        } else if (cached.integrity !== locked.integrity) {
+          return {
+            ok: false,
+            failure: {
+              code: 'CACHE_INTEGRITY_MISMATCH',
+              facet: facetName,
+              slotPath: lookup.path,
+              cachedIntegrity: cached.integrity,
+              lockedIntegrity: locked.integrity,
+            },
+          }
+        } else {
+          sourceDir = lookup.path
+          trustedCacheHit = true
+          onLog(`[verbose]   cache hit ${lookup.path}`)
+        }
+      }
+    }
+
+    if (sourceDir === undefined) {
+      onStage({ kind: 'facet-stage', facet: facetName, stage: 'fetch' })
+      const metaResult = await resolveRegistryMetadataBatch([
+        { name: parsed.value.name, version: parsed.value.version },
+      ])
+      if (!metaResult.ok) {
+        return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: metaResult.error } }
+      }
+      const meta = metaResult.value[0]
+      if (meta === undefined) {
+        return {
+          ok: false,
+          failure: {
+            code: 'REGISTRY_ERROR',
+            facet: facetName,
+            error: { code: 'NETWORK_ERROR', cause: 'registry returned no metadata for the requested facet' },
+          },
+        }
+      }
+
+      const tempDir = await mkdtemp(join(tmpdir(), 'facet-registry-'))
+      onStage({ kind: 'facet-stage', facet: facetName, stage: 'verify' })
+      const downloadResult = await downloadAndExtractFacet(meta, tempDir)
+      if (!downloadResult.ok) {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+        return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: downloadResult.error } }
+      }
+      sourceDir = tempDir
+      cleanup = async () => {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+      }
+      onLog(`[verbose]   downloaded ${meta.name}@${meta.version} → ${sourceDir}`)
     }
   }
 
@@ -547,7 +602,9 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
       // an integrity drift is expected, not an attack. The lockfile
       // entry's integrity gets overwritten by the new build for local
       // sources. See `verifyGitOneCheck` docstring for the rationale.
-      if (locked !== undefined && parsed.value.kind === 'git') {
+      // Same integrity guard as git: locked registry entry MUST reproduce
+      // its locked integrity. The lockfile is the security contract.
+      if (locked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
         const guard = verifyGitOneCheck({
           facet: facetName,
           computedIntegrity: buildResult.integrity,
@@ -558,15 +615,15 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
         }
       }
 
-      // Fresh git clone → audit-then-write to cache. Cache hits already
-      // have content in the slot; local sources skip the cache entirely.
-      if (cleanup !== undefined && parsed.value.kind === 'git') {
+      // Fresh git clone or fresh registry download → audit-then-write to
+      // cache. Cache hits already have content in the slot; local sources
+      // skip the cache entirely.
+      if (cleanup !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
         const buildManifest = JSON.parse(buildResult.manifestJson) as BuildManifest
-        const cacheId: CacheIdentity = {
-          kind: 'git',
-          name: facetName,
-          version: buildResult.data.version,
-        }
+        const cacheId: CacheIdentity =
+          parsed.value.kind === 'git'
+            ? { kind: 'git', name: facetName, version: buildResult.data.version }
+            : { kind: 'registry', name: facetName, version: buildResult.data.version }
         const putResult = cachePutVerified(cacheId, sourceDir, buildManifest, buildResult.integrity, facetName)
         if (!putResult.ok) {
           if ('corruption' in putResult) {
@@ -589,14 +646,15 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
 
       // Construct the entry.
       //
-      //   - Locked GIT entries inherit locked.* verbatim (we just
+      //   - Locked GIT/REGISTRY entries inherit locked.* verbatim (we just
       //     verified buildResult matches, so values are equal — but the
       //     lockfile is the source of truth and we never rewrite it).
       //   - Local sources (locked or fresh) derive from the build.
       //     Local is mutable by design; the user owns the version and
       //     content, and the lockfile follows what's on disk.
       //   - Fresh git adds derive from the build + the clone's commit.
-      if (locked !== undefined && parsed.value.kind === 'git') {
+      //   - Fresh registry adds derive from the build (no ref/commit).
+      if (locked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
         entry = {
           source: specifier,
           ...(locked.ref !== undefined ? { ref: locked.ref } : {}),

--- a/packages/core/src/registry/download.ts
+++ b/packages/core/src/registry/download.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join, normalize, relative } from 'node:path'
+import { dirname, isAbsolute, join, normalize, relative } from 'node:path'
 import { parseTarGzip } from 'nanotar'
 import type { RegistryMetadata, RegistryResult } from './types.ts'
 
@@ -99,9 +99,18 @@ export async function downloadAndExtractFacet(meta: RegistryMetadata, dest: stri
     }
   }
 
-  // Make sure dest exists; mkdir -p is idempotent.
-  await mkdir(dest, { recursive: true })
-
+  // Two-pass extraction to honor the all-or-nothing contract:
+  //   Pass 1 — validate every entry's path. No filesystem writes. If any
+  //            entry is unsafe, return immediately; `dest` is untouched.
+  //   Pass 2 — only after every entry has cleared sanitization, mkdir
+  //            `dest` and write the files.
+  // Without the split, a malicious tar with a safe entry followed by an
+  // unsafe one would land the safe entry on disk before we noticed.
+  interface PreparedEntry {
+    target: string
+    data: Uint8Array
+  }
+  const prepared: PreparedEntry[] = []
   for (const entry of entries) {
     if (entry.data === undefined) continue // directory entry; recreated as we write files
     const safeName = sanitizeEntryName(entry.name)
@@ -128,8 +137,14 @@ export async function downloadAndExtractFacet(meta: RegistryMetadata, dest: stri
         },
       }
     }
+    prepared.push({ target, data: entry.data })
+  }
+
+  // All entries cleared sanitization — now it's safe to touch the filesystem.
+  await mkdir(dest, { recursive: true })
+  for (const { target, data } of prepared) {
     await mkdir(dirname(target), { recursive: true })
-    await writeFile(target, entry.data)
+    await writeFile(target, data)
   }
 
   return { ok: true, value: undefined }
@@ -139,17 +154,30 @@ export async function downloadAndExtractFacet(meta: RegistryMetadata, dest: stri
  * Reject tar entry names that would escape the extraction directory.
  * Returns the safe relative form, or null if the entry should be refused.
  *
- *   - Strip a leading `./`.
- *   - Reject leading `/` (absolute path).
- *   - Reject any segment equal to `..` (parent traversal).
  *   - Reject empty names.
+ *   - Strip a leading `./`; if nothing remains, reject (no useful target).
+ *   - Reject any platform-absolute path (`/foo`, `C:\foo`, `\\?\foo`,
+ *     `\\server\share`). On POSIX `isAbsolute('C:\\...')` is false, so
+ *     we also explicitly reject Windows-style drive letters and UNC
+ *     prefixes — defense in depth in case a malicious tar is unpacked
+ *     on a Windows host.
+ *   - Reject any segment equal to `..` (parent traversal).
+ *   - Reject `.` after normalization (entry would target `dest` itself,
+ *     which `writeFile` cannot do because `dest` is a directory).
  */
 function sanitizeEntryName(name: string): string | null {
   if (name.length === 0) return null
   let cleaned = name
   if (cleaned.startsWith('./')) cleaned = cleaned.slice(2)
+  if (cleaned.length === 0) return null
+  if (isAbsolute(cleaned)) return null
+  // Windows drive letters and UNC, even on POSIX hosts where `isAbsolute`
+  // returns false for them. (`C:\path`, `C:/path`, `\\server\share`.)
+  if (/^[A-Za-z]:[\\/]/.test(cleaned)) return null
+  if (cleaned.startsWith('\\\\')) return null
   if (cleaned.startsWith('/')) return null
   const normalized = normalize(cleaned)
+  if (normalized === '.' || normalized === '..') return null
   const segments = normalized.split('/')
   if (segments.some((s) => s === '..')) return null
   return normalized

--- a/packages/core/src/registry/download.ts
+++ b/packages/core/src/registry/download.ts
@@ -1,43 +1,156 @@
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join, normalize, relative } from 'node:path'
+import { parseTarGzip } from 'nanotar'
 import type { RegistryMetadata, RegistryResult } from './types.ts'
 
 /**
- * Download a `.facet` tarball from the registry and extract its
- * contents into `dest`.
+ * Download a `.tar.gz` archive from the registry and extract its contents
+ * into `dest`.
  *
- * Today this function is a stub: it returns `REGISTRY_NOT_AVAILABLE`
- * for every call and delegates the user toward git/local sources
- * until the real registry ships.
+ * The V0 archive endpoint returns a 302 redirect to a presigned S3 URL;
+ * `fetch` follows redirects by default so the call site doesn't need to
+ * special-case it. The downloaded bytes are a gzipped tarball with
+ * `facet.json` at the root (the same shape `facet build` would produce
+ * before any `.facet` outer-tar wrapping — V0 publishes the source
+ * distribution directly).
  *
- * Tomorrow's implementation will:
+ * Verification: the registry's `expectedIntegrity` (sha256 of the
+ * tarball-as-uploaded) is checked against the bytes we just downloaded.
+ * Mismatch is a hard error — the tarball was tampered with in transit
+ * or the registry's record is corrupt; either way, refuse to extract.
  *
- *   1. Fetch the tarball bytes from `meta.tarballUrl`.
- *   2. Run the dual-extraction:
- *        - outer tar (uncompressed): contains `build-manifest.json`
- *          and `archive.tar.gz`.
- *        - inner tar (gzipped): the actual facet content.
- *   3. Verify the inner archive's self-declared integrity matches the
- *      outer manifest's claim, then matches `meta.expectedIntegrity`
- *      (Checks B and C of the three-check protocol).
- *   4. Write the extracted content into `dest`.
- *
- * The integrity verification belongs to the caller (it's the bridge
- * between this function's bytes and the lockfile's recorded hash);
- * `downloadAndExtractFacet` produces the bytes and returns.
+ * Path safety: tar entry names that would escape `dest` (absolute paths,
+ * `../` segments, leading slashes) are rejected. A single bad entry
+ * fails the entire extraction so we never end up with a half-written
+ * directory containing some malicious files.
  *
  * Always returns; never throws.
  */
-export async function downloadAndExtractFacet(
-  meta: RegistryMetadata,
-  // biome-ignore lint/correctness/noUnusedFunctionParameters: stub; will be used by the real implementation
-  dest: string,
-): Promise<RegistryResult<void>> {
-  // TODO(registry): replace with real .facet tarball fetch + extraction.
-  return {
-    ok: false,
-    error: {
-      code: 'REGISTRY_NOT_AVAILABLE',
-      what: `registry tarball download is not yet available (would fetch ${meta.tarballUrl} for ${meta.name}@${meta.version})`,
-      fix: 'use a github: shortcut, https URL, ssh URL, or local path until the registry ships',
-    },
+export async function downloadAndExtractFacet(meta: RegistryMetadata, dest: string): Promise<RegistryResult<void>> {
+  let response: Response
+  try {
+    response = await fetch(meta.tarballUrl, { redirect: 'follow' })
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `archive download failed: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
   }
+  if (response.status === 404) {
+    // The archive endpoint and the metadata endpoint should agree on
+    // existence, but if metadata succeeded and archive 404s the most
+    // useful framing is still "not found" — the row exists but the
+    // S3 object is missing (orphaned write).
+    return {
+      ok: false,
+      error: { code: 'NOT_FOUND', name: meta.name, spec: meta.version },
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `archive download returned HTTP ${response.status} ${response.statusText}`,
+      },
+    }
+  }
+
+  let bytes: Uint8Array
+  try {
+    bytes = new Uint8Array(await response.arrayBuffer())
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `archive read failed: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
+  }
+
+  // Integrity check before any extraction. If the bytes are not what the
+  // registry told us they would be, do NOT touch the filesystem.
+  const actualIntegrity = `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+  if (actualIntegrity !== meta.expectedIntegrity) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `archive sha256 mismatch: expected ${meta.expectedIntegrity}, got ${actualIntegrity}`,
+      },
+    }
+  }
+
+  let entries: ReadonlyArray<{ name: string; data?: Uint8Array }>
+  try {
+    entries = await parseTarGzip(bytes)
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `archive is not a valid gzipped tar: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
+  }
+
+  // Make sure dest exists; mkdir -p is idempotent.
+  await mkdir(dest, { recursive: true })
+
+  for (const entry of entries) {
+    if (entry.data === undefined) continue // directory entry; recreated as we write files
+    const safeName = sanitizeEntryName(entry.name)
+    if (safeName === null) {
+      return {
+        ok: false,
+        error: {
+          code: 'NETWORK_ERROR',
+          cause: `archive contains an unsafe path: "${entry.name}"`,
+        },
+      }
+    }
+    const target = join(dest, safeName)
+    // Defense-in-depth: ensure the resolved path is still under dest after
+    // join+normalize. `sanitizeEntryName` should have caught this, but
+    // a second check costs nothing.
+    const rel = relative(dest, target)
+    if (rel.startsWith('..') || rel.startsWith('/')) {
+      return {
+        ok: false,
+        error: {
+          code: 'NETWORK_ERROR',
+          cause: `archive entry "${entry.name}" resolves outside the extraction directory`,
+        },
+      }
+    }
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(target, entry.data)
+  }
+
+  return { ok: true, value: undefined }
+}
+
+/**
+ * Reject tar entry names that would escape the extraction directory.
+ * Returns the safe relative form, or null if the entry should be refused.
+ *
+ *   - Strip a leading `./`.
+ *   - Reject leading `/` (absolute path).
+ *   - Reject any segment equal to `..` (parent traversal).
+ *   - Reject empty names.
+ */
+function sanitizeEntryName(name: string): string | null {
+  if (name.length === 0) return null
+  let cleaned = name
+  if (cleaned.startsWith('./')) cleaned = cleaned.slice(2)
+  if (cleaned.startsWith('/')) return null
+  const normalized = normalize(cleaned)
+  const segments = normalized.split('/')
+  if (segments.some((s) => s === '..')) return null
+  return normalized
 }

--- a/packages/core/src/registry/http.ts
+++ b/packages/core/src/registry/http.ts
@@ -1,0 +1,32 @@
+/**
+ * Default registry base URL. Overridable via `FACET_REGISTRY_URL` env so
+ * V0 can point the conference build at the `dev` stage without rebuilding.
+ * Once `main` ships this constant becomes the prod URL.
+ */
+const DEFAULT_REGISTRY_URL = 'https://api.dev.facet.cafe/v0'
+
+/**
+ * Resolve the registry base URL from env, stripping any trailing slash so
+ * callers can append paths without double-slashing.
+ *
+ * Lives in core because both the install pipeline (resolve-metadata,
+ * download) and the CLI's standalone helpers (search, publish) need to
+ * agree on the URL — duplicating the constant invites silent drift.
+ */
+export function getRegistryBaseUrl(): string {
+  const fromEnv = process.env.FACET_REGISTRY_URL
+  const raw = fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_REGISTRY_URL
+  return raw.replace(/\/+$/, '')
+}
+
+/**
+ * Encode a canonical facet name for use in a URL path. Namespaced names
+ * like `acme/cowsay` become `acme%2Fcowsay` (npm-style); bare names pass
+ * through unchanged.
+ *
+ * Centralized so every call site encodes identically — silent mismatches
+ * between client and server URL forms are notoriously hard to debug.
+ */
+export function encodeFacetName(name: string): string {
+  return encodeURIComponent(name)
+}

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -1,4 +1,6 @@
 export { describeVersionSpec } from './describe.ts'
 export { downloadAndExtractFacet } from './download.ts'
+export { encodeFacetName, getRegistryBaseUrl } from './http.ts'
+export { packFacetSource } from './pack.ts'
 export { resolveRegistryMetadataBatch } from './resolve-metadata.ts'
 export type { RegistryError, RegistryMetadata, RegistryResult, RegistrySpec } from './types.ts'

--- a/packages/core/src/registry/pack.ts
+++ b/packages/core/src/registry/pack.ts
@@ -1,0 +1,51 @@
+import { existsSync, statSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+import { createTar } from 'nanotar'
+
+/**
+ * Pack a facet source directory into the V0 publish format: a gzipped
+ * tar with `facet.json` at the root plus all conventional asset
+ * directories (`skills/`, `agents/`, `commands/`) recursively.
+ *
+ * Other top-level files are skipped — they aren't part of the facet's
+ * published surface and would just bloat the tarball
+ * (node_modules, dist, .git, etc.).
+ *
+ * The output is the bytes the publish endpoint expects on the wire:
+ * gunzip → tar containing facet.json at root.
+ */
+export async function packFacetSource(rootDir: string): Promise<Uint8Array<ArrayBuffer>> {
+  const entries: Array<{ name: string; data: Uint8Array }> = []
+
+  const manifestBytes = await readFile(join(rootDir, 'facet.json'))
+  entries.push({ name: 'facet.json', data: new Uint8Array(manifestBytes) })
+
+  for (const dirName of ['skills', 'agents', 'commands']) {
+    const dirPath = join(rootDir, dirName)
+    if (!existsSync(dirPath)) continue
+    const stat = statSync(dirPath)
+    if (!stat.isDirectory()) continue
+    await collectFiles(dirPath, rootDir, entries)
+  }
+
+  const tar = createTar(entries) as Uint8Array<ArrayBuffer>
+  return Bun.gzipSync(tar) as unknown as Uint8Array<ArrayBuffer>
+}
+
+async function collectFiles(
+  dir: string,
+  rootDir: string,
+  out: Array<{ name: string; data: Uint8Array }>,
+): Promise<void> {
+  const items = await readdir(dir, { withFileTypes: true })
+  for (const item of items) {
+    const full = join(dir, item.name)
+    if (item.isDirectory()) {
+      await collectFiles(full, rootDir, out)
+    } else if (item.isFile()) {
+      const bytes = await readFile(full)
+      out.push({ name: relative(rootDir, full), data: new Uint8Array(bytes) })
+    }
+  }
+}

--- a/packages/core/src/registry/resolve-metadata.ts
+++ b/packages/core/src/registry/resolve-metadata.ts
@@ -31,11 +31,14 @@ interface WireMetadataResponse {
  *
  * Empty input returns `{ ok: true, value: [] }`.
  *
- * Wildcards / `latest` collapse to the literal `latest` string when sent
- * to the server — V0 doesn't support range resolution server-side, so
- * `1.*` and `*` are treated identically to `latest`. The server returns
- * the actual resolved version in the response, which is what we record
- * on the metadata.
+ * Version specs are sent verbatim in the form the user wrote (`1.2.3`,
+ * `1.*`, `1.2.*`, `*`, `latest`). The server is the authority on which
+ * forms it can resolve; the client must not silently widen a constrained
+ * spec. V0 currently only resolves exact versions and `latest` — every
+ * other form returns NOT_FOUND, which we surface unchanged. (Once the
+ * server gains range-resolution support, this code does not need to
+ * change.) The semantic correctness of the contract belongs on the
+ * client; the limits of what's resolvable belong on the server.
  */
 export async function resolveRegistryMetadataBatch(
   specs: ReadonlyArray<RegistrySpec>,
@@ -58,7 +61,9 @@ export async function resolveRegistryMetadataBatch(
 }
 
 async function fetchOne(base: string, spec: RegistrySpec): Promise<RegistryResult<RegistryMetadata>> {
-  const versionForUrl = serverVersionString(spec)
+  // Surface form ('1.2.3', '1.*', '*', 'latest', etc.) is sent verbatim.
+  // The server is responsible for accepting/rejecting; we don't widen.
+  const versionForUrl = describeVersionSpec(spec.version)
   const encodedName = encodeFacetName(spec.name)
   const url = `${base}/packages/${encodedName}/${encodeURIComponent(versionForUrl)}`
   let response: Response
@@ -121,16 +126,4 @@ async function fetchOne(base: string, spec: RegistrySpec): Promise<RegistryResul
       tarballUrl,
     },
   }
-}
-
-/**
- * Translate a parsed VersionSpec into the version string the V0 server
- * understands. Exact versions pass through; everything else collapses to
- * `latest` (server-side range resolution is post-V0).
- */
-function serverVersionString(spec: RegistrySpec): string {
-  if (spec.version.kind === 'exact') {
-    return `${spec.version.major}.${spec.version.minor}.${spec.version.patch}`
-  }
-  return 'latest'
 }

--- a/packages/core/src/registry/resolve-metadata.ts
+++ b/packages/core/src/registry/resolve-metadata.ts
@@ -1,47 +1,136 @@
 import { describeVersionSpec } from './describe.ts'
+import { encodeFacetName, getRegistryBaseUrl } from './http.ts'
 import type { RegistryMetadata, RegistryResult, RegistrySpec } from './types.ts'
+
+/**
+ * Wire-format response from `GET /v0/packages/:name/:version`. Mirrors the
+ * osaka backend at `packages/v0/api/src/routes/fetch.ts` lines 134-144.
+ *
+ * `contentHash` is the sha256 of the gzipped tarball as it was uploaded;
+ * we use it as `expectedIntegrity` on the metadata to anchor the download
+ * verification. (See `download.ts` for the bytes-level check.)
+ */
+interface WireMetadataResponse {
+  name: string
+  version: string
+  contentHash: string
+  sizeBytes: number
+  publishedAt: string
+  manifestJson?: string
+}
 
 /**
  * Resolve registry metadata for a batch of `(name, version)` pairs.
  *
- * Today this function is a stub: it returns `REGISTRY_NOT_AVAILABLE`
- * for every non-empty input and delegates the user toward git/local
- * sources until the real registry ships.
+ * V0 fans out concurrent per-spec fetches (no batch endpoint server-side
+ * yet). Returns one RegistryMetadata per input spec in input order, or
+ * surfaces NOT_FOUND / NETWORK_ERROR for the first failure encountered —
+ * all-or-nothing semantics keep the caller-side branching simple. (No
+ * partial-failure surface area in V0; if the demo is the use case, a
+ * single facet is being resolved at a time anyway.)
  *
- * Tomorrow's implementation can either fan out concurrent fetches or
- * call a real batch endpoint without touching callers — the batch
- * shape is the durable contract.
+ * Empty input returns `{ ok: true, value: [] }`.
  *
- * Empty input returns `{ ok: true, value: [] }` to keep callers that
- * dynamically build batches simple.
- *
- * Pure (no I/O) today; will perform I/O when the real client lands.
- * Always returns; never throws.
+ * Wildcards / `latest` collapse to the literal `latest` string when sent
+ * to the server — V0 doesn't support range resolution server-side, so
+ * `1.*` and `*` are treated identically to `latest`. The server returns
+ * the actual resolved version in the response, which is what we record
+ * on the metadata.
  */
 export async function resolveRegistryMetadataBatch(
   specs: ReadonlyArray<RegistrySpec>,
 ): Promise<RegistryResult<ReadonlyArray<RegistryMetadata>>> {
-  // TODO(registry): replace with real call to facets.cafe metadata API.
-  // The real implementation will: (a) batch all specs into a single
-  // request when the API supports it, (b) otherwise fan out concurrent
-  // per-spec fetches, (c) return one RegistryMetadata per input spec
-  // in input order, or surface NOT_FOUND/NETWORK_ERROR as appropriate.
-  if (specs.length === 0) {
-    return { ok: true, value: [] }
-  }
+  if (specs.length === 0) return { ok: true, value: [] }
 
-  const first = specs[0]
-  if (first === undefined) {
-    return { ok: true, value: [] }
+  const base = getRegistryBaseUrl()
+  const results = await Promise.all(specs.map((spec) => fetchOne(base, spec)))
+  for (const r of results) {
+    if (!r.ok) return r
   }
-  const sample = `${first.name}@${describeVersionSpec(first.version)}`
-
   return {
-    ok: false,
-    error: {
-      code: 'REGISTRY_NOT_AVAILABLE',
-      what: `registry is not yet available (would query facets.cafe for ${specs.length === 1 ? `"${sample}"` : `${specs.length} facets including "${sample}"`})`,
-      fix: 'use a github: shortcut, https URL, ssh URL, or local path until the registry ships',
+    ok: true,
+    value: results.map((r) => {
+      // Type narrowing for the all-ok case.
+      if (!r.ok) throw new Error('unreachable: failure should have short-circuited')
+      return r.value
+    }),
+  }
+}
+
+async function fetchOne(base: string, spec: RegistrySpec): Promise<RegistryResult<RegistryMetadata>> {
+  const versionForUrl = serverVersionString(spec)
+  const encodedName = encodeFacetName(spec.name)
+  const url = `${base}/packages/${encodedName}/${encodeURIComponent(versionForUrl)}`
+  let response: Response
+  try {
+    response = await fetch(url)
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: err instanceof Error ? err.message : String(err),
+      },
+    }
+  }
+  if (response.status === 404) {
+    return {
+      ok: false,
+      error: { code: 'NOT_FOUND', name: spec.name, spec: describeVersionSpec(spec.version) },
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `registry returned HTTP ${response.status} ${response.statusText}`,
+      },
+    }
+  }
+  let body: WireMetadataResponse
+  try {
+    body = (await response.json()) as WireMetadataResponse
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: `registry returned non-JSON body: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
+  }
+  if (typeof body.name !== 'string' || typeof body.version !== 'string' || typeof body.contentHash !== 'string') {
+    return {
+      ok: false,
+      error: {
+        code: 'NETWORK_ERROR',
+        cause: 'registry response is missing required fields (name, version, contentHash)',
+      },
+    }
+  }
+  // Compute the archive URL the same way the metadata URL was computed,
+  // but with the SERVER-RESOLVED version (in case the input was `latest`).
+  const tarballUrl = `${base}/packages/${encodedName}/${encodeURIComponent(body.version)}/archive`
+  return {
+    ok: true,
+    value: {
+      name: body.name,
+      version: body.version,
+      expectedIntegrity: body.contentHash,
+      tarballUrl,
     },
   }
+}
+
+/**
+ * Translate a parsed VersionSpec into the version string the V0 server
+ * understands. Exact versions pass through; everything else collapses to
+ * `latest` (server-side range resolution is post-V0).
+ */
+function serverVersionString(spec: RegistrySpec): string {
+  if (spec.version.kind === 'exact') {
+    return `${spec.version.major}.${spec.version.minor}.${spec.version.patch}`
+  }
+  return 'latest'
 }


### PR DESCRIPTION
### Why

<!-- Why does this change exist? Link an issue or describe the motivation. Remove this section for trivial changes where the title says it all. -->

### Details

<!-- What should the reviewer know that isn't obvious from the diff? Approach, trade-offs, edge cases. Remove this section if the change is self-explanatory. -->

### Verification

<!-- How do you know it works? Manual test steps, deployment notes, or just "CI". Remove this section if CI covers it. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds networked registry resolution/download and a new `publish` flow that mutates `facet.json` and POSTs tarballs, which impacts install integrity/security and release behavior. Also changes CLI surface area and output formatting, so regressions could affect common workflows and error handling.
> 
> **Overview**
> **CLI now talks to the live registry.** `facet search` fetches `/packages` and renders copy-pastable next steps; `facet list` reads `facets.json` and prefers resolved versions from `facets.lock`; and `facet publish` packs the current facet, auto-bumps patch versions, POSTs to the registry (with one retry on `VERSION_EXISTS`), and surfaces translated registry errors.
> 
> **Install pipeline gains real registry sources.** Core replaces registry stubs with metadata resolution (`getRegistryBaseUrl`, `encodeFacetName`), archive download/extract with sha256 verification + path-safety checks, cache integration for locked registry installs, and integrity guarding for registry entries.
> 
> **UX/error output updates.** Install TUI adds an “asset bundle” summary and an `add`-only landing line (`Now /<cmd>…`), and CLI errors can now include a `docsUrl` line; tests/e2e expectations are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c3042f57dd64801b562b88f0190e5c5783f3ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->