### PR TITLE
Honor edited versions in `facets.json`; add `facet install --frozen-lockfile`

### DIFF
--- a/.changeset/chilly-turkeys-hug.md
+++ b/.changeset/chilly-turkeys-hug.md
@@ -1,0 +1,8 @@
+---
+"@agent-facets/protocol": minor
+"agent-facets": minor
+---
+
+Honor edited versions in `facets.json` and add `facet install --frozen-lockfile`.
+
+`facet install` now re-resolves a lockfile entry whose version no longer satisfies the manifest (e.g. a hand-edited bump), and fails if the requested version doesn't exist instead of silently keeping the old one. The new `--frozen-lockfile` flag treats the lockfile as authoritative and fails on any manifest/lockfile drift, for reproducible CI installs.

--- a/.changeset/orphaned-frozen-drift.md
+++ b/.changeset/orphaned-frozen-drift.md
@@ -1,0 +1,7 @@
+---
+"agent-facets": patch
+---
+
+Make `facet install --frozen-lockfile` fail on orphaned lockfile entries.
+
+A frozen install now reports a facet that is pinned in `facets.lock` but no longer declared in `facets.json` as drift (`orphaned`) and fails before touching the project. Previously the preflight only checked manifest entries, so an orphaned entry slipped through and the drift-removal pass pruned its assets while skipping the lockfile write — mutating adapter state and leaving a stale lockfile. The drift report's per-facet shape is now a discriminated union on its reason, so an `unsatisfied` entry always carries its locked version and an `orphaned` entry carries no manifest specifier.

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -4,9 +4,9 @@ description: What's new in Agent Facets
 rss: true
 ---
 
-<Update label="2026-06-05" description="Bearer-token auth for the registry; new login/whoami/logout commands; FACET_REGISTRY_API_KEY removed" tags={["CLI", "Breaking", "New Feature"]} rss={{
-  title: "Registry auth moves to bearer tokens; new login/whoami/logout commands",
-  description: "The facet CLI now authenticates to the registry with a personal access token sent as a bearer credential, replacing the old FACET_REGISTRY_API_KEY API key. FACET_REGISTRY_API_KEY has been removed with no shim. Provide a token via the FACET_TOKEN environment variable or by running the new `facet login` command, which verifies the token and saves it to ~/.facet/credentials. Two more new commands: `facet whoami` prints the signed-in identity, and `facet logout` clears the saved credential. `facet publish` now also accepts an optional directory argument. Registry errors are now rendered using the registry's own message and suggested fix."
+<Update label="2026-06-05" description="Bearer-token auth for the registry; new login/whoami/logout commands; FACET_REGISTRY_API_KEY removed; install now re-resolves a stale lockfile; new --frozen-lockfile flag" tags={["CLI", "Breaking", "New Feature", "Fix"]} rss={{
+  title: "Registry auth moves to bearer tokens; new login/whoami/logout commands; install honors manifest edits",
+  description: "The facet CLI now authenticates to the registry with a personal access token sent as a bearer credential, replacing the old FACET_REGISTRY_API_KEY API key. FACET_REGISTRY_API_KEY has been removed with no shim. Provide a token via the FACET_TOKEN environment variable or by running the new `facet login` command, which verifies the token and saves it to ~/.facet/credentials. Two more new commands: `facet whoami` prints the signed-in identity, and `facet logout` clears the saved credential. `facet publish` now also accepts an optional directory argument. Registry errors are now rendered using the registry's own message and suggested fix. Bug fix: editing a facet's version in facets.json now takes effect — facet install re-resolves a lockfile entry that no longer satisfies the manifest, and fails if the requested version does not exist, instead of silently keeping the old version. New flag: facet install --frozen-lockfile treats the lockfile as the source of truth and fails on any manifest/lockfile drift, for reproducible CI installs."
 }}>
   ## Registry authentication is now bearer-token based
 
@@ -66,6 +66,42 @@ rss: true
 
   See the [Publish Flow](/specification/publish) spec for the full
   authentication model.
+
+  ## Editing a version in `facets.json` now takes effect
+
+  **Fix:** `facets.json` is the source of truth, but `facet install` was
+  ignoring an edited version when the lockfile still pinned the old one. If you
+  bumped a facet to a version that didn't exist, install "succeeded" and wrote a
+  self-contradictory lockfile entry instead of failing.
+
+  Now `facet install` compares each lockfile entry against its manifest
+  specifier. A locked version that no longer satisfies the manifest is treated
+  as stale and re-resolved:
+
+  ```bash
+  # facets.json edited: cowsay 0.1.1 → 0.1.2
+  facet install          # fetches 0.1.2, updates the lockfile (was 0.1.1 → 0.1.2)
+
+  # facets.json edited to a version that doesn't exist
+  facet install          # fails: version not found; project left unchanged
+  ```
+
+  A wildcard the lock still satisfies (manifest `1.*`, lock `1.2.3`) is
+  unaffected — it stays pinned and reproducible. See [`facet install`](/cli/install#lockfile-semantics).
+
+  ## New: `facet install --frozen-lockfile`
+
+  For reproducible CI installs, `--frozen-lockfile` makes the lockfile the
+  source of truth: install never re-resolves or writes the lockfile, and fails
+  if the lockfile is missing, omits a manifest facet, or has drifted out of sync
+  with `facets.json`.
+
+  ```bash
+  facet install --frozen-lockfile   # passes only if facets.json and facets.lock agree
+  ```
+
+  This mirrors `--frozen-lockfile` from `npm` and `bun`. See [the flag
+  reference](/cli/install#frozen-lockfile).
 </Update>
 
 <Update label="2026-05-14" description="Consolidate everything under FACET_DIR; new FACET_BIN_OVERRIDE; lock moves out of project root" tags={["CLI", "Breaking"]} rss={{

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -21,7 +21,8 @@ Reads `facets.json`, fetches and materializes every facet declared there, and wr
 2. **Acquire an install lock** at `$FACET_DIR/locks/<basename>-<hash>.lock` so two installs can't race. The lock lives under the facet directory tree (not in your project root), keyed by `sha256(realpath(projectRoot))` so each project gets its own slot.
 3. **Load the existing lockfile**, or use an empty skeleton if `facets.lock` is absent — `facet install` bootstraps the lockfile on first run, the same way `bun install` creates `bun.lock`.
 4. **For each facet in `facets.json`:**
-   - If the lockfile pins a version, that version is honored verbatim; ranges in the manifest are not re-resolved.
+   - If the lockfile pins a version that **satisfies** the manifest specifier, that version is honored; ranges in the manifest are not re-resolved.
+   - If the locked version **no longer satisfies** the manifest specifier — because you edited `facets.json` or pulled a teammate's change — the entry is stale: the manifest specifier is re-resolved and the lockfile entry is replaced. If the new specifier resolves to nothing (e.g. a version that doesn't exist), install fails and the project is left unchanged.
    - If the lockfile has no entry yet (newly-added or freshly-bootstrapped), the manifest specifier is resolved fresh.
    - Fetch (from cache, or via git clone / registry / local path), verify integrity, build, and materialize the assets into every adapter.
 5. **Drift removal.** Any facet in the prior lockfile but no longer in `facets.json` has its assets cleaned up.
@@ -30,9 +31,13 @@ Reads `facets.json`, fetches and materializes every facet declared there, and wr
 
 ## Lockfile semantics
 
-`facet install` is **lockfile-driven**: any pinned entry in `facets.lock` is the source of truth for what gets installed, regardless of what range or wildcard the manifest declares. This is what makes installs reproducible across machines.
+`facets.json` is the source of truth; `facets.lock` records the resolved state so that an **unchanged** manifest installs reproducibly across machines. A pinned entry in `facets.lock` is honored as long as it **satisfies** its manifest specifier — a wildcard like `1.*` keeps using the locked `1.2.3` and won't drift to a newer `1.2.4`.
 
-To change the locked version of a facet, run `facet add <facet>@<new-version>` — that updates both the manifest and the lockfile. (A dedicated `facet update` command is on the roadmap; until then, re-`add` is the path.)
+When the manifest and lockfile disagree — you bumped an exact version, widened a wildcard the lock no longer falls within, or pulled a manifest change — the lockfile entry is **stale**. `facet install` re-resolves the manifest specifier and updates the lockfile to match. If the requested version doesn't exist in the registry, install fails rather than silently keeping the old one.
+
+To change the locked version of a facet, you can also run `facet add <facet>@<new-version>` — that updates both the manifest and the lockfile in one step. (A dedicated `facet update` command is on the roadmap.)
+
+To enforce that the lockfile is already in sync — never re-resolving — use [`--frozen-lockfile`](#frozen-lockfile).
 
 ## Outcomes
 
@@ -41,7 +46,7 @@ The summary line classifies each facet by what happened on disk:
 | Outcome      | Meaning                                                                                       |
 | ------------ | --------------------------------------------------------------------------------------------- |
 | `installed`  | Facet was not in the previous lockfile.                                                       |
-| `updated`    | Facet was in the lockfile at a different version. Summary shows `(was X → Y)`.                |
+| `updated`    | Facet was in the lockfile at a different version — including when a stale entry was re-resolved to match the manifest. Summary shows `(was X → Y)`. |
 | `repaired`   | Same lockfile entry, but at least one adapter file was missing or had drifted from the lockfile content. Restored. |
 | `unchanged`  | Same lockfile entry, every asset already in its desired state. Nothing was written.           |
 | `removed`    | Facet was in the lockfile but is no longer declared in `facets.json`. Assets cleaned up.      |
@@ -76,9 +81,21 @@ A facet that declares `facets: [...]` (cherry-picking from other facets) is hard
 
 ## Flags
 
-| Flag        | Description                                |
-| ----------- | ------------------------------------------ |
-| `--verbose` | Show detailed step output on stderr.       |
+| Flag                | Description                                                                                          |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
+| `--verbose`         | Show detailed step output on stderr.                                                                 |
+| `--frozen-lockfile` | Treat the lockfile as the source of truth; fail on any manifest/lockfile drift. See [below](#frozen-lockfile). |
+
+## Frozen lockfile
+
+`facet install --frozen-lockfile` inverts the source of truth: the **lockfile** becomes authoritative. In this mode install never re-resolves a specifier and never writes `facets.lock`. Before installing, it verifies the lockfile fully covers the manifest, and fails — changing nothing on disk — if any of these hold:
+
+- no `facets.lock` exists;
+- a facet in `facets.json` has no lockfile entry;
+- a lockfile entry's version no longer satisfies its manifest specifier;
+- the lockfile pins a facet `facets.json` no longer declares (an orphaned entry a normal install would prune).
+
+This is the mode to use in CI: it guarantees that `facets.json` and `facets.lock` are already in agreement, so a forgotten `facet add` or a hand-edited manifest fails the build loudly instead of silently mutating the lockfile. It mirrors the `--frozen-lockfile` contract from `npm` and `bun`.
 
 ## Exit codes
 

--- a/docs/specification/install.md
+++ b/docs/specification/install.md
@@ -18,10 +18,14 @@ existing manifest. Both run the same flow internally.
    `MAJOR.MINOR.PATCH`, and `latest`; caret/tilde/comparator/OR/x-style
    ranges are rejected.
 
-2. **Honor the lockfile.** If `facets.lock` already pins a facet, that
-   exact version is fetched without re-resolving the manifest range. If
-   no lockfile exists, one is bootstrapped on first run (bun-style).
-   Manifest entries without a lockfile entry resolve fresh.
+2. **Honor the lockfile when it satisfies the manifest.** If `facets.lock`
+   pins a facet at a version that satisfies the manifest specifier, that
+   exact version is fetched without re-resolving the manifest range. If the
+   locked version no longer satisfies the manifest (a hand-edit or pull
+   changed `facets.json`), the entry is stale and the manifest specifier is
+   re-resolved, replacing the lockfile entry. If no lockfile exists, one is
+   bootstrapped on first run (bun-style). Manifest entries without a
+   lockfile entry resolve fresh.
 
 3. **Reject composition; warn on servers.** A source `facet.json` with a
    non-empty `facets: [...]` is hard-rejected. A `servers:` declaration
@@ -151,11 +155,13 @@ A facet name (or name@version) to install.
 
 ## Lockfile-First Installs
 
-If a lockfile already exists, `facet install` MUST use the pinned versions instead of resolving from the registry. This ensures reproducible installs across team members and environments.
+If a lockfile already exists, `facet install` MUST use the pinned versions **when they satisfy the manifest specifiers**, instead of resolving from the registry. This ensures reproducible installs across team members and environments. A pinned version that no longer satisfies its manifest specifier is stale: `facet install` MUST re-resolve that entry against the registry and update the lockfile, because the manifest is the source of truth.
 
-Only `facet upgrade` resolves newer versions.
+Only `facet upgrade` resolves newer versions for entries that already satisfy the manifest.
 
 The lockfile SHOULD be version-controlled so that all team members and CI environments get the same versions.
+
+`facet install --frozen-lockfile` inverts this: the lockfile becomes the source of truth. It MUST NOT re-resolve any specifier and MUST NOT write the lockfile, and it MUST fail without modifying the project if the lockfile is missing, omits a manifest facet, contains an entry that no longer satisfies its specifier, or pins a facet the manifest no longer declares (an orphaned entry a normal install would prune). This is the mode for reproducible CI installs.
 
 ## Upgrade
 

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -339,22 +339,23 @@ The system SHALL verify the integrity of fetched facet content before writing an
 - **THEN** the system SHALL abort the install
 - **AND** the system SHALL print a security error identifying the affected facet
 
-### Requirement: Lockfile-driven install does not re-resolve specifiers
+### Requirement: Lockfile-driven install honors the lock only when it satisfies the manifest
 
-When a user runs install on a project that already has a lockfile, the system SHALL install exactly the versions and integrity hashes recorded in the lockfile. The system SHALL NOT re-resolve specifiers against the registry. Refreshing locked versions against the project manifest SHALL be a separate, opt-in operation.
+The project manifest is the source of truth; the lockfile is a record of resolution results that keeps an unchanged manifest reproducible. When a user runs install on a project that already has a lockfile, the system SHALL install the locked version and integrity hash for a facet **when the locked version satisfies that facet's manifest specifier**, and SHALL NOT re-resolve a satisfying entry against the registry. When the locked version does **not** satisfy the manifest specifier, the lockfile entry SHALL be treated as stale: the system SHALL re-resolve the manifest specifier against the registry. If re-resolution succeeds, the system SHALL install the resolved version and SHALL replace the stale entry in the lockfile; if the manifest specifier resolves to no published version, the system SHALL fail and SHALL leave the project unchanged. A locked exact version SHALL satisfy an exact specifier only when they are equal, SHALL satisfy a wildcard specifier only when the locked version falls within the wildcard's pinned components, and SHALL always satisfy an unconstrained specifier (`*` or `latest`). Re-resolution SHALL apply only to registry-sourced facets.
 
-#### Scenario: Lockfile entry is honored verbatim
+#### Scenario: Lockfile entry is honored when it satisfies the manifest
 
 - **WHEN** a user runs install
 - **AND** the lockfile records a facet at an exact resolved version with an integrity hash
+- **AND** that version satisfies the facet's manifest specifier
 - **THEN** the system SHALL fetch (or read from cache) exactly that version
 - **AND** the system SHALL verify the fetched content against the lockfile's integrity hash
 - **AND** the system SHALL NOT contact the registry to look up newer versions
 
-#### Scenario: Manifest specifier widens but lockfile narrows
+#### Scenario: Manifest specifier widens but lockfile still satisfies it
 
 - **WHEN** a user's manifest specifies a wildcard version (e.g., `1.*`)
-- **AND** the lockfile records a specific resolved version (e.g., `1.2.3`)
+- **AND** the lockfile records a specific resolved version that satisfies it (e.g., `1.2.3`)
 - **THEN** install SHALL use `1.2.3`
 - **AND** install SHALL NOT pick up `1.2.4` even if it has been published
 
@@ -364,6 +365,83 @@ When a user runs install on a project that already has a lockfile, the system SH
 - **THEN** the system SHALL resolve that specifier
 - **AND** the system SHALL append the resolved version and integrity to the lockfile
 - **AND** the system SHALL NOT re-resolve any other entry that is already locked
+
+#### Scenario: Manifest pins an exact version the lockfile does not match
+
+- **WHEN** a user edits the manifest to pin an exact version (e.g., `0.1.2`) that differs from the lockfile's recorded version (e.g., `0.1.1`)
+- **AND** the user runs install
+- **THEN** the system SHALL treat the lockfile entry as stale and SHALL re-resolve the manifest's exact version against the registry
+- **AND** if that exact version is published, the system SHALL install it and SHALL replace the lockfile's version, integrity, and asset record with the resolved result
+- **AND** the system SHALL report the facet as updated from the previous version to the new one
+
+#### Scenario: Manifest pins a version that does not exist in the registry
+
+- **WHEN** a user edits the manifest to pin an exact version that does not exist in the registry (e.g., `0.1.2` with no such published version)
+- **AND** the user runs install
+- **THEN** the system SHALL fail with an error identifying the facet and the version that could not be found
+- **AND** the system SHALL NOT record the nonexistent version in the lockfile
+- **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Lockfile version no longer falls within a wildcard the manifest widened to
+
+- **WHEN** a user's manifest specifies a wildcard version (e.g., `2.*`)
+- **AND** the lockfile records a version outside that wildcard (e.g., `1.2.3`)
+- **THEN** the system SHALL treat the lockfile entry as stale and SHALL re-resolve the manifest specifier against the registry
+- **AND** the system SHALL NOT install the stale `1.2.3` in satisfaction of `2.*`
+
+#### Scenario: A stale re-resolve still verifies integrity of the freshly fetched content
+
+- **WHEN** the system re-resolves a stale lockfile entry and fetches new content from the registry
+- **THEN** the system SHALL verify the freshly fetched content through the full registry integrity protocol before writing any asset
+- **AND** the system SHALL NOT check the new content against the discarded stale entry's integrity hash
+
+#### Scenario: Lockfile entry and its source specifier always describe the same artifact
+
+- **WHEN** the system writes or updates a lockfile entry for a facet
+- **THEN** the entry's recorded source specifier, resolved version, and integrity hash SHALL all describe the same resolved artifact
+- **AND** the system SHALL NOT record a source specifier whose version disagrees with the entry's resolved version and integrity hash
+
+### Requirement: Frozen-lockfile install treats the lockfile as authoritative
+
+The system SHALL provide a frozen-lockfile mode for install in which the lockfile is treated as the source of truth. In this mode the system SHALL NOT re-resolve any specifier and SHALL NOT write the lockfile. Before installing, the system SHALL verify that the lockfile fully and consistently covers the manifest. The system SHALL fail without modifying the project if any of the following is true: no lockfile exists, the manifest declares a facet that has no lockfile entry, a lockfile entry's recorded version does not satisfy its manifest specifier, or the lockfile pins a facet the manifest no longer declares (an orphaned entry that a non-frozen install would prune). When the lockfile fully covers the manifest, the system SHALL install exactly the versions and integrity hashes recorded in the lockfile. Frozen-lockfile mode SHALL be available only on install; the command that adds a facet SHALL NOT offer it, because adding a facet inherently updates the lockfile.
+
+#### Scenario: Frozen install proceeds when the lockfile covers the manifest
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** every facet in the manifest has a lockfile entry whose version satisfies its manifest specifier
+- **THEN** the system SHALL install exactly the versions and integrity hashes recorded in the lockfile
+- **AND** the system SHALL NOT re-resolve any specifier against the registry
+- **AND** the system SHALL NOT write the lockfile
+
+#### Scenario: Frozen install fails when no lockfile exists
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** no lockfile exists for the project
+- **THEN** the system SHALL fail with an error stating the lockfile is missing
+- **AND** the system SHALL NOT create or modify the lockfile
+
+#### Scenario: Frozen install fails when a manifest facet is missing from the lockfile
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** the manifest declares a facet that has no entry in the lockfile
+- **THEN** the system SHALL fail with an error identifying the uncovered facet
+- **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Frozen install fails when the lockfile drifts from the manifest
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** a lockfile entry's recorded version does not satisfy its manifest specifier
+- **THEN** the system SHALL fail with an error identifying each drifting facet, its manifest specifier, and its locked version
+- **AND** the system SHALL NOT re-resolve or update any entry
+- **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Frozen install fails on an orphaned lockfile entry
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** the lockfile pins a facet the manifest no longer declares
+- **THEN** the system SHALL fail with an error identifying the orphaned facet and its locked version
+- **AND** the system SHALL NOT prune the orphaned facet's assets
+- **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
 
 ### Requirement: Declared MCP servers do not block installation
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -621,3 +621,36 @@ describe('InstallView — partial rollback failure surfaces', () => {
     instance.unmount()
   })
 })
+
+describe('InstallView — frozen-lockfile drift', () => {
+  test('renders each drifting facet with its reason', async () => {
+    const failure: RunInstallFailure = {
+      code: 'LOCKFILE_DRIFT',
+      facets: [
+        { name: 'cowsay', reason: 'unsatisfied', manifestSpec: '0.1.2', lockedVersion: '0.1.1' },
+        { name: 'extra', reason: 'no-entry', manifestSpec: '0.2.0' },
+        { name: 'stale', reason: 'orphaned', lockedVersion: '4.5.6' },
+      ],
+    }
+    const events: StageEvent[] = [{ kind: 'install-complete', outcome: 'failure' }]
+    const result: RunInstallResult = {
+      ok: false,
+      failure,
+      rollback: { kind: 'not-needed', reason: 'test fixture' },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun(events, result),
+      }),
+    )
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('lockfile is out of date')
+    expect(frame).toContain('locked 0.1.1 does not satisfy 0.1.2')
+    expect(frame).toContain('not in lockfile (manifest wants 0.2.0)')
+    expect(frame).toContain('in lockfile but not in facets.json (locked 4.5.6)')
+    expect(frame).toContain('without --frozen-lockfile')
+    instance.unmount()
+  })
+})

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -26,6 +26,10 @@ export const installCommand: Command = {
   implemented: true,
   flags: {
     verbose: { type: 'boolean', description: 'Show detailed step output on stderr' },
+    'frozen-lockfile': {
+      type: 'boolean',
+      description: 'Treat the lockfile as the source of truth; fail on any manifest/lockfile drift',
+    },
   },
   run: async (args, flags) => {
     if (args.length > 0) {
@@ -37,6 +41,7 @@ export const installCommand: Command = {
     }
 
     const verbose = flags.verbose === true
+    const frozenLockfile = flags['frozen-lockfile'] === true
     const onLog = verbose ? (line: string) => process.stderr.write(`${line}\n`) : undefined
 
     const projectRoot = process.cwd()
@@ -87,6 +92,7 @@ export const installCommand: Command = {
             onStage,
             onLog,
             signal: controller.signal,
+            frozenLockfile,
           })
           captured = result
           return result
@@ -150,6 +156,9 @@ function failureFix(failure: RunInstallFailure, rollback: RollbackOutcome): stri
   }
   if (failure.code === 'ABORTED') {
     return 'rollback complete; project state unchanged'
+  }
+  if (failure.code === 'LOCKFILE_DRIFT') {
+    return "lockfile is out of date; run 'facet install' (without --frozen-lockfile) or 'facet add' to update it"
   }
   return "rollback complete; fix the underlying issue and re-run 'facet install'"
 }

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -264,6 +264,28 @@ export function FailureBlock({ failure }: { failure: RunInstallFailure }): React
           <Text color={THEME.hint}> Rolled back to pre-install state.</Text>
         </Box>
       )
+    case 'LOCKFILE_DRIFT':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ lockfile is out of date with facets.json
+          </Text>
+          {failure.facets.map((f) => (
+            <Text key={f.name}>
+              {' '}
+              {f.name}:{' '}
+              {f.reason === 'missing-lockfile'
+                ? 'no lockfile'
+                : f.reason === 'no-entry'
+                  ? `not in lockfile (manifest wants ${f.manifestSpec})`
+                  : f.reason === 'orphaned'
+                    ? `in lockfile but not in facets.json (locked ${f.lockedVersion})`
+                    : `locked ${f.lockedVersion} does not satisfy ${f.manifestSpec}`}
+            </Text>
+          ))}
+          <Text color={THEME.hint}> Run without --frozen-lockfile, or `facet add` to update the lockfile.</Text>
+        </Box>
+      )
     default: {
       // Exhaustiveness guard: any new `RunInstallFailure` variant must
       // get a `case` arm above. Without this, an un-rendered failure

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -91,6 +91,7 @@ export type {
   FacetOutcome,
   FacetStage,
   InstallSummary,
+  LockfileDriftEntry,
   RollbackOutcome,
   RunInstallFailure,
   RunInstallOptions,

--- a/packages/engine/src/install/__tests__/classify-outcome.test.ts
+++ b/packages/engine/src/install/__tests__/classify-outcome.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import type { LockfileFacet } from '@agent-facets/protocol'
+import { classifyOutcome } from '../classify-outcome.ts'
+
+const entry = (version: string): LockfileFacet => ({
+  source: version,
+  version,
+  integrity: 'sha256:stub',
+  assets: [{ scope: 'user', type: 'skill', name: 'planning' }],
+})
+
+describe('classifyOutcome', () => {
+  test('no previous entry → installed', () => {
+    expect(classifyOutcome('cowsay', undefined, entry('1.0.0'), 1)).toEqual({
+      kind: 'installed',
+      name: 'cowsay',
+      version: '1.0.0',
+    })
+  })
+
+  test('version changed → updated with old/new versions', () => {
+    expect(classifyOutcome('cowsay', entry('1.0.0'), entry('1.1.0'), 1)).toEqual({
+      kind: 'updated',
+      name: 'cowsay',
+      oldVersion: '1.0.0',
+      newVersion: '1.1.0',
+    })
+  })
+
+  test('same version, assets written → repaired', () => {
+    expect(classifyOutcome('cowsay', entry('1.0.0'), entry('1.0.0'), 2)).toEqual({
+      kind: 'repaired',
+      name: 'cowsay',
+      version: '1.0.0',
+    })
+  })
+
+  test('same version, nothing written → unchanged', () => {
+    expect(classifyOutcome('cowsay', entry('1.0.0'), entry('1.0.0'), 0)).toEqual({
+      kind: 'unchanged',
+      name: 'cowsay',
+      version: '1.0.0',
+    })
+  })
+
+  test('version change takes precedence over assetsWritten count', () => {
+    // Even with 0 assets written, a version difference is an update.
+    expect(classifyOutcome('cowsay', entry('1.0.0'), entry('2.0.0'), 0).kind).toBe('updated')
+  })
+})

--- a/packages/engine/src/install/__tests__/clone-failure.test.ts
+++ b/packages/engine/src/install/__tests__/clone-failure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import { cloneFailureToRunInstall } from '../clone-failure.ts'
+
+describe('cloneFailureToRunInstall', () => {
+  test('git-binary-missing → GIT_BINARY_MISSING', () => {
+    expect(cloneFailureToRunInstall('cowsay', { ok: false, reason: 'git-binary-missing' })).toEqual({
+      code: 'GIT_BINARY_MISSING',
+      facet: 'cowsay',
+    })
+  })
+
+  test('auth-required → GIT_AUTH_REQUIRED with url', () => {
+    expect(cloneFailureToRunInstall('cowsay', { ok: false, reason: 'auth-required', url: 'https://x/r.git' })).toEqual({
+      code: 'GIT_AUTH_REQUIRED',
+      facet: 'cowsay',
+      url: 'https://x/r.git',
+    })
+  })
+
+  test('clone-failed → GIT_CLONE_FAILED with url + stderr', () => {
+    expect(
+      cloneFailureToRunInstall('cowsay', {
+        ok: false,
+        reason: 'clone-failed',
+        url: 'https://x/r.git',
+        stderr: 'boom',
+      }),
+    ).toEqual({ code: 'GIT_CLONE_FAILED', facet: 'cowsay', url: 'https://x/r.git', stderr: 'boom' })
+  })
+
+  test('checkout-failed → GIT_CHECKOUT_FAILED with commitish + stderr', () => {
+    expect(
+      cloneFailureToRunInstall('cowsay', {
+        ok: false,
+        reason: 'checkout-failed',
+        url: 'https://x/r.git',
+        commitish: 'abc123',
+        stderr: 'nope',
+      }),
+    ).toEqual({
+      code: 'GIT_CHECKOUT_FAILED',
+      facet: 'cowsay',
+      url: 'https://x/r.git',
+      commitish: 'abc123',
+      stderr: 'nope',
+    })
+  })
+})

--- a/packages/engine/src/install/__tests__/detect-lockfile-drift.test.ts
+++ b/packages/engine/src/install/__tests__/detect-lockfile-drift.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test'
+import type { FacetsJson, Lockfile, LockfileFacet } from '@agent-facets/protocol'
+import { LOCKFILE_VERSION } from '@agent-facets/protocol'
+import { detectLockfileDrift } from '../detect-lockfile-drift.ts'
+
+const manifest = (facets: Record<string, string>): FacetsJson => ({ facets })
+
+const lockEntry = (version: string, source = version): LockfileFacet => ({
+  source,
+  version,
+  integrity: 'sha256:stub',
+  assets: [{ scope: 'user', type: 'skill', name: 'planning' }],
+})
+
+const lock = (facets: Record<string, LockfileFacet>): Lockfile => ({
+  lockfileVersion: LOCKFILE_VERSION,
+  facets,
+})
+
+describe('detectLockfileDrift', () => {
+  test('no drift when every registry entry satisfies its specifier', () => {
+    const drift = detectLockfileDrift(
+      manifest({ cowsay: '1.2.3', other: '1.*' }),
+      lock({ cowsay: lockEntry('1.2.3'), other: lockEntry('1.5.0') }),
+      true,
+    )
+    expect(drift).toEqual([])
+  })
+
+  test('missing lockfile → every manifest facet reported as missing-lockfile', () => {
+    const drift = detectLockfileDrift(manifest({ cowsay: '1.2.3', other: '2.0.0' }), lock({}), false)
+    expect(drift).toEqual([
+      { name: 'cowsay', reason: 'missing-lockfile', manifestSpec: '1.2.3' },
+      { name: 'other', reason: 'missing-lockfile', manifestSpec: '2.0.0' },
+    ])
+  })
+
+  test('manifest facet absent from lockfile → no-entry', () => {
+    const drift = detectLockfileDrift(
+      manifest({ cowsay: '1.2.3', extra: '0.2.0' }),
+      lock({ cowsay: lockEntry('1.2.3') }),
+      true,
+    )
+    expect(drift).toEqual([{ name: 'extra', reason: 'no-entry', manifestSpec: '0.2.0' }])
+  })
+
+  test('locked version does not satisfy exact specifier → unsatisfied with lockedVersion', () => {
+    const drift = detectLockfileDrift(manifest({ cowsay: '0.1.2' }), lock({ cowsay: lockEntry('0.1.1') }), true)
+    expect(drift).toEqual([{ name: 'cowsay', reason: 'unsatisfied', manifestSpec: '0.1.2', lockedVersion: '0.1.1' }])
+  })
+
+  test('locked version outside a widened wildcard → unsatisfied', () => {
+    const drift = detectLockfileDrift(manifest({ cowsay: '2.*' }), lock({ cowsay: lockEntry('1.2.3') }), true)
+    expect(drift).toEqual([{ name: 'cowsay', reason: 'unsatisfied', manifestSpec: '2.*', lockedVersion: '1.2.3' }])
+  })
+
+  test('non-registry (local/git) entries are not version-checked, only required to exist', () => {
+    // A local source whose entry exists is fine regardless of version.
+    const drift = detectLockfileDrift(manifest({ local: './pkg' }), lock({ local: lockEntry('9.9.9', './pkg') }), true)
+    expect(drift).toEqual([])
+  })
+
+  test('lockfile entry absent from the manifest → orphaned', () => {
+    const drift = detectLockfileDrift(
+      manifest({ cowsay: '1.2.3' }),
+      lock({ cowsay: lockEntry('1.2.3'), stale: lockEntry('4.5.6') }),
+      true,
+    )
+    expect(drift).toEqual([{ name: 'stale', reason: 'orphaned', lockedVersion: '4.5.6' }])
+  })
+
+  test('manifest-side drift is reported before orphans', () => {
+    const drift = detectLockfileDrift(
+      manifest({ cowsay: '0.1.2' }),
+      lock({ cowsay: lockEntry('0.1.1'), stale: lockEntry('4.5.6') }),
+      true,
+    )
+    expect(drift).toEqual([
+      { name: 'cowsay', reason: 'unsatisfied', manifestSpec: '0.1.2', lockedVersion: '0.1.1' },
+      { name: 'stale', reason: 'orphaned', lockedVersion: '4.5.6' },
+    ])
+  })
+
+  test('orphans are not reported when the lockfile did not previously exist', () => {
+    // lockfileExisted=false means a fresh bootstrap: every manifest facet is
+    // missing-lockfile and there is no prior lockfile to orphan from.
+    const drift = detectLockfileDrift(manifest({ cowsay: '1.2.3' }), lock({}), false)
+    expect(drift).toEqual([{ name: 'cowsay', reason: 'missing-lockfile', manifestSpec: '1.2.3' }])
+  })
+})

--- a/packages/engine/src/install/__tests__/materialize-failure.test.ts
+++ b/packages/engine/src/install/__tests__/materialize-failure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import type { LockfileAssetEntry } from '@agent-facets/protocol'
+import { materializeFailureToRunInstall } from '../materialize-failure.ts'
+
+const asset: LockfileAssetEntry = { scope: 'user', type: 'skill', name: 'planning' }
+
+describe('materializeFailureToRunInstall', () => {
+  test('unsupported-adapter → ADAPTER_UNSUPPORTED', () => {
+    expect(materializeFailureToRunInstall('cowsay', { kind: 'unsupported-adapter', adapter: 'opencode' })).toEqual({
+      code: 'ADAPTER_UNSUPPORTED',
+      facet: 'cowsay',
+      adapter: 'opencode',
+    })
+  })
+
+  test('read-failed → ADAPTER_READ_FAILED with asset + cause', () => {
+    expect(
+      materializeFailureToRunInstall('cowsay', {
+        kind: 'read-failed',
+        adapter: 'opencode',
+        asset,
+        cause: 'EACCES',
+      }),
+    ).toEqual({ code: 'ADAPTER_READ_FAILED', facet: 'cowsay', adapter: 'opencode', asset, cause: 'EACCES' })
+  })
+
+  test('install-failed → ADAPTER_INSTALL_FAILED with asset + cause', () => {
+    expect(
+      materializeFailureToRunInstall('cowsay', {
+        kind: 'install-failed',
+        adapter: 'opencode',
+        asset,
+        cause: 'disk full',
+      }),
+    ).toEqual({ code: 'ADAPTER_INSTALL_FAILED', facet: 'cowsay', adapter: 'opencode', asset, cause: 'disk full' })
+  })
+
+  test('delete-failed → ADAPTER_DELETE_FAILED with asset + cause', () => {
+    expect(
+      materializeFailureToRunInstall('cowsay', {
+        kind: 'delete-failed',
+        adapter: 'opencode',
+        asset,
+        cause: 'locked',
+      }),
+    ).toEqual({ code: 'ADAPTER_DELETE_FAILED', facet: 'cowsay', adapter: 'opencode', asset, cause: 'locked' })
+  })
+})

--- a/packages/engine/src/install/__tests__/parse-locked-version.test.ts
+++ b/packages/engine/src/install/__tests__/parse-locked-version.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { parseLockedVersion } from '../parse-locked-version.ts'
+
+describe('parseLockedVersion', () => {
+  test('parses an exact M.N.P into a structured exact VersionSpec', () => {
+    expect(parseLockedVersion('1.2.3')).toEqual({ kind: 'exact', major: 1, minor: 2, patch: 3 })
+  })
+
+  test('parses multi-digit components', () => {
+    expect(parseLockedVersion('10.20.30')).toEqual({ kind: 'exact', major: 10, minor: 20, patch: 30 })
+  })
+
+  test('parses 0.0.0', () => {
+    expect(parseLockedVersion('0.0.0')).toEqual({ kind: 'exact', major: 0, minor: 0, patch: 0 })
+  })
+
+  test('throws on a non-M.N.P string (schema/parser drift is a programmer bug)', () => {
+    // Lockfile schema narrows `version` to M.N.P, so this is unreachable on
+    // validated input — the throw guards against schema/parser drift.
+    expect(() => parseLockedVersion('1.2')).toThrow('parseLockedVersion regex rejected it')
+    expect(() => parseLockedVersion('1.2.3-rc.1')).toThrow()
+    expect(() => parseLockedVersion('latest')).toThrow()
+  })
+})

--- a/packages/engine/src/install/__tests__/removal-manifest.test.ts
+++ b/packages/engine/src/install/__tests__/removal-manifest.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test'
+import { removalManifest } from '../removal-manifest.ts'
+
+describe('removalManifest', () => {
+  test('synthesizes a placeholder manifest carrying the facet name', () => {
+    expect(removalManifest('cowsay')).toEqual({ name: 'cowsay', version: '0.0.0' })
+  })
+
+  test('uses the given name verbatim', () => {
+    expect(removalManifest('viper-plans').name).toBe('viper-plans')
+  })
+})

--- a/packages/engine/src/install/__tests__/resolve-clone-ref.test.ts
+++ b/packages/engine/src/install/__tests__/resolve-clone-ref.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { LockfileFacet } from '@agent-facets/protocol'
-import { resolveCloneRef } from '../run-install.ts'
+import { resolveCloneRef } from '../resolve-clone-ref.ts'
 
 const lockedWithCommit: LockfileFacet = {
   source: 'github:agent-facets/viper-plans#main',

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Tests for `runInstall`'s manifest-vs-lockfile reconciliation.
+ *
+ * The registry resolve + download path is stubbed via `mock.module` so the
+ * test exercises the satisfy-or-re-resolve logic without a live registry.
+ * The resolver echoes back the exact version it was ASKED for (recording
+ * each request), and 404s a designated nonexistent version — so a test can
+ * assert that install fetched the MANIFEST's version, not the locked one.
+ * The download stub copies a local fixture (built to match the resolved
+ * version) into the staging dir; everything downstream (build, content
+ * hash, materialize, lockfile) runs for real.
+ */
+
+// --- Registry mock state (mutated per-test before calling runInstall) -----
+
+type FixtureForVersion = (version: string) => string | null
+let fixtureForVersion: FixtureForVersion = () => null
+let resolveRequests: Array<{ name: string; version: string }> = []
+let nonexistentVersions = new Set<string>()
+
+/** Render a VersionSpec the way the engine describes it for the registry. */
+function describeSpec(spec: { kind: string; major?: number; minor?: number; patch?: number }): string {
+  switch (spec.kind) {
+    case 'exact':
+      return `${spec.major}.${spec.minor}.${spec.patch}`
+    case 'majorWildcard':
+      return `${spec.major}.*`
+    case 'minorWildcard':
+      return `${spec.major}.${spec.minor}.*`
+    default:
+      return spec.kind === 'latest' ? 'latest' : '*'
+  }
+}
+
+mock.module('../../registry/resolve-metadata.ts', () => ({
+  resolveRegistryMetadataBatch: async (
+    specs: ReadonlyArray<{ name: string; version: { kind: string; major?: number; minor?: number; patch?: number } }>,
+  ) => {
+    const spec = specs[0]
+    if (spec === undefined) return { ok: true, value: [] }
+    const requested = describeSpec(spec.version)
+    resolveRequests.push({ name: spec.name, version: requested })
+    if (nonexistentVersions.has(requested)) {
+      return { ok: false, error: { code: 'NOT_FOUND', name: spec.name, spec: requested } }
+    }
+    // Exact specifiers resolve to themselves; wildcard/latest resolve to a
+    // representative published version the test sets via fixtureForVersion.
+    const resolved = spec.version.kind === 'exact' ? requested : (resolveRequests.at(-1)?.version ?? requested)
+    return {
+      ok: true,
+      value: [{ name: spec.name, version: resolved, expectedIntegrity: 'sha256:stub' }],
+    }
+  },
+}))
+
+mock.module('../../registry/download.ts', () => ({
+  downloadAndExtractFacet: async (meta: { name: string; version: string }, dest: string) => {
+    const fixture = fixtureForVersion(meta.version)
+    if (fixture === null) {
+      return { ok: false, error: { code: 'NETWORK_ERROR', cause: `no fixture for ${meta.version}`, attempts: 1 } }
+    }
+    cpSync(fixture, dest, { recursive: true })
+    return { ok: true, value: undefined }
+  },
+}))
+
+const { runInstall } = await import('../run-install.ts')
+const { loadInstalledAdapters } = await import('../../adapters/loader.ts')
+const { runBuildPipeline } = await import('../../build/pipeline.ts')
+const { LOCKFILE_VERSION } = await import('@agent-facets/protocol')
+
+/** Build a fixture and return the genuine content-hash the install pipeline
+ *  would compute for it — so a satisfying lock entry can carry a real
+ *  integrity that passes the tag-move guard. */
+async function realIntegrity(fixtureDir: string): Promise<string> {
+  const built = await runBuildPipeline(fixtureDir, [])
+  if (!built.ok) throw new Error('test bug: fixture failed to build')
+  return built.integrity
+}
+
+let projectRoot: string
+let originalCwd: string
+let fakeHome: string
+let originalHome: string | undefined
+let originalFacetDir: string | undefined
+let adaptersDir: string
+
+function buildFixture(parent: string, name: string, version: string): string {
+  const repo = realpathSync(mkdtempSync(join(parent, 'fixture-')))
+  writeFileSync(
+    join(repo, 'facet.json'),
+    JSON.stringify({ name, version, skills: { planning: { description: 'planning skill' } } }),
+  )
+  mkdirSync(join(repo, 'skills/planning'), { recursive: true })
+  writeFileSync(join(repo, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
+  return repo
+}
+
+function installFakeAdapter(baseDir: string, name: string): void {
+  const dir = join(baseDir, name)
+  mkdirSync(dir, { recursive: true })
+  const assetFsImport = require.resolve('@agent-facets/adapter')
+  writeFileSync(
+    join(dir, 'adapter.js'),
+    `
+import { installAssetFile, readAssetFile, deleteAssetFile } from '${assetFsImport}'
+import { join } from 'node:path'
+function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
+export default {
+  name: '${name}',
+  supportsInstall: true,
+  buildAssetMetadata(data) { return { ok: true, data: data || {} } },
+  async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
+  async readAsset(scope, type, name) { return readAssetFile({ file: path(type, name) }) },
+  async deleteAsset(scope, type, name) { await deleteAssetFile({ file: path(type, name) }) },
+}
+`,
+  )
+}
+
+function writeFacets(facets: Record<string, string>): string {
+  const bytes = `${JSON.stringify({ facets }, null, 2)}\n`
+  writeFileSync(join(projectRoot, 'facets.json'), bytes)
+  return bytes
+}
+
+/** Seed a lockfile entry. `integrity` defaults to the stub the download path uses. */
+function writeLock(facets: Record<string, { source: string; version: string; integrity?: string }>): string {
+  const entries: Record<string, unknown> = {}
+  for (const [name, e] of Object.entries(facets)) {
+    entries[name] = {
+      source: e.source,
+      version: e.version,
+      integrity: e.integrity ?? 'sha256:stub',
+      assets: [{ scope: 'user', type: 'skill', name: 'planning' }],
+    }
+  }
+  const bytes = `${JSON.stringify({ lockfileVersion: LOCKFILE_VERSION, facets: entries }, null, 2)}\n`
+  writeFileSync(join(projectRoot, 'facets.lock'), bytes)
+  return bytes
+}
+
+function readLock(): {
+  facets: Record<string, { source: string; version: string; integrity: string }>
+} {
+  return JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+}
+
+async function install() {
+  const adapters = await loadInstalledAdapters()
+  return runInstall({ projectRoot, adapters: adapters.filter((a) => a.supportsInstall === true) })
+}
+
+async function installFrozen() {
+  const adapters = await loadInstalledAdapters()
+  return runInstall({
+    projectRoot,
+    adapters: adapters.filter((a) => a.supportsInstall === true),
+    frozenLockfile: true,
+  })
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-runinstall-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-home-')))
+  const facetDir = join(fakeHome, '.facet')
+  adaptersDir = join(facetDir, 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+  process.env.HOME = fakeHome
+  process.env.FACET_DIR = facetDir
+  process.chdir(projectRoot)
+  installFakeAdapter(adaptersDir, 'test-adapter')
+  fixtureForVersion = () => null
+  resolveRequests = []
+  nonexistentVersions = new Set()
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('runInstall — exact manifest pin differing from the lockfile', () => {
+  test('re-resolves to the manifest version and reports updated', async () => {
+    // Fixtures exist for both versions; the lock pins 0.1.1, manifest bumps to 0.1.2.
+    fixtureForVersion = (v) => (v === '0.1.2' ? buildFixture(fakeHome, 'cowsay', '0.1.2') : null)
+    writeFacets({ cowsay: '0.1.2' })
+    writeLock({ cowsay: { source: '0.1.1', version: '0.1.1' } })
+
+    const result = await install()
+    if (!result.ok) expect.unreachable()
+
+    // Install fetched the MANIFEST version, not the locked one.
+    expect(resolveRequests).toEqual([{ name: 'cowsay', version: '0.1.2' }])
+    // The lockfile now records the re-resolved version.
+    expect(readLock().facets.cowsay?.version).toBe('0.1.2')
+    // The outcome is reported as an update from 0.1.1 → 0.1.2.
+    const outcome = result.perFacet.find((o) => o.name === 'cowsay')
+    if (outcome === undefined) expect.unreachable()
+    if (outcome.kind !== 'updated') expect.unreachable()
+    expect(outcome.oldVersion).toBe('0.1.1')
+    expect(outcome.newVersion).toBe('0.1.2')
+  })
+
+  test('fails on a version that does not exist and leaves the project unchanged', async () => {
+    nonexistentVersions = new Set(['0.1.2'])
+    const facetsBefore = writeFacets({ cowsay: '0.1.2' })
+    const lockBefore = writeLock({ cowsay: { source: '0.1.1', version: '0.1.1' } })
+
+    const result = await install()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'REGISTRY_ERROR') expect.unreachable()
+    expect(result.failure.error.code).toBe('NOT_FOUND')
+
+    // It tried to resolve the bumped version (and only that).
+    expect(resolveRequests).toEqual([{ name: 'cowsay', version: '0.1.2' }])
+    // Manifest and lockfile are byte-for-byte unchanged.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+    // The nonexistent version was never recorded.
+    expect(readLock().facets.cowsay?.version).toBe('0.1.1')
+  })
+})
+
+describe('runInstall — wildcard manifest vs lockfile', () => {
+  test('honors the locked version (not the wildcard) when the lock satisfies the manifest', async () => {
+    // Manifest 1.* satisfied by locked 1.2.3. On a cold cache the install
+    // fetches the LOCKED version 1.2.3 for reproducibility — it must NOT
+    // re-resolve the manifest's `1.*` (which could drift to a newer 1.x).
+    const fixture = buildFixture(fakeHome, 'cowsay', '1.2.3')
+    fixtureForVersion = (v) => (v === '1.2.3' ? fixture : null)
+    writeFacets({ cowsay: '1.*' })
+    // Real integrity so the satisfying-lock tag-move guard passes.
+    writeLock({ cowsay: { source: '1.*', version: '1.2.3', integrity: await realIntegrity(fixture) } })
+
+    const result = await install()
+    if (!result.ok) expect.unreachable()
+
+    // Resolution was pinned to the locked exact version, never the wildcard.
+    expect(resolveRequests).toEqual([{ name: 'cowsay', version: '1.2.3' }])
+    expect(readLock().facets.cowsay?.version).toBe('1.2.3')
+    const outcome = result.perFacet.find((o) => o.name === 'cowsay')
+    if (outcome === undefined) expect.unreachable()
+    // Same version in and out → not an update.
+    expect(outcome.kind).not.toBe('updated')
+  })
+
+  test('re-resolves when the locked version no longer satisfies the wildcard', async () => {
+    // Manifest widened to 2.*, lock still at 1.2.3 → stale → re-resolve.
+    fixtureForVersion = (v) => (v === '2.*' ? buildFixture(fakeHome, 'cowsay', '2.0.0') : null)
+    // Wildcard resolves to the requested wildcard string in the mock, and the
+    // download fixture is keyed on that string; the built facet's version is 2.0.0.
+    writeFacets({ cowsay: '2.*' })
+    writeLock({ cowsay: { source: '1.*', version: '1.2.3' } })
+
+    const result = await install()
+    if (!result.ok) expect.unreachable()
+
+    // It re-resolved against the manifest's wildcard rather than honoring 1.2.3.
+    expect(resolveRequests).toEqual([{ name: 'cowsay', version: '2.*' }])
+    // The lockfile now records the freshly built version, not the stale 1.2.3.
+    expect(readLock().facets.cowsay?.version).toBe('2.0.0')
+  })
+})
+
+describe('runInstall — frozen-lockfile mode', () => {
+  test('proceeds when the lockfile covers the manifest and writes nothing', async () => {
+    const fixture = buildFixture(fakeHome, 'cowsay', '0.1.1')
+    fixtureForVersion = (v) => (v === '0.1.1' ? fixture : null)
+    writeFacets({ cowsay: '0.1.1' })
+    const lockBefore = writeLock({
+      cowsay: { source: '0.1.1', version: '0.1.1', integrity: await realIntegrity(fixture) },
+    })
+
+    const result = await installFrozen()
+    if (!result.ok) expect.unreachable()
+
+    // No re-resolution; resolution pinned to the locked version on cache miss.
+    expect(resolveRequests).toEqual([{ name: 'cowsay', version: '0.1.1' }])
+    // The lockfile is byte-for-byte unchanged (never written in frozen mode).
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+  })
+
+  test('fails on an orphaned lockfile entry without pruning anything', async () => {
+    // `stale` is pinned in the lockfile but absent from the manifest. In
+    // frozen mode the drift-removal loop would otherwise delete its assets
+    // while the lockfile write is skipped — leaving adapter state mutated and
+    // the orphan entry stranded. The preflight must catch it first.
+    const facetsBefore = writeFacets({ cowsay: '0.1.1' })
+    const lockBefore = writeLock({
+      cowsay: { source: '0.1.1', version: '0.1.1' },
+      stale: { source: '4.5.6', version: '4.5.6' },
+    })
+
+    const result = await installFrozen()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'LOCKFILE_DRIFT') expect.unreachable()
+    expect(result.failure.facets).toEqual([{ name: 'stale', reason: 'orphaned', lockedVersion: '4.5.6' }])
+    // Nothing was resolved and both project files are byte-for-byte unchanged.
+    expect(resolveRequests).toEqual([])
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+  })
+
+  test('fails when no lockfile exists', async () => {
+    const facetsBefore = writeFacets({ cowsay: '0.1.1' })
+
+    const result = await installFrozen()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'LOCKFILE_DRIFT') expect.unreachable()
+    expect(result.failure.facets).toEqual([{ name: 'cowsay', reason: 'missing-lockfile', manifestSpec: '0.1.1' }])
+    // Never resolved; project untouched; no lockfile created.
+    expect(resolveRequests).toEqual([])
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
+    expect(() => readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toThrow()
+  })
+
+  test('fails when a manifest facet is missing from the lockfile', async () => {
+    writeFacets({ cowsay: '0.1.1', extra: '0.2.0' })
+    writeLock({ cowsay: { source: '0.1.1', version: '0.1.1' } })
+
+    const result = await installFrozen()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'LOCKFILE_DRIFT') expect.unreachable()
+    expect(result.failure.facets).toEqual([{ name: 'extra', reason: 'no-entry', manifestSpec: '0.2.0' }])
+    expect(resolveRequests).toEqual([])
+  })
+
+  test('fails when the locked version does not satisfy the manifest specifier', async () => {
+    writeFacets({ cowsay: '0.1.2' })
+    writeLock({ cowsay: { source: '0.1.1', version: '0.1.1' } })
+
+    const result = await installFrozen()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'LOCKFILE_DRIFT') expect.unreachable()
+    expect(result.failure.facets).toEqual([
+      { name: 'cowsay', reason: 'unsatisfied', manifestSpec: '0.1.2', lockedVersion: '0.1.1' },
+    ])
+    // The lockfile is never re-resolved or updated.
+    expect(resolveRequests).toEqual([])
+    expect(readLock().facets.cowsay?.version).toBe('0.1.1')
+  })
+})

--- a/packages/engine/src/install/classify-outcome.ts
+++ b/packages/engine/src/install/classify-outcome.ts
@@ -1,0 +1,33 @@
+import type { LockfileFacet } from '@agent-facets/protocol'
+import type { FacetOutcome } from './types.ts'
+
+/**
+ * Classify a per-facet outcome by comparing the previous lockfile entry
+ * (if any) against the new one. `assetsWritten` is the count of assets
+ * `materialize` actually wrote (excluding skipped no-ops); when it's >0
+ * but the lockfile entry is identical, the facet was "repaired" — the
+ * on-disk state had drifted (file deleted, content edited) and we
+ * restored it without bumping the version.
+ */
+export function classifyOutcome(
+  name: string,
+  previous: LockfileFacet | undefined,
+  current: LockfileFacet,
+  assetsWritten: number,
+): FacetOutcome {
+  if (previous === undefined) {
+    return { kind: 'installed', name, version: current.version }
+  }
+  if (previous.version !== current.version) {
+    return {
+      kind: 'updated',
+      name,
+      oldVersion: previous.version,
+      newVersion: current.version,
+    }
+  }
+  if (assetsWritten > 0) {
+    return { kind: 'repaired', name, version: current.version }
+  }
+  return { kind: 'unchanged', name, version: current.version }
+}

--- a/packages/engine/src/install/clone-failure.ts
+++ b/packages/engine/src/install/clone-failure.ts
@@ -1,0 +1,30 @@
+import type { CloneFacetGitResult } from '../sources/facet/resolve-git.ts'
+import type { RunInstallFailure } from './types.ts'
+
+/**
+ * Translate a `cloneFacetGitSource` failure into the matching
+ * `RunInstallFailure` code. Each `reason` arm maps to exactly one
+ * code; structured fields (URL, stderr, commitish) flow through
+ * unchanged so the CLI doesn't have to reparse stderr text.
+ */
+export function cloneFailureToRunInstall(
+  facet: string,
+  cloned: Extract<CloneFacetGitResult, { ok: false }>,
+): RunInstallFailure {
+  switch (cloned.reason) {
+    case 'git-binary-missing':
+      return { code: 'GIT_BINARY_MISSING', facet }
+    case 'auth-required':
+      return { code: 'GIT_AUTH_REQUIRED', facet, url: cloned.url }
+    case 'clone-failed':
+      return { code: 'GIT_CLONE_FAILED', facet, url: cloned.url, stderr: cloned.stderr }
+    case 'checkout-failed':
+      return {
+        code: 'GIT_CHECKOUT_FAILED',
+        facet,
+        url: cloned.url,
+        commitish: cloned.commitish,
+        stderr: cloned.stderr,
+      }
+  }
+}

--- a/packages/engine/src/install/detect-lockfile-drift.ts
+++ b/packages/engine/src/install/detect-lockfile-drift.ts
@@ -1,0 +1,54 @@
+import type { FacetsJson, Lockfile } from '@agent-facets/protocol'
+import { satisfies } from '@agent-facets/protocol'
+import { parseFacetSource } from '../sources/facet/parse-source.ts'
+import { parseVersionSpec } from '../sources/facet/parse-version.ts'
+import { parseLockedVersion } from './parse-locked-version.ts'
+import type { LockfileDriftEntry } from './types.ts'
+
+/**
+ * Frozen-lockfile pre-flight: collect every manifest facet whose lockfile
+ * coverage is missing or stale. Returns an empty array when the lockfile
+ * fully and consistently covers the manifest. Registry specifiers must be
+ * satisfied by the locked version; git/local entries need only exist.
+ */
+export function detectLockfileDrift(
+  facetsJson: FacetsJson,
+  previousLockfile: Lockfile,
+  lockfileExisted: boolean,
+): LockfileDriftEntry[] {
+  const drift: LockfileDriftEntry[] = []
+  for (const [name, specifier] of Object.entries(facetsJson.facets)) {
+    if (!lockfileExisted) {
+      drift.push({ name, reason: 'missing-lockfile', manifestSpec: specifier })
+      continue
+    }
+    const locked = previousLockfile.facets[name]
+    if (locked === undefined) {
+      drift.push({ name, reason: 'no-entry', manifestSpec: specifier })
+      continue
+    }
+    const sourceString = parseVersionSpec(specifier).ok ? `${name}@${specifier}` : specifier
+    const parsed = parseFacetSource(sourceString)
+    if (parsed.ok && parsed.value.kind === 'registry') {
+      if (!satisfies(parseLockedVersion(locked.version), parsed.value.version)) {
+        drift.push({ name, reason: 'unsatisfied', manifestSpec: specifier, lockedVersion: locked.version })
+      }
+    }
+  }
+
+  // Orphaned entries: pinned in the lockfile but no longer declared in the
+  // manifest. In frozen mode these would otherwise be silently pruned by the
+  // drift-removal loop (assets deleted) while the lockfile write is skipped —
+  // mutating adapter state and leaving the orphan entry stale on disk. Surface
+  // them as drift so the preflight fails before any mutation. Only meaningful
+  // when a lockfile exists (a missing lockfile is already reported above).
+  if (lockfileExisted) {
+    for (const [name, locked] of Object.entries(previousLockfile.facets)) {
+      if (facetsJson.facets[name] === undefined) {
+        drift.push({ name, reason: 'orphaned', lockedVersion: locked.version })
+      }
+    }
+  }
+
+  return drift
+}

--- a/packages/engine/src/install/materialize-failure.ts
+++ b/packages/engine/src/install/materialize-failure.ts
@@ -1,0 +1,41 @@
+import type { MaterializeFailure } from './materialize.ts'
+import type { RunInstallFailure } from './types.ts'
+
+/**
+ * Translate a `MaterializeFailure` (engine-internal) into the matching
+ * `RunInstallFailure` code (engine-public). Each `MaterializeFailure.kind`
+ * maps to exactly one `RunInstallFailure.code`; the per-adapter context
+ * (adapter name, asset, cause) flows through unchanged. Centralizes the
+ * mapping so both materialize call sites in `runInstall` (the install
+ * branch and the drift-removal branch) route failures the same way.
+ */
+export function materializeFailureToRunInstall(facet: string, failure: MaterializeFailure): RunInstallFailure {
+  switch (failure.kind) {
+    case 'unsupported-adapter':
+      return { code: 'ADAPTER_UNSUPPORTED', facet, adapter: failure.adapter }
+    case 'read-failed':
+      return {
+        code: 'ADAPTER_READ_FAILED',
+        facet,
+        adapter: failure.adapter,
+        asset: failure.asset,
+        cause: failure.cause,
+      }
+    case 'install-failed':
+      return {
+        code: 'ADAPTER_INSTALL_FAILED',
+        facet,
+        adapter: failure.adapter,
+        asset: failure.asset,
+        cause: failure.cause,
+      }
+    case 'delete-failed':
+      return {
+        code: 'ADAPTER_DELETE_FAILED',
+        facet,
+        adapter: failure.adapter,
+        asset: failure.asset,
+        cause: failure.cause,
+      }
+  }
+}

--- a/packages/engine/src/install/parse-locked-version.ts
+++ b/packages/engine/src/install/parse-locked-version.ts
@@ -1,0 +1,57 @@
+import { regex } from 'arkregex'
+
+/**
+ * Pre-compiled M.N.P matcher for `parseLockedVersion`. The pattern is
+ * the same shape narrowed by `LockfileSchema.version` — schema and
+ * parser stay aligned by deliberate convention; if you widen one, widen
+ * the other. `arkregex` types the captures so destructuring is
+ * cast-free; the runtime `RegExp` instance behaves identically to a
+ * native one.
+ *
+ * No prerelease support: `VersionSpec` (the type returned below) only
+ * models `M.N.P`. Adding prerelease support means widening this regex
+ * AND the lockfile schema's narrow check AND `VersionSpec` itself.
+ */
+const LOCKED_VERSION_RE = regex('^(\\d+)\\.(\\d+)\\.(\\d+)$')
+
+/**
+ * Parse a `LockfileFacet.version` string into an exact `VersionSpec` for
+ * the registry resolver. Lockfile versions are always concrete `M.N.P`
+ * by contract (the lockfile schema narrows the field to exactly that
+ * shape — see `LockfileSchema.version` in protocol). This function is
+ * the engine-side counterpart that turns the validated string into the
+ * structured form the registry resolver consumes.
+ *
+ * The schema gates malformed versions up front — by the time we get
+ * here, `version` has already passed the narrow regex. If the regex
+ * disagrees at runtime, that's a programmer bug (schema and parser
+ * regex got out of sync), not a user-facing failure mode — hence the
+ * `expect.unreachable`-style throw. Anti-pattern 4: this branch is
+ * genuinely unreachable on validated input.
+ *
+ * Used on the registry-source cache-miss path to pin the metadata
+ * fetch at `locked.version` instead of re-resolving the manifest spec
+ * (which may be `@latest` or a wildcard). See the call site for the
+ * reproducibility rationale.
+ */
+export function parseLockedVersion(version: string): {
+  kind: 'exact'
+  major: number
+  minor: number
+  patch: number
+} {
+  const match = LOCKED_VERSION_RE.exec(version)
+  if (match === null) {
+    // The schema narrow regex (`LockfileSchema.version`) has the same
+    // shape as `LOCKED_VERSION_RE`. A null here means schema and parser
+    // regex have drifted apart — programmer bug, not user input.
+    throw new Error(`internal: lockfile schema accepted "${version}" but parseLockedVersion regex rejected it`)
+  }
+  const [, major, minor, patch] = match
+  return {
+    kind: 'exact',
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+  }
+}

--- a/packages/engine/src/install/plan-facet.ts
+++ b/packages/engine/src/install/plan-facet.ts
@@ -1,0 +1,409 @@
+import { rm } from 'node:fs/promises'
+import type { Adapter } from '@agent-facets/adapter'
+import type { BuildManifest, Lockfile, LockfileFacet, ResolvedFacetManifest } from '@agent-facets/protocol'
+import { satisfies, verifyGitOneCheck } from '@agent-facets/protocol'
+import { runBuildPipeline } from '../build/pipeline.ts'
+import { type CacheIdentity, cacheGet, cachePutVerified, cacheStagingDir, readCachedIntegrity } from '../cache/index.ts'
+import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
+import { downloadAndExtractFacet } from '../registry/download.ts'
+import { resolveRegistryMetadataBatch } from '../registry/resolve-metadata.ts'
+import { parseFacetSource } from '../sources/facet/parse-source.ts'
+import { parseVersionSpec } from '../sources/facet/parse-version.ts'
+import { cloneFacetGitSource } from '../sources/facet/resolve-git.ts'
+import { resolveLocalFacetSource } from '../sources/facet/resolve-local.ts'
+import { cloneFailureToRunInstall } from './clone-failure.ts'
+import { computeAssetList } from './materialize.ts'
+import { parseLockedVersion } from './parse-locked-version.ts'
+import { resolveCloneRef } from './resolve-clone-ref.ts'
+import type { RunInstallFailure, StageEvent } from './types.ts'
+
+/**
+ * Per-facet plan: parse → resolve → load → build → return entry.
+ *
+ * Wraps the entire flow in a try/finally that always cleans up the
+ * cloned git directory, even if a downstream step fails.
+ */
+export interface PlanFacetArgs {
+  facetName: string
+  specifier: string
+  projectRoot: string
+  adapters: ReadonlyArray<Adapter>
+  previousLockfile: Lockfile
+  onStage: (event: StageEvent) => void
+  onLog: (line: string) => void
+}
+
+export interface PlanFacetSuccess {
+  entry: LockfileFacet
+  resolved: ResolvedFacetManifest
+  serversDeclared: ReadonlyArray<string>
+}
+
+export type PlanFacetResult = { ok: true; value: PlanFacetSuccess } | { ok: false; failure: RunInstallFailure }
+
+export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
+  const { facetName, specifier, projectRoot, previousLockfile, onStage, onLog } = args
+
+  // Parse the source specifier.
+  //
+  // The manifest is a `name → value` map. For a registry source the value
+  // is a bare version specifier (`1.2.3`, `1.*`, `*`, `latest`) and the
+  // facet name lives in the KEY — so when the value parses as a bare
+  // VersionSpec we reconstruct the full source as `${facetName}@${value}`.
+  // For git/local sources the value is a self-contained source string
+  // (URL, `file:` path) and the key is just a label; we parse the value
+  // standalone. This keeps `facets.json` values semver-shaped for registry
+  // entries (the value the user sees is `1.2.3`, not `cowsay@1.2.3`) while
+  // still round-tripping through source resolution.
+  onStage({ kind: 'facet-stage', facet: facetName, stage: 'parse' })
+  const sourceString = parseVersionSpec(specifier).ok ? `${facetName}@${specifier}` : specifier
+  const parsed = parseFacetSource(sourceString)
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      failure: { code: 'PARSE_ERROR', facet: facetName, specifier, error: parsed.error },
+    }
+  }
+
+  let sourceDir: string | undefined
+  let cleanup: (() => Promise<void>) | undefined
+  // Captured by the clone path; consumed when constructing a fresh-add
+  // lockfile entry. Locked entries inherit ref/commit from `locked`.
+  let clonedRef: string | undefined
+  let clonedCommit: string | undefined
+  // `locked` is the committed lockfile entry for this facet, if any.
+  // When defined, it's the security contract: the install MUST reproduce
+  // exactly these bytes (or fail loudly). Cache hits short-circuit when
+  // the sidecar matches `locked.integrity`.
+  const locked = previousLockfile.facets[facetName]
+  // A registry lock is stale when its version no longer satisfies the
+  // manifest spec (hand-edit / pull / merge). Only registry sources carry
+  // a VersionSpec; git is ref-based and local is mutable, so neither
+  // is ever stale here. A stale entry is treated as absent below so the
+  // facet re-resolves like a fresh add, overwriting the stale entry.
+  const isStale =
+    locked !== undefined &&
+    parsed.value.kind === 'registry' &&
+    !satisfies(parseLockedVersion(locked.version), parsed.value.version)
+  const effectiveLocked = isStale ? undefined : locked
+  // Set when a cache hit's sidecar matches the locked integrity. The
+  // sidecar IS the post-write trust certificate; we don't rebuild to
+  // re-derive what the cache already proved at write time.
+  let trustedCacheHit = false
+
+  // Resolve to a sourceDir.
+  onStage({ kind: 'facet-stage', facet: facetName, stage: 'resolve' })
+  if (parsed.value.kind === 'git') {
+    // Cache-first when we have a locked entry: name + version are both
+    // known from `locked`, so we can look up the cache slot without any
+    // clone or network round-trip.
+    if (locked !== undefined) {
+      const cacheId: CacheIdentity = {
+        kind: 'git',
+        name: facetName,
+        version: locked.version,
+      }
+      const lookup = cacheGet(cacheId)
+      if (lookup.hit) {
+        const cached = readCachedIntegrity(lookup.path)
+        if (cached === null) {
+          // Sidecar missing/invalid — incomplete cache slot. Treat as
+          // soft miss and fall through to clone.
+          onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; refetching`)
+        } else if (cached.integrity !== locked.integrity) {
+          // Cache disagrees with lockfile. Lockfile is the source of
+          // truth; surface as hard error rather than silently refetching.
+          return {
+            ok: false,
+            failure: {
+              code: 'CACHE_INTEGRITY_MISMATCH',
+              facet: facetName,
+              slotPath: lookup.path,
+              cachedIntegrity: cached.integrity,
+              lockedIntegrity: locked.integrity,
+            },
+          }
+        } else {
+          // Cache hit + sidecar matches lockfile. The sidecar is the
+          // post-write trust certificate; we trust it without rebuilding.
+          // No clone, no build pipeline, no rehashing.
+          sourceDir = lookup.path
+          trustedCacheHit = true
+          // No cleanup — cache entries are durable.
+          onLog(`[verbose]   cache hit ${lookup.path}`)
+        }
+      }
+    }
+
+    // Cache miss (or no locked entry, or sidecar invalid). Clone.
+    if (sourceDir === undefined) {
+      const cloneRef = resolveCloneRef(locked, parsed.value.ref)
+      const cloned = await cloneFacetGitSource(parsed.value.url, cloneRef)
+      if (!cloned.ok) {
+        return {
+          ok: false,
+          failure: cloneFailureToRunInstall(facetName, cloned),
+        }
+      }
+      sourceDir = cloned.dir
+      cleanup = async () => {
+        await rm(cloned.dir, { recursive: true, force: true }).catch(() => {})
+      }
+      clonedRef = cloneRef
+      clonedCommit = cloned.commit
+      onLog(`[verbose]   cloned ${parsed.value.url} → ${sourceDir} (sha: ${cloned.commit ?? '?'})`)
+    }
+  } else if (parsed.value.kind === 'local') {
+    const local = await resolveLocalFacetSource(parsed.value.path, projectRoot)
+    if (!local.ok) {
+      return {
+        ok: false,
+        failure: { code: 'LOCAL_RESOLVE_FAILED', facet: facetName, cause: local.error },
+      }
+    }
+    sourceDir = local.dir
+  } else {
+    // Registry source. Cache-first when locked AND satisfying; otherwise
+    // resolve metadata → download archive → extract to temp dir → let the
+    // build pipeline re-derive integrity (the cache write below moves temp
+    // → cache slot).
+    if (effectiveLocked !== undefined) {
+      const cacheId: CacheIdentity = {
+        kind: 'registry',
+        name: facetName,
+        version: effectiveLocked.version,
+      }
+      const lookup = cacheGet(cacheId)
+      if (lookup.hit) {
+        const cached = readCachedIntegrity(lookup.path)
+        if (cached === null) {
+          onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; refetching`)
+        } else if (cached.integrity !== effectiveLocked.integrity) {
+          return {
+            ok: false,
+            failure: {
+              code: 'CACHE_INTEGRITY_MISMATCH',
+              facet: facetName,
+              slotPath: lookup.path,
+              cachedIntegrity: cached.integrity,
+              lockedIntegrity: effectiveLocked.integrity,
+            },
+          }
+        } else {
+          sourceDir = lookup.path
+          trustedCacheHit = true
+          onLog(`[verbose]   cache hit ${lookup.path}`)
+        }
+      }
+    }
+
+    if (sourceDir === undefined) {
+      onStage({ kind: 'facet-stage', facet: facetName, stage: 'fetch' })
+      // Reproducibility: when a satisfying lockfile entry pins a version,
+      // resolve metadata for THAT exact version on a cache miss — never
+      // re-resolve from the manifest specifier (which may be `@latest` or a
+      // wildcard). Without this, a cold-cache reinstall of a project locked
+      // to `1.2.3` against a manifest of `@latest` would silently fetch
+      // `1.3.0` and trip the integrity check. Mirrors `resolveCloneRef` for
+      // the git path.
+      const versionForFetch: typeof parsed.value.version =
+        effectiveLocked !== undefined ? parseLockedVersion(effectiveLocked.version) : parsed.value.version
+      const metaResult = await resolveRegistryMetadataBatch([{ name: parsed.value.name, version: versionForFetch }])
+      if (!metaResult.ok) {
+        return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: metaResult.error } }
+      }
+      const meta = metaResult.value[0]
+      if (meta === undefined) {
+        return {
+          ok: false,
+          failure: {
+            code: 'REGISTRY_ERROR',
+            facet: facetName,
+            error: {
+              code: 'NETWORK_ERROR',
+              cause: 'registry returned no metadata for the requested facet',
+              attempts: 1,
+            },
+          },
+        }
+      }
+
+      // Stage under the cache root (not the OS tmp dir). cachePutVerified's
+      // final rename into the cache slot must be atomic, which requires the
+      // staging dir and the slot to share a filesystem. If FACET_DIR
+      // points at a volume different from /tmp, mkdtemp under tmpdir() would
+      // make the rename throw EXDEV.
+      const tempDir = cacheStagingDir()
+      onStage({ kind: 'facet-stage', facet: facetName, stage: 'verify' })
+      const downloadResult = await downloadAndExtractFacet(meta, tempDir)
+      if (!downloadResult.ok) {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+        return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: downloadResult.error } }
+      }
+      sourceDir = tempDir
+      cleanup = async () => {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => {})
+      }
+      onLog(`[verbose]   downloaded ${meta.name}@${meta.version} → ${sourceDir}`)
+    }
+  }
+
+  try {
+    // Load and validate the facet.json.
+    onStage({ kind: 'facet-stage', facet: facetName, stage: 'load' })
+    const rawManifest = await loadManifest(sourceDir)
+    if (!rawManifest.ok) {
+      return {
+        ok: false,
+        failure: { code: 'MANIFEST_LOAD_FAILED', facet: facetName, errors: rawManifest.errors },
+      }
+    }
+    if (rawManifest.data.name !== facetName) {
+      return {
+        ok: false,
+        failure: {
+          code: 'MANIFEST_NAME_MISMATCH',
+          facet: facetName,
+          manifestName: rawManifest.data.name,
+        },
+      }
+    }
+    if (rawManifest.data.facets && rawManifest.data.facets.length > 0) {
+      return { ok: false, failure: { code: 'COMPOSITION_REJECTED', facet: facetName } }
+    }
+
+    const serversDeclared = rawManifest.data.servers ? Object.keys(rawManifest.data.servers) : []
+
+    // Resolve prompts (loads actual prompt content from disk). Always
+    // runs — `materialize` reads prompt bodies from the resolved
+    // manifest, so this is needed on both the trusted-cache-hit path
+    // and the build path.
+    const resolved = await resolvePrompts(rawManifest.data, sourceDir)
+    if (!resolved.ok) {
+      return {
+        ok: false,
+        failure: { code: 'BUILD_FAILED', facet: facetName, errors: resolved.errors },
+      }
+    }
+
+    let entry: LockfileFacet
+    if (trustedCacheHit && effectiveLocked !== undefined) {
+      // Trusted cache hit: sidecar already certified the integrity at write
+      // time. Skip the build pipeline entirely and inherit the locked entry
+      // verbatim. A stale entry never reaches here — it never sets
+      // `trustedCacheHit`.
+      entry = {
+        source: specifier,
+        ...(effectiveLocked.ref !== undefined ? { ref: effectiveLocked.ref } : {}),
+        ...(effectiveLocked.commit !== undefined ? { commit: effectiveLocked.commit } : {}),
+        version: effectiveLocked.version,
+        integrity: effectiveLocked.integrity,
+        assets: effectiveLocked.assets,
+      }
+    } else {
+      // Build path: cache miss, soft miss, or local source.
+      onStage({ kind: 'facet-stage', facet: facetName, stage: 'build' })
+      const buildResult = await runBuildPipeline(sourceDir, [...args.adapters])
+      if (!buildResult.ok) {
+        return {
+          ok: false,
+          failure: { code: 'BUILD_FAILED', facet: facetName, errors: buildResult.errors },
+        }
+      }
+
+      // Tag-move guard: if this is a LOCKED GIT source, the just-built
+      // integrity MUST match the locked integrity. The lockfile is the
+      // security contract; the network-served artifact has been modified
+      // since we locked it if these disagree. Refuse the install — do
+      // NOT cache, do NOT write the lockfile, do NOT materialize.
+      //
+      // Local sources are intentionally exempt: filesystem-backed
+      // sources are mutable by definition (the user edits them), so
+      // an integrity drift is expected, not an attack. The lockfile
+      // entry's integrity gets overwritten by the new build for local
+      // sources. See `verifyGitOneCheck` docstring for the rationale.
+      // Tag-move guard: a satisfying locked git/registry entry MUST
+      // reproduce its locked integrity (the lockfile is the security
+      // contract). A stale entry is being discarded, so it has no locked
+      // integrity to reproduce — the guard is skipped and the fresh
+      // download is verified by the registry three-check instead.
+      if (effectiveLocked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
+        const guard = verifyGitOneCheck({
+          facet: facetName,
+          computedIntegrity: buildResult.integrity,
+          lockfileIntegrity: effectiveLocked.integrity,
+        })
+        if (!guard.ok) {
+          return { ok: false, failure: { code: 'INTEGRITY_FAILURE', failure: guard.failure } }
+        }
+      }
+
+      // Fresh git clone or fresh registry download → audit-then-write to
+      // cache. Cache hits already have content in the slot; local sources
+      // skip the cache entirely.
+      if (cleanup !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
+        const buildManifest = JSON.parse(buildResult.manifestJson) as BuildManifest
+        const cacheId: CacheIdentity =
+          parsed.value.kind === 'git'
+            ? { kind: 'git', name: facetName, version: buildResult.data.version }
+            : { kind: 'registry', name: facetName, version: buildResult.data.version }
+        const putResult = cachePutVerified(cacheId, sourceDir, buildManifest, buildResult.integrity, facetName)
+        if (!putResult.ok) {
+          if ('corruption' in putResult) {
+            return {
+              ok: false,
+              failure: {
+                code: 'CACHE_INTEGRITY_MISMATCH',
+                facet: facetName,
+                slotPath: putResult.corruption.slotPath,
+                cachedIntegrity: '<corrupt>',
+                lockedIntegrity: buildResult.integrity,
+              },
+            }
+          }
+          return { ok: false, failure: { code: 'INTEGRITY_FAILURE', failure: putResult.integrity } }
+        }
+        sourceDir = putResult.path
+        cleanup = undefined
+      }
+
+      // Construct the entry.
+      //
+      //   - Satisfying GIT/REGISTRY entries inherit locked.* verbatim (we
+      //     just verified buildResult matches, so values are equal — but the
+      //     lockfile is the source of truth and we never rewrite it).
+      //   - Stale registry entries (`effectiveLocked === undefined`) fall
+      //     into the build-derived branch below, overwriting the
+      //     contradictory entry with the freshly resolved version/integrity.
+      //   - Local sources (locked or fresh) derive from the build.
+      //     Local is mutable by design; the user owns the version and
+      //     content, and the lockfile follows what's on disk.
+      //   - Fresh git adds derive from the build + the clone's commit.
+      //   - Fresh registry adds derive from the build (no ref/commit).
+      if (effectiveLocked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
+        entry = {
+          source: specifier,
+          ...(effectiveLocked.ref !== undefined ? { ref: effectiveLocked.ref } : {}),
+          ...(effectiveLocked.commit !== undefined ? { commit: effectiveLocked.commit } : {}),
+          version: effectiveLocked.version,
+          integrity: effectiveLocked.integrity,
+          assets: effectiveLocked.assets,
+        }
+      } else {
+        const newAssets = computeAssetList(resolved.data)
+        entry = {
+          source: specifier,
+          ...(clonedRef !== undefined ? { ref: clonedRef } : {}),
+          ...(clonedCommit !== undefined ? { commit: clonedCommit } : {}),
+          version: buildResult.data.version,
+          integrity: buildResult.integrity,
+          assets: newAssets,
+        }
+      }
+    }
+
+    return { ok: true, value: { entry, resolved: resolved.data, serversDeclared } }
+  } finally {
+    if (cleanup) await cleanup()
+  }
+}

--- a/packages/engine/src/install/removal-manifest.ts
+++ b/packages/engine/src/install/removal-manifest.ts
@@ -1,0 +1,14 @@
+import type { ResolvedFacetManifest } from '@agent-facets/protocol'
+
+/**
+ * Synthesize a placeholder manifest for a facet being removed during
+ * drift cleanup. `materialize` only touches `manifest` for the install
+ * branch, which is empty (`newAssets: []`) for removals — so the fields
+ * here are never read.
+ */
+export function removalManifest(facetName: string): ResolvedFacetManifest {
+  return {
+    name: facetName,
+    version: '0.0.0',
+  }
+}

--- a/packages/engine/src/install/resolve-clone-ref.ts
+++ b/packages/engine/src/install/resolve-clone-ref.ts
@@ -1,0 +1,22 @@
+import type { LockfileFacet } from '@agent-facets/protocol'
+
+/**
+ * Resolve which git commitish to clone for a facet on a cache miss.
+ *
+ * Reproducibility: when the lockfile pins a commit, clone exactly that
+ * commit — never the manifest ref. The manifest ref can move (`#main`,
+ * mutable tags); the locked commit cannot. Without this, a cache-miss
+ * reinstall of a locked entry pointing at `#main` would silently pull
+ * whatever main points to today, then either fail integrity
+ * verification (frustrating) or rewrite the lockfile (worse — a silent
+ * reproducibility break). Fresh adds (no `locked` entry) fall back to
+ * the manifest ref.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function resolveCloneRef(
+  locked: LockfileFacet | undefined,
+  manifestRef: string | undefined,
+): string | undefined {
+  return locked?.commit ?? manifestRef
+}

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -1,23 +1,15 @@
-import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
-import type { Adapter } from '@agent-facets/adapter'
-import type { BuildManifest, FacetsJson, Lockfile, LockfileFacet, ResolvedFacetManifest } from '@agent-facets/protocol'
-import { verifyGitOneCheck } from '@agent-facets/protocol'
-import { regex } from 'arkregex'
-import { runBuildPipeline } from '../build/pipeline.ts'
-import { type CacheIdentity, cacheGet, cachePutVerified, cacheStagingDir, readCachedIntegrity } from '../cache/index.ts'
-import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
+import type { FacetsJson, Lockfile, LockfileFacet } from '@agent-facets/protocol'
 import { loadFacetsJson } from '../manifest/project-files.ts'
-import { downloadAndExtractFacet } from '../registry/download.ts'
-import { resolveRegistryMetadataBatch } from '../registry/resolve-metadata.ts'
-import { parseFacetSource } from '../sources/facet/parse-source.ts'
-import { parseVersionSpec } from '../sources/facet/parse-version.ts'
-import { type CloneFacetGitResult, cloneFacetGitSource } from '../sources/facet/resolve-git.ts'
-import { resolveLocalFacetSource } from '../sources/facet/resolve-local.ts'
+import { classifyOutcome } from './classify-outcome.ts'
+import { detectLockfileDrift } from './detect-lockfile-drift.ts'
 import { InstallJournal } from './journal.ts'
 import { acquireInstallLock } from './lockfile-guard.ts'
 import { emptyLockfile, FACETS_LOCK_FILE, loadLockfile, writeLockfile } from './lockfile-io.ts'
-import { computeAssetList, type MaterializeFailure, materialize } from './materialize.ts'
+import { materialize } from './materialize.ts'
+import { materializeFailureToRunInstall } from './materialize-failure.ts'
+import { planFacet } from './plan-facet.ts'
+import { removalManifest } from './removal-manifest.ts'
 import type {
   FacetOutcome,
   InstallSummary,
@@ -28,165 +20,18 @@ import type {
 } from './types.ts'
 
 /**
- * Resolve which git commitish to clone for a facet on a cache miss.
- *
- * Reproducibility: when the lockfile pins a commit, clone exactly that
- * commit — never the manifest ref. The manifest ref can move (`#main`,
- * mutable tags); the locked commit cannot. Without this, a cache-miss
- * reinstall of a locked entry pointing at `#main` would silently pull
- * whatever main points to today, then either fail integrity
- * verification (frustrating) or rewrite the lockfile (worse — a silent
- * reproducibility break). Fresh adds (no `locked` entry) fall back to
- * the manifest ref.
- *
- * Pure function — exported for unit testing.
- */
-export function resolveCloneRef(
-  locked: LockfileFacet | undefined,
-  manifestRef: string | undefined,
-): string | undefined {
-  return locked?.commit ?? manifestRef
-}
-
-/**
- * Pre-compiled M.N.P matcher for `parseLockedVersion`. The pattern is
- * the same shape narrowed by `LockfileSchema.version` — schema and
- * parser stay aligned by deliberate convention; if you widen one, widen
- * the other. `arkregex` types the captures so destructuring is
- * cast-free; the runtime `RegExp` instance behaves identically to a
- * native one.
- *
- * No prerelease support: `VersionSpec` (the type returned below) only
- * models `M.N.P`. Adding prerelease support means widening this regex
- * AND the lockfile schema's narrow check AND `VersionSpec` itself.
- */
-const LOCKED_VERSION_RE = regex('^(\\d+)\\.(\\d+)\\.(\\d+)$')
-
-/**
- * Parse a `LockfileFacet.version` string into an exact `VersionSpec` for
- * the registry resolver. Lockfile versions are always concrete `M.N.P`
- * by contract (the lockfile schema narrows the field to exactly that
- * shape — see `LockfileSchema.version` in protocol). This function is
- * the engine-side counterpart that turns the validated string into the
- * structured form the registry resolver consumes.
- *
- * The schema gates malformed versions up front — by the time we get
- * here, `version` has already passed the narrow regex. If the regex
- * disagrees at runtime, that's a programmer bug (schema and parser
- * regex got out of sync), not a user-facing failure mode — hence the
- * `expect.unreachable`-style throw. Anti-pattern 4: this branch is
- * genuinely unreachable on validated input.
- *
- * Used on the registry-source cache-miss path to pin the metadata
- * fetch at `locked.version` instead of re-resolving the manifest spec
- * (which may be `@latest` or a wildcard). See the call site for the
- * reproducibility rationale.
- */
-function parseLockedVersion(version: string): {
-  kind: 'exact'
-  major: number
-  minor: number
-  patch: number
-} {
-  const match = LOCKED_VERSION_RE.exec(version)
-  if (match === null) {
-    // The schema narrow regex (`LockfileSchema.version`) has the same
-    // shape as `LOCKED_VERSION_RE`. A null here means schema and parser
-    // regex have drifted apart — programmer bug, not user input.
-    throw new Error(`internal: lockfile schema accepted "${version}" but parseLockedVersion regex rejected it`)
-  }
-  const [, major, minor, patch] = match
-  return {
-    kind: 'exact',
-    major: Number(major),
-    minor: Number(minor),
-    patch: Number(patch),
-  }
-}
-
-/**
- * Translate a `MaterializeFailure` (engine-internal) into the matching
- * `RunInstallFailure` code (engine-public). Each `MaterializeFailure.kind`
- * maps to exactly one `RunInstallFailure.code`; the per-adapter context
- * (adapter name, asset, cause) flows through unchanged. Centralizes the
- * mapping so both materialize call sites in `runInstall` (the install
- * branch and the drift-removal branch) route failures the same way.
- */
-/**
- * Translate a `cloneFacetGitSource` failure into the matching
- * `RunInstallFailure` code. Each `reason` arm maps to exactly one
- * code; structured fields (URL, stderr, commitish) flow through
- * unchanged so the CLI doesn't have to reparse stderr text.
- */
-function cloneFailureToRunInstall(
-  facet: string,
-  cloned: Extract<CloneFacetGitResult, { ok: false }>,
-): RunInstallFailure {
-  switch (cloned.reason) {
-    case 'git-binary-missing':
-      return { code: 'GIT_BINARY_MISSING', facet }
-    case 'auth-required':
-      return { code: 'GIT_AUTH_REQUIRED', facet, url: cloned.url }
-    case 'clone-failed':
-      return { code: 'GIT_CLONE_FAILED', facet, url: cloned.url, stderr: cloned.stderr }
-    case 'checkout-failed':
-      return {
-        code: 'GIT_CHECKOUT_FAILED',
-        facet,
-        url: cloned.url,
-        commitish: cloned.commitish,
-        stderr: cloned.stderr,
-      }
-  }
-}
-
-function materializeFailureToRunInstall(facet: string, failure: MaterializeFailure): RunInstallFailure {
-  switch (failure.kind) {
-    case 'unsupported-adapter':
-      return { code: 'ADAPTER_UNSUPPORTED', facet, adapter: failure.adapter }
-    case 'read-failed':
-      return {
-        code: 'ADAPTER_READ_FAILED',
-        facet,
-        adapter: failure.adapter,
-        asset: failure.asset,
-        cause: failure.cause,
-      }
-    case 'install-failed':
-      return {
-        code: 'ADAPTER_INSTALL_FAILED',
-        facet,
-        adapter: failure.adapter,
-        asset: failure.asset,
-        cause: failure.cause,
-      }
-    case 'delete-failed':
-      return {
-        code: 'ADAPTER_DELETE_FAILED',
-        facet,
-        adapter: failure.adapter,
-        asset: failure.asset,
-        cause: failure.cause,
-      }
-  }
-}
-
-/**
  * Run the install pipeline for a project.
  *
  * Behavior is uniform across all callers (add, install, future TUI):
  *
  *   - For each facet declared in `facets.json`, honor the lockfile
- *     entry's pinned version if one exists; otherwise resolve fresh
- *     from the manifest specifier (bun-style bootstrap).
+ *     entry's pinned version if one exists and satisfies the manifest;
+ *     otherwise resolve fresh from the manifest specifier (bun-style
+ *     bootstrap, or re-resolving a stale entry).
  *   - Drift removal: any facet in the prior lockfile that's no longer
  *     in `facets.json` has its assets removed.
- *   - Always materialize, always write the lockfile.
- *
- * The "lockfile honored verbatim" property gives reproducible installs
- * across machines without `facet update` having to exist yet. When real
- * registry I/O lands, locked entries fetch their pinned version, while
- * newly-added manifest entries resolve their range.
+ *   - Always materialize, always write the lockfile (except in
+ *     frozen-lockfile mode).
  *
  * Always returns; never throws. Failures are reported via
  * `result.failure`; rollback status via `result.rollback`.
@@ -211,7 +56,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       path: join(projectRoot, 'facets.json'),
     })
   }
-  const facetsJson = facetsJsonResult.data
+  const facetsJson: FacetsJson = facetsJsonResult.data
 
   // 2. Acquire install lock.
   const lockResult = acquireInstallLock(projectRoot)
@@ -237,6 +82,17 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       })
     }
     const previousLockfile = lockfileResult.existed ? lockfileResult.data : emptyLockfile()
+
+    // Frozen-lockfile pre-flight. Runs before any mutation/journal entry so
+    // drift leaves the project untouched. The lockfile is authoritative:
+    // every manifest facet MUST have a lockfile entry whose version
+    // satisfies its specifier, or the install fails with LOCKFILE_DRIFT.
+    if (opts.frozenLockfile === true) {
+      const drift = detectLockfileDrift(facetsJson, previousLockfile, lockfileResult.existed)
+      if (drift.length > 0) {
+        return failureNoMutation({ code: 'LOCKFILE_DRIFT', facets: drift })
+      }
+    }
 
     onStage({
       kind: 'install-start',
@@ -360,20 +216,30 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       lockfileVersion: previousLockfile.lockfileVersion,
       facets: newFacetEntries,
     }
-    try {
-      writeLockfile(projectRoot, newLockfile)
-    } catch (error) {
-      return await rollbackAndFail(
-        journal,
-        {
-          code: 'LOCKFILE_WRITE_FAILED',
-          path: join(projectRoot, FACETS_LOCK_FILE),
-          cause: error instanceof Error ? error.message : String(error),
-        },
-        onLog,
-      )
+    // Frozen-lockfile mode treats the lockfile as the source of truth and
+    // MUST NOT write it. The pre-flight already proved the lockfile covers
+    // the manifest, so install reused each entry's locked version, integrity,
+    // and assets. `newLockfile` is rebuilt in memory for the return value but
+    // is intentionally not persisted — note that each entry's `source` tracks
+    // the current manifest specifier (e.g. a `1.*` range) and may therefore
+    // differ from the pinned `source` on disk even when the version still
+    // satisfies, so `newLockfile` is not necessarily byte-equal to the file.
+    if (opts.frozenLockfile !== true) {
+      try {
+        writeLockfile(projectRoot, newLockfile)
+      } catch (error) {
+        return await rollbackAndFail(
+          journal,
+          {
+            code: 'LOCKFILE_WRITE_FAILED',
+            path: join(projectRoot, FACETS_LOCK_FILE),
+            cause: error instanceof Error ? error.message : String(error),
+          },
+          onLog,
+        )
+      }
+      onStage({ kind: 'lockfile-write', path: join(projectRoot, FACETS_LOCK_FILE) })
     }
-    onStage({ kind: 'lockfile-write', path: join(projectRoot, FACETS_LOCK_FILE) })
 
     const summary: InstallSummary = {
       installed,
@@ -451,430 +317,3 @@ async function rollbackAndFail(
       : { kind: 'partial-failure', entriesUndone: rollback.entriesUndone, failures: rollback.failures },
   }
 }
-
-/**
- * Per-facet plan: parse → resolve → load → build → return entry.
- *
- * Wraps the entire flow in a try/finally that always cleans up the
- * cloned git directory, even if a downstream step fails.
- */
-interface PlanFacetArgs {
-  facetName: string
-  specifier: string
-  projectRoot: string
-  adapters: ReadonlyArray<Adapter>
-  previousLockfile: Lockfile
-  onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
-}
-
-interface PlanFacetSuccess {
-  entry: LockfileFacet
-  resolved: ResolvedFacetManifest
-  serversDeclared: ReadonlyArray<string>
-}
-
-type PlanFacetResult = { ok: true; value: PlanFacetSuccess } | { ok: false; failure: RunInstallFailure }
-
-async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
-  const { facetName, specifier, projectRoot, previousLockfile, onStage, onLog } = args
-
-  // Parse the source specifier.
-  //
-  // The manifest is a `name → value` map. For a registry source the value
-  // is a bare version specifier (`1.2.3`, `1.*`, `*`, `latest`) and the
-  // facet name lives in the KEY — so when the value parses as a bare
-  // VersionSpec we reconstruct the full source as `${facetName}@${value}`.
-  // For git/local sources the value is a self-contained source string
-  // (URL, `file:` path) and the key is just a label; we parse the value
-  // standalone. This keeps `facets.json` values semver-shaped for registry
-  // entries (the value the user sees is `1.2.3`, not `cowsay@1.2.3`) while
-  // still round-tripping through source resolution.
-  onStage({ kind: 'facet-stage', facet: facetName, stage: 'parse' })
-  const sourceString = parseVersionSpec(specifier).ok ? `${facetName}@${specifier}` : specifier
-  const parsed = parseFacetSource(sourceString)
-  if (!parsed.ok) {
-    return {
-      ok: false,
-      failure: { code: 'PARSE_ERROR', facet: facetName, specifier, error: parsed.error },
-    }
-  }
-
-  let sourceDir: string | undefined
-  let cleanup: (() => Promise<void>) | undefined
-  // Captured by the clone path; consumed when constructing a fresh-add
-  // lockfile entry. Locked entries inherit ref/commit from `locked`.
-  let clonedRef: string | undefined
-  let clonedCommit: string | undefined
-  // `locked` is the committed lockfile entry for this facet, if any.
-  // When defined, it's the security contract: the install MUST reproduce
-  // exactly these bytes (or fail loudly). Cache hits short-circuit when
-  // the sidecar matches `locked.integrity`.
-  const locked = previousLockfile.facets[facetName]
-  // Set when a cache hit's sidecar matches the locked integrity. The
-  // sidecar IS the post-write trust certificate; we don't rebuild to
-  // re-derive what the cache already proved at write time.
-  let trustedCacheHit = false
-
-  // Resolve to a sourceDir.
-  onStage({ kind: 'facet-stage', facet: facetName, stage: 'resolve' })
-  if (parsed.value.kind === 'git') {
-    // Cache-first when we have a locked entry: name + version are both
-    // known from `locked`, so we can look up the cache slot without any
-    // clone or network round-trip.
-    if (locked !== undefined) {
-      const cacheId: CacheIdentity = {
-        kind: 'git',
-        name: facetName,
-        version: locked.version,
-      }
-      const lookup = cacheGet(cacheId)
-      if (lookup.hit) {
-        const cached = readCachedIntegrity(lookup.path)
-        if (cached === null) {
-          // Sidecar missing/invalid — incomplete cache slot. Treat as
-          // soft miss and fall through to clone.
-          onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; refetching`)
-        } else if (cached.integrity !== locked.integrity) {
-          // Cache disagrees with lockfile. Lockfile is the source of
-          // truth; surface as hard error rather than silently refetching.
-          return {
-            ok: false,
-            failure: {
-              code: 'CACHE_INTEGRITY_MISMATCH',
-              facet: facetName,
-              slotPath: lookup.path,
-              cachedIntegrity: cached.integrity,
-              lockedIntegrity: locked.integrity,
-            },
-          }
-        } else {
-          // Cache hit + sidecar matches lockfile. The sidecar is the
-          // post-write trust certificate; we trust it without rebuilding.
-          // No clone, no build pipeline, no rehashing.
-          sourceDir = lookup.path
-          trustedCacheHit = true
-          // No cleanup — cache entries are durable.
-          onLog(`[verbose]   cache hit ${lookup.path}`)
-        }
-      }
-    }
-
-    // Cache miss (or no locked entry, or sidecar invalid). Clone.
-    if (sourceDir === undefined) {
-      const cloneRef = resolveCloneRef(locked, parsed.value.ref)
-      const cloned = await cloneFacetGitSource(parsed.value.url, cloneRef)
-      if (!cloned.ok) {
-        return {
-          ok: false,
-          failure: cloneFailureToRunInstall(facetName, cloned),
-        }
-      }
-      sourceDir = cloned.dir
-      cleanup = async () => {
-        await rm(cloned.dir, { recursive: true, force: true }).catch(() => {})
-      }
-      clonedRef = cloneRef
-      clonedCommit = cloned.commit
-      onLog(`[verbose]   cloned ${parsed.value.url} → ${sourceDir} (sha: ${cloned.commit ?? '?'})`)
-    }
-  } else if (parsed.value.kind === 'local') {
-    const local = await resolveLocalFacetSource(parsed.value.path, projectRoot)
-    if (!local.ok) {
-      return {
-        ok: false,
-        failure: { code: 'LOCAL_RESOLVE_FAILED', facet: facetName, cause: local.error },
-      }
-    }
-    sourceDir = local.dir
-  } else {
-    // Registry source. Cache-first when locked; otherwise resolve metadata
-    // → download archive → extract to temp dir → let the build pipeline
-    // re-derive integrity (the cache write below moves temp → cache slot).
-    if (locked !== undefined) {
-      const cacheId: CacheIdentity = {
-        kind: 'registry',
-        name: facetName,
-        version: locked.version,
-      }
-      const lookup = cacheGet(cacheId)
-      if (lookup.hit) {
-        const cached = readCachedIntegrity(lookup.path)
-        if (cached === null) {
-          onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; refetching`)
-        } else if (cached.integrity !== locked.integrity) {
-          return {
-            ok: false,
-            failure: {
-              code: 'CACHE_INTEGRITY_MISMATCH',
-              facet: facetName,
-              slotPath: lookup.path,
-              cachedIntegrity: cached.integrity,
-              lockedIntegrity: locked.integrity,
-            },
-          }
-        } else {
-          sourceDir = lookup.path
-          trustedCacheHit = true
-          onLog(`[verbose]   cache hit ${lookup.path}`)
-        }
-      }
-    }
-
-    if (sourceDir === undefined) {
-      onStage({ kind: 'facet-stage', facet: facetName, stage: 'fetch' })
-      // Reproducibility: when the lockfile pins a version, resolve metadata
-      // for THAT exact version on a cache miss — never re-resolve from the
-      // manifest specifier (which may be `@latest` or a wildcard). Without
-      // this, a cold-cache reinstall of a project locked to `1.2.3` against
-      // a manifest of `@latest` would silently fetch `1.3.0` and trip the
-      // integrity check. Mirrors `resolveCloneRef` for the git path.
-      const versionForFetch: typeof parsed.value.version =
-        locked !== undefined ? parseLockedVersion(locked.version) : parsed.value.version
-      const metaResult = await resolveRegistryMetadataBatch([{ name: parsed.value.name, version: versionForFetch }])
-      if (!metaResult.ok) {
-        return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: metaResult.error } }
-      }
-      const meta = metaResult.value[0]
-      if (meta === undefined) {
-        return {
-          ok: false,
-          failure: {
-            code: 'REGISTRY_ERROR',
-            facet: facetName,
-            error: {
-              code: 'NETWORK_ERROR',
-              cause: 'registry returned no metadata for the requested facet',
-              attempts: 1,
-            },
-          },
-        }
-      }
-
-      // Stage under the cache root (not the OS tmp dir). cachePutVerified's
-      // final rename into the cache slot must be atomic, which requires the
-      // staging dir and the slot to share a filesystem. If FACET_DIR
-      // points at a volume different from /tmp, mkdtemp under tmpdir() would
-      // make the rename throw EXDEV.
-      const tempDir = cacheStagingDir()
-      onStage({ kind: 'facet-stage', facet: facetName, stage: 'verify' })
-      const downloadResult = await downloadAndExtractFacet(meta, tempDir)
-      if (!downloadResult.ok) {
-        await rm(tempDir, { recursive: true, force: true }).catch(() => {})
-        return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: downloadResult.error } }
-      }
-      sourceDir = tempDir
-      cleanup = async () => {
-        await rm(tempDir, { recursive: true, force: true }).catch(() => {})
-      }
-      onLog(`[verbose]   downloaded ${meta.name}@${meta.version} → ${sourceDir}`)
-    }
-  }
-
-  try {
-    // Load and validate the facet.json.
-    onStage({ kind: 'facet-stage', facet: facetName, stage: 'load' })
-    const rawManifest = await loadManifest(sourceDir)
-    if (!rawManifest.ok) {
-      return {
-        ok: false,
-        failure: { code: 'MANIFEST_LOAD_FAILED', facet: facetName, errors: rawManifest.errors },
-      }
-    }
-    if (rawManifest.data.name !== facetName) {
-      return {
-        ok: false,
-        failure: {
-          code: 'MANIFEST_NAME_MISMATCH',
-          facet: facetName,
-          manifestName: rawManifest.data.name,
-        },
-      }
-    }
-    if (rawManifest.data.facets && rawManifest.data.facets.length > 0) {
-      return { ok: false, failure: { code: 'COMPOSITION_REJECTED', facet: facetName } }
-    }
-
-    const serversDeclared = rawManifest.data.servers ? Object.keys(rawManifest.data.servers) : []
-
-    // Resolve prompts (loads actual prompt content from disk). Always
-    // runs — `materialize` reads prompt bodies from the resolved
-    // manifest, so this is needed on both the trusted-cache-hit path
-    // and the build path.
-    const resolved = await resolvePrompts(rawManifest.data, sourceDir)
-    if (!resolved.ok) {
-      return {
-        ok: false,
-        failure: { code: 'BUILD_FAILED', facet: facetName, errors: resolved.errors },
-      }
-    }
-
-    let entry: LockfileFacet
-    if (trustedCacheHit && locked !== undefined) {
-      // Trusted cache hit: sidecar already certified `locked.integrity`
-      // at write time. Skip the build pipeline entirely (no canonical
-      // tar assembly, no rehashing) and inherit the locked entry verbatim.
-      // The lockfile is sticky; we never rewrite locked fields.
-      entry = {
-        source: specifier,
-        ...(locked.ref !== undefined ? { ref: locked.ref } : {}),
-        ...(locked.commit !== undefined ? { commit: locked.commit } : {}),
-        version: locked.version,
-        integrity: locked.integrity,
-        assets: locked.assets,
-      }
-    } else {
-      // Build path: cache miss, soft miss, or local source.
-      onStage({ kind: 'facet-stage', facet: facetName, stage: 'build' })
-      const buildResult = await runBuildPipeline(sourceDir, [...args.adapters])
-      if (!buildResult.ok) {
-        return {
-          ok: false,
-          failure: { code: 'BUILD_FAILED', facet: facetName, errors: buildResult.errors },
-        }
-      }
-
-      // Tag-move guard: if this is a LOCKED GIT source, the just-built
-      // integrity MUST match the locked integrity. The lockfile is the
-      // security contract; the network-served artifact has been modified
-      // since we locked it if these disagree. Refuse the install — do
-      // NOT cache, do NOT write the lockfile, do NOT materialize.
-      //
-      // Local sources are intentionally exempt: filesystem-backed
-      // sources are mutable by definition (the user edits them), so
-      // an integrity drift is expected, not an attack. The lockfile
-      // entry's integrity gets overwritten by the new build for local
-      // sources. See `verifyGitOneCheck` docstring for the rationale.
-      // Same integrity guard as git: locked registry entry MUST reproduce
-      // its locked integrity. The lockfile is the security contract.
-      if (locked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
-        const guard = verifyGitOneCheck({
-          facet: facetName,
-          computedIntegrity: buildResult.integrity,
-          lockfileIntegrity: locked.integrity,
-        })
-        if (!guard.ok) {
-          return { ok: false, failure: { code: 'INTEGRITY_FAILURE', failure: guard.failure } }
-        }
-      }
-
-      // Fresh git clone or fresh registry download → audit-then-write to
-      // cache. Cache hits already have content in the slot; local sources
-      // skip the cache entirely.
-      if (cleanup !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
-        const buildManifest = JSON.parse(buildResult.manifestJson) as BuildManifest
-        const cacheId: CacheIdentity =
-          parsed.value.kind === 'git'
-            ? { kind: 'git', name: facetName, version: buildResult.data.version }
-            : { kind: 'registry', name: facetName, version: buildResult.data.version }
-        const putResult = cachePutVerified(cacheId, sourceDir, buildManifest, buildResult.integrity, facetName)
-        if (!putResult.ok) {
-          if ('corruption' in putResult) {
-            return {
-              ok: false,
-              failure: {
-                code: 'CACHE_INTEGRITY_MISMATCH',
-                facet: facetName,
-                slotPath: putResult.corruption.slotPath,
-                cachedIntegrity: '<corrupt>',
-                lockedIntegrity: buildResult.integrity,
-              },
-            }
-          }
-          return { ok: false, failure: { code: 'INTEGRITY_FAILURE', failure: putResult.integrity } }
-        }
-        sourceDir = putResult.path
-        cleanup = undefined
-      }
-
-      // Construct the entry.
-      //
-      //   - Locked GIT/REGISTRY entries inherit locked.* verbatim (we just
-      //     verified buildResult matches, so values are equal — but the
-      //     lockfile is the source of truth and we never rewrite it).
-      //   - Local sources (locked or fresh) derive from the build.
-      //     Local is mutable by design; the user owns the version and
-      //     content, and the lockfile follows what's on disk.
-      //   - Fresh git adds derive from the build + the clone's commit.
-      //   - Fresh registry adds derive from the build (no ref/commit).
-      if (locked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
-        entry = {
-          source: specifier,
-          ...(locked.ref !== undefined ? { ref: locked.ref } : {}),
-          ...(locked.commit !== undefined ? { commit: locked.commit } : {}),
-          version: locked.version,
-          integrity: locked.integrity,
-          assets: locked.assets,
-        }
-      } else {
-        const newAssets = computeAssetList(resolved.data)
-        entry = {
-          source: specifier,
-          ...(clonedRef !== undefined ? { ref: clonedRef } : {}),
-          ...(clonedCommit !== undefined ? { commit: clonedCommit } : {}),
-          version: buildResult.data.version,
-          integrity: buildResult.integrity,
-          assets: newAssets,
-        }
-      }
-    }
-
-    return { ok: true, value: { entry, resolved: resolved.data, serversDeclared } }
-  } finally {
-    if (cleanup) await cleanup()
-  }
-}
-
-/**
- * Synthesize a placeholder manifest for a facet being removed during
- * drift cleanup. `materialize` only touches `manifest` for the install
- * branch, which is empty (`newAssets: []`) for removals — so the fields
- * here are never read.
- */
-function removalManifest(facetName: string): ResolvedFacetManifest {
-  return {
-    name: facetName,
-    version: '0.0.0',
-  }
-}
-
-/**
- * Classify a per-facet outcome by comparing the previous lockfile entry
- * (if any) against the new one. `assetsWritten` is the count of assets
- * `materialize` actually wrote (excluding skipped no-ops); when it's >0
- * but the lockfile entry is identical, the facet was "repaired" — the
- * on-disk state had drifted (file deleted, content edited) and we
- * restored it without bumping the version.
- */
-function classifyOutcome(
-  name: string,
-  previous: LockfileFacet | undefined,
-  current: LockfileFacet,
-  assetsWritten: number,
-): FacetOutcome {
-  if (previous === undefined) {
-    return { kind: 'installed', name, version: current.version }
-  }
-  if (previous.version !== current.version) {
-    return {
-      kind: 'updated',
-      name,
-      oldVersion: previous.version,
-      newVersion: current.version,
-    }
-  }
-  if (assetsWritten > 0) {
-    return { kind: 'repaired', name, version: current.version }
-  }
-  return { kind: 'unchanged', name, version: current.version }
-}
-
-/**
- * Helper used by callers (notably the add command) to compute the
- * default `facets.json` map after a successful planFacet — exported so
- * the `facet add` flow can byte-snapshot, mutate, write, then call
- * runInstall.
- *
- * Currently unused but reserved for the add command's wiring.
- */
-export type { FacetsJson }

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -65,6 +65,24 @@ export type StageEvent =
   | { kind: 'install-complete'; outcome: 'success' | 'failure' | 'aborted' }
 
 /**
+ * One drifting facet in a frozen-lockfile (`--frozen-lockfile`) preflight
+ * failure. Tagged on `reason` so each arm carries exactly the fields that
+ * reason implies — no optional field doubles as a discriminator:
+ *   - `missing-lockfile` — no lockfile exists at all; only the spec is known.
+ *   - `no-entry`         — the manifest declares a facet the lockfile omits.
+ *   - `unsatisfied`      — the locked version does not satisfy the spec;
+ *                          always carries the offending `lockedVersion`.
+ *   - `orphaned`         — the lockfile pins a facet the manifest no longer
+ *                          declares; carries `lockedVersion` but no
+ *                          `manifestSpec` (the manifest says nothing about it).
+ */
+export type LockfileDriftEntry =
+  | { name: string; reason: 'missing-lockfile'; manifestSpec: string }
+  | { name: string; reason: 'no-entry'; manifestSpec: string }
+  | { name: string; reason: 'unsatisfied'; manifestSpec: string; lockedVersion: string }
+  | { name: string; reason: 'orphaned'; lockedVersion: string }
+
+/**
  * Discriminated failure type for `runInstall`. Every failure mode
  * carries the structured fields a view layer needs to render the
  * failure without parsing message strings.
@@ -86,6 +104,18 @@ export type RunInstallFailure =
       lockedIntegrity: string
     }
   | { code: 'COMPOSITION_REJECTED'; facet: string }
+  /**
+   * Frozen-lockfile mode (`--frozen-lockfile`) found the lockfile out of
+   * date relative to the manifest. Carries every drifting facet (see
+   * `LockfileDriftEntry` for the per-reason shape) so the CLI can render a
+   * complete report in one shot. No mutation occurs; the user must
+   * reconcile the files (run a normal install, or `facet add` to update
+   * the lockfile).
+   */
+  | {
+      code: 'LOCKFILE_DRIFT'
+      facets: ReadonlyArray<LockfileDriftEntry>
+    }
   /** `git` is not installed (or not on PATH). */
   | { code: 'GIT_BINARY_MISSING'; facet: string }
   /**
@@ -208,13 +238,25 @@ export type RunInstallResult =
  *   - `signal`: aborts the install at the next safe checkpoint and
  *     triggers rollback. Replaces direct SIGINT handling so core never
  *     installs process-global signal handlers.
+ *   - `frozenLockfile`: treat the lockfile as the source of truth.
+ *     Specifiers are never re-resolved, the lockfile is never written,
+ *     and any manifest/lockfile drift (missing lockfile, an uncovered
+ *     manifest entry, or a locked version that does not satisfy its
+ *     specifier) fails with `LOCKFILE_DRIFT` before any disk mutation.
+ *     Mirrors the ecosystem-standard `--frozen-lockfile` CI contract.
  *
  * The behavior is the same regardless of who's calling. If a lockfile
- * entry exists for a facet, its locked version is honored verbatim —
- * the manifest's range is not re-resolved. If no lockfile entry exists
+ * entry exists for a facet AND its locked version satisfies the
+ * manifest specifier, that locked version is honored verbatim — the
+ * manifest's range is not re-resolved. If the locked version does NOT
+ * satisfy the manifest specifier (a hand-edit or pull changed the
+ * manifest), the entry is stale: the manifest specifier is re-resolved
+ * and the stale entry is overwritten. If no lockfile entry exists
  * (bootstrap case, or a newly-added manifest entry), the manifest
  * specifier is resolved fresh and added to the lockfile. Drift removal
- * always runs. The lockfile is always written.
+ * always runs. The lockfile is always written — except in
+ * frozen-lockfile mode (see `frozenLockfile`), where it is never
+ * written and any manifest/lockfile drift is a hard error.
  */
 export interface RunInstallOptions {
   projectRoot: string
@@ -222,4 +264,5 @@ export interface RunInstallOptions {
   onStage?: (event: StageEvent) => void
   onLog?: (line: string) => void
   signal?: AbortSignal
+  frozenLockfile?: boolean
 }

--- a/packages/protocol/src/__tests__/version-spec.test.ts
+++ b/packages/protocol/src/__tests__/version-spec.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+import { resolvesToLatest, satisfies, type VersionSpec } from '@agent-facets/protocol'
+
+const v = (major: number, minor: number, patch: number) => ({ major, minor, patch })
+
+describe('satisfies — exact specifier', () => {
+  const spec: VersionSpec = { kind: 'exact', major: 1, minor: 2, patch: 3 }
+
+  test('matches when all components are equal', () => {
+    expect(satisfies(v(1, 2, 3), spec)).toBe(true)
+  })
+
+  test('does not match a different patch', () => {
+    expect(satisfies(v(1, 2, 4), spec)).toBe(false)
+  })
+
+  test('does not match a different minor', () => {
+    expect(satisfies(v(1, 3, 3), spec)).toBe(false)
+  })
+
+  test('does not match a different major', () => {
+    expect(satisfies(v(2, 2, 3), spec)).toBe(false)
+  })
+
+  test('the reported bug: 0.1.1 does not satisfy exact 0.1.2', () => {
+    const bumped: VersionSpec = { kind: 'exact', major: 0, minor: 1, patch: 2 }
+    expect(satisfies(v(0, 1, 1), bumped)).toBe(false)
+  })
+})
+
+describe('satisfies — majorWildcard specifier', () => {
+  const spec: VersionSpec = { kind: 'majorWildcard', major: 1 }
+
+  test('matches any version sharing the major', () => {
+    expect(satisfies(v(1, 0, 0), spec)).toBe(true)
+    expect(satisfies(v(1, 9, 9), spec)).toBe(true)
+  })
+
+  test('does not match a different major', () => {
+    expect(satisfies(v(2, 0, 0), spec)).toBe(false)
+    expect(satisfies(v(0, 1, 1), spec)).toBe(false)
+  })
+})
+
+describe('satisfies — minorWildcard specifier', () => {
+  const spec: VersionSpec = { kind: 'minorWildcard', major: 1, minor: 2 }
+
+  test('matches any version sharing major and minor', () => {
+    expect(satisfies(v(1, 2, 0), spec)).toBe(true)
+    expect(satisfies(v(1, 2, 99), spec)).toBe(true)
+  })
+
+  test('does not match a different minor', () => {
+    expect(satisfies(v(1, 3, 0), spec)).toBe(false)
+  })
+
+  test('does not match a different major', () => {
+    expect(satisfies(v(2, 2, 0), spec)).toBe(false)
+  })
+})
+
+describe('satisfies — unconstrained specifiers', () => {
+  test('wildcard is always satisfied', () => {
+    const spec: VersionSpec = { kind: 'wildcard' }
+    expect(satisfies(v(0, 0, 1), spec)).toBe(true)
+    expect(satisfies(v(99, 99, 99), spec)).toBe(true)
+  })
+
+  test('latest is always satisfied', () => {
+    const spec: VersionSpec = { kind: 'latest' }
+    expect(satisfies(v(0, 0, 1), spec)).toBe(true)
+    expect(satisfies(v(99, 99, 99), spec)).toBe(true)
+  })
+
+  test('agrees with resolvesToLatest on which specifiers are unconstrained', () => {
+    const wildcard: VersionSpec = { kind: 'wildcard' }
+    const latest: VersionSpec = { kind: 'latest' }
+    expect(resolvesToLatest(wildcard)).toBe(true)
+    expect(resolvesToLatest(latest)).toBe(true)
+  })
+})

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -57,4 +57,4 @@ export type { ServerManifest } from './schemas/server-manifest.ts'
 export { ServerManifestSchema } from './schemas/server-manifest.ts'
 // version-spec grammar (versions as they appear inside artifacts)
 export type { VersionSpec } from './sources/version-spec.ts'
-export { resolvesToLatest } from './sources/version-spec.ts'
+export { resolvesToLatest, satisfies } from './sources/version-spec.ts'

--- a/packages/protocol/src/sources/version-spec.ts
+++ b/packages/protocol/src/sources/version-spec.ts
@@ -33,3 +33,34 @@ export type VersionSpec =
 export function resolvesToLatest(spec: VersionSpec): boolean {
   return spec.kind === 'wildcard' || spec.kind === 'latest'
 }
+
+/**
+ * True when a resolved exact version (the `M.N.P` a lockfile records)
+ * satisfies a manifest's `VersionSpec`. Used by the installer to decide
+ * whether a lockfile entry is still valid for its manifest specifier
+ * (satisfying → honor the lock) or stale (not satisfying → re-resolve
+ * against the registry).
+ *
+ *   - `exact`         → all three components equal
+ *   - `majorWildcard` → major equal
+ *   - `minorWildcard` → major and minor equal
+ *   - `wildcard`      → always true (any version satisfies "highest")
+ *   - `latest`        → always true
+ *
+ * Takes parsed components rather than a version string: the lockfile
+ * schema narrows `version` to exact `M.N.P`, and engine parses it once
+ * already, so the predicate stays pure and parse-free.
+ */
+export function satisfies(resolved: { major: number; minor: number; patch: number }, spec: VersionSpec): boolean {
+  switch (spec.kind) {
+    case 'exact':
+      return resolved.major === spec.major && resolved.minor === spec.minor && resolved.patch === spec.patch
+    case 'minorWildcard':
+      return resolved.major === spec.major && resolved.minor === spec.minor
+    case 'majorWildcard':
+      return resolved.major === spec.major
+    case 'wildcard':
+    case 'latest':
+      return true
+  }
+}


### PR DESCRIPTION
### Why

Editing a version in `facets.json` had no effect if the lockfile still pinned the old version — `facet install` would "succeed" and write a self-contradictory lockfile entry instead of fetching the requested version. If the edited version didn't exist in the registry, install silently kept the old one rather than failing. This also adds `--frozen-lockfile` for reproducible CI installs.

### Details

`facets.json` is now the source of truth. A lockfile entry is only honored if its recorded version **satisfies** the manifest specifier. When it doesn't (e.g. you bumped an exact version, widened a wildcard the lock no longer falls within, or pulled a teammate's manifest change), the entry is treated as stale: the manifest specifier is re-resolved and the lockfile entry is replaced. If the requested version doesn't exist in the registry, install fails and leaves the project unchanged.

A satisfying lock entry (e.g. manifest `1.*`, lock `1.2.3`) is unaffected — it stays pinned and reproducible.

The new `--frozen-lockfile` flag inverts the source of truth: the lockfile becomes authoritative. Install never re-resolves or writes the lockfile, and fails before any disk mutation if the lockfile is missing, omits a manifest facet, or contains an entry whose version no longer satisfies its specifier. This mirrors the `--frozen-lockfile` contract from `npm` and `bun`.

Implementation changes:
- Added `satisfies` to `@agent-facets/protocol`'s `VersionSpec` utilities, exported from the package index.
- Extracted `planFacet`, `classifyOutcome`, `cloneFailureToRunInstall`, `materializeFailureToRunInstall`, `removalManifest`, `resolveCloneRef`, `parseLockedVersion`, and `detectLockfileDrift` into their own modules, each with dedicated unit tests.
- `runInstall` gains a `frozenLockfile` option; when set, `detectLockfileDrift` runs as a pre-flight before any mutation, and the lockfile write is skipped on success.
- A new `LOCKFILE_DRIFT` failure code carries the full list of drifting facets (with reasons: `missing-lockfile`, `no-entry`, `unsatisfied`) so the CLI can render a complete report in one shot.
- The TUI `FailureBlock` renders the `LOCKFILE_DRIFT` case with per-facet detail and a hint to run without `--frozen-lockfile`.

### Verification

CI — new unit tests cover `satisfies`, `detectLockfileDrift`, `parseLockedVersion`, `classifyOutcome`, `cloneFailureToRunInstall`, `materializeFailureToRunInstall`, `removalManifest`, and the full `runInstall` reconciliation scenarios (stale exact pin, nonexistent version, satisfying wildcard, stale wildcard, and all frozen-lockfile failure modes).