### PR TITLE
Allow YAML front matter in content files; merge with manifest at install time

### DIFF
--- a/.changeset/twenty-goats-confess.md
+++ b/.changeset/twenty-goats-confess.md
@@ -1,0 +1,8 @@
+---
+"@agent-facets/adapter": patch
+"agent-facets": patch
+"@agent-facets/common": patch
+"@agent-facets/core": patch
+---
+
+Allow YAML front matter in content files; merge with manifest at install time

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,9 @@
     },
     "packages/common": {
       "name": "@agent-facets/common",
+      "dependencies": {
+        "yaml": "2.8.3",
+      },
     },
     "packages/core": {
       "name": "@agent-facets/core",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,7 +22,7 @@ The following are the most common `facet` commands. See the [roadmap](/roadmap) 
     Scaffolds a new **facet** project with an interactive wizard — name, description, version, and initial assets
   </Card>
   <Card title={<Badge>facet edit</Badge>}>
-    Full authoring workbench — edit identity, manage assets, reconcile disk vs manifest, strip front matter
+    Full authoring workbench — edit identity, manage assets, reconcile disk vs manifest
   </Card>
   <Card title={<Badge>facet build</Badge>}>
     Validates and packages your **facet** into a distributable archive with integrity hashes

--- a/docs/cli/authoring/build.md
+++ b/docs/cli/authoring/build.md
@@ -19,7 +19,7 @@ The build command runs a validation pipeline, assembles an archive, and computes
 
 1. **Parse manifest** — reads `facet.json`, parses JSON, validates against the schema including business-rule constraints (at least one text asset, etc.)
 2. **Resolve prompts** — reads prompt files at conventional paths. Skills use `skills/<name>/SKILL.md` (Agent Skills directory convention). Agents use `agents/<name>.md`. Commands use `commands/<name>.md`. If an expected file doesn't exist, the build fails.
-3. **Validate assets** — checks that all content files are non-empty and contain no YAML front matter. The manifest is the single source of truth for metadata — content files must be pure markdown.
+3. **Validate assets** — checks that all content files are non-empty. Author-supplied YAML front matter is preserved verbatim in the archive; the manifest's `name`, `description`, and any per-adapter extras are merged on top of it at install time.
 4. **Check collisions** — validates compact facets entries match the `name@version` format. Fails if the same name is used more than once within the same asset type.
 5. **Validate adapters** — validates adapter metadata for installed adapters (e.g., `opencode`, `claude-code`). Each adapter validates its own metadata schema. Unknown adapters produce a warning but do not fail the build.
 6. **Assemble archive** — collects the manifest and all resolved text assets into a deterministic tar archive, computes the integrity hash, compresses it with gzip, then wraps the compressed archive and a build manifest into the self-contained `.facet` file.

--- a/docs/cli/authoring/create.md
+++ b/docs/cli/authoring/create.md
@@ -32,7 +32,7 @@ On confirmation, the wizard writes:
 - `agents/<name>.md` — starter agent template
 - `commands/<name>.md` — starter command template
 
-Content files contain pure markdown with no YAML front matter. The manifest is the single source of truth for metadata.
+Content files are markdown. Optional YAML front matter is preserved verbatim through the build; at install time the manifest's `name`, `description`, and any per-adapter extras are merged on top of whatever the author wrote.
 
 After creating the project, use `facet edit` to iterate on your facet, or `facet build` to validate and package it.
 

--- a/docs/cli/authoring/edit.md
+++ b/docs/cli/authoring/edit.md
@@ -23,7 +23,8 @@ If the edit command detects drift between the manifest and the files on disk, it
 
 - **New files on disk** not tracked in the manifest — choose "Add to manifest" or "Ignore for now"
 - **Missing files** declared in the manifest but absent from disk — choose "Scaffold template" or "Remove from manifest"
-- **Front matter detected** in content files — choose "Strip front matter" or "Remove from manifest"
+
+YAML front matter in content files is not flagged here — it is permitted and preserved verbatim through the build, then merged with the manifest's `name`, `description`, and any per-adapter extras at install time.
 
 All reconciliation items must be resolved before proceeding to editing.
 
@@ -44,7 +45,6 @@ Before applying, a summary shows the final state of your facet — identity fiel
 On apply, the edit command:
 - Writes the updated `facet.json`
 - Scaffolds template files for new assets
-- Strips front matter from flagged files
 - Deletes files for removed assets
 
 ## Exit codes

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -21,7 +21,7 @@ The following are the most common `facet` commands. See the [roadmap](/roadmap) 
     Scaffolds a new **facet** project with an interactive wizard — name, description, version, and initial assets
   </Card>
   <Card title={<Badge>facet edit</Badge>}>
-    Full authoring workbench — edit identity, manage assets, reconcile disk vs manifest, strip front matter
+    Full authoring workbench — edit identity, manage assets, reconcile disk vs manifest
   </Card>
   <Card title={<Badge>facet build</Badge>}>
     Validates and packages your **facet** into a distributable archive with integrity hashes

--- a/docs/specification/publish.md
+++ b/docs/specification/publish.md
@@ -17,7 +17,7 @@ The publish flow addresses two concerns:
 
 ### Steps
 
-1. **Parse the manifest.** Read the facet manifest (`facet.json`) and validate against the manifest schema. The manifest MUST be valid. Invalid manifests MUST be rejected with a descriptive error. Content files MUST contain no YAML front matter and MUST not be empty.
+1. **Parse the manifest.** Read the facet manifest (`facet.json`) and validate against the manifest schema. The manifest MUST be valid. Invalid manifests MUST be rejected with a descriptive error. Content files MUST NOT be empty. YAML front matter in content files is permitted and MUST be preserved verbatim in the archive — the manifest's `name`, `description`, and any per-adapter extras are merged on top of the author's front matter at install time.
 
 2. **Resolve text composition.** For each entry in the `facets` section:
    - Fetch the referenced facet at the exact pinned version from the registry or local cache.

--- a/facets.json
+++ b/facets.json
@@ -1,5 +1,6 @@
 {
   "facets": {
-    "viper-plans": "github:agent-facets/viper-plans"
+    "viper-plans": "github:agent-facets/viper-plans",
+    "cowsay": "./fixtures/cowsay"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -28,6 +28,33 @@
           "name": "viper-run"
         }
       ]
+    },
+    "cowsay": {
+      "source": "./fixtures/cowsay",
+      "version": "0.1.1",
+      "integrity": "sha256:b9382c785593c404ea61b8aae43b63ffc7fec426e0d4419233de71c0080a3fe1",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "cowsay-rules"
+        },
+        {
+          "scope": "project",
+          "type": "agent",
+          "name": "cowsay"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "cowchat"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "cowsay"
+        }
+      ]
     }
   }
 }

--- a/fixtures/cowsay/agents/cowsay.md
+++ b/fixtures/cowsay/agents/cowsay.md
@@ -1,0 +1,23 @@
+# Cowsay
+
+## Role
+
+You are a cow. Your only job is to speak through ASCII speech bubbles
+above your own ASCII body.
+
+When loading skills don't say anything, just load them silently, then
+execute. The goal is to be a helpful and polite cow (aka always talk as
+the cow).
+
+## Behavior
+
+- Load and follow the `cowsay-rules` skill for every response. The skill
+  defines the ASCII cow, the bubble format, the two modes (`say` and
+  `chat`), and the strict output rule.
+- The caller will tell you which mode to use. If they don't, default to
+  `say`.
+- Never break character. You are the cow. You do not have access to the
+  filesystem, the shell, or any other tools — you only render cows.
+- Never output anything outside the code block. No greetings, no
+  follow-up questions, no "let me know if you'd like another." Just the
+  cow.

--- a/fixtures/cowsay/commands/cowchat.md
+++ b/fixtures/cowsay/commands/cowchat.md
@@ -1,0 +1,25 @@
+---
+agent: cowsay
+---
+
+# Cowchat
+
+Load the `cowsay-rules` skill and render an ASCII cow **replying** to the
+user's message.
+
+## Input
+
+The user's message to the cow:
+
+$ARGUMENTS
+
+## Task
+
+Render the cow in **chat** mode:
+
+- Generate a short, in-character cow reply to the input above (one or two
+  sentences, ideally under ~80 characters).
+- Put **the reply** in the speech bubble — not the original input.
+- Follow the skill's bubble format and the hard output rule: your entire
+  response is one fenced code block containing only the bubble and the
+  cow. Nothing else.

--- a/fixtures/cowsay/commands/cowsay.md
+++ b/fixtures/cowsay/commands/cowsay.md
@@ -1,0 +1,25 @@
+---
+agent: cowsay
+---
+
+# Cowsay
+
+Load the `cowsay-rules` skill and render an ASCII cow saying the user's
+message **verbatim**.
+
+## Input
+
+The user's message:
+
+$ARGUMENTS
+
+## Task
+
+Render the cow in **say** mode:
+
+- Put the input above, exactly as written, into the speech bubble.
+- Do not rephrase, summarize, translate, correct, or comment.
+- If the input is empty, put `...` in the bubble.
+- Follow the skill's bubble format and the hard output rule: your entire
+  response is one fenced code block containing only the bubble and the
+  cow. Nothing else.

--- a/fixtures/cowsay/facet.json
+++ b/fixtures/cowsay/facet.json
@@ -1,0 +1,23 @@
+{
+  "name": "cowsay",
+  "version": "0.1.1",
+  "description": "What does the cow say?",
+  "skills": {
+    "cowsay-rules": {
+      "description": "A Cowsay Rules skill"
+    }
+  },
+  "agents": {
+    "cowsay": {
+      "description": "A Cowsay agent"
+    }
+  },
+  "commands": {
+    "cowsay": {
+      "description": "A Cowsay command"
+    },
+    "cowchat": {
+      "description": "A Cowchat command"
+    }
+  }
+}

--- a/fixtures/cowsay/skills/cowsay-rules/SKILL.md
+++ b/fixtures/cowsay/skills/cowsay-rules/SKILL.md
@@ -1,0 +1,101 @@
+# Cowsay Rules
+
+## Purpose
+
+Defines the canonical ASCII cow + speech-bubble format used by the `cowsay`
+agent and the `/cowsay` and `/cowchat` commands. Anything in this facet that
+makes a cow speak MUST follow these rules.
+
+## The cow
+
+The cow is fixed. Reproduce it byte-for-byte every time. Do not redesign,
+restyle, or "improve" it.
+
+```
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+```
+
+The two leading backslashes are the tether from the bubble to the cow's
+head. They MUST appear, indented as shown.
+
+## The speech bubble
+
+The bubble sits directly above the cow.
+
+For a single-line message of length `N`:
+
+```
+ _<N underscores>_
+< MESSAGE >
+ -<N hyphens>-
+```
+
+Concretely, for the message `Hello`:
+
+```
+ _______
+< Hello >
+ -------
+```
+
+The top border is one space, then `N + 2` underscores. The bottom border
+is one space, then `N + 2` hyphens. The message line is `< MESSAGE >`
+(angle bracket, space, message, space, angle bracket).
+
+### Multi-line messages
+
+If the message is longer than ~40 characters, wrap it onto multiple lines
+at word boundaries. Use `/` and `\` for the corner brackets and `|` for
+the vertical sides. Pad every line to the same inner width:
+
+```
+ _______________________________________
+/ This is a longer message that wraps    \
+| across multiple lines so the cow can   |
+\ keep saying important things.          /
+ ---------------------------------------
+```
+
+- First line opens with `/`, last line closes with `\` on the left and
+  `/` on the right.
+- Middle lines use `|` on both sides.
+- All inner content is padded to the same width with trailing spaces.
+
+## Modes
+
+This skill is invoked in one of two modes. The caller (a command or
+agent) tells you which.
+
+### `say` mode
+
+The user-supplied text goes into the bubble **verbatim**. Do not rephrase,
+summarize, translate, correct spelling, expand abbreviations, or add
+anything. The cow is a literal megaphone.
+
+If the input is empty, put `...` in the bubble.
+
+### `chat` mode
+
+Treat the user-supplied text as a prompt or question directed at the cow.
+Generate a short, in-character reply (one or two sentences, ideally under
+~80 characters) and put **the reply** in the bubble — not the original
+prompt.
+
+The cow:
+- Speaks plainly. Bovine puns ("moo", "udder", "graze", "herd") are
+  highly desired, but don't force them.
+- Stays brief. The bubble is small.
+- Never breaks character to explain itself, apologize, or hedge.
+
+## Output rule (HARD)
+
+Your entire response MUST be a single fenced code block containing only
+the bubble and the cow. Nothing before it. Nothing after it. No preamble
+("Here you go:"), no commentary ("Hope this helps!"), no explanation of
+what mode you used. Just the cow.
+
+If you find yourself typing anything outside the code block, delete it.

--- a/packages/adapter/src/asset-fs.ts
+++ b/packages/adapter/src/asset-fs.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import { normalizeLineEndings, validateAssetName } from '@agent-facets/common'
-import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import { splitFrontMatter, validateAssetName } from '@agent-facets/common'
+import { stringify as stringifyYaml } from 'yaml'
 
 /**
  * Shared filesystem helpers for adapter install/read/delete.
@@ -85,8 +85,6 @@ export async function deleteAssetFile(path: AssetPath): Promise<void> {
 
 // --- front-matter helpers (exported for adapter-level customization) ---
 
-const FRONT_MATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/
-
 /**
  * Assemble a full file string from optional front-matter metadata + body.
  * When `body` already contains a front-matter block, the two are merged
@@ -117,31 +115,14 @@ export function assembleAssetContent(body: string, metadata?: Record<string, unk
  * the raw string as `content` when no front-matter is detected. Malformed
  * YAML falls back to "no front-matter."
  *
- * Known limitation (tracked as a post-alpha TODO — see plan F10): the regex
- * below is non-greedy, so if a body legitimately contains a literal line of
- * exactly `---` followed by content and another `---` line, the first
- * terminator wins and the body will be split in the wrong place. Skills and
- * commands rarely include frontmatter-shaped content inside their bodies,
- * so in practice this is benign — but replacing the regex with `gray-matter`
- * or an equivalent well-tested parser is the right fix.
+ * Thin re-export over `@agent-facets/common`'s `splitFrontMatter` so the
+ * adapter SDK and `core` share one canonical implementation. Kept as a
+ * named export here because adapter authors may import it directly when
+ * they customize their read path; `common` is bundled into the published
+ * adapter SDK so this stays a leaf import for consumers.
  */
 export function splitAssetContent(raw: string): { content: string; metadata?: Record<string, unknown> } {
-  // Normalize BOM + CRLF so Windows checkouts (or cross-platform git with
-  // core.autocrlf=true) match the same \n-anchored regex as Unix checkouts.
-  // Mirrors the behavior in `@agent-facets/core`'s front-matter parser.
-  const normalized = normalizeLineEndings(raw)
-  const match = normalized.match(FRONT_MATTER_RE)
-  if (!match) return { content: normalized }
-  try {
-    const yamlSource = match[1] ?? ''
-    const parsed = parseYaml(yamlSource) as unknown
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return { content: match[2] ?? '', metadata: parsed as Record<string, unknown> }
-    }
-    return { content: normalized }
-  } catch {
-    return { content: normalized }
-  }
+  return splitFrontMatter(raw)
 }
 
 /**

--- a/packages/cli/src/__tests__/edit-integration.test.ts
+++ b/packages/cli/src/__tests__/edit-integration.test.ts
@@ -62,8 +62,12 @@ describe('edit integration', () => {
     expect(missing[0]?.name).toBe('gone')
   })
 
-  test('buildEditContext detects front matter in matched files', async () => {
-    const dir = await createFixtureDir('detect-frontmatter')
+  test('buildEditContext does NOT flag matched files that contain front matter', async () => {
+    // Author-supplied front matter is permitted. It is preserved verbatim
+    // through the build and reconciled with the manifest only at install
+    // time (see materialize + the adapter SDK's assembleAssetContent).
+    // `facet edit` should never surface it as a reconciliation item.
+    const dir = await createFixtureDir('frontmatter-allowed')
     await writeManifest(dir, {
       name: 'test',
       version: '1.0.0',
@@ -75,6 +79,7 @@ describe('edit integration', () => {
       dedent`
         ---
         name: Review
+        agent: cowsay
         ---
         # Review skill
       `,
@@ -82,11 +87,9 @@ describe('edit integration', () => {
 
     const result = await buildEditContext(dir)
     expect(result.ok).toBe(true)
-    if (!result.ok) return
+    if (!result.ok) expect.unreachable()
 
-    const fm = result.context.reconciliationItems.filter((i) => i.kind === 'front-matter')
-    expect(fm).toHaveLength(1)
-    expect(fm[0]?.name).toBe('review')
+    expect(result.context.reconciliationItems).toHaveLength(0)
   })
 
   test('applyOperations scaffolds new skill files', async () => {
@@ -105,38 +108,6 @@ describe('edit integration', () => {
 
     const skillExists = await Bun.file(join(dir, 'skills/helper/SKILL.md')).exists()
     expect(skillExists).toBe(true)
-  })
-
-  test('applyOperations strips front matter from files', async () => {
-    const dir = await createFixtureDir('strip-fm')
-    await mkdir(join(dir, 'skills/review'), { recursive: true })
-    await Bun.write(
-      join(dir, 'skills/review/SKILL.md'),
-      dedent`
-        ---
-        name: Review
-        description: A review skill
-        ---
-        # Review
-        Review all code.
-      `,
-    )
-
-    const manifest = {
-      name: 'test',
-      version: '1.0.0',
-      skills: { review: { description: 'A review skill' } },
-    }
-    const operations: EditOperation[] = [
-      { op: 'write-manifest' },
-      { op: 'strip-front-matter', type: 'skills', name: 'review', path: 'skills/review/SKILL.md' },
-    ]
-
-    await applyOperations(manifest, operations, dir)
-
-    const content = await Bun.file(join(dir, 'skills/review/SKILL.md')).text()
-    expect(content).not.toContain('---')
-    expect(content).toContain('# Review')
   })
 
   test('applyOperations deletes removed asset files', async () => {

--- a/packages/cli/src/tui/views/edit/reconciliation-view.tsx
+++ b/packages/cli/src/tui/views/edit/reconciliation-view.tsx
@@ -18,8 +18,6 @@ function optionsForKind(kind: ReconciliationItem['kind']): [{ label: string }, {
       return [{ label: 'Add to manifest' }, { label: 'Ignore for now' }]
     case 'missing':
       return [{ label: 'Scaffold template' }, { label: 'Remove from manifest' }]
-    case 'front-matter':
-      return [{ label: 'Strip front matter' }, { label: 'Remove from manifest' }]
   }
 }
 
@@ -30,8 +28,6 @@ function indexToResolution(kind: ReconciliationItem['kind'], index: number): Rec
       return index === 0 ? { action: 'add-to-manifest' } : { action: 'ignore' }
     case 'missing':
       return index === 0 ? { action: 'scaffold-template' } : { action: 'remove-from-manifest' }
-    case 'front-matter':
-      return index === 0 ? { action: 'strip-front-matter' } : { action: 'remove-from-manifest' }
   }
 }
 
@@ -46,8 +42,6 @@ function resolutionToIndex(
       return resolution.action === 'add-to-manifest' ? 0 : resolution.action === 'ignore' ? 1 : null
     case 'missing':
       return resolution.action === 'scaffold-template' ? 0 : resolution.action === 'remove-from-manifest' ? 1 : null
-    case 'front-matter':
-      return resolution.action === 'strip-front-matter' ? 0 : resolution.action === 'remove-from-manifest' ? 1 : null
   }
 }
 
@@ -69,7 +63,6 @@ export function ReconciliationView({
   // Group items by kind
   const additions = items.filter((i) => i.kind === 'addition')
   const missing = items.filter((i) => i.kind === 'missing')
-  const frontMatter = items.filter((i) => i.kind === 'front-matter')
 
   // Build focus order: all items then continue button
   const focusIds = useMemo(() => {
@@ -119,12 +112,7 @@ export function ReconciliationView({
         </Box>
         {groupItems.map((item) => {
           const key = itemKey(item)
-          const description =
-            item.kind === 'missing'
-              ? `${item.name} (${item.type}) — ${item.expectedPath}`
-              : 'path' in item
-                ? item.path
-                : ''
+          const description = item.kind === 'missing' ? `${item.name} (${item.type}) — ${item.expectedPath}` : item.path
 
           return (
             <ReconciliationItemRow
@@ -149,7 +137,6 @@ export function ReconciliationView({
 
       {renderGroup('New files on disk:', additions)}
       {renderGroup('Missing from disk:', missing)}
-      {renderGroup('Front matter detected:', frontMatter)}
 
       <Box marginTop={1}>
         <Button

--- a/packages/cli/src/tui/views/edit/use-edit-session.ts
+++ b/packages/cli/src/tui/views/edit/use-edit-session.ts
@@ -57,22 +57,12 @@ function buildOperations(
   // Operations from reconciliation resolutions
   for (const [key, resolution] of resolutions) {
     const parts = key.split(':')
-    const kind = parts[0]
     const assetType = parts[1] as 'skills' | 'agents' | 'commands'
     const name = parts[2]
-    if (!kind || !assetType || !name) continue
+    if (!assetType || !name) continue
 
     if (resolution.action === 'scaffold-template') {
       operations.push({ op: 'scaffold', type: assetType, name })
-    } else if (resolution.action === 'remove-from-manifest' && kind === 'front-matter') {
-      operations.push({ op: 'delete-file', type: assetType, name })
-    } else if (resolution.action === 'strip-front-matter') {
-      const item = context.reconciliationItems.find(
-        (i) => i.kind === 'front-matter' && i.type === assetType && i.name === name,
-      )
-      if (item && 'path' in item) {
-        operations.push({ op: 'strip-front-matter', type: assetType, name, path: item.path })
-      }
     }
   }
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,5 +8,8 @@
   "scripts": {
     "types": "tsc --noEmit",
     "test": "bun test"
+  },
+  "dependencies": {
+    "yaml": "2.8.3"
   }
 }

--- a/packages/common/src/front-matter.ts
+++ b/packages/common/src/front-matter.ts
@@ -1,0 +1,52 @@
+import { parse as parseYaml } from 'yaml'
+import { normalizeLineEndings } from './text.ts'
+
+/**
+ * Split a string into a body without front matter and the parsed YAML
+ * front-matter metadata, when present.
+ *
+ * Used by:
+ *  - the adapter SDK's `splitAssetContent` (and via it, every adapter's
+ *    read path) to recover the body + metadata from on-disk asset files.
+ *  - core's materialize skip-if-identical compare to normalize the
+ *    candidate write content the same way the read path would, so the
+ *    body comparison is symmetric.
+ *
+ * Lives in `common` because both the adapter SDK and `core` need
+ * identical splitting semantics. A core-side implementation that
+ * imported `splitAssetContent` from the adapter SDK directly would
+ * pull `yaml` and friends into `core`'s runtime graph, which collides
+ * with `Bun.build` when the CLI's adapter integration tests bundle the
+ * same source files in the same process. Putting the primitive here
+ * means both packages get the same code without a cross-package value
+ * import.
+ *
+ * Returns `{ content: <normalized raw> }` when no front matter is
+ * detected or the YAML is malformed.
+ *
+ * Known limitation: the regex below is non-greedy, so a body that
+ * legitimately contains a literal `---` terminator line will be split
+ * at the first match. Skills and commands rarely contain frontmatter-
+ * shaped content inside their bodies, so in practice this is benign;
+ * a parser swap (e.g., `gray-matter`) is the right fix when needed.
+ */
+const FRONT_MATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/
+
+export function splitFrontMatter(raw: string): {
+  content: string
+  metadata?: Record<string, unknown>
+} {
+  const normalized = normalizeLineEndings(raw)
+  const match = normalized.match(FRONT_MATTER_RE)
+  if (!match) return { content: normalized }
+  try {
+    const yamlSource = match[1] ?? ''
+    const parsed = parseYaml(yamlSource) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { content: match[2] ?? '', metadata: parsed as Record<string, unknown> }
+    }
+    return { content: normalized }
+  } catch {
+    return { content: normalized }
+  }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export { type AssetNameValidation, validateAssetName } from './asset-name.ts'
 export { atomicWriteFileSync } from './atomic-write.ts'
+export { splitFrontMatter } from './front-matter.ts'
 export { normalizeLineEndings } from './text.ts'
 export type { AssetType, Scope, Validated, ValidationError } from './types.ts'

--- a/packages/core/src/__tests__/build-pipeline.test.ts
+++ b/packages/core/src/__tests__/build-pipeline.test.ts
@@ -534,19 +534,18 @@ describe('runBuildPipeline', () => {
 // --- Content validation ---
 
 describe('content validation', () => {
-  test('build fails on file with YAML front matter', async () => {
+  test('build succeeds when content files contain YAML front matter; archive preserves the body verbatim', async () => {
     const dir = await createFixtureDir('front-matter')
-    await Bun.write(
-      join(dir, 'skills/review/SKILL.md'),
-      dedent`
-        ---
-        name: Review
-        description: A review skill
-        ---
-        # Review
-        Review all code.
-      `,
-    )
+    const authoredBody = dedent`
+      ---
+      name: Review
+      description: A review skill
+      agent: cowsay
+      ---
+      # Review
+      Review all code.
+    `
+    await Bun.write(join(dir, 'skills/review/SKILL.md'), authoredBody)
     await Bun.write(
       join(dir, 'facet.json'),
       JSON.stringify({
@@ -559,13 +558,15 @@ describe('content validation', () => {
     )
 
     const result = await runBuildPipeline(dir)
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.errors).toHaveLength(1)
-      expect(result.errors[0]?.path).toBe('skills.review')
-      expect(result.errors[0]?.message).toContain('front matter')
-      expect(result.errors[0]?.message).toContain('skills/review/SKILL.md')
-    }
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+
+    // Build resolved the prompt verbatim — front matter survives untouched.
+    expect(result.data.skills?.review?.prompt).toBe(authoredBody)
+
+    // The asset hash is computed over the verbatim file contents, so the
+    // entry exists in the archive's per-asset hash map.
+    expect(result.assetHashes['skills/review/SKILL.md']).toMatch(/^sha256:/)
   })
 
   test('build fails on empty content file', async () => {

--- a/packages/core/src/__tests__/materialize.test.ts
+++ b/packages/core/src/__tests__/materialize.test.ts
@@ -148,6 +148,58 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
     expect(second.skipped).toBe(1)
   })
 
+  test('author front matter in the prompt body survives, manifest wins on conflict, and re-install skips', async () => {
+    // The user-shipped scenario: an author writes a `commands/foo.md` with
+    // their own YAML front matter (e.g., `agent: cowsay`), maybe also
+    // including their own `name`/`description` that conflict with what
+    // the manifest says. The build pipeline preserves the file verbatim;
+    // materialize merges the manifest's canonical name + description on
+    // top, the adapter SDK serializes the merged metadata to the file's
+    // front matter, and the body is preserved. A second install must
+    // skip — proving that the skip-if-identical comparison handles the
+    // body-vs-merged-content asymmetry correctly.
+    const promptBody = '---\nagent: cowsay\nname: bogus\n---\n# foo body\n'
+    const manifest: ResolvedFacetManifest = {
+      name: 'viper-plans',
+      version: '0.1.0',
+      commands: { foo: { description: 'real desc', prompt: promptBody } },
+    }
+    const fixture = buildSdkAdapter('sdk-author-fm')
+    const newAssets = computeAssetList(manifest)
+
+    const first = await materialize({
+      manifest,
+      adapters: [fixture.adapter],
+      oldAssets: [],
+      newAssets,
+      journal: new InstallJournal(),
+    })
+    expect(first.written).toBe(1)
+    expect(first.skipped).toBe(0)
+
+    // Inspect on-disk file directly: manifest wins on name/description,
+    // author's other front-matter keys survive, body is preserved.
+    const file = join(projectRoot, '.sdk-author-fm', 'commands', 'foo.md')
+    const onDisk = readFileSync(file, 'utf8')
+    expect(onDisk).toContain('name: foo')
+    expect(onDisk).toContain('description: real desc')
+    expect(onDisk).toContain('agent: cowsay')
+    expect(onDisk).not.toContain('name: bogus')
+    expect(onDisk).toContain('# foo body')
+
+    // Second materialize against the same disk state must skip — this
+    // exercises the skip-if-identical fix in materialize.ts.
+    const second = await materialize({
+      manifest,
+      adapters: [fixture.adapter],
+      oldAssets: newAssets,
+      newAssets,
+      journal: new InstallJournal(),
+    })
+    expect(second.written).toBe(0)
+    expect(second.skipped).toBe(1)
+  })
+
   test('SDK round-trip with adapter extras reports skipped:1 on re-install', async () => {
     // The case that production hit: a facet declares an `adapters.<name>`
     // block. materialize merges those extras into the metadata bag. The

--- a/packages/core/src/build/pipeline.ts
+++ b/packages/core/src/build/pipeline.ts
@@ -57,7 +57,7 @@ export type BuildStage = (typeof BUILD_STAGES)[number]
  * Runs the full build pipeline:
  * 1. Parse manifest — read facet.json, parse JSON, validate schema, check constraints
  * 2. Resolve prompts — read prompt files at conventional paths (also verifies files exist)
- * 3. Validate content — no front matter, no empty files
+ * 3. Validate content — no empty files (author front matter is permitted)
  * 4. Check collisions — fail if same name used within an asset type
  * 5. Validate adapters — delegate metadata building to each adapter, warn on unknown
  * 6. Assemble archive — collect entries, compute hashes, build tar, compress
@@ -98,7 +98,7 @@ export async function runBuildPipeline(
 
   onProgress?.({ stage: 'Resolving prompts', status: 'done' })
 
-  // Stage 3: Validate assets (no front matter, no empty files)
+  // Stage 3: Validate assets (no empty files; author front matter is OK)
   onProgress?.({ stage: 'Validating assets', status: 'running' })
 
   const contentErrors = validateContentFiles(resolveResult.data)

--- a/packages/core/src/build/validate-content.ts
+++ b/packages/core/src/build/validate-content.ts
@@ -1,11 +1,16 @@
 import type { ValidationError } from '@agent-facets/common'
-import { hasFrontMatter } from '../front-matter.ts'
 import type { ResolvedFacetManifest } from '../loaders/facet.ts'
 
 /**
  * Validates resolved prompt content for all assets:
- * - No YAML front matter (manifest is the single source of truth for metadata)
  * - No empty files (zero bytes or whitespace only)
+ *
+ * Author-supplied YAML front matter is permitted and is preserved verbatim
+ * in the archive. Front matter is reconciled with the manifest only at
+ * install time: `materialize` merges the manifest's `name`, `description`,
+ * and any per-adapter extras on top of whatever the author wrote, and the
+ * adapter SDK writes the merged result to disk. See
+ * `packages/adapter/src/asset-fs.ts#assembleAssetContent`.
  *
  * Returns an array of validation errors, one per offending file.
  */
@@ -30,17 +35,6 @@ export function validateContentFiles(resolved: ResolvedFacetManifest): Validatio
           message: `File is empty: ${relativePath}. Content files must contain prompt content.`,
           expected: 'non-empty content',
           actual: 'empty or whitespace only',
-        })
-        continue // Skip front matter check on empty files
-      }
-
-      // Check for YAML front matter
-      if (hasFrontMatter(asset.prompt)) {
-        errors.push({
-          path: `${type}.${name}`,
-          message: `File contains YAML front matter: ${relativePath}. The manifest is the source of truth for metadata — use \`facet edit\` to reconcile.`,
-          expected: 'no front matter',
-          actual: 'front matter detected',
         })
       }
     }

--- a/packages/core/src/edit/context.ts
+++ b/packages/core/src/edit/context.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path'
-import { hasFrontMatter } from '../front-matter.ts'
 import { loadManifest } from '../loaders/facet.ts'
 import { reconcile } from './reconcile.ts'
 import { scanAssets } from './scanner.ts'
@@ -45,14 +43,9 @@ export async function buildEditContext(
     items.push({ kind: 'missing', type: missing.type, name: missing.name, expectedPath: missing.expectedPath })
   }
 
-  // Check matched assets for front matter
-  for (const matched of recon.matched) {
-    const filePath = join(rootDir, matched.path)
-    const content = await Bun.file(filePath).text()
-    if (hasFrontMatter(content)) {
-      items.push({ kind: 'front-matter', type: matched.type, name: matched.name, path: matched.path })
-    }
-  }
+  // Matched assets are not inspected. Author-supplied front matter in
+  // matched files is permitted and reconciled at install time, not at
+  // edit time — see `materialize` and the SDK's `assembleAssetContent`.
 
   return { ok: true, context: { rootDir, manifest, reconciliationItems: items } }
 }

--- a/packages/core/src/edit/operations.ts
+++ b/packages/core/src/edit/operations.ts
@@ -1,6 +1,5 @@
 import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
-import { extractFrontMatter } from '../front-matter.ts'
 import { agentTemplate, commandTemplate, skillTemplate } from '../scaffold/index.ts'
 import type { FacetManifest } from '../schemas/facet-manifest.ts'
 import { writeManifest } from './manifest-writer.ts'
@@ -8,8 +7,7 @@ import type { EditOperation } from './types.ts'
 
 /**
  * Apply a sequence of edit operations to disk: write the manifest, scaffold
- * new asset templates, delete files, and strip front matter from existing
- * asset files.
+ * new asset templates, and delete files.
  */
 export async function applyEditOperations(
   manifest: FacetManifest,
@@ -46,14 +44,6 @@ export async function applyEditOperations(
         } catch {
           // File already gone — that's fine
         }
-        break
-      }
-
-      case 'strip-front-matter': {
-        const filePath = join(rootDir, op.path)
-        const raw = await Bun.file(filePath).text()
-        const { content } = extractFrontMatter(raw)
-        await Bun.write(filePath, content)
         break
       }
     }

--- a/packages/core/src/edit/types.ts
+++ b/packages/core/src/edit/types.ts
@@ -5,7 +5,6 @@ import type { AssetManifestKey } from './scanner.ts'
 export type ReconciliationItem =
   | { kind: 'addition'; type: AssetManifestKey; name: string; path: string }
   | { kind: 'missing'; type: AssetManifestKey; name: string; expectedPath: string }
-  | { kind: 'front-matter'; type: AssetManifestKey; name: string; path: string }
 
 /** The resolution chosen for a reconciliation item. */
 export type ReconciliationResolution =
@@ -13,7 +12,6 @@ export type ReconciliationResolution =
   | { action: 'ignore' }
   | { action: 'scaffold-template' }
   | { action: 'remove-from-manifest' }
-  | { action: 'strip-front-matter' }
 
 /** All data needed to run the edit TUI. */
 export interface EditContext {
@@ -32,4 +30,3 @@ export type EditOperation =
   | { op: 'write-manifest' }
   | { op: 'scaffold'; type: AssetManifestKey; name: string }
   | { op: 'delete-file'; type: AssetManifestKey; name: string }
-  | { op: 'strip-front-matter'; type: AssetManifestKey; name: string; path: string }

--- a/packages/core/src/install/materialize.ts
+++ b/packages/core/src/install/materialize.ts
@@ -1,4 +1,5 @@
 import type { Adapter } from '@agent-facets/adapter'
+import { splitFrontMatter } from '@agent-facets/common'
 import type { ResolvedFacetManifest } from '../loaders/facet.ts'
 import type { LockfileAssetEntry } from '../schemas/lockfile.ts'
 import type { InstallJournal } from './journal.ts'
@@ -125,10 +126,31 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
       // Skip-if-identical: when the on-disk content + metadata already
       // matches what we would write, no work is needed and no journal
       // entry is recorded (there's nothing to undo).
+      //
+      // The candidate (`content`, `metadata`) we hand to `installAsset`
+      // is NOT what lands on disk byte-for-byte. The adapter SDK's
+      // `assembleAssetContent` splits any author-supplied front matter
+      // out of `content` and merges it under the caller's `metadata`
+      // (caller wins on key collisions), then re-emits a `--- yaml ---
+      // body` file. To compare apples-to-apples with what `readAsset`
+      // returns, we replay that merge here:
+      //   - body is the post-split candidate body (via the same
+      //     `splitFrontMatter` primitive the adapter SDK uses)
+      //   - metadata is the same merge the SDK would do
+      // The on-disk `previous.content` and `previous.metadata` reflect
+      // that merged shape, so equality holds iff a no-op write is safe.
+      //
+      // We import `splitFrontMatter` from `common` rather than
+      // `splitAssetContent` from the adapter SDK to keep the adapter SDK
+      // a type-only dep of `core`: a value import from the SDK pulls
+      // `yaml` into core's runtime graph and collides with `Bun.build`
+      // when the CLI's adapter integration tests bundle the same source.
+      const candidateSplit = splitFrontMatter(content)
+      const mergedCandidateMetadata = { ...(candidateSplit.metadata ?? {}), ...metadata }
       if (
         previous &&
-        previous.content === content &&
-        JSON.stringify(previous.metadata ?? {}) === JSON.stringify(metadata)
+        previous.content === candidateSplit.content &&
+        JSON.stringify(previous.metadata ?? {}) === JSON.stringify(mergedCandidateMetadata)
       ) {
         opts.onLog?.(`[verbose]   =${asset.type}:${asset.name} → ${adapter.name} (skipped)`)
         skipped++


### PR DESCRIPTION
### Why

Author-supplied YAML front matter in content files was previously treated as an error — the build pipeline rejected it, `facet edit` surfaced it as a reconciliation item, and `applyOperations` would strip it. This was too restrictive: adapter commands like `agent:` are legitimate front matter that authors need to ship with their content files.

### Details

Front matter is now permitted end-to-end. The build pipeline preserves content files verbatim in the archive. At install time, `materialize` merges the manifest's `name`, `description`, and any per-adapter extras on top of whatever the author wrote (manifest wins on key conflicts), and the adapter SDK writes the merged result to disk.

The `splitFrontMatter` primitive has been extracted into `@agent-facets/common` so that both `core`'s materialize skip-if-identical comparison and the adapter SDK's `splitAssetContent` use identical splitting semantics. This avoids pulling `yaml` into `core`'s runtime graph as a value import from the adapter SDK, which previously caused collisions with `Bun.build` during CLI adapter integration tests.

The skip-if-identical check in `materialize` has been fixed to account for the body/metadata asymmetry: the candidate content is split through `splitFrontMatter` before comparison, and the author's front matter keys are merged with the caller's metadata the same way `assembleAssetContent` would, so a second install correctly skips rather than re-writing.

Removed from `facet edit`: the `front-matter` reconciliation item kind, the `strip-front-matter` operation, and all associated TUI options and apply logic. The `facet build` content validation step no longer checks for front matter. Documentation has been updated throughout to reflect the new behavior.

A new `cowsay` fixture has been added that exercises front matter in command files (`agent: cowsay`) as a realistic end-to-end example.

### Verification

Updated and added tests cover: build succeeding with front matter present and preserving the body verbatim in the archive; `buildEditContext` not flagging front matter as a reconciliation item; and the materialize round-trip confirming that manifest keys win on conflict, author keys survive, and a second install skips.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build/install semantics to preserve YAML front matter and adjusts `materialize` skip-if-identical logic, which can affect whether assets are rewritten or skipped during installs. Moderate risk due to behavior changes across CLI, build pipeline, and adapter file I/O paths.
> 
> **Overview**
> **YAML front matter in asset files is now allowed end-to-end.** The build pipeline no longer rejects front matter, and docs/tests are updated to reflect that authored content is archived verbatim while manifest `name`/`description` (plus adapter extras) are merged on top at install time.
> 
> `facet edit` reconciliation removes the front-matter detection/strip flow (TUI options, operations, and tests), and install-time `materialize` fixes its skip-if-identical comparison by splitting authored front matter (via a new shared `splitFrontMatter` in `@agent-facets/common`) and comparing against the merged body/metadata shape the adapter SDK writes. A new `fixtures/cowsay` facet is added to exercise realistic front matter (e.g., `agent:`) in commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adaea80e62996f8f1c3853c5f69dcdb57d25cc66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->