### PR TITLE
Change Dependabot update intervals from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,11 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
### Why

Dependabot was generating too many pull requests on a weekly cadence, creating noise. Switching to monthly reduces that overhead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI/dependency automation config changes; no application code, auth, or data handling.
> 
> **Overview**
> Updates **Dependabot** so both the **bun** (repo root) and **github-actions** ecosystems run on a **monthly** schedule instead of **weekly**. Open PR limits stay at 10 and 5 respectively.
> 
> This should cut dependency and Actions update noise while keeping automated updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4334cafaea1ccdcc8e6b4d80f9a744497aead24d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->