### PR TITLE
Add engine `add` orchestrator; fix registry manifest value to pin resolved version

### DIFF
--- a/.changeset/beige-berries-mix.md
+++ b/.changeset/beige-berries-mix.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": patch
+---
+
+Fix `facet add` to write resolved versions instead of the facet name

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -81,6 +81,8 @@ Running `facet add` against a facet that's already in `facets.json` is supported
 
 - Same source as before → no-op (lockfile may report `unchanged` or `repaired`).
 - Different version pin → updates the entry; the install summary shows `(was X → Y)`.
+- Bare re-add (no version) over an existing **valid** version spec → the spec is **preserved**. A bare re-add never clobbers a deliberate pin or range — re-running `facet add viper-plans` won't overwrite a `viper-plans@1.*` you set on purpose.
+- Bare re-add over an **invalid** value (e.g. a stale entry where the name leaked into the version position) → the value is **healed** to the resolved exact version.
 
 ## Flags
 

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
     "viper-plans": "github:agent-facets/viper-plans",
-    "cowsay": "cowsay"
+    "cowsay": "0.1.1"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -30,7 +30,7 @@
       ]
     },
     "cowsay": {
-      "source": "cowsay",
+      "source": "0.1.1",
       "version": "0.1.1",
       "integrity": "sha256:dfbc7a5521ae40579e89abbd6958fa597e9eadd926110f6aad90adf37406f2fa",
       "assets": [

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -193,17 +193,22 @@ When a user specifies a version, the system SHALL accept only one of five forms:
 
 ### Requirement: Adding a facet without a version stores the resolved version pinned
 
-When a user adds a registry facet without specifying a version, the system SHALL resolve the latest published version and SHALL record that exact version in the project manifest. A bare name and the literal tag `@latest` SHALL be equivalent and SHALL produce identical results. The user SHALL NOT need to specify a version explicitly to get reproducible builds.
+When a user adds a registry facet without specifying a version, the system SHALL resolve the latest published version and SHALL record a version specifier in the project manifest. The system SHALL NOT record the facet name in the version position. A bare name and the literal tag `@latest` SHALL be equivalent and SHALL produce identical results. The user SHALL NOT need to specify a version explicitly to get reproducible builds.
+
+When no manifest entry for the facet exists, or the existing entry's value is not a valid version specifier, the system SHALL record the resolved exact version (`name@MAJOR.MINOR.PATCH`). When a manifest entry already exists and its value is a valid version specifier, the system SHALL preserve that value unchanged, so that a re-add without a version does not overwrite a version the user previously chose.
 
 #### Scenario: Bare facet name is recorded as exact version
 
 - **WHEN** a user adds a registry facet using only its name (no version)
+- **AND** no entry for that facet exists in the project manifest
 - **THEN** the system SHALL resolve the latest published version
 - **AND** the system SHALL record `name@MAJOR.MINOR.PATCH` in the project manifest
+- **AND** the system SHALL NOT record the facet name as the version value
 
 #### Scenario: @latest tag is equivalent to a bare name
 
 - **WHEN** a user adds a registry facet using the literal `name@latest` form
+- **AND** no entry for that facet exists in the project manifest
 - **THEN** the system SHALL resolve the latest published version
 - **AND** the system SHALL record `name@MAJOR.MINOR.PATCH` in the project manifest
 - **AND** the resulting manifest, lockfile, and on-disk state SHALL be identical to what would have been produced by the bare-name form
@@ -213,6 +218,26 @@ When a user adds a registry facet without specifying a version, the system SHALL
 - **WHEN** a user adds a registry facet using a wildcard form (e.g., `name@1.*`)
 - **THEN** the system SHALL record the wildcard as written in the project manifest
 - **AND** the system SHALL record the resolved exact version in the lockfile
+
+#### Scenario: Re-adding without a version preserves an existing valid version
+
+- **WHEN** the project manifest already records a facet with a valid version specifier (e.g., `1.*`, `1.2.*`, `1.2.3`, `*`, or `latest`)
+- **AND** a user re-adds that facet without specifying a version
+- **THEN** the system SHALL preserve the existing version specifier in the project manifest unchanged
+- **AND** the system SHALL NOT overwrite it with the resolved exact version
+
+#### Scenario: Re-adding without a version heals an invalid recorded value
+
+- **WHEN** the project manifest records a facet whose value is not a valid version specifier (e.g., the facet name appears in the version position)
+- **AND** a user re-adds that facet without specifying a version
+- **THEN** the system SHALL resolve the latest published version
+- **AND** the system SHALL replace the invalid value with the resolved exact version (`name@MAJOR.MINOR.PATCH`) in the project manifest
+
+#### Scenario: Adding a git or local facet records the full source specifier
+
+- **WHEN** a user adds a facet from a git source or a local path
+- **THEN** the system SHALL record the full source specifier (the git URL with any ref, or the local path) as the manifest value
+- **AND** the system SHALL NOT replace it with a version specifier
 
 ### Requirement: Source specifier syntax matches established package-manager conventions
 

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -1,17 +1,12 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
 import {
-  emptyFacetsJson,
-  loadFacetsJson,
+  type AddPrepareFailure,
+  type AddSource,
   loadInstalledAdapters,
   type ParseError,
   parseFacetSource,
-  type RunInstallResult,
-  runInstall,
-  type Source,
-  upsertFacetInManifest,
-  writeFacetsJson,
+  type RunAddResult,
+  runAdd,
 } from '@agent-facets/engine'
 import { render } from 'ink'
 import { createElement } from 'react'
@@ -24,17 +19,14 @@ import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
  * `facet add <source> [more sources...]` — adds one or more facets to
  * `facets.json` and immediately installs them.
  *
- * The pipeline:
- *   1. Parse every source up front (no I/O). Any parse error aborts
- *      before mutating disk.
- *   2. Discover installable adapters. If none and stdout is a TTY,
- *      auto-launch the adapter picker. Non-TTY → fail.
- *   3. Byte-snapshot `facets.json` for rollback.
- *   4. Write the new entries to `facets.json` (default-to-pinned for
- *      bare/wildcard versions; wildcard form preserved as written).
- *   5. Mount `<InstallView mode="add" />` and call `runInstall`.
- *   6. On `runInstall` failure, restore the manifest snapshot
- *      byte-for-byte so the project is exactly as it was pre-command.
+ * This command is a thin caller over the engine `add` orchestrator
+ * (`runAdd`), which owns the entire manifest transaction: resolve each
+ * source's facet name, snapshot `facets.json`, write provisional entries
+ * (applying the per-source manifest-value rule), run the install
+ * pipeline, rewrite pinned entries with the resolved version on success,
+ * and restore the snapshot on failure. This file only parses argv,
+ * ensures adapters, renders progress, and maps the result to an exit
+ * code + error block.
  */
 export const addCommand: Command = {
   name: 'add',
@@ -57,73 +49,30 @@ export const addCommand: Command = {
     const verbose = flags.verbose === true
     const onLog = verbose ? (line: string) => process.stderr.write(`${line}\n`) : undefined
 
-    // Step 1: parse every source up front. No I/O happens here.
-    const parsed: Array<{ specifier: string; source: Source }> = []
+    // Parse every source up front. No I/O happens here; any parse error
+    // aborts before mounting the view or touching disk.
+    const sources: AddSource[] = []
     for (const specifier of args) {
       const result = parseFacetSource(specifier)
       if (!result.ok) {
         writeParseError(specifier, result.error)
         return 1
       }
-      parsed.push({ specifier, source: result.value })
+      sources.push({ specifier, source: result.value })
     }
 
     const projectRoot = process.cwd()
 
-    // Step 2: discover or pick adapters.
+    // Discover or pick adapters.
     const adapters = await ensureAdapters()
     if (adapters === null) {
       // ensureAdapters already wrote the appropriate CLI error.
       return 1
     }
 
-    // Step 3: byte-snapshot facets.json for rollback.
-    const facetsJsonPath = join(projectRoot, 'facets.json')
-    const snapshot: Buffer | null = existsSync(facetsJsonPath) ? readFileSync(facetsJsonPath) : null
-
-    // Step 4: write new entries to facets.json.
-    // Each entry is keyed by the facet's name; that comes from the
-    // facet's own facet.json which we'll learn during runInstall's
-    // planFacet step. For now we use the user's specifier as both the
-    // key candidate AND the value, then rely on runInstall to surface
-    // any name mismatch via its MANIFEST_NAME_MISMATCH failure code —
-    // but to write a sensible facets.json before the install runs, we
-    // need the name now. Pre-resolve it cheaply by reading the source's
-    // facet.json directly (the same loadManifest call runInstall makes
-    // internally; doing it here too is the price of "write manifest
-    // before install").
-    const namesByIndex: string[] = []
-    for (let i = 0; i < parsed.length; i++) {
-      const entry = parsed[i]
-      if (!entry) continue
-      const name = await peekFacetName(entry.source, entry.specifier)
-      if (name === null) {
-        // peekFacetName already wrote a CLI error.
-        return 1
-      }
-      namesByIndex[i] = name
-    }
-
-    // Now mutate facets.json with the new entries.
-    const loaded = loadFacetsJson(projectRoot)
-    if (!loaded.ok) {
-      writeCliError({
-        what: 'could not read facets.json',
-        detail: loaded.error,
-        fix: 'fix or delete the malformed facets.json and retry',
-      })
-      return 1
-    }
-    const json = loaded.existed ? loaded.data : emptyFacetsJson()
-    for (let i = 0; i < parsed.length; i++) {
-      const entry = parsed[i]
-      const name = namesByIndex[i]
-      if (!entry || !name) continue
-      upsertFacetInManifest(json, name, entry.specifier)
-    }
-    writeFacetsJson(projectRoot, json)
-
-    // Step 5: mount InstallView and run runInstall.
+    // Wire SIGINT to an AbortController so engine never installs a
+    // process-global signal handler. The view's deferred-exit pattern
+    // ensures the rollback render lands before unmount.
     const controller = new AbortController()
     const sigintHandler = () => {
       process.stderr.write('\nInterrupted. Rolling back...\n')
@@ -131,23 +80,32 @@ export const addCommand: Command = {
     }
     process.on('SIGINT', sigintHandler)
 
-    let captured: RunInstallResult | undefined
+    let captured: RunAddResult | undefined
     const instance = render(
       createElement(InstallView, {
         mode: 'add',
         run: async (onStage) => {
-          const result = await runInstall({
+          const result = await runAdd({
             projectRoot,
+            sources,
             adapters,
             onStage,
-            onLog,
+            ...(onLog ? { onLog } : {}),
             signal: controller.signal,
           })
           captured = result
-          return result
+          // The view renders from a RunInstallResult-shaped value. Map
+          // runAdd's result into what the view expects: install success
+          // and install failures pass through verbatim; a prepare-phase
+          // failure surfaces via the dedicated prepare-failure arm.
+          if (result.ok) return result.install
+          if (result.phase === 'install') return result.install
+          return { ok: false, prepareFailure: result.failure }
         },
         onComplete: (r) => {
-          captured = r
+          // `onComplete` receives the view-shaped result; `captured` is
+          // already the richer RunAddResult set in `run`.
+          void r
         },
       }),
     )
@@ -160,28 +118,36 @@ export const addCommand: Command = {
       process.off('SIGINT', sigintHandler)
     }
 
-    // Step 6: on failure, restore the manifest snapshot.
-    if (!captured?.ok) {
-      restoreSnapshot(facetsJsonPath, snapshot)
-      // Branch the user-facing guidance on the rollback outcome's `kind`.
-      // When `partial-failure`, the journal couldn't reverse some
-      // materialize operations and adapter files may remain on disk — the
-      // user needs to know that rather than be told "project state
-      // unchanged" and assume a clean retry.
-      const rollback = captured?.rollback
-      const partialFailureCount = rollback?.kind === 'partial-failure' ? rollback.failures : 0
-      const rollbackFailed = partialFailureCount > 0
+    if (!captured) {
       writeCliError({
         what: 'add failed',
-        detail: captured ? `code=${captured.failure.code}` : 'no result from install pipeline',
-        fix: rollbackFailed
-          ? `partial rollback: ${partialFailureCount} undo step(s) failed; some adapter files may remain. Inspect and clean manually before re-running 'facet add'.`
-          : "rollback complete; project state unchanged. Fix the underlying issue and re-run 'facet add'.",
+        detail: 'the add pipeline returned no result',
+        fix: 'this is a bug; please file an issue with the verbose log',
       })
       return 1
     }
 
-    return 0
+    if (captured.ok) return 0
+
+    if (captured.phase === 'prepare') {
+      writePrepareError(captured.failure)
+      return 1
+    }
+
+    // Install-phase failure. The orchestrator restored the manifest
+    // snapshot; branch the guidance on whether restore succeeded and
+    // whether the install rollback was partial.
+    const rollback = captured.install.rollback
+    const partialFailureCount = rollback.kind === 'partial-failure' ? rollback.failures : 0
+    const rollbackFailed = partialFailureCount > 0 || !captured.manifestRestored
+    writeCliError({
+      what: 'add failed',
+      detail: `code=${captured.install.failure.code}`,
+      fix: rollbackFailed
+        ? `partial rollback: some state may remain (manifest restored: ${captured.manifestRestored}). Inspect and clean manually before re-running 'facet add'.`
+        : "rollback complete; project state unchanged. Fix the underlying issue and re-run 'facet add'.",
+    })
+    return 1
   },
 }
 
@@ -232,109 +198,6 @@ async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
   return null
 }
 
-/**
- * Read the source's `facet.json` just far enough to learn the facet's
- * name. We do this here (not just inside runInstall) so the manifest
- * write step can use the correct name as the `facets.json` key.
- *
- * This duplicates a small slice of `runInstall.planFacet`'s work. The
- * alternative is to pass the user's specifier in as the key and let
- * the install fail with `MANIFEST_NAME_MISMATCH` after the manifest is
- * already on disk — uglier and harder to roll back from cleanly.
- */
-async function peekFacetName(source: Source, specifier: string): Promise<string | null> {
-  if (source.kind === 'registry') {
-    // Registry source: the canonical name on the parsed source IS the
-    // facet name (the registry keys by canonical name), so we can write
-    // the manifest entry without a network round-trip. runInstall will
-    // verify the manifest's declared name matches when it downloads.
-    return source.name
-  }
-  const { loadManifest } = await import('@agent-facets/engine')
-  let sourceDir: string
-  let cleanup: (() => Promise<void>) | undefined
-  if (source.kind === 'git') {
-    const { cloneFacetGitSource } = await import('@agent-facets/engine')
-    const cloned = await cloneFacetGitSource(source.url, source.ref)
-    if (!cloned.ok) {
-      // Each failure mode gets its own user-facing message — engine
-      // returns the structured `reason`, the CLI renders prose. Adding
-      // a new variant to `CloneFacetGitResult` forces this switch to
-      // update (compile-time obligation).
-      switch (cloned.reason) {
-        case 'git-binary-missing':
-          writeCliError({
-            what: `could not clone git source "${specifier}"`,
-            detail: 'git is not installed (or not on PATH)',
-            fix: 'install git and re-run this command',
-          })
-          return null
-        case 'auth-required':
-          writeCliError({
-            what: `git authentication required for ${cloned.url}`,
-            detail: 'closed alpha supports public repos and SSH (via agent) only',
-            fix: 'use a public URL or configure your SSH agent',
-          })
-          return null
-        case 'clone-failed':
-          writeCliError({
-            what: `could not clone git source "${specifier}"`,
-            detail: cloned.stderr,
-            fix: 'verify the URL and your network connectivity',
-          })
-          return null
-        case 'checkout-failed':
-          writeCliError({
-            what: `could not check out commit ${cloned.commitish} in ${cloned.url}`,
-            detail: cloned.stderr,
-            fix: 'verify the commit SHA exists in the repository',
-          })
-          return null
-      }
-    }
-    sourceDir = cloned.dir
-    const { rm } = await import('node:fs/promises')
-    cleanup = async () => {
-      await rm(cloned.dir, { recursive: true, force: true }).catch(() => {})
-    }
-  } else {
-    const { resolveLocalFacetSource } = await import('@agent-facets/engine')
-    const resolved = await resolveLocalFacetSource(source.path, process.cwd())
-    if (!resolved.ok) {
-      writeCliError({
-        what: `could not resolve local source "${specifier}"`,
-        detail: resolved.error,
-        fix: 'check the path exists inside the project tree',
-      })
-      return null
-    }
-    sourceDir = resolved.dir
-  }
-
-  try {
-    const manifest = await loadManifest(sourceDir)
-    if (!manifest.ok) {
-      writeCliError({
-        what: `could not load facet.json from ${specifier}`,
-        detail: manifest.errors.map((e) => e.message).join('; '),
-        fix: 'verify the source is a facet directory with a valid facet.json',
-      })
-      return null
-    }
-    if (manifest.data.facets && manifest.data.facets.length > 0) {
-      writeCliError({
-        what: 'facet composition is not supported',
-        detail: `${specifier} declares dependencies on other facets`,
-        fix: 'use a non-composing facet, or wait until composition support ships',
-      })
-      return null
-    }
-    return manifest.data.name
-  } finally {
-    if (cleanup) await cleanup()
-  }
-}
-
 function writeParseError(specifier: string, error: ParseError): void {
   writeCliError({
     what: `could not parse source "${specifier}"`,
@@ -343,10 +206,68 @@ function writeParseError(specifier: string, error: ParseError): void {
   })
 }
 
-function restoreSnapshot(path: string, snapshot: Buffer | null): void {
-  if (snapshot === null) {
-    if (existsSync(path)) rmSync(path)
-    return
+/**
+ * Map an `AddPrepareFailure` (engine) to the canonical CLI error block on
+ * stderr. The view already rendered a richer block on stdout; this keeps
+ * stderr grep-friendly and gives each failure a precise fix line.
+ */
+function writePrepareError(failure: AddPrepareFailure): void {
+  switch (failure.reason) {
+    case 'manifest-read':
+      writeCliError({
+        what: 'could not read facets.json',
+        detail: failure.error,
+        fix: 'fix or delete the malformed facets.json and retry',
+      })
+      return
+    case 'git-binary-missing':
+      writeCliError({
+        what: `could not clone git source "${failure.specifier}"`,
+        detail: 'git is not installed (or not on PATH)',
+        fix: 'install git and re-run this command',
+      })
+      return
+    case 'git-auth-required':
+      writeCliError({
+        what: `git authentication required for ${failure.url}`,
+        detail: 'closed alpha supports public repos and SSH (via agent) only',
+        fix: 'use a public URL or configure your SSH agent',
+      })
+      return
+    case 'git-clone-failed':
+      writeCliError({
+        what: `could not clone git source "${failure.specifier}"`,
+        detail: failure.stderr,
+        fix: 'verify the URL and your network connectivity',
+      })
+      return
+    case 'git-checkout-failed':
+      writeCliError({
+        what: `could not check out commit ${failure.commitish} in "${failure.specifier}"`,
+        detail: failure.stderr,
+        fix: 'verify the commit SHA exists in the repository',
+      })
+      return
+    case 'local-resolve-failed':
+      writeCliError({
+        what: `could not resolve local source "${failure.specifier}"`,
+        detail: failure.error,
+        fix: 'check the path exists inside the project tree',
+      })
+      return
+    case 'manifest-load-failed':
+      writeCliError({
+        what: `could not load facet.json from ${failure.specifier}`,
+        detail: failure.detail,
+        fix: 'verify the source is a facet directory with a valid facet.json',
+      })
+      return
+    case 'composition-rejected':
+      writeCliError({
+        what: 'facet composition is not supported',
+        detail: `${failure.specifier} declares dependencies on other facets`,
+        fix: 'use a non-composing facet, or wait until composition support ships',
+      })
+      return
   }
-  writeFileSync(path, snapshot)
 }

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -92,7 +92,10 @@ export const installCommand: Command = {
           return result
         },
         onComplete: (r) => {
-          captured = r
+          // `install` never produces a prepare-phase failure; guard the
+          // wider InstallViewResult so the captured value stays a
+          // RunInstallResult. The `run` closure already set `captured`.
+          if (!('prepareFailure' in r)) captured = r
         },
       }),
     )

--- a/packages/cli/src/tui/views/install/add-prepare-failure-block.tsx
+++ b/packages/cli/src/tui/views/install/add-prepare-failure-block.tsx
@@ -1,0 +1,100 @@
+import type { AddPrepareFailure } from '@agent-facets/engine'
+import { Box, Text } from 'ink'
+import type React from 'react'
+import { THEME } from '../../theme.ts'
+
+/**
+ * Renders the structured failure detail for the `add` flow's pre-install
+ * (prepare) phase — name resolution and manifest read. These failures
+ * occur before the install pipeline runs, so they have no
+ * `RunInstallFailure` shape; the `add` orchestrator reports them as
+ * `AddPrepareFailure` and the view renders them here.
+ *
+ * The explicit return type + `assertNever` default arm makes any new
+ * `AddPrepareFailure` variant a compile-time error here, mirroring
+ * {@link FailureBlock}.
+ */
+export function AddPrepareFailureBlock({ failure }: { failure: AddPrepareFailure }): React.JSX.Element {
+  switch (failure.reason) {
+    case 'manifest-read':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ could not read facets.json
+          </Text>
+          <Text> {failure.error}</Text>
+        </Box>
+      )
+    case 'git-binary-missing':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ git is not installed (or not on PATH)
+          </Text>
+          <Text> source: {failure.specifier}</Text>
+          <Text color={THEME.hint}> install git and re-run this command</Text>
+        </Box>
+      )
+    case 'git-auth-required':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ git authentication required for {failure.url}
+          </Text>
+          <Text> source: {failure.specifier}</Text>
+          <Text color={THEME.hint}> closed alpha supports public repos and SSH (via agent) only</Text>
+        </Box>
+      )
+    case 'git-clone-failed':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ git clone failed for {failure.specifier}
+          </Text>
+          <Text> {failure.stderr}</Text>
+        </Box>
+      )
+    case 'git-checkout-failed':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ git checkout {failure.commitish} failed for {failure.specifier}
+          </Text>
+          <Text> {failure.stderr}</Text>
+        </Box>
+      )
+    case 'local-resolve-failed':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ could not resolve local source {failure.specifier}
+          </Text>
+          <Text> {failure.error}</Text>
+        </Box>
+      )
+    case 'manifest-load-failed':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ could not load facet.json from {failure.specifier}
+          </Text>
+          <Text> {failure.detail}</Text>
+        </Box>
+      )
+    case 'composition-rejected':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ facet composition is not supported
+          </Text>
+          <Text> {failure.specifier} declares dependencies on other facets</Text>
+        </Box>
+      )
+    default: {
+      // Exhaustiveness guard: any new `AddPrepareFailure` variant must get
+      // a `case` arm above.
+      const _exhaustive: never = failure
+      return _exhaustive
+    }
+  }
+}

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -1,9 +1,19 @@
-import type { RunInstallResult, StageEvent } from '@agent-facets/engine'
+import type { AddPrepareFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
 import { Box, Text, useApp } from 'ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { THEME } from '../../theme.ts'
+import { AddPrepareFailureBlock } from './add-prepare-failure-block.tsx'
 import { FacetRow, type FacetState } from './facet-row.tsx'
 import { FailureBlock } from './failure-block.tsx'
+
+/**
+ * Driver result. The `install` flow returns a `RunInstallResult`. The
+ * `add` flow may instead fail in its pre-install (prepare) phase — name
+ * resolution / manifest read — which has no `RunInstallResult` shape, so
+ * it surfaces as a distinct `prepare-failure` arm the view renders via
+ * {@link AddPrepareFailureBlock}.
+ */
+export type InstallViewResult = RunInstallResult | { ok: false; prepareFailure: AddPrepareFailure }
 
 export interface InstallViewProps {
   /**
@@ -11,7 +21,7 @@ export interface InstallViewProps {
    * an `onStage` callback and returns the result. The view runs it once
    * on mount and surfaces its events / outcome.
    */
-  run: (onStage: (event: StageEvent) => void) => Promise<RunInstallResult>
+  run: (onStage: (event: StageEvent) => void) => Promise<InstallViewResult>
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
    * renders "Installing facets...". Functional behavior is identical.
@@ -21,7 +31,12 @@ export interface InstallViewProps {
    * Fires once when the install completes, before Ink unmounts. Lets
    * the caller capture the result for exit-code mapping.
    */
-  onComplete?: (result: RunInstallResult) => void
+  onComplete?: (result: InstallViewResult) => void
+}
+
+/** Type guard: a driver result that is an add prepare-phase failure. */
+function isPrepareFailure(r: InstallViewResult): r is { ok: false; prepareFailure: AddPrepareFailure } {
+  return !r.ok && 'prepareFailure' in r
 }
 
 interface ServerWarning {
@@ -40,7 +55,7 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   const [facets, setFacets] = useState<Record<string, FacetState>>({})
   const [serverWarnings, setServerWarnings] = useState<ServerWarning[]>([])
   const [driftRemovals, setDriftRemovals] = useState<DriftRemoval[]>([])
-  const [result, setResult] = useState<RunInstallResult | null>(null)
+  const [result, setResult] = useState<InstallViewResult | null>(null)
   const [exitState, setExitState] = useState<
     { kind: 'idle' } | { kind: 'success' } | { kind: 'failure'; error: Error }
   >({ kind: 'idle' })
@@ -179,8 +194,9 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
       )}
 
       {result?.ok && <SuccessSummary result={result} mode={mode} />}
-      {result && !result.ok && <FailureBlock failure={result.failure} />}
-      {result && !result.ok && result.rollback.kind === 'partial-failure' && (
+      {result && isPrepareFailure(result) && <AddPrepareFailureBlock failure={result.prepareFailure} />}
+      {result && !result.ok && !isPrepareFailure(result) && <FailureBlock failure={result.failure} />}
+      {result && !result.ok && !isPrepareFailure(result) && result.rollback.kind === 'partial-failure' && (
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.warning}>
             ⚠ rollback completed with {result.rollback.failures} partial failure

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -82,6 +82,9 @@ export type { LoadLockfileResult } from './install/lockfile-io.ts'
 export { emptyLockfile, FACETS_LOCK_FILE, loadLockfile, writeLockfile } from './install/lockfile-io.ts'
 export type { MaterializeOptions, MaterializeResult } from './install/materialize.ts'
 export { computeAssetList, diffAssetsForDeletion, materialize } from './install/materialize.ts'
+// add orchestrator (owns the facet add manifest transaction)
+export type { AddPrepareFailure, AddSource, RunAddOptions, RunAddResult } from './install/run-add.ts'
+export { runAdd } from './install/run-add.ts'
 // install orchestrator
 export { runInstall } from './install/run-install.ts'
 export type {

--- a/packages/engine/src/install/__tests__/run-add.test.ts
+++ b/packages/engine/src/install/__tests__/run-add.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Tests for the `facet add` orchestrator (`runAdd`).
+ *
+ * The registry resolve + download path is stubbed via `mock.module` so the
+ * test exercises `runAdd`'s manifest transaction (preserve / heal / pin and
+ * the per-source value rule) without a live registry. The stubbed
+ * `downloadAndExtractFacet` copies a local fixture into the staging dir it
+ * is handed; everything downstream (build, content-hash, materialize, lock-
+ * file) runs for real, so `lockfile.facets[name].version` is the fixture's
+ * own version. Production download verification (`download.ts`) is covered
+ * by its own tests and is intentionally bypassed here.
+ */
+
+// --- Registry mock state (mutated per-test before calling runAdd) ---------
+
+let registryFixtureDir: string | null = null
+let registryResolvedVersion = '0.1.1'
+
+mock.module('../../registry/resolve-metadata.ts', () => ({
+  resolveRegistryMetadataBatch: async (specs: ReadonlyArray<{ name: string }>) => ({
+    ok: true,
+    value: specs.map((s) => ({
+      name: s.name,
+      version: registryResolvedVersion,
+      expectedIntegrity: 'sha256:stub',
+    })),
+  }),
+}))
+
+mock.module('../../registry/download.ts', () => ({
+  downloadAndExtractFacet: async (_meta: { name: string }, dest: string) => {
+    if (registryFixtureDir === null) {
+      return { ok: false, error: { code: 'NETWORK_ERROR', cause: 'no fixture set', attempts: 1 } }
+    }
+    cpSync(registryFixtureDir, dest, { recursive: true })
+    return { ok: true, value: undefined }
+  },
+}))
+
+// Imported AFTER the mocks are registered so run-install picks up the stubs.
+const { runAdd } = await import('../run-add.ts')
+const { parseFacetSource } = await import('../../sources/facet/parse-source.ts')
+const { loadInstalledAdapters } = await import('../../adapters/loader.ts')
+
+let projectRoot: string
+let originalCwd: string
+let fakeHome: string
+let originalHome: string | undefined
+let originalFacetDir: string | undefined
+let adaptersDir: string
+
+/** Build a facet fixture directory (a `facet.json` + one skill). */
+function buildFixture(parent: string, name: string, version: string): string {
+  const repo = realpathSync(mkdtempSync(join(parent, 'fixture-')))
+  writeFileSync(
+    join(repo, 'facet.json'),
+    JSON.stringify({ name, version, skills: { planning: { description: 'planning skill' } } }),
+  )
+  mkdirSync(join(repo, 'skills/planning'), { recursive: true })
+  writeFileSync(join(repo, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
+  return repo
+}
+
+function installFakeAdapter(baseDir: string, name: string): void {
+  const dir = join(baseDir, name)
+  mkdirSync(dir, { recursive: true })
+  const assetFsImport = require.resolve('@agent-facets/adapter')
+  writeFileSync(
+    join(dir, 'adapter.js'),
+    `
+import { installAssetFile, readAssetFile, deleteAssetFile } from '${assetFsImport}'
+import { join } from 'node:path'
+function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
+export default {
+  name: '${name}',
+  supportsInstall: true,
+  buildAssetMetadata(data) { return { ok: true, data: data || {} } },
+  async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
+  async readAsset(scope, type, name) { return readAssetFile({ file: path(type, name) }) },
+  async deleteAsset(scope, type, name) { await deleteAssetFile({ file: path(type, name) }) },
+}
+`,
+  )
+}
+
+function readFacets(): Record<string, string> {
+  return JSON.parse(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).facets
+}
+
+function writeFacets(facets: Record<string, string>): string {
+  const bytes = `${JSON.stringify({ facets }, null, 2)}\n`
+  writeFileSync(join(projectRoot, 'facets.json'), bytes)
+  return bytes
+}
+
+/** Run `runAdd` for a single specifier with the standard wiring. */
+async function add(specifier: string) {
+  const parsed = parseFacetSource(specifier)
+  if (!parsed.ok) throw new Error(`test bug: unparseable specifier ${specifier}`)
+  const adapters = await loadInstalledAdapters()
+  return runAdd({
+    projectRoot,
+    sources: [{ specifier, source: parsed.value }],
+    adapters: adapters.filter((a) => a.supportsInstall === true),
+  })
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-runadd-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-home-')))
+  const facetDir = join(fakeHome, '.facet')
+  adaptersDir = join(facetDir, 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+  process.env.HOME = fakeHome
+  process.env.FACET_DIR = facetDir
+  process.chdir(projectRoot)
+  installFakeAdapter(adaptersDir, 'test-adapter')
+  registryFixtureDir = null
+  registryResolvedVersion = '0.1.1'
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('runAdd — registry manifest-value rule', () => {
+  test('bare name pins the resolved exact version', async () => {
+    registryResolvedVersion = '0.1.1'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '0.1.1')
+    const result = await add('cowsay')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('0.1.1')
+  })
+
+  test('@latest is equivalent to a bare name (pins resolved exact)', async () => {
+    registryResolvedVersion = '0.1.1'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '0.1.1')
+    const result = await add('cowsay@latest')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('0.1.1')
+  })
+
+  test('explicit exact version is recorded as written', async () => {
+    registryResolvedVersion = '0.1.1'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '0.1.1')
+    const result = await add('cowsay@0.1.1')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('0.1.1')
+  })
+
+  test('major wildcard is preserved in the manifest as written', async () => {
+    registryResolvedVersion = '1.4.2'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '1.4.2')
+    const result = await add('cowsay@1.*')
+    expect(result.ok).toBe(true)
+    // Wildcard preserved in manifest; lockfile carries the exact version.
+    expect(readFacets().cowsay).toBe('1.*')
+  })
+
+  test('minor wildcard is preserved in the manifest as written', async () => {
+    registryResolvedVersion = '1.2.9'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '1.2.9')
+    const result = await add('cowsay@1.2.*')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('1.2.*')
+  })
+
+  test('bare wildcard is preserved in the manifest as written', async () => {
+    registryResolvedVersion = '2.0.0'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '2.0.0')
+    const result = await add('cowsay@*')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('*')
+  })
+
+  test('never records the facet name in the version position', async () => {
+    registryResolvedVersion = '0.1.1'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '0.1.1')
+    await add('cowsay')
+    expect(readFacets().cowsay).not.toBe('cowsay')
+  })
+})
+
+describe('runAdd — git/local manifest-value rule', () => {
+  test('local source records the full specifier', async () => {
+    const fixture = buildFixture(projectRoot, 'viper-plans', '0.1.0')
+    const rel = `./${fixture.split('/').pop()}`
+    const result = await add(rel)
+    expect(result.ok).toBe(true)
+    expect(readFacets()['viper-plans']).toBe(rel)
+  })
+})
+
+describe('runAdd — preserve / heal / pin', () => {
+  test('bare re-add preserves an existing valid version spec', async () => {
+    registryResolvedVersion = '2.5.0'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '2.5.0')
+    writeFacets({ cowsay: '1.*' })
+    const result = await add('cowsay')
+    expect(result.ok).toBe(true)
+    // Existing valid spec is preserved, NOT clobbered to the resolved exact.
+    expect(readFacets().cowsay).toBe('1.*')
+  })
+
+  test('bare re-add heals an invalid recorded value (name leaked into version)', async () => {
+    registryResolvedVersion = '0.1.1'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '0.1.1')
+    writeFacets({ cowsay: 'cowsay' })
+    const result = await add('cowsay')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('0.1.1')
+  })
+
+  test('bare add pins the resolved exact version when no entry exists', async () => {
+    registryResolvedVersion = '0.3.0'
+    registryFixtureDir = buildFixture(fakeHome, 'cowsay', '0.3.0')
+    const result = await add('cowsay')
+    expect(result.ok).toBe(true)
+    expect(readFacets().cowsay).toBe('0.3.0')
+  })
+})
+
+describe('runAdd — install-failure restore', () => {
+  test('install failure restores facets.json byte-for-byte', async () => {
+    // No adapters → runInstall is given an empty adapter set. But the
+    // failure we force here is a manifest-name mismatch: the resolved
+    // registry name resolves to "cowsay", yet the fixture's facet.json
+    // declares a different name, tripping MANIFEST_NAME_MISMATCH inside
+    // runInstall after the provisional manifest write.
+    registryResolvedVersion = '0.1.1'
+    registryFixtureDir = buildFixture(fakeHome, 'not-cowsay', '0.1.1')
+    const before = writeFacets({ 'pre-existing': './fake' })
+
+    const result = await add('cowsay')
+    expect(result.ok).toBe(false)
+
+    // facets.json restored to its exact pre-command bytes.
+    const after = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+    expect(after).toBe(before)
+  })
+})

--- a/packages/engine/src/install/run-add.ts
+++ b/packages/engine/src/install/run-add.ts
@@ -1,0 +1,315 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
+import { loadManifest } from '../loaders/facet.ts'
+import { emptyFacetsJson, FACETS_JSON_FILE, upsertFacetInManifest } from '../manifest/mutations.ts'
+import { loadFacetsJson, writeFacetsJson } from '../manifest/project-files.ts'
+import { describeVersionSpec } from '../registry/describe.ts'
+import { parseVersionSpec } from '../sources/facet/parse-version.ts'
+import { cloneFacetGitSource } from '../sources/facet/resolve-git.ts'
+import { resolveLocalFacetSource } from '../sources/facet/resolve-local.ts'
+import type { Source } from '../sources/facet/types.ts'
+import { runInstall } from './run-install.ts'
+import type { RunInstallResult, StageEvent } from './types.ts'
+
+/**
+ * The `facet add` orchestrator. Owns the entire manifest transaction for
+ * the add flow on a developer's machine:
+ *
+ *   1. Resolve each source's facet name (the `facets.json` key).
+ *   2. Snapshot `facets.json` for rollback.
+ *   3. Write provisional entries, applying the per-source manifest-value
+ *      rule (git/local → full specifier; registry explicit → rendered
+ *      spec; registry no-version → preserve / heal / pin).
+ *   4. Run the install pipeline.
+ *   5. On success, rewrite the heal/pin entries with the resolved exact
+ *      version read from the new lockfile.
+ *   6. On failure, restore the manifest snapshot byte-for-byte.
+ *
+ * The source→manifest-value mapping and the manifest snapshot/restore are
+ * engine concerns (manifest authoring + filesystem mutation), not CLI
+ * presentation. The CLI is a thin caller that renders this result.
+ *
+ * Never throws. Failures are reported via the discriminated result.
+ */
+
+/**
+ * A source the user asked to add, with its already-parsed `Source`. The
+ * orchestrator resolves the facet name itself (it may clone git / resolve
+ * a local path to read the source's `facet.json`).
+ */
+export interface AddSource {
+  /** The raw specifier as the user typed it (manifest value for git/local). */
+  specifier: string
+  /** The parsed source discriminant. */
+  source: Source
+}
+
+export interface RunAddOptions {
+  projectRoot: string
+  sources: ReadonlyArray<AddSource>
+  adapters: ReadonlyArray<Adapter>
+  onStage?: (event: StageEvent) => void
+  onLog?: (line: string) => void
+  signal?: AbortSignal
+}
+
+/**
+ * Structured failure for the pre-install phase of `runAdd` (name
+ * resolution and manifest read). Mirrors the shapes the CLI already
+ * renders for git clone / local resolve / manifest load so the display
+ * layer needs no new translation logic beyond a discriminator switch.
+ */
+export type AddPrepareFailure =
+  | { reason: 'manifest-read'; error: string }
+  | { reason: 'git-binary-missing'; specifier: string }
+  | { reason: 'git-auth-required'; specifier: string; url: string }
+  | { reason: 'git-clone-failed'; specifier: string; stderr: string }
+  | { reason: 'git-checkout-failed'; specifier: string; commitish: string; stderr: string }
+  | { reason: 'local-resolve-failed'; specifier: string; error: string }
+  | { reason: 'manifest-load-failed'; specifier: string; detail: string }
+  | { reason: 'composition-rejected'; specifier: string }
+
+/**
+ * Result of `runAdd`. Discriminated by `ok`.
+ *
+ *   - `{ ok: true; install }` — install succeeded; the manifest holds the
+ *     final (pinned/preserved) values.
+ *   - `{ ok: false; phase: 'prepare'; failure }` — failed before install
+ *     (name resolution / manifest read); no disk mutation has occurred
+ *     beyond what is already rolled back.
+ *   - `{ ok: false; phase: 'install'; install; manifestRestored }` —
+ *     install failed; the manifest snapshot has been restored.
+ *     `install` is the underlying `runInstall` failure for the CLI to
+ *     render; `manifestRestored` reports whether restore succeeded.
+ */
+export type RunAddResult =
+  | { ok: true; install: Extract<RunInstallResult, { ok: true }> }
+  | { ok: false; phase: 'prepare'; failure: AddPrepareFailure }
+  | {
+      ok: false
+      phase: 'install'
+      install: Extract<RunInstallResult, { ok: false }>
+      manifestRestored: boolean
+    }
+
+/**
+ * How a registry entry's manifest value is determined at provisional-write
+ * time, and whether it must be rewritten with the resolved exact version
+ * after a successful install.
+ */
+interface ProvisionalEntry {
+  name: string
+  /** The value to write to facets.json before install. */
+  value: string
+  /** When true, rewrite `value` with the resolved exact version on success. */
+  rewritePinned: boolean
+}
+
+export async function runAdd(opts: RunAddOptions): Promise<RunAddResult> {
+  const { projectRoot, sources, adapters, signal } = opts
+  const onStage = opts.onStage
+  const onLog = opts.onLog
+
+  // 1. Resolve names for every source (may clone git / resolve local).
+  const resolved: Array<{ entry: AddSource; name: string }> = []
+  for (const entry of sources) {
+    const nameResult = await resolveFacetName(entry.source, entry.specifier, onLog)
+    if (!nameResult.ok) {
+      return { ok: false, phase: 'prepare', failure: nameResult.failure }
+    }
+    resolved.push({ entry, name: nameResult.name })
+  }
+
+  // 2. Snapshot facets.json for rollback.
+  const facetsJsonPath = join(projectRoot, FACETS_JSON_FILE)
+  const snapshot: Buffer | null = existsSync(facetsJsonPath) ? readFileSync(facetsJsonPath) : null
+
+  // 3. Load (or skeleton) the manifest and compute + write provisional entries.
+  const loaded = loadFacetsJson(projectRoot)
+  if (!loaded.ok) {
+    return { ok: false, phase: 'prepare', failure: { reason: 'manifest-read', error: loaded.error } }
+  }
+  const json = loaded.existed ? loaded.data : emptyFacetsJson()
+
+  const provisional: ProvisionalEntry[] = []
+  for (const { entry, name } of resolved) {
+    const existingValue = json.facets[name]
+    const planned = planManifestValue(entry, existingValue)
+    upsertFacetInManifest(json, name, planned.value)
+    provisional.push({ name, value: planned.value, rewritePinned: planned.rewritePinned })
+  }
+  writeFacetsJson(projectRoot, json)
+
+  // 4. Run install.
+  const install = await runInstall({
+    projectRoot,
+    adapters,
+    ...(onStage ? { onStage } : {}),
+    ...(onLog ? { onLog } : {}),
+    ...(signal ? { signal } : {}),
+  })
+
+  // 5/6. Rewrite pinned on success, restore on failure.
+  if (!install.ok) {
+    const manifestRestored = restoreSnapshot(facetsJsonPath, snapshot)
+    return { ok: false, phase: 'install', install, manifestRestored }
+  }
+
+  rewritePinnedEntries(projectRoot, provisional, install)
+  return { ok: true, install }
+}
+
+/**
+ * Determine the manifest value to write for a source, and whether it must
+ * be rewritten with the resolved exact version after install.
+ *
+ *   - git / local              → the full specifier, unconditional.
+ *   - registry explicit version → the rendered spec, unconditional.
+ *   - registry no-version (latest):
+ *       - existing value is a valid version spec → preserve it (no rewrite).
+ *       - existing value invalid, or no entry     → write `latest`, rewrite-pin.
+ */
+function planManifestValue(
+  entry: AddSource,
+  existingValue: string | undefined,
+): { value: string; rewritePinned: boolean } {
+  const { source, specifier } = entry
+  if (source.kind !== 'registry') {
+    // git / local: the manifest value is the full source specifier.
+    return { value: specifier, rewritePinned: false }
+  }
+
+  if (source.version.kind !== 'latest') {
+    // Explicit version (exact / wildcards): render as written; no rewrite.
+    return { value: describeVersionSpec(source.version), rewritePinned: false }
+  }
+
+  // No-version registry add (bare name / @latest): preserve / heal / pin.
+  if (existingValue !== undefined && parseVersionSpec(existingValue).ok) {
+    // Existing value is a valid version spec — preserve the user's choice.
+    return { value: existingValue, rewritePinned: false }
+  }
+  // No entry, or an invalid existing value (e.g. the facet name leaked
+  // into the version position) — write `latest` provisionally and pin the
+  // resolved exact version after install.
+  return { value: describeVersionSpec(source.version), rewritePinned: true }
+}
+
+/**
+ * Rewrite the heal/pin entries with the exact resolved version read from
+ * the freshly-written lockfile. Re-loads the manifest so comment metadata
+ * is preserved, mutates in place, and writes back. Best-effort: a rewrite
+ * failure leaves the provisional `latest` value (which the lockfile still
+ * backstops), and a subsequent bare re-add heals it.
+ */
+function rewritePinnedEntries(
+  projectRoot: string,
+  provisional: ReadonlyArray<ProvisionalEntry>,
+  install: Extract<RunInstallResult, { ok: true }>,
+): void {
+  const toPin = provisional.filter((p) => p.rewritePinned)
+  if (toPin.length === 0) return
+
+  const loaded = loadFacetsJson(projectRoot)
+  if (!loaded.ok) return
+  const json = loaded.existed ? loaded.data : emptyFacetsJson()
+
+  let changed = false
+  for (const p of toPin) {
+    const lockEntry = install.lockfile.facets[p.name]
+    if (lockEntry === undefined) continue
+    upsertFacetInManifest(json, p.name, lockEntry.version)
+    changed = true
+  }
+  if (changed) writeFacetsJson(projectRoot, json)
+}
+
+/**
+ * Restore the manifest snapshot. Returns whether the restore succeeded so
+ * the CLI can warn the user when the project may be in a partial state.
+ */
+function restoreSnapshot(path: string, snapshot: Buffer | null): boolean {
+  try {
+    if (snapshot === null) {
+      if (existsSync(path)) rmSync(path)
+      return true
+    }
+    writeFileSync(path, snapshot)
+    return true
+  } catch {
+    return false
+  }
+}
+
+type ResolveNameResult = { ok: true; name: string } | { ok: false; failure: AddPrepareFailure }
+
+/**
+ * Resolve a source's facet name (the `facets.json` key).
+ *
+ *   - registry: the canonical name on the parsed source IS the facet name
+ *     (the registry keys by canonical name); no I/O. `runInstall` verifies
+ *     the downloaded manifest's declared name matches.
+ *   - git: clone, read `facet.json`, return its `name`; clean up the clone.
+ *   - local: resolve the path, read `facet.json`, return its `name`.
+ *
+ * Composition (a facet that declares other facets) is rejected — the same
+ * constraint the install pipeline enforces.
+ */
+async function resolveFacetName(
+  source: Source,
+  specifier: string,
+  onLog: ((line: string) => void) | undefined,
+): Promise<ResolveNameResult> {
+  if (source.kind === 'registry') {
+    return { ok: true, name: source.name }
+  }
+
+  let sourceDir: string
+  let cleanup: (() => Promise<void>) | undefined
+
+  if (source.kind === 'git') {
+    const cloned = await cloneFacetGitSource(source.url, source.ref)
+    if (!cloned.ok) {
+      switch (cloned.reason) {
+        case 'git-binary-missing':
+          return { ok: false, failure: { reason: 'git-binary-missing', specifier } }
+        case 'auth-required':
+          return { ok: false, failure: { reason: 'git-auth-required', specifier, url: cloned.url } }
+        case 'clone-failed':
+          return { ok: false, failure: { reason: 'git-clone-failed', specifier, stderr: cloned.stderr } }
+        case 'checkout-failed':
+          return {
+            ok: false,
+            failure: { reason: 'git-checkout-failed', specifier, commitish: cloned.commitish, stderr: cloned.stderr },
+          }
+      }
+    }
+    sourceDir = cloned.dir
+    cleanup = async () => {
+      await rm(cloned.dir, { recursive: true, force: true }).catch(() => {})
+    }
+  } else {
+    const resolvedLocal = await resolveLocalFacetSource(source.path, process.cwd())
+    if (!resolvedLocal.ok) {
+      return { ok: false, failure: { reason: 'local-resolve-failed', specifier, error: resolvedLocal.error } }
+    }
+    sourceDir = resolvedLocal.dir
+  }
+
+  try {
+    const manifest = await loadManifest(sourceDir)
+    if (!manifest.ok) {
+      const detail = manifest.errors.map((e) => e.message).join('; ')
+      return { ok: false, failure: { reason: 'manifest-load-failed', specifier, detail } }
+    }
+    if (manifest.data.facets && manifest.data.facets.length > 0) {
+      return { ok: false, failure: { reason: 'composition-rejected', specifier } }
+    }
+    onLog?.(`[verbose]   resolved name "${manifest.data.name}" from ${specifier}`)
+    return { ok: true, name: manifest.data.name }
+  } finally {
+    if (cleanup) await cleanup()
+  }
+}

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -11,6 +11,7 @@ import { loadFacetsJson } from '../manifest/project-files.ts'
 import { downloadAndExtractFacet } from '../registry/download.ts'
 import { resolveRegistryMetadataBatch } from '../registry/resolve-metadata.ts'
 import { parseFacetSource } from '../sources/facet/parse-source.ts'
+import { parseVersionSpec } from '../sources/facet/parse-version.ts'
 import { type CloneFacetGitResult, cloneFacetGitSource } from '../sources/facet/resolve-git.ts'
 import { resolveLocalFacetSource } from '../sources/facet/resolve-local.ts'
 import { InstallJournal } from './journal.ts'
@@ -479,8 +480,19 @@ async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
   const { facetName, specifier, projectRoot, previousLockfile, onStage, onLog } = args
 
   // Parse the source specifier.
+  //
+  // The manifest is a `name → value` map. For a registry source the value
+  // is a bare version specifier (`1.2.3`, `1.*`, `*`, `latest`) and the
+  // facet name lives in the KEY — so when the value parses as a bare
+  // VersionSpec we reconstruct the full source as `${facetName}@${value}`.
+  // For git/local sources the value is a self-contained source string
+  // (URL, `file:` path) and the key is just a label; we parse the value
+  // standalone. This keeps `facets.json` values semver-shaped for registry
+  // entries (the value the user sees is `1.2.3`, not `cowsay@1.2.3`) while
+  // still round-tripping through source resolution.
   onStage({ kind: 'facet-stage', facet: facetName, stage: 'parse' })
-  const parsed = parseFacetSource(specifier)
+  const sourceString = parseVersionSpec(specifier).ok ? `${facetName}@${specifier}` : specifier
+  const parsed = parseFacetSource(sourceString)
   if (!parsed.ok) {
     return {
       ok: false,


### PR DESCRIPTION
### Why

`facet add cowsay` currently writes `"cowsay": "cowsay"` into `facets.json` — the raw user specifier is used verbatim, causing the facet name to leak into the version position. This violates the existing `installation` spec requirement ("Adding a facet without a version stores the resolved version pinned") and contradicts the published changelog, which states that bare-name adds produce a pinned semver value like `viper-plans@1.2.3`.

### Details

**Correct manifest value rules by source form:**

| Input form | Manifest value written |
|---|---|
| Bare name (`cowsay`) or `@latest` with no existing entry | Resolved exact version (`0.1.1`) |
| Explicit version (`cowsay@1.2.3`, `cowsay@1.*`, `cowsay@1.2.*`, `cowsay@*`) | Version spec as written |
| Git / local sources | Full specifier unchanged |

**Preserve / heal / pin rule for bare re-adds:** When a bare name or `@latest` is added and an entry already exists, a valid version spec is preserved untouched (a bare re-add must not clobber a deliberate pin or range), an invalid value (e.g. the buggy `"cowsay": "cowsay"`) is healed to the resolved exact version, and a missing entry is pinned to the resolved exact version. This makes the existing bug self-healing on re-add.

**Engine `add` orchestrator:** A new `runAdd` orchestrator in the engine package owns the full manifest transaction — resolve each source's facet name, snapshot `facets.json`, write provisional entries, call `runInstall`, rewrite pinned entries on success, restore the snapshot on failure. The source→manifest-value rule, facet-name resolution, and the snapshot/restore plumbing move out of the CLI and into the engine, correcting an existing CLI/engine boundary violation where the CLI was directly mutating `facets.json` via `node:fs`. The CLI `add` command becomes a thin caller that parses argv, calls `runAdd`, and renders results (including a new prepare-phase failure block for name-resolution errors).

**Post-install pinning:** The resolved exact version is only known after `runInstall` completes, so the orchestrator writes a provisional value (`latest`) before install and rewrites it with the exact `MAJOR.MINOR.PATCH` from `result.lockfile.facets[name].version` after a successful install. No `runInstall` signature change is needed.

**`runInstall` source reconstruction (gap found during implementation):** `runInstall` previously parsed each manifest map *value* as a complete source string, ignoring the *key*. That worked only because the old buggy value was a full specifier; once the value is a bare version spec (`1.*`, `0.1.1`, `latest`), `parseFacetSource` rejected it. Fixed so that when a manifest value parses as a bare version spec, the source is reconstructed as `${name}@${value}` (the key supplies the name); git/local values are still parsed standalone. This is what makes the corrected, semver-shaped manifest values actually round-trip through install.

**Trade-offs:** There is a narrow two-write window where, if the process is killed between install success and the post-install rewrite, the manifest holds `latest` while the lockfile holds the exact version. This is strictly better than the current behavior, the lockfile remains the reproducibility source of truth, and a subsequent bare re-add heals it via the heal case.

### Verification

`bun check` is green (lint, types, unit + e2e across the monorepo). Engine orchestrator tests cover the `facets.json` value for bare name, `@latest`, exact, and all three wildcard registry forms; git/local unchanged; and the preserve/heal/pin cases plus install-failure snapshot restore (registry resolve/download are stubbed so the test isolates the manifest transaction; production download integrity verification is covered by its own tests). The heal path was also confirmed live in the CLI against the real registry. `docs/cli/add.md` was updated to document the preserve/heal behavior; its source table and examples already described pinned-on-add and contained no buggy `name: name` example to correct.
