### PR TITLE
Use `Bun.Glob` global instead of importing `Glob` from `'bun'`; add `neverBundle: ['bun']` as defense in depth

### DIFF
--- a/.changeset/sweet-areas-rule.md
+++ b/.changeset/sweet-areas-rule.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/engine": patch
+---
+
+Suppress build warnings when bundling Bun

--- a/packages/engine/src/edit/scanner.ts
+++ b/packages/engine/src/edit/scanner.ts
@@ -1,5 +1,3 @@
-import { Glob } from 'bun'
-
 /** Kebab-case pattern for valid asset names. */
 export const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
 
@@ -31,7 +29,7 @@ export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
   const assets: DiscoveredAsset[] = []
 
   // Scan skills: skills/*/SKILL.md
-  const skillGlob = new Glob('skills/*/SKILL.md')
+  const skillGlob = new Bun.Glob('skills/*/SKILL.md')
   for await (const match of skillGlob.scan({ cwd: rootDir, onlyFiles: true })) {
     // match is e.g. 'skills/review/SKILL.md'
     const parts = match.split('/')
@@ -42,7 +40,7 @@ export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
   }
 
   // Scan agents: agents/*.md
-  const agentGlob = new Glob('agents/*.md')
+  const agentGlob = new Bun.Glob('agents/*.md')
   for await (const match of agentGlob.scan({ cwd: rootDir, onlyFiles: true })) {
     const name = match.replace('agents/', '').replace('.md', '')
     if (KEBAB_CASE.test(name)) {
@@ -51,7 +49,7 @@ export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
   }
 
   // Scan commands: commands/*.md
-  const commandGlob = new Glob('commands/*.md')
+  const commandGlob = new Bun.Glob('commands/*.md')
   for await (const match of commandGlob.scan({ cwd: rootDir, onlyFiles: true })) {
     const name = match.replace('commands/', '').replace('.md', '')
     if (KEBAB_CASE.test(name)) {

--- a/packages/engine/tsdown.config.ts
+++ b/packages/engine/tsdown.config.ts
@@ -10,7 +10,14 @@ export default defineConfig({
   // Engine is private — no published tarball to worry about. We still bundle
   // @agent-facets/common because the workspace dep resolves at build time and
   // the bundled output stays consistent with the protocol/adapter pattern.
+  //
+  // 'bun' is a virtual module provided by the Bun runtime, not an npm package.
+  // neverBundle keeps rolldown from emitting UNRESOLVED_IMPORT warnings if a
+  // bare `import ... from 'bun'` slips back in. Engine source uses the `Bun.*`
+  // global form (Bun.file, Bun.Glob, etc.) per packages/engine/AGENTS.md;
+  // this is defense in depth.
   deps: {
     alwaysBundle: ['@agent-facets/common'],
+    neverBundle: ['bun'],
   },
 })


### PR DESCRIPTION
### Why

`Glob` was being imported from the `'bun'` module as a named import, but Bun exposes its built-ins as globals (e.g. `Bun.Glob`, `Bun.file`). Using the global form is the preferred convention per `packages/engine/AGENTS.md` and avoids a bare `import ... from 'bun'` that can cause bundler warnings.

### Details

All three `new Glob(...)` calls in `scanner.ts` are replaced with `new Bun.Glob(...)`, and the now-unused `import { Glob } from 'bun'` is removed.

As a defense-in-depth measure, `neverBundle: ['bun']` is added to the tsdown config so that if a bare `'bun'` import ever reappears, rolldown will treat it as an external rather than emitting an `UNRESOLVED_IMPORT` warning during the build.

### Verification

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps `Glob` construction to the equivalent `Bun.Glob` global and tweaks bundler config to treat `bun` as external, reducing build-time unresolved import warnings.
> 
> **Overview**
> Updates asset scanning to use the Bun global `Bun.Glob` instead of importing `Glob` from `'bun'`, removing the runtime module import entirely.
> 
> Adds a `deps.neverBundle: ['bun']` safeguard in `tsdown.config.ts` so the bundler won’t warn or try to bundle the virtual `bun` module if a bare import is reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99875c8a894818ac731df652a023fd1b68eefb0c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->