### PR TITLE
Bump all packages to verify release machinery after CI config upgrade

### DIFF
--- a/.changeset/modern-spiders-own.md
+++ b/.changeset/modern-spiders-own.md
@@ -1,0 +1,12 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/engine": patch
+"@agent-facets/protocol": patch
+---
+
+Bump it all, upgraded CI config need to verify release machinery


### PR DESCRIPTION
### Why

After upgrading the CI configuration, a patch-level changeset was added across all packages to verify that the release machinery is functioning correctly end-to-end.

### Verification

CI and the release pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets patch bumps file across packages to force a release; no runtime code changes. Risk is limited to triggering version publishes and any downstream release automation behavior.
> 
> **Overview**
> Adds a new Changesets entry (`.changeset/modern-spiders-own.md`) that applies a **patch bump** to all published packages (`@agent-facets/*` and `agent-facets`).
> 
> This is intended to **trigger and verify the end-to-end release machinery** after a CI configuration upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19acae61e659b6d3fabdf0df7fd9eb1891f5618. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->