### PR TITLE
Add `viper-edit-plan` tool with atomic writes and per-session read-tracking guard

### DIFF
--- a/.opencode/lib/atomic-write.ts
+++ b/.opencode/lib/atomic-write.ts
@@ -1,0 +1,16 @@
+import { renameSync, writeFileSync } from 'node:fs'
+
+/**
+ * Atomic file write: write to `<path>.tmp` then rename over `path`.
+ *
+ * Mirrors `atomicWriteFileSync` in `@agent-facets/common`. Inlined here
+ * because the `.opencode/` plugin runtime is intentionally isolated
+ * from the monorepo workspaces (its own package.json, its own
+ * node_modules) and we don't want to couple plugin tools to the
+ * monorepo just for four lines of fs.
+ */
+export function atomicWriteFileSync(path: string, data: string, encoding: BufferEncoding = 'utf8'): void {
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, data, encoding)
+  renameSync(tmp, path)
+}

--- a/.opencode/lib/viper-read-tracker.ts
+++ b/.opencode/lib/viper-read-tracker.ts
@@ -1,0 +1,29 @@
+/**
+ * Per-(session, plan, artifact) read-tracking for the viper-* tools.
+ *
+ * Tools call `markRead` after they've read or written an artifact so the
+ * LLM in that session has a "fresh" view of it on disk. `viper-edit-plan`
+ * then refuses to operate unless:
+ *
+ *   - the artifact has been read in this session at all, AND
+ *   - the file's current mtime is not newer than what was recorded
+ *     (i.e. nothing modified the file behind the LLM's back since it
+ *     was last seen).
+ *
+ * State is module-level and lives only for the lifetime of the OpenCode
+ * plugin process. All viper-* tools share this process at runtime,
+ * so the same Map instance is visible to all of them.
+ */
+const readMtimes = new Map<string, number>()
+
+function key(sessionID: string, plan: string, artifact: string): string {
+  return `${sessionID}:${plan}:${artifact}`
+}
+
+export function markRead(sessionID: string, plan: string, artifact: string, mtimeMs: number): void {
+  readMtimes.set(key(sessionID, plan, artifact), mtimeMs)
+}
+
+export function getReadMtime(sessionID: string, plan: string, artifact: string): number | undefined {
+  return readMtimes.get(key(sessionID, plan, artifact))
+}

--- a/.opencode/tools/viper-edit-plan.ts
+++ b/.opencode/tools/viper-edit-plan.ts
@@ -1,0 +1,142 @@
+import { stat } from 'node:fs/promises'
+import path from 'node:path'
+import { tool } from '@opencode-ai/plugin'
+import { atomicWriteFileSync } from '../lib/atomic-write.ts'
+import { getReadMtime, markRead } from '../lib/viper-read-tracker.ts'
+
+const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
+
+/**
+ * Count non-overlapping occurrences of `needle` in `haystack`.
+ * Uses indexOf in a loop so we don't pay the cost of allocating
+ * an array of all matches just to know if there are 0, 1, or more.
+ */
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0
+  let count = 0
+  let from = 0
+  while (true) {
+    const idx = haystack.indexOf(needle, from)
+    if (idx === -1) return count
+    count++
+    from = idx + needle.length
+  }
+}
+
+export default tool({
+  description:
+    "Edit a VIPER plan artifact in place via exact string replacement. Mirrors OpenCode's Edit tool: requires the artifact to have been read this session and unchanged on disk since.",
+  args: {
+    plan: tool.schema.string().describe('Plan name to edit'),
+    artifact: tool.schema.string().optional().describe('Artifact name (defaults to "plan")'),
+    oldString: tool.schema
+      .string()
+      .describe('Exact text to find. Include enough surrounding context to be unique unless replaceAll is true.'),
+    newString: tool.schema.string().describe('Replacement text'),
+    replaceAll: tool.schema.boolean().optional().describe('Replace every occurrence of oldString. Defaults to false.'),
+  },
+  async execute(args, context): Promise<string> {
+    if (!SAFE_NAME.test(args.plan)) {
+      return JSON.stringify({ success: false, reason: 'invalid_name', name: args.plan })
+    }
+
+    const artifact = (args.artifact ?? 'plan').replace(/\.md$/, '')
+    if (!SAFE_NAME.test(artifact)) {
+      return JSON.stringify({ success: false, reason: 'invalid_artifact', artifact })
+    }
+
+    const filePath = path.join(context.worktree, '.opencode', 'plans', args.plan, `${artifact}.md`)
+
+    // Existence check.
+    let stats: Awaited<ReturnType<typeof stat>>
+    try {
+      stats = await stat(filePath)
+    } catch {
+      return JSON.stringify({ success: false, reason: 'not_found', plan: args.plan, artifact })
+    }
+
+    // Read-first guard.
+    const lastReadMtime = getReadMtime(context.sessionID, args.plan, artifact)
+    if (lastReadMtime === undefined) {
+      return JSON.stringify({
+        success: false,
+        reason: 'must_read_first',
+        message: 'Read the plan with viper-read-plan (or write it with viper-write-plan) before editing.',
+      })
+    }
+    if (stats.mtimeMs > lastReadMtime) {
+      return JSON.stringify({
+        success: false,
+        reason: 'stale_read',
+        message: 'Artifact was modified since last read. Re-read with viper-read-plan before editing.',
+      })
+    }
+
+    if (args.oldString === args.newString) {
+      return JSON.stringify({ success: false, reason: 'no_change' })
+    }
+
+    const original = await Bun.file(filePath).text()
+
+    // Re-stat after the read to close the TOCTOU window between the
+    // existence stat above and the read here. If the file changed
+    // between then and now, the content we just read is newer than
+    // what the session was tracking — treat it as a stale read.
+    const postReadStats = await stat(filePath)
+    if (postReadStats.mtimeMs > stats.mtimeMs) {
+      return JSON.stringify({
+        success: false,
+        reason: 'stale_read',
+        message: 'Artifact was modified since last read. Re-read with viper-read-plan before editing.',
+      })
+    }
+
+    const matches = countOccurrences(original, args.oldString)
+
+    if (matches === 0) {
+      return JSON.stringify({ success: false, reason: 'old_string_not_found' })
+    }
+
+    const replaceAll = args.replaceAll ?? false
+    if (matches > 1 && !replaceAll) {
+      return JSON.stringify({
+        success: false,
+        reason: 'ambiguous_match',
+        count: matches,
+        message: 'Provide more context in oldString to make it unique, or set replaceAll: true.',
+      })
+    }
+
+    // Both branches use literal replacement (no `$&`/`` $` ``/`$'`/`$N`
+    // interpretation). String.prototype.replace would interpret those
+    // patterns in newString, which is wrong for plan files that may
+    // contain shell variables, prices, or regex examples.
+    let updated: string
+    if (replaceAll) {
+      updated = original.split(args.oldString).join(args.newString)
+    } else {
+      const idx = original.indexOf(args.oldString)
+      // matches > 0 was checked above, so idx !== -1.
+      updated = original.slice(0, idx) + args.newString + original.slice(idx + args.oldString.length)
+    }
+
+    atomicWriteFileSync(filePath, updated)
+
+    // Refresh tracker mtime so the same session can edit again without
+    // re-read. Best-effort: the write already succeeded, so a transient
+    // FS error here should not turn it into a reported failure. Worst
+    // case: the next viper-edit-plan in this session has to re-read.
+    try {
+      const newStats = await stat(filePath)
+      markRead(context.sessionID, args.plan, artifact, newStats.mtimeMs)
+    } catch {
+      // Intentionally swallowed.
+    }
+
+    return JSON.stringify({
+      success: true,
+      path: filePath,
+      replacements: replaceAll ? matches : 1,
+    })
+  },
+})

--- a/.opencode/tools/viper-read-plan.ts
+++ b/.opencode/tools/viper-read-plan.ts
@@ -1,5 +1,7 @@
+import { stat } from 'node:fs/promises'
 import path from 'node:path'
 import { tool } from '@opencode-ai/plugin'
+import { markRead } from '../lib/viper-read-tracker.ts'
 
 const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
 
@@ -21,8 +23,23 @@ export default tool({
 
     const filePath = path.join(context.worktree, '.opencode', 'plans', args.plan, `${artifact}.md`)
 
+    // Stat-before-read + post-read re-stat verification:
+    //   1. Capture pre-read mtime.
+    //   2. Read content.
+    //   3. Re-stat and verify mtime didn't change. If it did, another
+    //      writer modified the file between our stat and read, so the
+    //      content we hold is from a different version than the mtime
+    //      we'd record. Refuse rather than poison the read tracker.
     try {
+      const preStats = await stat(filePath)
       const content = await Bun.file(filePath).text()
+      const postStats = await stat(filePath)
+      if (postStats.mtimeMs !== preStats.mtimeMs) {
+        // Concurrent write between stat and read; treat as not-found
+        // to keep the public surface stable.
+        return JSON.stringify({ success: false, reason: 'not_found', plan: args.plan, artifact })
+      }
+      markRead(context.sessionID, args.plan, artifact, preStats.mtimeMs)
       return JSON.stringify({ content, plan: args.plan, artifact })
     } catch {
       return JSON.stringify({ success: false, reason: 'not_found', plan: args.plan, artifact })

--- a/.opencode/tools/viper-write-plan.ts
+++ b/.opencode/tools/viper-write-plan.ts
@@ -1,6 +1,8 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 import { tool } from '@opencode-ai/plugin'
+import { atomicWriteFileSync } from '../lib/atomic-write.ts'
+import { markRead } from '../lib/viper-read-tracker.ts'
 
 const SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
 
@@ -29,7 +31,21 @@ export default tool({
     await mkdir(planDir, { recursive: true })
 
     const filePath = path.join(planDir, `${artifact}.md`)
-    await Bun.write(filePath, args.content)
+    atomicWriteFileSync(filePath, args.content)
+
+    // Record this session's view of the file so subsequent viper-edit-plan
+    // calls don't have to read-then-edit what they just wrote.
+    // Tracker update is best-effort: the write already succeeded, so a
+    // transient FS error or external deletion between write and stat
+    // should not turn a successful write into a reported failure.
+    // Worst case: a follow-up viper-edit-plan in this session has to
+    // re-read the file via viper-read-plan first.
+    try {
+      const stats = await stat(filePath)
+      markRead(context.sessionID, args.plan, artifact, stats.mtimeMs)
+    } catch {
+      // Intentionally swallowed.
+    }
 
     return JSON.stringify({ success: true, path: filePath })
   },


### PR DESCRIPTION
### Why

<!-- Why does this change exist? Link an issue or describe the motivation. Remove this section for trivial changes where the title says it all. -->

### Details

<!-- What should the reviewer know that isn't obvious from the diff? Approach, trade-offs, edge cases. Remove this section if the change is self-explanatory. -->

### Verification

<!-- How do you know it works? Manual test steps, deployment notes, or just "CI". Remove this section if CI covers it. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new in-place editing tool that modifies plan artifacts on disk and introduces session-based mtime gating; bugs here could lead to failed edits or unintended file overwrites. Risk is mitigated by strict name validation, exact-match replacement checks, and stale-read detection.
> 
> **Overview**
> Adds a new `viper-edit-plan` OpenCode tool to update VIPER plan artifacts via exact string replacement, with ambiguity checks (0/multiple matches) and optional `replaceAll` support.
> 
> Introduces per-session read tracking (`viper-read-tracker`) and updates `viper-read-plan`/`viper-write-plan` to record artifact mtimes so edits are **blocked unless the file was read/written in-session and hasn’t changed on disk**.
> 
> Switches plan writes to an inlined `atomicWriteFileSync` helper (write `*.tmp` then rename) to reduce the chance of partially-written artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28b7280e66e4541bbd6d86a5beb733a21dc6c6b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->