### PR TITLE
Cache `~/.mintlify` in CI `run-check` to avoid transient CDN timeouts

### DIFF
--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -12,11 +12,19 @@ commands:
                 when: on_fail
     run-check:
         steps:
+            - restore_cache:
+                keys:
+                    - v1-mint-{{ checksum "bun.lock" }}
+                    - v1-mint-
             - run:
                 command: bun turbo check
                 environment:
                     TURBO_CONCURRENCY: "1"
                 name: Check
+            - save_cache:
+                key: v1-mint-{{ checksum "bun.lock" }}
+                paths:
+                    - ~/.mintlify
     setup-mise:
         steps:
             - checkout

--- a/.circleci/development/commands/run-check.yml
+++ b/.circleci/development/commands/run-check.yml
@@ -1,4 +1,8 @@
 steps:
+  - restore_cache:
+      keys:
+        - v1-mint-{{ checksum "bun.lock" }}
+        - v1-mint-
   - run:
       name: Check
       # Runs on a `medium` resource class (4 GB, 2 vCPU). Even on `medium`,
@@ -12,3 +16,13 @@ steps:
       environment:
         TURBO_CONCURRENCY: "1"
       command: bun turbo check
+  - save_cache:
+      # Caches the ~306 MB Mintlify framework workspace that `mint validate`
+      # lazily downloads to ~/.mintlify/mint/ on first run. Keyed on bun.lock
+      # because the mint CLI version (which determines the framework version)
+      # is pinned there. Without this cache, every CI run is exposed to
+      # transient CDN failures from Mintlify's framework downloads
+      # (RequestError: read ETIMEDOUT).
+      key: v1-mint-{{ checksum "bun.lock" }}
+      paths:
+        - ~/.mintlify


### PR DESCRIPTION
### Why

Every CI run downloads the ~306 MB Mintlify framework workspace that `mint validate` lazily fetches to `~/.mintlify/mint/` on first run. Without caching this directory, each run is exposed to transient CDN failures from Mintlify's framework downloads (e.g., `RequestError: read ETIMEDOUT`).

### Details

The cache is keyed on `bun.lock` because the `mint` CLI version — which determines the framework version downloaded — is pinned there. This ensures the cache is invalidated whenever the CLI version changes, while being reused across runs that share the same lockfile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only caching around docs validation; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Adds **CircleCI cache** steps to the shared **`run-check`** command so **`~/.mintlify`** (the Mintlify framework workspace used by **`mint validate`**) is restored before **`bun turbo check`** and saved afterward.
> 
> The cache key is **`v1-mint-{{ checksum "bun.lock" }}`**, with a **`v1-mint-`** fallback, so framework downloads are reused across runs and only refresh when the pinned **`mint`** CLI version in the lockfile changes. The same steps are wired in both **`.circleci/development.yml`** and **`.circleci/development/commands/run-check.yml`**, which should cut repeated ~306 MB CDN fetches and reduce flaky **`ETIMEDOUT`** failures on **`check`** and **`main-pipeline`** jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b07f96d02c715dbd2eb3fabf0735d830e689fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->