### PR TITLE
Scope release `turbo build` to published package; upgrade release jobs to `medium` with `TURBO_CONCURRENCY=1` to prevent OOM

### DIFF
--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -89,7 +89,8 @@ jobs:
         environment:
             LEFTHOOK: "0"
             MISE_ENV: release
-        resource_class: small
+            TURBO_CONCURRENCY: "1"
+        resource_class: medium
         steps:
             - setup-mise
             - run:

--- a/.circleci/development/commands/run-check.yml
+++ b/.circleci/development/commands/run-check.yml
@@ -2,12 +2,13 @@ steps:
   - run:
       name: Check
       # Runs on a `medium` resource class (4 GB, 2 vCPU). Even on `medium`,
-      # parallel adapter DTS builds (arktype inlined via tsdown's
-      # `deps.alwaysBundle`, heavy `rolldown-plugin-dts:generate` pass) peak
-      # over 4 GB when core + three adapter builds fan out simultaneously and
+      # parallel DTS builds (arktype inlined via tsdown's `deps.alwaysBundle`,
+      # heavy `rolldown-plugin-dts:generate` pass) peak over 4 GB when
+      # protocol + engine + three adapter builds fan out simultaneously and
       # intermittently get SIGKILL'd by the OOM killer (exit 137). Forcing
       # `TURBO_CONCURRENCY=1` serializes all tasks at the cost of ~30–45s of
-      # wall-time, which is well under the cost of a flaky CI.
+      # wall-time, which is well under the cost of a flaky CI. The release
+      # job applies the same mitigations — see development/jobs/release.yml.
       environment:
         TURBO_CONCURRENCY: "1"
       command: bun turbo check

--- a/.circleci/development/jobs/release.yml
+++ b/.circleci/development/jobs/release.yml
@@ -1,9 +1,18 @@
 docker:
   - image: cimg/base:current
-resource_class: small
+# `medium` (4 GB, 2 vCPU). `small` (2 GB) gets OOM-killed by the
+# rolldown-plugin-dts:generate pass during `turbo build` even with the build
+# scoped to one package — see scripts/release/publish.ts and the equivalent
+# rationale in development/commands/run-check.yml.
+resource_class: medium
 environment:
   LEFTHOOK: "0"
   MISE_ENV: release
+  # Belt-and-suspenders against the same OOM. With the build scoped to one
+  # package + its deps, this is rarely needed, but on a cache miss the dts
+  # build still spends most of its time in a memory-hungry plugin pass — and
+  # serializing tasks costs us seconds, not minutes.
+  TURBO_CONCURRENCY: "1"
 steps:
   - setup-mise
   - run:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -115,7 +115,8 @@ jobs:
         environment:
             LEFTHOOK: "0"
             MISE_ENV: release
-        resource_class: small
+            TURBO_CONCURRENCY: "1"
+        resource_class: medium
         steps:
             - setup-mise
             - run:

--- a/docs/docs/contributing/ci-architecture.md
+++ b/docs/docs/contributing/ci-architecture.md
@@ -101,9 +101,11 @@ CircleCI contexts provide environment variables to jobs.
 
 | Context         | Variables                                                             | Used by                                    |
 |-----------------|-----------------------------------------------------------------------|--------------------------------------------|
-| `turbo-cache`   | Turborepo remote cache credentials                                    | `check`, `main-pipeline`, all release jobs |
+| `turbo-cache`   | `TURBO_API`, `TURBO_TOKEN` (`TURBO_TEAM` lives in `mise.toml`)        | `check`, `main-pipeline`, all release jobs |
 | `bot-context`   | npm OIDC config, GitHub app credentials, CircleCI API token           | `main-pipeline`, all release jobs          |
 | `slack-secrets` | Notification webhook credentials                                      | `main-pipeline`, all release jobs          |
+
+`turbo-cache` provides the consumer-side credentials for the self-hosted Turborepo remote cache. The cache server itself is deployed from the sibling `facet-cafe` repo at `infra/turbo-cache.ts` — an SST AWS Lambda backed by an S3 bucket, fronted by a CloudFront router. The current production URL is `https://turbo-cache.facet.cafe` (the `main` SST stage); the bearer token is held in 1Password and mirrored into both the `turbo-cache` CircleCI context (as `TURBO_TOKEN`) and the AWS-side `TurboToken` SST secret. To verify the cache is healthy, `curl https://turbo-cache.facet.cafe/v8/artifacts/status` should return `{"status":"enabled",...}`.
 
 `bot-context` includes `CIRCLECI_API_TOKEN` (a personal API token with write access to the project), which `scripts/release/tag.ts` uses to explicitly trigger release pipelines via the [CircleCI v2 API](https://circleci.com/docs/api/v2/index.html#operation/triggerPipelineRun). See [Release Pipeline troubleshooting](./release-pipeline#circleci-trigger-api-returns-401-or-404) for rotation steps.
 

--- a/scripts/lib/io/shell.ts
+++ b/scripts/lib/io/shell.ts
@@ -18,7 +18,7 @@ export const shellIo = {
 
   // Build pipeline
   changesetVersion: () => $`bun changeset version`,
-  turboBuild: () => $`bun turbo build`,
+  turboBuild: (filter?: string) => (filter ? $`bun turbo build --filter=${filter}` : $`bun turbo build`),
   bunInstall: () => $`bun install`,
   publishCliPackage: () => $`bun scripts/release-cli/publish-cli-package.ts`,
   verifyPackages: (packages: string[], version: string) =>

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -24,20 +24,22 @@ Version PR merged to main
 └────────────────────────────────────────────────────────────────────┘
   │
   ▼ (one release pipeline per tag)
-┌──────────────────────────────────────────────┐
-│  release/publish.ts                          │
-│                                              │
-│  1. Parse package name + version from tag    │
-│  2. Find package in workspace                │
-│  3. Skip if private (guard)                  │
-│  4. Skip if version already on npm (guard)   │
-│  5. Mint OIDC token (npm trusted publishing) │
-│  6. Build via turbo                          │
-│  7. npm publish --access public              │
-│  8. Create GitHub Release                    │
-│  9. Send Slack notification                  │
-└──────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│  release/publish.ts                              │
+│                                                  │
+│  1. Parse package name + version from tag        │
+│  2. Find package in workspace                    │
+│  3. Skip if private (guard)                      │
+│  4. Skip if version already on npm (guard)       │
+│  5. Mint OIDC token (npm trusted publishing)     │
+│  6. Build via `turbo build --filter=<pkg>...`    │
+│  7. npm publish --access public                  │
+│  8. Create GitHub Release                        │
+│  9. Send Slack notification                      │
+└──────────────────────────────────────────────────┘
 ```
+
+The `--filter=<pkg>...` scope is critical: an unfiltered `turbo build` fans out to all 11 workspace packages and OOM-killed the executor (exit 137) because four `tsdown` + `rolldown-plugin-dts` builds run in parallel. The release job runs on `resource_class: medium` with `TURBO_CONCURRENCY=1` for the same reason — see `.circleci/development/commands/run-check.yml` for the full memory analysis.
 
 ## Scripts
 

--- a/scripts/release/publish.test.ts
+++ b/scripts/release/publish.test.ts
@@ -116,6 +116,21 @@ describe('publish.ts', () => {
       expect(publishSpy).toHaveBeenCalledWith('packages/core')
     })
 
+    test('builds with scoped filter for the released package', async () => {
+      // Releases scope the turbo build to the released package + its workspace
+      // deps so we don't fan out to all 11 packages and OOM the executor.
+      process.env.CIRCLE_TAG = '@agent-facets/core@1.1.0'
+      setupPublishPath()
+
+      const buildSpy = spyOn(io.shell, 'turboBuild').mockResolvedValue(shellResult())
+
+      const { release } = await import('./publish')
+      await release()
+
+      expect(buildSpy).toHaveBeenCalledTimes(1)
+      expect(buildSpy).toHaveBeenCalledWith('@agent-facets/core...')
+    })
+
     test('skips private packages without publishing', async () => {
       process.env.CIRCLE_TAG = '@agent-facets/platform-opencode@0.1.0'
       spyOn(ci, 'loadWorkspacePackages').mockResolvedValue([

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -77,7 +77,12 @@ export async function release(): Promise<number> {
   // Library packages — build and publish directly
   if (!alreadyPublished) {
     await mintNpmToken()
-    await io.shell.turboBuild()
+    // Scope build to the released package + its workspace deps. The trailing
+    // `...` is Turbo's "include dependencies" filter, so e.g. `engine` still
+    // builds `protocol` first when an engine tag fires. Avoids the OOM that
+    // killed releases when all 11 packages built in parallel — see
+    // .circleci/development/commands/run-check.yml for the memory analysis.
+    await io.shell.turboBuild(`${pkg.name}...`)
     await packAndPublish(pkg.dir)
     io.console.log(`Published ${parsed.name}@${parsed.version} to npm`)
   }


### PR DESCRIPTION
### Why

Release jobs were being OOM-killed (exit 137) during `turbo build` because an unfiltered build fans out to all 11 workspace packages, causing multiple `tsdown` + `rolldown-plugin-dts` passes to run in parallel and exceed the memory available on the `small` (2 GB) resource class.

### Details

Two mitigations are applied together:

**Scoped build filter:** `turboBuild` now accepts an optional filter argument. The release script passes `<pkg>...` (Turbo's "include dependencies" syntax), so only the released package and its workspace dependencies are built. This prevents the full 11-package fan-out that caused the OOM.

**Upgraded resource class + serialized concurrency:** Release jobs are moved from `resource_class: small` (2 GB) to `medium` (4 GB), and `TURBO_CONCURRENCY=1` is set as a belt-and-suspenders measure. Even with a scoped build, the `rolldown-plugin-dts:generate` pass is memory-hungry on a cache miss, and serializing tasks costs seconds rather than minutes compared to a flaky or failed CI run. The `check` command already used this same approach; the release job now mirrors it.

The CI architecture docs are also updated to clarify what the `turbo-cache` context provides and to document the self-hosted Turborepo remote cache deployment.

### Verification

A new test asserts that `turboBuild` is called with the scoped filter (`@agent-facets/core...`) rather than without arguments. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release CI behavior and build scoping; mis-scoped filters or serialized Turbo execution could cause incomplete builds or longer release times.
> 
> **Overview**
> Prevents CircleCI release jobs from getting OOM-killed by **scoping `turbo build` to the tagged package plus its workspace deps** (`--filter=<pkg>...`) instead of building the entire monorepo.
> 
> Updates release workflows to run on `resource_class: medium` and sets `TURBO_CONCURRENCY=1` (mirroring `check`) to reduce peak memory usage, and adds a regression test asserting the scoped `turboBuild` invocation; docs are updated to reflect the remote turbo cache context and deployment details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a71d1cee2d0627944d6eac78af2b0c587ebab8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->