### PR TITLE
Remove `@agent-facets/common` from changeset

### DIFF
--- a/.changeset/twenty-goats-confess.md
+++ b/.changeset/twenty-goats-confess.md
@@ -1,7 +1,6 @@
 ---
 "@agent-facets/adapter": patch
 "agent-facets": patch
-"@agent-facets/common": patch
 "@agent-facets/core": patch
 ---
 


### PR DESCRIPTION
### Why

The `@agent-facets/common` package was incorrectly included in the changeset and does not need to be released as part of this patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only adjusts release metadata (a changeset) and does not modify runtime code.
> 
> **Overview**
> Updates the changeset `twenty-goats-confess` to **stop publishing a patch for `@agent-facets/common`**, leaving patch bumps only for `@agent-facets/adapter`, `agent-facets`, and `@agent-facets/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea15fc820129d130e795fde1f551ace2a3f0a8fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->