### PR TITLE
Add `facet login/whoami/logout`; migrate registry auth to Bearer and repoint paths to `/v0/facets/*`

### DIFF
--- a/openspec/changes/update-cli-registry-auth/.openspec.yaml
+++ b/openspec/changes/update-cli-registry-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/update-cli-registry-auth/design.md
+++ b/openspec/changes/update-cli-registry-auth/design.md
@@ -1,0 +1,423 @@
+## Context
+
+The facet.cafe registry shipped a coordinated rework (registry repo
+`facet-cafe`, archived change `2026-06-03-add-v0-publish-flow`). Two
+breaking shifts land at once:
+
+1. **Endpoint rename.** Every versioned path moved from `/v0/packages/*`
+   to `/v0/facets/*` — publish, version-metadata, archive download,
+   info, and search.
+2. **Auth scheme.** The static `X-Api-Key` header was replaced with
+   `Authorization: Bearer <credential>`, where the credential is either
+   a Cognito JWT (interactive web session) or an opaque `fct_pub_*`
+   personal access token minted in the web UI.
+
+The CLI's vendored OpenAPI snapshot predates both shifts, so the CLI is
+broken end-to-end against production: `publish`, `add`, `install`, and
+`search` all call paths the registry no longer serves.
+
+Current state worth naming precisely:
+
+- The registry client factory (`createRegistryClient`) applies timeout
+  and retry middleware only — no auth. The single auth header on the
+  wire is set inline at the publish call site as `X-Api-Key`.
+- The only credential read is `process.env.FACET_REGISTRY_API_KEY` in
+  the publish command. No credential file, no `login`/`logout`/`whoami`
+  commands exist.
+- `$FACET_DIR` (default `~/.facet/`) is the established single root for
+  all on-disk CLI state, with per-subsystem helpers (`facetCacheDir()`
+  et al.). The legacy `~/.facets/` was retired with no migration.
+- The deployed error envelope is `{ code, error, fix, docsUrl }` (all
+  four required). The CLI today still carries a **local** code→message
+  map (`whatForCode`/`fixForCode`) and deliberately prefers its own
+  strings over the server's — a stopgap from when the envelope had no
+  `fix` field. That stopgap now contradicts the registry's
+  `api-conventions` spec, which states consumers SHALL NOT need a local
+  code-to-meaning map for registry-originated codes.
+
+Production Cognito permits no CLI loopback callback URL, so a
+browser-based PKCE sign-in cannot ship in this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Repoint every registry call from `/v0/packages/*` to `/v0/facets/*`
+  by refreshing the vendored OpenAPI snapshot, and eliminate the one
+  hand-built registry URL so no registry path lives outside the
+  generated contract.
+- Replace `X-Api-Key` auth with `Authorization: Bearer`, sourced from
+  `FACET_TOKEN` (env, preferred) with a `$FACET_DIR/credentials` file
+  fallback.
+- Centralize Bearer injection so the credential is attached whenever
+  one is available — on reads as well as writes — to earn the
+  authenticated rate-limit tier; reads with no credential remain
+  functional anonymously.
+- Add `facet login` (guided PAT paste + verify + save), `facet whoami`
+  (profile readout), and `facet logout` (clear local credentials).
+- Make the CLI fully registry-dumb for registry-origin errors: render
+  the server's `error` and `fix` verbatim; delete the local code map.
+
+**Non-Goals:**
+
+- A working browser sign-in flow, local PKCE machinery, or a local
+  callback server. The `facet login` menu shows a disabled "coming
+  soon" option only.
+- CLI commands for token mint/list/revoke (web UI owns those).
+- Server-side PAT revocation on `logout`.
+- Changes to the published archive bytes (`packFacetSource` output is
+  unchanged; the new endpoint accepts the same `application/gzip` body).
+- Any rename of `FACET_DIR` or its `~/.facet/` default.
+
+## Decisions
+
+### D1 — Refresh the snapshot; treat codegen as the source of the path rename
+
+The endpoint rename SHALL land by running `bun run codegen:registry`
+against the live registry, regenerating the OpenAPI snapshot, the
+generated types, and the curated wire re-exports in one pass. The
+Bearer security scheme, the renamed `/v0/facets/*` paths, the expanded
+error-code enum, and the now-required `fix` field all arrive together.
+
+No registry-facing request path SHALL be hand-built as a string
+literal. Today the archive-download URL is assembled by hand
+(`${base}/v0/packages/{name}/{version}/archive`) and handed to a raw
+`fetch`, because the archive endpoint responds with a `302` redirect to
+a short-lived presigned S3 URL rather than with bytes, and the typed
+`openapi-fetch` client is shaped to parse a response body rather than
+to stream bytes through a redirect chain. That hand-built path is the
+exact failure mode this rename exposes: a literal `/v0/packages/...`
+that a snapshot refresh does not touch, that breaks silently if a human
+forgets it.
+
+This change SHALL eliminate the hand-built registry path. The archive
+request SHALL be issued through the typed client against
+`/v0/facets/{name}/{version}/archive` with redirect-following disabled
+(`redirect: 'manual'`), so the request path, its parameters, and any
+future auth requirement all derive from the generated contract. The
+client then reads the `Location` header off the `302` and performs a
+raw `fetch` of THAT URL to stream the tarball bytes.
+
+The presigned-S3 fetch is the only remaining raw, non-codegen request,
+and it MUST stay that way: a presigned S3 URL is minted on the fly by
+the registry and points at a different system; it is not — and never
+will be — a registry endpoint in the OpenAPI spec. The line is drawn
+exactly where reality draws it: every request the registry *serves* is
+codegen-typed; only the off-spec S3 leg is raw.
+
+*Why this matters beyond the current rename:* routing the archive
+request through the typed client also means that if the registry ever
+puts auth on the archive endpoint (e.g. private facets in a future
+version), the Bearer credential flows through the same centralized
+injection (see D3) with no new plumbing. A hand-built URL handed to a
+bare `fetch` would silently send no credential.
+
+*Alternative considered:* keep the hand-built archive URL and update it
+by hand, optionally guarded by a test asserting it matches the snapshot
+path. Rejected — it leaves a second source of truth for a registry path
+and only *alarms* on drift rather than eliminating it; it also does not
+survive a future auth-on-archive change.
+
+*Alternative considered:* hand-edit only the publish path and leave the
+rest of the snapshot stale. Rejected — search/install/download are also
+broken against the live registry today; a partial fix ships a CLI that
+still fails for read paths.
+
+### D2 — Credential resolution: a single engine-side resolver, env-over-file
+
+A new engine module SHALL own credential resolution with this
+precedence:
+
+1. `FACET_TOKEN` environment variable, when set to a non-empty
+   (trimmed) value.
+2. The token persisted at `$FACET_DIR/credentials`.
+3. Absent — no credential available.
+
+The resolver SHALL return a discriminated result that names which
+source supplied the credential (or that none did), so callers can both
+authenticate and render source-aware notices (e.g. `whoami` indicating
+the env var is in use, `login`/`logout` warning that the env var
+shadows the file). Modeling "absent" as an explicit arm — rather than
+an empty string or `undefined` — keeps the missing-credential path a
+compile-time obligation at every call site.
+
+A new `facetCredentialsPath()` helper SHALL be added to the facet-dir
+module alongside the existing `facetCacheDir()` / `facetAdaptersDir()`
+helpers, returning `$FACET_DIR/credentials`. The credentials file SHALL
+be written with mode `600` (owner read/write only). Its on-disk format
+(INI with a `[default]` profile) is specified in D8.
+
+*Alternative considered:* read the env var inline in each command, as
+publish does today. Rejected — three commands now need the credential,
+and the env-over-file precedence plus source-aware messaging is logic
+that must not be duplicated.
+
+### D3 — Bearer injection centralized in the client factory; send the credential whenever one exists
+
+`createRegistryClient` SHALL accept an optional credential. When a
+credential is present, the client SHALL attach `Authorization: Bearer
+<token>` to **every** outgoing request via request middleware,
+regardless of whether the call is a read or a write; when absent, no
+auth header is sent. This removes the inline `X-Api-Key` header from the
+publish call site and makes "do we have a credential?" a property of how
+the client is constructed, not a per-call-site concern.
+
+**Reads send the credential opportunistically.** The CLI does not
+reserve the Bearer header for write calls. If a credential is available,
+search, info, version-metadata, and archive-download requests carry it
+too. The reason is server-side rate limiting: anonymous reads will be
+aggressively rate-limited to deter bulk scanning/scraping, and
+authenticated reads are expected to earn a higher limit. Sending the
+credential on reads lets the registry apply the authenticated tier. A
+read with no credential available remains fully functional — it is sent
+anonymously and served at the anonymous limit.
+
+**The CLI never inspects or validates the credential it holds.** If the
+CLI has a credential, it sends it — expired, revoked, or malformed
+included. The CLI does not pre-check token validity and does not
+implement any "retry the read without the credential" degrade path.
+What happens to a request bearing a bad token is entirely the
+registry's decision: for a truly anonymous-readable endpoint the
+registry MAY ignore the bad token and serve the read (falling back to
+anonymous server-side); if the registry instead rejects the request,
+that rejection is the registry's deliberate policy and the CLI renders
+the returned `error`/`fix` verbatim per D4. This keeps the CLI dumb on
+the read path exactly as it is dumb on the error-rendering path.
+
+**Credential resolution stays with the caller (per D2).** Every command
+resolves the credential via the D2 resolver and passes the result to
+`createRegistryClient`. Publish *requires* a credential and fails fast
+when none is available; read commands pass it *opportunistically* and
+proceed anonymously when it is absent. The factory itself does no env or
+file I/O — it is a pure "here is a credential, or not; build a client"
+function, which keeps it trivially testable. The one exception is
+`facet login`'s verification call, which authenticates with the
+freshly-pasted token (see D5) rather than the resolved credential.
+
+Token-expiry *management* (refresh, re-prompt on `401`) is explicitly
+out of scope for this change: V0 is PAT-only, and PATs are long-lived
+enough that a token will not lapse mid-workflow, so lifecycle handling
+is deferred to a later phase.
+
+*Alternative considered:* attach the Bearer header only on write calls
+and keep reads strictly anonymous. Rejected — it forfeits the
+authenticated rate-limit tier on reads for logged-in users, and a
+read-vs-write branch in the auth layer is exactly the per-call coupling
+this decision removes.
+
+*Alternative considered:* have `createRegistryClient` resolve the
+credential itself by default. Rejected — it couples the factory to the
+resolver's env/file I/O, making the factory harder to test in isolation
+and hiding the credential source from the call site.
+
+*Alternative considered:* keep setting the header per-call. Rejected —
+it scatters the auth decision across every command and repeats the "is
+there a credential?" branch.
+
+### D4 — Registry-dumb error rendering; delete the local code map
+
+For any error the registry returns as a structured `{ code, error,
+fix, docsUrl }` envelope, the CLI SHALL render the server's `error` and
+`fix` text verbatim. The CLI-side `whatForCode()` and `fixForCode()`
+maps SHALL be removed, along with the `wireCode`-routing branch that
+preferred them over the server's text, and the synthesized
+`docsUrlFor()` links for registry-origin codes.
+
+To carry the server's text to the renderer without loss, the engine's
+wire-error translation SHALL stop collapsing structured envelopes into
+the generic `REGISTRY_NOT_AVAILABLE` discriminator. A `RegistryError`
+variant SHALL preserve the envelope's `code`, `error`, `fix`, and
+`docsUrl` verbatim. The CLI bridge renders those fields directly.
+
+The CLI SHALL author its own message text in exactly two situations,
+neither of which is a registry-returned error code:
+
+1. **Pre-flight failures** that never reach the registry: no credential
+   available, no `facet.json` in the working directory, and network
+   unreachable / request aborted.
+2. **Unparseable registry response**: the registry replied with
+   something that is not a valid structured envelope (e.g. an HTML 502
+   from a middlebox, an empty 503, raw text). The CLI SHALL render a
+   plain message stating that the registry returned a response it could
+   not process, and SHALL NOT synthesize a docs link or redirect for
+   this case.
+
+*Alternative considered:* keep the local map as a fallback for codes
+the CLI recognizes. Rejected — it reintroduces the exact duplication
+the registry's `api-conventions` spec forbids, and it goes stale every
+time the registry adds or rewords a code. The registry now ships `fix`
+on every error, so the gap that originally justified the map is closed.
+
+### D5 — `facet login` is a guided, verifying flow
+
+`facet login` SHALL present a menu with two options: *paste a personal
+access token* (active) and *sign in via browser* (shown, disabled, with
+a "coming soon" label). The PAT path SHALL:
+
+1. Prompt for the token with masked input (asterisks per character).
+2. Verify it by calling `GET /v0/auth/me` with the pasted token as a
+   Bearer credential.
+3. On success, write the token to `$FACET_DIR/credentials` (mode 600)
+   and print `Logged in as <username> (<tier>)`.
+4. On a registry rejection (401 or other), render the registry's own
+   error/fix text and reprompt rather than persisting an unusable
+   token.
+
+If `FACET_TOKEN` is set in the environment when `login` begins, the
+command SHALL display an explicit notice before prompting — naming the
+variable, stating it will be used for every command in place of the
+file about to be written, and directing the user to `unset FACET_TOKEN`
+if they want the file to take effect. The user MAY proceed (CI and
+scripted setups legitimately want env precedence).
+
+*Alternative considered:* save the pasted token without verifying.
+Rejected — a typo or expired paste would surface only at the next
+publish; verifying at entry time fails fast with the registry's own
+message.
+
+### D6 — `whoami` and `logout` are thin and local-first
+
+`facet whoami` SHALL call `GET /v0/auth/me` with the resolved
+credential and print username, email, tier, and suspension state. When
+the credential came from `FACET_TOKEN`, the output SHALL indicate the
+env var is the credential in use. With no credential available, it
+SHALL print a clear "not logged in" message directing the user to
+`facet login` or to set `FACET_TOKEN`.
+
+`facet logout` SHALL delete `$FACET_DIR/credentials` (a no-op if the
+file is absent, reported plainly) and SHALL make no server call. When
+`FACET_TOKEN` is set, it SHALL tell the user the file was removed but
+the env var is still active and direct them to `unset FACET_TOKEN` to
+fully sign out of the shell.
+
+### D7 — Command registration
+
+`login`, `whoami`, and `logout` SHALL be registered in the CLI command
+registry following the existing per-command module pattern. No aliases
+are introduced. Help text SHALL be derived from command metadata as the
+existing commands do.
+
+### D8 — Credentials file format: INI with a `[default]` profile
+
+The credentials file at `$FACET_DIR/credentials` SHALL be **INI**
+format, following the AWS-CLI `~/.aws/credentials` convention. The V0
+file SHALL contain exactly one profile section, `[default]`, with a
+single `token` key:
+
+```ini
+[default]
+token = fct_pub_...
+```
+
+There SHALL be no version field. The profile-section structure is
+itself the format contract — future format evolution adds keys or
+sections rather than bumping a version number, exactly as AWS does.
+
+INI (over JSON) is chosen deliberately for its forward path: the named
+`[default]` section is the seam that lets later work add multiple named
+profiles, per-registry credentials, and directory-scoped credential
+resolution without a format break. JSON would model a single token
+fine but would have to grow an ad-hoc profile convention to reach the
+same place. V0 reads and writes only `[default]`; no `--profile` flag,
+no multi-registry resolution, and no other sections are honored yet —
+but the format does not have to change when they arrive.
+
+Parsing and serialization SHALL use a small, well-established INI
+library (the same `ini` package used widely for files like `.npmrc`)
+rather than a hand-rolled parser. This is an auth-path parser handling
+a secret, and INI's edge cases (inline `#`/`;` comment markers, value
+quoting, whitespace trimming, duplicate keys) are exactly where a
+hand-rolled subset silently corrupts a token and produces confusing
+`401`s. Leaning on the audited library is the safe default and is the
+foundation the multi-profile future builds on. This adds one
+dependency to engine, which is acceptable for a credentials parser.
+
+The file SHALL be written with mode `600` (per D2). `facet logout`
+deletes the whole file (per D6); V0 has no per-profile removal because
+V0 has only the one profile.
+
+*Alternative considered:* JSON, consistent with every other file the
+CLI writes and requiring no new dependency. Rejected — a single flat
+token object does not carry the multi-profile / multi-registry future
+the team wants, and retrofitting profiles onto JSON later would mean an
+ad-hoc nested convention rather than the established INI profile model.
+
+*Alternative considered:* hand-roll a minimal INI reader/writer to
+avoid the dependency. Rejected — credentials parsing is
+security-adjacent, INI has more edge cases than its surface suggests,
+and the multi-profile future is exactly where a home-grown INI dialect
+accumulates bugs.
+
+## Risks / Trade-offs
+
+- **[Snapshot drift between refresh and merge]** → The registry could
+  change again between the codegen run and this change landing. The
+  existing snapshot-freshness CI check bounds this; the refresh is
+  idempotent, so re-running before merge resolves any drift.
+
+- **[Registry `fix` text quality is now load-bearing]** → With the
+  local map gone, a vague or missing server `fix` directly degrades the
+  user's experience. Mitigation: the envelope makes `fix` required, and
+  any weak `fix` text is a registry-side fix tracked in `facet-cafe`,
+  not worked around in the CLI. The CLI's job is faithful rendering.
+
+- **[`FACET_TOKEN` silently shadows the credentials file]** → A user
+  who runs `login` then wonders why `logout` "didn't work" is the
+  classic confusion. Mitigation: both `login` and `logout` emit an
+  explicit env-precedence notice naming the variable and the `unset`
+  remedy; `whoami` names the active source.
+
+- **[Credentials file written to a shared/owner-readable location]** →
+  A token at rest is a secret. Mitigation: mode `600`; the file lives
+  under `$FACET_DIR` which the user already controls; `logout` deletes
+  it; no server-side mint/refresh is stored.
+
+- **[Verifying the token at login adds a network round-trip]** → A user
+  offline at login time cannot complete the flow. Accepted — login is
+  an interactive, online action by nature; the fail-fast benefit
+  outweighs supporting offline login.
+
+## Migration Plan
+
+1. Run `bun run codegen:registry`; commit the regenerated snapshot,
+   types, and wire re-exports. Confirm BearerAuth, `/v0/facets/*`
+   paths, the `fix` field, and the expanded code enum are present.
+2. Add the credential resolver module and `facetCredentialsPath()`;
+   add the `ini` dependency and the INI credentials read/write per D8;
+   add Bearer support to the client factory.
+3. Rewrite publish to use the resolver + Bearer; route the archive
+   request through the typed client with manual redirect handling (per
+   D1, eliminating the hand-built archive path); and handle the
+   `202 QUEUED_FOR_REVIEW` success outcome.
+4. Add `login`, `whoami`, `logout`; register them.
+5. Strip the local code map and `wireCode` routing; switch the engine
+   wire-error translation to carry the structured envelope through.
+6. Update tests; update docs (see below).
+
+No data migration is required: there is no production publish data, no
+stored `X-Api-Key` to migrate, and `~/.facet/` is already the single
+on-disk convention. Rollback is a straight revert — nothing persists
+irreversibly beyond a user's own credentials file, which `logout`
+clears.
+
+## Documentation Impact
+
+This change alters observable CLI behavior, commands, and an
+environment variable that user-facing documentation covers. The
+following SHALL be updated as scoped work:
+
+- `docs/docs/contributing/publishing.md` (or its current equivalent) —
+  the publish workflow: replace `FACET_REGISTRY_API_KEY` guidance with
+  the `facet login` / `FACET_TOKEN` flow; describe minting a PAT in the
+  web UI.
+- `docs/specification/install.md` — any reference to the registry fetch
+  contract or `/v0/packages` paths shifts to `/v0/facets`.
+- `docs/changelog/index.md` — a new entry recording the breaking
+  removal of `FACET_REGISTRY_API_KEY`, the endpoint rename, and the new
+  `login`/`whoami`/`logout` commands.
+- Root `README.md` / CLI package README — a short "Publishing" section
+  pointing at the web UI for PATs and documenting `facet login`.
+
+No existing documentation conflicts with this design beyond the
+`FACET_REGISTRY_API_KEY` references being superseded; those are the
+updates enumerated above.

--- a/openspec/changes/update-cli-registry-auth/proposal.md
+++ b/openspec/changes/update-cli-registry-auth/proposal.md
@@ -1,0 +1,177 @@
+## Why
+
+The facet.cafe registry shipped a coordinated rework that renamed every
+versioned endpoint from `/v0/packages/*` to `/v0/facets/*` and replaced the
+static `X-Api-Key` header with `Authorization: Bearer <credential>` (a Cognito
+JWT or an opaque `fct_pub_*` personal-access token minted in the web UI). The
+CLI's vendored OpenAPI snapshot is from before that cut, so the CLI is
+broken end-to-end against production today — `facet publish`, `facet add`,
+`facet install`, and `facet search` all call paths the registry no longer
+serves, and even if they reached the new paths, publish would be rejected
+for sending the wrong auth header.
+
+Production Cognito does NOT permit a CLI loopback callback URL, so a
+browser-based PKCE sign-in flow cannot be deployed in this change. The
+registry team's coordinated CLI contract (`facet-cafe` design D14,
+archived change `2026-06-03-add-v0-publish-flow`) anticipates a
+PAT-first V0: the user mints a `fct_pub_*` token in the web UI and
+the CLI consumes it. This change is the CLI half of that coordinated
+cut, with a guided `facet login` command as the on-ramp so the
+PAT-paste path is discoverable and the future browser-sign-in path
+has a place to land without further command-surface change.
+
+## What Changes
+
+- **BREAKING — Endpoint rename**: every registry call updates from
+  `/v0/packages/*` to `/v0/facets/*`. Affects publish, version-metadata
+  resolution, archive download, info, and search.
+- **BREAKING — Auth scheme**: the publish header changes from
+  `X-Api-Key: <key>` to `Authorization: Bearer <token>`. The
+  credential source environment variable `FACET_REGISTRY_API_KEY` is
+  **removed outright** (no dual-read, no deprecation shim, per the
+  coordinated contract). Two new credential sources replace it: the
+  `FACET_TOKEN` environment variable (preferred for CI), and a
+  credentials file at `$FACET_DIR/credentials` (mode 600, written by
+  `facet login`). The credentials file is INI-formatted with a
+  `[default]` profile section (AWS-CLI style), holding a single
+  `token` key in V0 — the profile structure is the seam for future
+  multi-profile / multi-registry credentials. When both sources are
+  present, `FACET_TOKEN` SHALL take precedence. `FACET_DIR` is the
+  existing root for all on-disk CLI state and defaults to `~/.facet/`;
+  the credentials file inherits that default.
+- **Snapshot refresh**: regenerate `openapi.snapshot.yaml` and the
+  generated types via `bun run codegen:registry`. The Bearer security
+  scheme, the renamed paths, the expanded error-code enum, and the
+  `fix` field on the error envelope all land in one regeneration. The
+  one registry URL still built by hand today (the archive-download URL)
+  SHALL be eliminated: the archive request is routed through the typed
+  client so that no registry request path lives outside the generated
+  contract.
+- **New command `facet login`**: a guided sign-in flow. The user is
+  shown a menu with two options — *paste a personal access token*
+  (available now) and *sign in via browser* (shown but disabled with
+  a "coming soon" label). The PAT path prompts for the token with
+  masked input (asterisks per character), verifies it by calling
+  `GET /v0/auth/me`, and on success writes the token to
+  `$FACET_DIR/credentials` and prints `Logged in as <username>
+  (<tier>)`. Invalid or expired tokens are rejected with the
+  registry's own error text and the user is reprompted. If
+  `FACET_TOKEN` is already set in the environment when `login`
+  begins, the user SHALL be shown an explicit notice before any
+  prompt — naming the variable, stating that it will be used for
+  every command instead of the file about to be written, and
+  directing the user to `unset FACET_TOKEN` if they want the
+  credentials file to take effect. The user MAY proceed past this
+  notice (CI and scripted use cases legitimately want env-var
+  precedence).
+- **New command `facet whoami`**: prints the authenticated user's
+  username, email, tier, and suspension state by calling
+  `GET /v0/auth/me`. When `FACET_TOKEN` is set, the output SHALL
+  indicate that the env var is the credential in use (so the user
+  isn't confused about which token authenticated the call).
+- **New command `facet logout`**: clears the local credentials file
+  at `$FACET_DIR/credentials`. No server call; users revoke PATs in
+  the web UI. If `FACET_TOKEN` is set in the environment when
+  `logout` runs, the user SHALL be told that the file has been
+  deleted but the env var is still active and directed to
+  `unset FACET_TOKEN` to fully sign out of this shell.
+- **The credential is sent whenever one exists**: when a credential is
+  available (from `FACET_TOKEN` or the credentials file), it SHALL be
+  attached to every registry request — reads (search, info,
+  version-metadata, archive download) as well as writes — so the
+  registry can apply a higher rate-limit tier to authenticated traffic
+  (anonymous reads are expected to be aggressively rate-limited to deter
+  bulk scraping). Reads with no credential available SHALL remain fully
+  functional, sent anonymously. The CLI never inspects the token it
+  holds; whether a bad token is tolerated on an anonymous-readable
+  endpoint is the registry's decision.
+- **Registry-dumb error rendering**: when the registry returns its
+  structured `{ code, error, fix, docsUrl }` envelope, the user sees
+  the registry's own `error` + `fix` text verbatim. The CLI's local
+  code-to-message map is **removed** — the CLI no longer needs to know
+  what any registry error code means. The CLI authors its own message
+  in only two situations, neither of which is a registry-returned
+  code: the three pre-flight failures the registry never sees (missing
+  credential, missing `facet.json`, unreachable network), and the case
+  where the registry replies with something that is not a valid
+  structured envelope at all (in which case the CLI states plainly
+  that it could not process the response and does not redirect the
+  user anywhere).
+- **Publish queue-for-review handling**: when a first-time global-facet
+  publish is accepted into the registry's review queue (HTTP 202), the
+  publish command exits 0 and renders the registry's queue message
+  verbatim. This is a success outcome, not a failure.
+
+The `FACET_DIR` root (default `~/.facet/`) is already the single
+on-disk convention in this repo, consolidated in the 2026-05-14
+changelog with no automatic migration from the legacy `~/.facets/`;
+no rename work is required.
+
+## Capabilities
+
+### New Capabilities
+
+None. All work fits within the existing `cli` domain.
+
+### Modified Capabilities
+
+- `cli`: the credential a user supplies for publishing changes from
+  `FACET_REGISTRY_API_KEY` to `FACET_TOKEN` (env), with a fallback
+  to a credentials file at `$FACET_DIR/credentials` (default
+  `~/.facet/credentials`); publish authenticates as a Bearer token
+  rather than an API key; three new commands (`login`, `whoami`,
+  `logout`) become available; the registry-contract view tracked by
+  the CLI's vendored OpenAPI snapshot moves from the legacy
+  `/v0/packages/*` surface to the renamed `/v0/facets/*` surface;
+  registry-originated errors render the registry's own `error` and
+  `fix` text verbatim, and the CLI no longer maintains a local
+  code-to-message map for them.
+
+## Impact
+
+- **Affected areas**: the engine's registry HTTP client and its vendored
+  OpenAPI snapshot; engine credential resolution (new); CLI commands
+  (`publish`, `search`, new `login`, new `whoami`, new `logout`); CLI
+  error rendering. The file-by-file map and the chosen module
+  boundaries live in `design.md`.
+- **Dependencies**: a single new dependency (`ini`) is added to the
+  engine for parsing/serializing the INI credentials file; the rationale
+  is in `design.md`.
+- **Tests**: publish, registry-client, and error-rendering tests are
+  updated; new tests cover credential resolution, `login`, `whoami`, and
+  `logout`.
+- **Documentation**: `docs/` publishing guidance updates from
+  `FACET_REGISTRY_API_KEY` to `FACET_TOKEN`; a changelog entry records
+  the breaking env-var removal and endpoint rename. The CLI README
+  gains a short "Publishing" section pointing at the web UI for
+  minting PATs. Existing docs informing this proposal:
+  `docs/specification/install.md` (registry fetch contract),
+  `docs/docs/contributing/publishing.md` (the current publish
+  workflow), `docs/changelog/index.md` (the 2026-05-14 `~/.facet`
+  consolidation entry that confirms no rename work is owed).
+- **External coordination**: the registry side (`facet-cafe`) is
+  already shipped; no further coordination is needed for this V0 cut.
+  A future `facet login` (browser PKCE with a CLI loopback callback)
+  requires a Cognito client URL addition on the registry side, tracked
+  as a separate follow-up.
+
+## Non-goals
+
+- A working browser sign-in flow inside `facet login`. The option
+  appears in the menu as a "coming soon" placeholder only; selecting
+  it does nothing. A functional implementation depends on a
+  registry-side Cognito callback URL addition for the CLI loopback
+  port and is tracked as a separate follow-up.
+- Local PKCE machinery, a local callback HTTP server, or any browser
+  redirect handling in this change.
+- CLI commands for token minting, listing, or revocation. The web UI
+  is the workflow surface for these per the coordinated design.
+- Server-side revocation of the PAT on `facet logout`. The user
+  revokes PATs in the web UI; `logout` only clears the local file.
+- Changes to the published archive format or to the bytes the publish
+  command uploads. The publish body shape is unchanged.
+- Any rename of `FACET_DIR` or its `~/.facet/` default. Already the
+  single on-disk convention.
+- Changes to the local pre-flight error messages (missing credential,
+  missing `facet.json`, network unreachable). The registry-dumb
+  rendering rule applies only to errors the registry returns.

--- a/openspec/changes/update-cli-registry-auth/specs/cli/spec.md
+++ b/openspec/changes/update-cli-registry-auth/specs/cli/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: Publishing authenticates with a bearer token
+
+When a user publishes a facet, the CLI SHALL authenticate to the registry with a bearer token. The token SHALL be resolved from, in order of precedence, the `FACET_TOKEN` environment variable, then a credentials file stored under the CLI's on-disk root. When no token can be resolved, the CLI SHALL refuse to publish before contacting the registry, and SHALL tell the user how to obtain a token.
+
+#### Scenario: Publish with a token in the environment
+
+- **WHEN** a user runs `publish` with `FACET_TOKEN` set to a valid token
+- **THEN** the CLI SHALL send the token to the registry as a bearer credential
+
+#### Scenario: Publish with a token only in the credentials file
+
+- **WHEN** a user runs `publish` with no `FACET_TOKEN` in the environment but a saved credentials file containing a token
+- **THEN** the CLI SHALL send the saved token to the registry as a bearer credential
+
+#### Scenario: Environment token wins over the credentials file
+
+- **WHEN** a user runs `publish` with `FACET_TOKEN` set in the environment AND a different token saved in the credentials file
+- **THEN** the CLI SHALL send the environment token
+- **AND** the CLI SHALL NOT send the saved file token
+
+#### Scenario: Publish with no resolvable credential
+
+- **WHEN** a user runs `publish` with no `FACET_TOKEN` in the environment and no saved credentials file
+- **THEN** the CLI SHALL print an error stating that no credential was found
+- **AND** the error SHALL direct the user to sign in or set a token
+- **AND** the CLI SHALL NOT contact the registry
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: A resolved credential is attached to every registry request
+
+When a credential is resolvable (from the environment or the credentials file), the CLI SHALL attach it to every registry request it makes — reads (such as search, facet info, version metadata, and archive download) as well as writes (publish) — so that authenticated traffic qualifies for the registry's authenticated rate-limit tier. When no credential is resolvable, read requests SHALL still be sent, without a credential, and SHALL remain fully functional. The CLI SHALL NOT inspect, parse, or validate the credential it holds before sending it; whether a given credential is accepted on a given request is the registry's decision.
+
+#### Scenario: Reads carry the credential when one exists
+
+- **WHEN** a user runs a read-only registry operation (such as `search`) with a resolvable credential
+- **THEN** the CLI SHALL attach the credential to the request as a bearer token
+
+#### Scenario: Reads work anonymously when no credential exists
+
+- **WHEN** a user runs a read-only registry operation with no resolvable credential
+- **THEN** the CLI SHALL send the request without a credential
+- **AND** the operation SHALL complete normally on success
+
+#### Scenario: The CLI does not pre-validate the credential
+
+- **WHEN** a resolved credential is malformed, expired, or revoked
+- **THEN** the CLI SHALL still send it unchanged to the registry
+- **AND** the CLI SHALL surface the registry's response rather than rejecting the credential itself
+
+### Requirement: Registry-originated errors render the registry's own text
+
+When the registry returns its structured error envelope, the CLI SHALL render the registry's own human-readable explanation and suggested-fix text to the user verbatim, and SHALL NOT translate the registry's error code through any CLI-side code-to-message map. The CLI SHALL author its own error text in only two cases, neither of which is a registry-returned error code: a pre-flight failure the registry never sees (a missing credential, a missing facet manifest, or an unreachable network), and a response from the registry that is not a valid structured error envelope at all.
+
+#### Scenario: Structured registry error is shown verbatim
+
+- **WHEN** the registry rejects a request with its structured error envelope containing an explanation and a suggested fix
+- **THEN** the CLI SHALL display the registry's explanation and suggested-fix text as written
+- **AND** the CLI SHALL NOT substitute its own message for the registry's error code
+
+#### Scenario: Unparseable registry response
+
+- **WHEN** the registry responds with a body that is not a valid structured error envelope
+- **THEN** the CLI SHALL print a CLI-authored message stating that it could not process the registry's response
+- **AND** the CLI SHALL NOT direct the user to any documentation link
+
+#### Scenario: Pre-flight failure uses CLI-authored text
+
+- **WHEN** a request fails before the registry is contacted (missing credential, missing facet manifest, or unreachable network)
+- **THEN** the CLI SHALL print its own error text for that failure
+- **AND** the registry-verbatim rendering rule SHALL NOT apply
+
+### Requirement: A first-time global-facet publish accepted for review is a success
+
+When a publish is accepted into the registry's moderation queue rather than published immediately, the CLI SHALL treat the outcome as a success. The CLI SHALL render the registry's queue-acknowledgement message to the user and SHALL exit with a success code.
+
+#### Scenario: Publish is queued for review
+
+- **WHEN** a user publishes a facet and the registry accepts it into its review queue instead of publishing it immediately
+- **THEN** the CLI SHALL render the registry's queue-acknowledgement message
+- **AND** the CLI SHALL exit with code 0
+- **AND** the CLI SHALL NOT present the outcome as a failure
+
+### Requirement: Users can sign in with a personal access token
+
+The CLI SHALL register a `login` command that guides a user through saving a registry credential. The command SHALL present a choice between pasting a personal access token (available now) and signing in via a web browser (shown as a disabled "coming soon" option that performs no action when chosen). When the user pastes a token, the CLI SHALL accept it with masked input so the token is not echoed in the clear, SHALL verify the token against the registry before saving it, and SHALL save it to the credentials file only after the registry confirms it is valid. On success the CLI SHALL confirm the signed-in identity to the user. On rejection the CLI SHALL render the registry's own error text and SHALL allow the user to try again.
+
+#### Scenario: login is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the help output SHALL list the `login` command with its description
+
+#### Scenario: Successful token sign-in
+
+- **WHEN** a user runs `login`, chooses to paste a personal access token, and provides a token the registry accepts
+- **THEN** the CLI SHALL accept the token with masked input
+- **AND** the CLI SHALL verify the token against the registry before saving it
+- **AND** the CLI SHALL save the token to the credentials file
+- **AND** the CLI SHALL print a confirmation naming the signed-in user and account tier
+
+#### Scenario: Rejected token
+
+- **WHEN** a user runs `login`, pastes a token, and the registry rejects it
+- **THEN** the CLI SHALL render the registry's own error text
+- **AND** the CLI SHALL NOT save the rejected token
+- **AND** the CLI SHALL allow the user to enter another token
+
+#### Scenario: Browser option is a disabled placeholder
+
+- **WHEN** a user runs `login` and selects the "sign in via browser" option
+- **THEN** the CLI SHALL take no action for that option
+- **AND** the CLI SHALL indicate that browser sign-in is not yet available
+
+#### Scenario: login warns when the environment token will take precedence
+
+- **WHEN** a user runs `login` while `FACET_TOKEN` is set in the environment
+- **THEN** the CLI SHALL warn, before prompting, that the environment variable will be used for every command in preference to the file about to be written
+- **AND** the warning SHALL direct the user to unset the environment variable if they want the saved credentials file to take effect
+- **AND** the user SHALL be allowed to proceed past the warning
+
+### Requirement: Users can see who they are signed in as
+
+The CLI SHALL register a `whoami` command that reports the identity associated with the resolved credential. The command SHALL display the authenticated user's username, email, account tier, and suspension state, as reported by the registry. When the credential in use comes from the `FACET_TOKEN` environment variable, the output SHALL indicate that the environment variable is the source, so the user is not confused about which credential authenticated the call.
+
+#### Scenario: whoami is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the help output SHALL list the `whoami` command with its description
+
+#### Scenario: whoami reports the authenticated identity
+
+- **WHEN** a user runs `whoami` with a credential the registry accepts
+- **THEN** the CLI SHALL display the username, email, account tier, and suspension state reported by the registry
+
+#### Scenario: whoami indicates the environment source
+
+- **WHEN** a user runs `whoami` while the credential in use comes from `FACET_TOKEN`
+- **THEN** the output SHALL indicate that the credential came from the environment variable
+
+#### Scenario: whoami with no credential
+
+- **WHEN** a user runs `whoami` with no resolvable credential
+- **THEN** the CLI SHALL print an error indicating the user is not signed in
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: Users can sign out by clearing the local credentials
+
+The CLI SHALL register a `logout` command that removes the saved credentials file. The command SHALL NOT contact the registry and SHALL NOT revoke any token server-side; token revocation is performed by the user in the web UI. When `FACET_TOKEN` is set in the environment at the time `logout` runs, the CLI SHALL inform the user that the file has been removed but the environment variable is still active, and SHALL direct the user to unset it to fully sign out of the current shell.
+
+#### Scenario: logout is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the help output SHALL list the `logout` command with its description
+
+#### Scenario: logout removes the saved credentials
+
+- **WHEN** a user runs `logout` with a saved credentials file present
+- **THEN** the CLI SHALL remove the saved credentials file
+- **AND** the CLI SHALL NOT contact the registry
+
+#### Scenario: logout warns that the environment token is still active
+
+- **WHEN** a user runs `logout` while `FACET_TOKEN` is set in the environment
+- **THEN** the CLI SHALL inform the user that the saved file was removed but the environment variable is still in effect
+- **AND** the CLI SHALL direct the user to unset the environment variable to fully sign out of the current shell
+
+#### Scenario: logout when no credentials file exists
+
+- **WHEN** a user runs `logout` with no saved credentials file present
+- **THEN** the CLI SHALL report that there were no saved credentials to remove
+- **AND** the process SHALL exit with code 0

--- a/openspec/changes/update-cli-registry-auth/tasks.md
+++ b/openspec/changes/update-cli-registry-auth/tasks.md
@@ -1,0 +1,92 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. Snapshot refresh + engine dependency
+
+- [ ] 1.1 Implement: Add the `ini` package as a dependency of `@agent-facets/engine`.
+- [ ] 1.2 Implement: Run `bun run codegen:registry` (in `packages/engine`) to regenerate `openapi.snapshot.yaml`, the generated registry types, and the curated wire re-exports against the live registry.
+- [ ] 1.3 Verify: Confirm the regenerated snapshot contains the BearerAuth security scheme, the `/v0/facets/*` paths (publish, info, version-metadata, archive), the expanded error-code enum, and the required `fix` field on the error envelope.
+
+## 2. Credential resolution + INI credentials file — Research
+
+- [ ] 2.1 Explore: the facet-dir module (`packages/engine/src/facet-dir.ts`): the existing `facetCacheDir()` / `facetAdaptersDir()` helper pattern, how `$FACET_DIR` is resolved and defaulted, and where a `facetCredentialsPath()` helper should slot in.
+- [ ] 2.2 Explore: the `ini` package API: parse, stringify, how it handles missing files, comment markers, and value trimming — confirm the exact calls for reading/writing a single `[default]` section with a `token` key.
+- [ ] 2.3 Explore: the repo's discriminated-result conventions (e.g. `Validated<T>`, `LoadLockfileResult`) to mirror the result shape for the credential resolver's three arms (env / file / absent).
+- [ ] 2.4 Propose: the engine credential module: the resolver's discriminated return type (naming the source), the `facetCredentialsPath()` helper, and the INI read/write functions (mode 600 on write), per D2 and D8.
+
+## 3. Credential resolution + INI credentials file — Implementation
+
+- [ ] 3.1 Implement: Add `facetCredentialsPath()` to the facet-dir module returning `$FACET_DIR/credentials`.
+- [ ] 3.2 Implement: INI credentials read/write using `ini`: read the `[default]` section's `token`; write the file with mode 600; treat an absent file as "no credential" (not an error).
+- [ ] 3.3 Implement: the credential resolver with precedence `FACET_TOKEN` (non-empty trimmed) → credentials file → absent, returning a discriminated result that names the supplying source.
+- [ ] 3.4 Implement: unit tests — env-over-file precedence, file-only, env-only, absent, empty/whitespace `FACET_TOKEN` treated as absent, and mode-600 on written files.
+- [ ] 3.5 Verify: run `bun check` for the engine credential + facet-dir changes.
+
+## 4. Bearer injection + registry-dumb error translation — Research
+
+- [ ] 4.1 Explore: `createRegistryClient` (`packages/engine/src/registry/client.ts`): the current timeout/retry middleware wiring and where a request middleware that attaches `Authorization: Bearer` should be added.
+- [ ] 4.2 Explore: the engine wire-error translation (`translateWireError` in `client.ts`): how structured envelopes are currently collapsed into `REGISTRY_NOT_AVAILABLE`, and what a `RegistryError` variant preserving `code`/`error`/`fix`/`docsUrl` requires.
+- [ ] 4.3 Explore: the CLI error-rendering layer (`packages/cli/src/util/registry-errors.ts`): the `whatForCode` / `fixForCode` / `docsUrlFor` maps and the `wireCode`-routing branch to be removed, and how the bridge renders an error today.
+- [ ] 4.4 Propose: the approach for the whole block — the optional-credential signature for `createRegistryClient`, the Bearer middleware, the `RegistryError` envelope-preserving variant, the deletions in the CLI error layer, and the two CLI-authored cases (pre-flight, unparseable response) per D3 and D4.
+
+## 5. Bearer injection + registry-dumb error translation — Implementation
+
+- [ ] 5.1 Implement: Extend `createRegistryClient` to accept an optional credential and attach `Authorization: Bearer <token>` to every request via middleware when present; send no auth header when absent. The factory itself does no env/file I/O.
+- [ ] 5.2 Implement: Change the engine wire-error translation to stop collapsing structured envelopes; add a `RegistryError` variant carrying `code`, `error`, `fix`, and `docsUrl` verbatim.
+- [ ] 5.3 Implement: Delete `whatForCode`, `fixForCode`, `docsUrlFor`, and the `wireCode`-routing branch from the CLI error layer; render the registry's `error` + `fix` verbatim from the `RegistryError` variant.
+- [ ] 5.4 Implement: the CLI-authored "unparseable registry response" message (no docs link) for responses that are not a valid structured envelope; keep the existing pre-flight messages (missing credential, missing `facet.json`, network unreachable) as CLI-authored.
+- [ ] 5.5 Implement: Update tests — registry-client auth-header behavior (present/absent), wire-error translation preserving the envelope, and CLI rendering of verbatim vs CLI-authored cases.
+- [ ] 5.6 Verify: run `bun check` for the engine client + CLI error-rendering changes.
+
+## 6. Publish + reads repointed to the new contract — Research
+
+- [ ] 6.1 Explore: the publish command + engine publish path (`packages/cli/src/commands/publish/index.ts`, `packages/engine/src/registry/publish.ts`): the current inline `X-Api-Key` header, the `FACET_REGISTRY_API_KEY` read, the publish path literal, and the success/status handling (including where a `202 QUEUED_FOR_REVIEW` outcome would land).
+- [ ] 6.2 Explore: the archive-download path (`packages/engine/src/registry/resolve-metadata.ts`, `download.ts`): the hand-built archive URL and the current `fetch(..., { redirect: 'follow' })`, to route the archive request through the typed client with `redirect: 'manual'`, read `Location`, then raw-fetch the presigned S3 URL (per D1).
+- [ ] 6.3 Explore: the search command (`packages/cli/src/commands/search/index.ts`) and any other read call sites for remaining `/v0/packages` literals or hand-built paths.
+- [ ] 6.4 Propose: the approach — publish resolves the credential via the D2 resolver (required, fail-fast) and passes it to `createRegistryClient`; reads resolve opportunistically and pass it through; the archive manual-redirect flow; and the `202` success handling.
+
+## 7. Publish + reads repointed to the new contract — Implementation
+
+- [ ] 7.1 Implement: Rewrite publish to resolve the credential via the resolver, fail fast with a CLI-authored message when absent, and pass the credential to `createRegistryClient` (removing the inline `X-Api-Key` header and the `FACET_REGISTRY_API_KEY` read).
+- [ ] 7.2 Implement: Handle the `202 QUEUED_FOR_REVIEW` publish outcome as a success — render the registry's queue-acknowledgement message and exit 0.
+- [ ] 7.3 Implement: Route the archive request through the typed client against `/v0/facets/{name}/{version}/archive` with `redirect: 'manual'`; read the `Location` header and raw-fetch the presigned S3 URL to stream the tarball; eliminate the hand-built archive URL.
+- [ ] 7.4 Implement: Repoint read commands (search and any remaining call sites) to resolve the credential opportunistically and pass it through; remove any lingering `/v0/packages` literals.
+- [ ] 7.5 Implement: Update tests — publish auth + no-credential fail-fast + 202 success; archive manual-redirect + S3 fetch; search against the new path.
+- [ ] 7.6 Verify: run `bun check` for the publish + read-path changes.
+
+## 8. login / whoami / logout commands — Research
+
+- [ ] 8.1 Explore: the command registration pattern (`packages/cli/src/commands.ts` and an existing per-command module such as `self-update`): how commands are registered, how metadata-driven help is derived, and the module/folder layout to mirror for three new commands.
+- [ ] 8.2 Explore: the CLI TUI prompt primitives — a menu/selection component for the login menu (active "paste PAT" + disabled "coming soon" browser option) and a masked-input prompt (asterisks per character).
+- [ ] 8.3 Explore: the `GET /v0/auth/me` typed call in the refreshed snapshot — the response fields (username, email, tier, suspension state) used by `login` verification and `whoami`.
+- [ ] 8.4 Propose: the approach for all three commands — `login` (menu → masked input → verify via `/v0/auth/me` with the pasted token → write file → confirm, reject→reprompt, env-precedence notice), `whoami` (resolve → `/v0/auth/me` → print profile + env-source indication, not-logged-in path), `logout` (delete file, no-op-if-absent, env-still-active warning), and their registration, per D5/D6/D7.
+
+## 9. login / whoami / logout commands — Implementation
+
+- [ ] 9.1 Implement: `facet login` — present the two-option menu (active paste-PAT / disabled "coming soon" browser); on paste, take masked input, verify the pasted token against `GET /v0/auth/me`, write it to the credentials file on success and print `Logged in as <username> (<tier>)`, render the registry's error and reprompt on rejection; show the env-precedence notice before prompting when `FACET_TOKEN` is set.
+- [ ] 9.2 Implement: `facet whoami` — resolve the credential, call `GET /v0/auth/me`, print username/email/tier/suspension; indicate when the credential came from `FACET_TOKEN`; print a clear "not logged in" message (non-zero exit) when no credential is resolvable.
+- [ ] 9.3 Implement: `facet logout` — delete the credentials file (report plainly when absent, exit 0), make no server call, and warn that the env var is still active (directing to `unset FACET_TOKEN`) when `FACET_TOKEN` is set.
+- [ ] 9.4 Implement: Register `login`, `whoami`, and `logout` in the command registry following the per-command pattern; no aliases.
+- [ ] 9.5 Implement: Add tests — login success/reject/reprompt + env-precedence notice + masked input + verify-before-save; whoami profile + env-source + not-logged-in; logout delete + no-op + env-warning; help lists all three commands.
+- [ ] 9.6 Verify: run `bun check` for the new commands and registration.
+
+## 10. Documentation + final verification
+
+- [ ] 10.1 Implement: Update `docs/docs/contributing/publishing.md` — replace `FACET_REGISTRY_API_KEY` guidance with the `facet login` / `FACET_TOKEN` flow and describe minting a PAT in the web UI.
+- [ ] 10.2 Implement: Update `docs/specification/install.md` — shift any `/v0/packages` references or registry fetch-contract details to `/v0/facets`.
+- [ ] 10.3 Implement: Add a `docs/changelog/index.md` entry recording the breaking removal of `FACET_REGISTRY_API_KEY`, the endpoint rename, and the new `login`/`whoami`/`logout` commands.
+- [ ] 10.4 Implement: Add a short "Publishing" section to the root `README.md` / CLI package README pointing at the web UI for PATs and documenting `facet login`.
+- [ ] 10.5 Verify: run the full `bun check` across the monorepo and confirm the change's specs are satisfied end-to-end.

--- a/openspec/specs/spec-governance/spec.md
+++ b/openspec/specs/spec-governance/spec.md
@@ -40,24 +40,49 @@ Requirements and scenarios SHALL NOT reference internal class names, method name
 
 ### Requirement: Category-domain naming for sibling domains
 
-When multiple independent domains share a parent concept, they MAY use `__` (double underscore) to encode the category: `category__domain`. Each `category__domain` SHALL be a fully independent spec with its own `spec.md`. The `__` separator SHALL NOT be used for domain-feature relationships where the feature is a capability within a single domain.
+When multiple independent domains share a parent concept, they MAY use `__` (double underscore) to encode the category: `category__domain`. Each `category__domain` SHALL be a fully independent spec with its own `spec.md`.
+
+A `<category>` parent spec at `openspec/specs/<category>/spec.md` MAY also exist alongside its `__`-suffixed siblings, forming a **cascade**: the parent holds requirements common to all siblings, and each sibling holds requirements specific to its target. When a parent spec is present, its requirements SHALL apply to every `<category>__<sibling>` spec as if inlined, AND sibling specs SHALL NOT restate parent requirements. The parent spec is OPTIONAL — sibling-only layouts (no parent) remain valid.
+
+The cascade SHALL be expressed by naming convention and reading order alone (parent first, then siblings). Spec files SHALL NOT use in-file inheritance, import, or extension syntax to link sibling specs to their parent.
+
+The `__` separator SHALL NOT be used to encode a *feature* of a single domain (a capability inside one domain that does not stand alone as an independently-testable target). The discriminator SHALL be whether the right-hand side is an independently-testable target variant with its own consumers and rules (allowed) or a capability inside one domain (forbidden).
+
+Only one level of cascade is permitted: `<category>` plus `<category>__<sibling>`. Multi-segment names such as `<category>__<sub>__<leaf>` SHALL NOT be used.
 
 #### Scenario: Sibling domains share a category
 
 - **WHEN** two or more domains are independent systems under a shared concept (e.g., facet authoring and server authoring are both authoring systems)
 - **THEN** they MAY use `category__domain` naming (e.g., `authoring__facets`, `authoring__servers`)
 - **AND** each SHALL have its own independent spec at `openspec/specs/category__domain/spec.md`
+- **AND** a parent `authoring/spec.md` is OPTIONAL — the sibling-only layout is valid
+
+#### Scenario: Parent category and sibling targets form a cascade
+
+- **WHEN** a parent concept carries genuinely-shared rules across multiple target variants (e.g., `publishing` holds shared identity, tokens, ownership, and provenance rules; `publishing__collections` holds rules specific to collection-scoped facets; `publishing__global_facets` holds rules specific to global facets)
+- **THEN** a parent spec MAY be created at `openspec/specs/publishing/spec.md` alongside sibling specs at `openspec/specs/publishing__collections/spec.md` and `openspec/specs/publishing__global_facets/spec.md`
+- **AND** the parent spec SHALL hold the shared requirements
+- **AND** each sibling spec SHALL hold only its target-specific requirements
+- **AND** sibling specs SHALL NOT restate any requirement already present in the parent
+- **AND** the cascade SHALL be conveyed by naming and reading order only — sibling specs SHALL NOT contain `extends:`, `imports:`, or any other inheritance directive
 
 #### Scenario: Feature within a domain does not use category separator
 
-- **WHEN** a capability is a feature within a single domain (e.g., login within auth, prompt resolution within facet authoring)
-- **THEN** it SHALL NOT use `__` to create a separate spec
+- **WHEN** a capability is a *feature* of a single domain — a capability inside that domain that does not stand alone as an independently-testable target with its own consumers and rules (e.g., login within auth, prompt resolution within facet authoring)
+- **THEN** it SHALL NOT use `__` to create a separate spec (e.g., `auth__login` is forbidden)
 - **AND** it SHALL be expressed as a requirement within the parent domain's spec
+- **AND** the cascade pattern (parent + `__`-siblings for independently-testable target variants) SHALL NOT be used to dress up a feature-of-a-domain split
 
 #### Scenario: Standalone domain does not require a category
 
 - **WHEN** a domain has no sibling domains under a shared concept (e.g., `installation`, `spec-governance`)
 - **THEN** it SHALL use a plain kebab-case name without a `__` separator
+
+#### Scenario: Multi-level nesting is not permitted
+
+- **WHEN** an author proposes a spec name with more than one `__` separator (e.g., `publishing__collections__facets`)
+- **THEN** the proposal SHALL be rejected
+- **AND** the author SHALL restructure into a single level of cascade or express the additional distinction as a requirement within a single sibling spec
 
 ### Requirement: Specifications are organized by product domain
 


### PR DESCRIPTION
### Why

The facet.cafe registry shipped a coordinated rework that renamed every versioned endpoint from `/v0/packages/*` to `/v0/facets/*` and replaced the static `X-Api-Key` header with `Authorization: Bearer <credential>`. The CLI's vendored OpenAPI snapshot predates both changes, leaving `publish`, `add`, `install`, and `search` broken end-to-end against production. This change is the CLI half of that coordinated cut.

### Details

**Endpoint rename and snapshot refresh**
The vendored OpenAPI snapshot is regenerated via `bun run codegen:registry`, bringing in the Bearer security scheme, the renamed `/v0/facets/*` paths, the expanded error-code enum, and the now-required `fix` field on the error envelope. The one registry URL previously built by hand (the archive-download URL) is eliminated: the archive request is routed through the typed client with `redirect: 'manual'`, the `Location` header is read off the `302`, and only the presigned S3 URL is fetched raw. Every request the registry serves is now codegen-typed.

**Credential resolution**
A new engine module resolves credentials with `FACET_TOKEN` (env) taking precedence over `$FACET_DIR/credentials` (file), with an explicit "absent" arm as a discriminated result. A `facetCredentialsPath()` helper is added alongside the existing facet-dir helpers. The credentials file is INI-formatted with a `[default]` profile section (AWS-CLI style, using the `ini` package), written with mode 600. The profile structure is the seam for future multi-profile and multi-registry credentials without a format break.

**Bearer injection**
`createRegistryClient` accepts an optional credential and attaches `Authorization: Bearer <token>` to every outgoing request via middleware when present. The credential is sent on reads as well as writes so authenticated traffic qualifies for the registry's higher rate-limit tier. The factory does no env or file I/O itself. The inline `X-Api-Key` header and `FACET_REGISTRY_API_KEY` environment variable are removed with no deprecation shim.

**Registry-dumb error rendering**
The CLI's local `whatForCode`/`fixForCode` code-to-message maps and the `wireCode`-routing branch are deleted. When the registry returns a structured `{ code, error, fix, docsUrl }` envelope, the CLI renders the registry's own `error` and `fix` text verbatim. The engine's wire-error translation is updated to carry the full envelope through as a `RegistryError` variant rather than collapsing it into `REGISTRY_NOT_AVAILABLE`. The CLI authors its own message text only for pre-flight failures (missing credential, missing `facet.json`, unreachable network) and for responses that are not a valid structured envelope.

**New commands**
- `facet login`: presents a menu with an active "paste a personal access token" path (masked input, verified against `GET /v0/auth/me` before saving) and a disabled "coming soon" browser sign-in option. Warns explicitly if `FACET_TOKEN` is set in the environment before prompting.
- `facet whoami`: calls `GET /v0/auth/me` and prints username, email, tier, and suspension state; indicates when the credential came from `FACET_TOKEN`.
- `facet logout`: deletes `$FACET_DIR/credentials` with no server call; warns when `FACET_TOKEN` is still active in the environment.

**Publish queue handling**
An HTTP 202 `QUEUED_FOR_REVIEW` response from a first-time global-facet publish is treated as a success — the registry's queue-acknowledgement message is rendered and the process exits 0.

**Spec governance update**
The `spec-governance` spec is extended to define the optional parent-plus-siblings cascade pattern for `category__domain` naming, clarify the feature-vs-independent-target discriminator, and prohibit multi-level nesting beyond one `__` separator.

**Not in scope:** browser PKCE sign-in, CLI token mint/list/revoke, server-side PAT revocation on logout, changes to the published archive format, or any rename of `FACET_DIR`.

### Verification

CI covers type checking and unit tests. The full `bun check` is run after each implementation phase. Specific coverage includes: credential resolver precedence and mode-600 file writes; registry client auth-header presence and absence; wire-error envelope preservation and verbatim CLI rendering; publish auth, no-credential fail-fast, and 202 success; archive manual-redirect and S3 fetch; and all three new commands including the env-precedence notice, masked input, verify-before-save, and help registration.