### PR TITLE
Add mise-tool, facet, and SST provider caches to CI; fix SST cache key over-invalidation

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -56,6 +56,49 @@ two paths cannot collide:
 Renaming the context env var to `GITHUB_TOKEN` would risk silently poisoning `gh`/script
 operations with the scopeless PAT in any job where `mintGithubTokens()` hasn't yet run.
 
+## Caches
+
+Three CircleCI caches keep CI from redownloading the same binaries and
+artifacts on every job. Two live in the shared `setup-mise` command (so all
+seven jobs that call it benefit); one is local to `deploy-site`.
+
+| Cache         | Key                                                                                   | Paths                                                       | Defined in                            |
+|---------------|---------------------------------------------------------------------------------------|------------------------------------------------------------|---------------------------------------|
+| mise tools    | `v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}` | `~/.local/share/mise/installs`, `~/.local/share/mise/downloads` | `commands/setup-mise.yml`            |
+| facets        | `v1-facet-{{ checksum "facets.lock" }}`                                                | `~/.facet/cache`                                            | `commands/setup-mise.yml`             |
+| bun deps      | `v1-deps-{{ checksum "bun.lock" }}`                                                    | `node_modules`, `~/.bun/install/cache`                     | `commands/setup-mise.yml`             |
+| SST providers | `v3-sst-{{ checksum "sst.config.ts" }}`                                                | `.sst`                                                      | `release/jobs/deploy-site.yml`        |
+
+### Why each key is shaped this way
+
+- **mise tools** — keyed on `MISE_ENV` because mise loads different config
+  files per env. With no `MISE_ENV` (CI jobs), mise loads `mise.toml` **and**
+  `mise.development.toml`, so the toolset includes `circleci`. With
+  `MISE_ENV=release` (the `deploy-site`, `build-cli`, `publish-platform`,
+  `finalize-cli` jobs), mise loads **only** `mise.toml` — no `circleci`.
+  Namespacing the key by `MISE_ENV` keeps the two toolsets in separate cache
+  slots so a release job never restores (or saves) a CI-shaped cache. Both
+  toml checksums are in the key so a bump to either file invalidates it. The
+  restore happens before `mise install`, which becomes a near-instant no-op on
+  a hit. (`mise.local.toml` is gitignored and absent in CI, so it's excluded
+  from the key.)
+- **facets** — keyed on `facets.lock`, not `facets.json`. `facets.json` can
+  reference a mutable git source (`viper-plans` tracks `#main`); the lockfile
+  records the resolved commit, so when `#main` moves, `facets.lock` changes and
+  the cache invalidates correctly. Pinned facets (e.g. `cowsay`) stay cached.
+- **SST providers** — keyed on `sst.config.ts` **alone**. Provider versions are
+  pinned there (`aws: '7.20.0'`), so the ~470 MB pulumi provider download only
+  changes when that file changes. The earlier `v2` key included `bun.lock`,
+  which over-invalidated: any unrelated dependency bump busted the cache even
+  though provider versions were unchanged. The save uses `when: on_success` so
+  a failed deploy can't persist a half-written `.sst` and poison later runs.
+  `bun sst install` (run explicitly in `scripts/deploy/site.ts`) is fast when
+  `.sst/platform` is restored — it just verifies providers rather than
+  redownloading them.
+
+When changing a cache's paths or invalidation inputs, bump the key's version
+prefix (`v1-` → `v2-`, etc.) so stale entries are retired rather than reused.
+
 ## Pipelines
 
 Two packed CircleCI configs, one per pipeline dir.

--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -33,9 +33,22 @@ commands:
                     curl https://mise.run | sh
                     echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
                 name: Install mise
+            - restore_cache:
+                keys:
+                    - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+                    - v1-mise-{{ .Environment.MISE_ENV }}-
             - run:
                 command: mise install --yes
                 name: Install tools
+            - save_cache:
+                key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+                paths:
+                    - ~/.local/share/mise/installs
+                    - ~/.local/share/mise/downloads
+            - restore_cache:
+                keys:
+                    - v1-facet-{{ checksum "facets.lock" }}
+                    - v1-facet-
             - restore_cache:
                 keys:
                     - v1-deps-{{ checksum "bun.lock" }}
@@ -48,6 +61,10 @@ commands:
                 paths:
                     - node_modules
                     - ~/.bun/install/cache
+            - save_cache:
+                key: v1-facet-{{ checksum "facets.lock" }}
+                paths:
+                    - ~/.facet/cache
 jobs:
     check:
         docker:

--- a/.circleci/development/commands/setup-mise.yml
+++ b/.circleci/development/commands/setup-mise.yml
@@ -5,9 +5,32 @@ steps:
       command: |
         curl https://mise.run | sh
         echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
+  # mise tool cache (~580 MB of bun/node/lefthook/gh, +circleci on CI jobs).
+  # Keyed on MISE_ENV so the two toolsets stay in separate slots: CI jobs (no
+  # MISE_ENV) load mise.toml + mise.development.toml and get the `circleci`
+  # tool; release jobs (MISE_ENV=release) load only mise.toml. Both checksums
+  # are in the key so a bump to either file invalidates the cache. Restore
+  # BEFORE `mise install` so it becomes a near-instant no-op on a hit.
+  - restore_cache:
+      keys:
+        - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+        - v1-mise-{{ .Environment.MISE_ENV }}-
   - run:
       name: Install tools
       command: mise install --yes
+  - save_cache:
+      key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+      paths:
+        - ~/.local/share/mise/installs
+        - ~/.local/share/mise/downloads
+  # Facet cache (~/.facet/cache/ — git clones + registry downloads pulled by
+  # `bun install`'s postinstall `facet install`). Keyed on facets.lock so a
+  # moving git source (e.g. viper-plans#main) invalidates correctly while
+  # pinned facets stay cached. Restore BEFORE `bun install`.
+  - restore_cache:
+      keys:
+        - v1-facet-{{ checksum "facets.lock" }}
+        - v1-facet-
   - restore_cache:
       keys:
         - v1-deps-{{ checksum "bun.lock" }}
@@ -20,4 +43,7 @@ steps:
       paths:
         - node_modules
         - ~/.bun/install/cache
-
+  - save_cache:
+      key: v1-facet-{{ checksum "facets.lock" }}
+      paths:
+        - ~/.facet/cache

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -18,9 +18,22 @@ commands:
                     curl https://mise.run | sh
                     echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
                 name: Install mise
+            - restore_cache:
+                keys:
+                    - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+                    - v1-mise-{{ .Environment.MISE_ENV }}-
             - run:
                 command: mise install --yes
                 name: Install tools
+            - save_cache:
+                key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+                paths:
+                    - ~/.local/share/mise/installs
+                    - ~/.local/share/mise/downloads
+            - restore_cache:
+                keys:
+                    - v1-facet-{{ checksum "facets.lock" }}
+                    - v1-facet-
             - restore_cache:
                 keys:
                     - v1-deps-{{ checksum "bun.lock" }}
@@ -33,6 +46,10 @@ commands:
                 paths:
                     - node_modules
                     - ~/.bun/install/cache
+            - save_cache:
+                key: v1-facet-{{ checksum "facets.lock" }}
+                paths:
+                    - ~/.facet/cache
 jobs:
     build-cli:
         docker:
@@ -63,18 +80,17 @@ jobs:
             - aws-oidc-setup
             - restore_cache:
                 keys:
-                    - v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
-                    - v2-sst-{{ checksum "bun.lock" }}-
-                    - v2-sst-
+                    - v3-sst-{{ checksum "sst.config.ts" }}
+                    - v3-sst-
             - run:
                 command: bun scripts/deploy/site.ts
                 name: Deploy SST main stage
                 no_output_timeout: 30m
             - save_cache:
-                key: v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+                key: v3-sst-{{ checksum "sst.config.ts" }}
                 paths:
                     - .sst
-                when: always
+                when: on_success
             - notify-failure
     finalize-cli:
         docker:

--- a/.circleci/release/jobs/deploy-site.yml
+++ b/.circleci/release/jobs/deploy-site.yml
@@ -7,18 +7,25 @@ environment:
 steps:
   - setup-mise
   - aws-oidc-setup
+  # SST platform + pulumi providers (~470 MB in .sst/platform/node_modules/@pulumi/*).
+  # Keyed on sst.config.ts ALONE — provider versions are pinned there
+  # (e.g. aws '7.20.0'), so the download only changes when that file changes.
+  # The previous key included bun.lock, which over-invalidated: any unrelated
+  # dependency bump busted the 470 MB cache even though provider versions were
+  # unchanged. Key bumped v2 -> v3 to retire the stale entries.
   - restore_cache:
       keys:
-        - v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
-        - v2-sst-{{ checksum "bun.lock" }}-
-        - v2-sst-
+        - v3-sst-{{ checksum "sst.config.ts" }}
+        - v3-sst-
   - run:
       name: Deploy SST main stage
       command: bun scripts/deploy/site.ts
       no_output_timeout: 30m
+  # `when: on_success` (not `always`): a failed deploy can leave .sst in a
+  # half-written state; persisting that would poison the cache for later runs.
   - save_cache:
-      key: v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}
+      key: v3-sst-{{ checksum "sst.config.ts" }}
       paths:
         - .sst
-      when: always
+      when: on_success
   - notify-failure

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -26,6 +26,12 @@ Defined in `.circleci/release/jobs/deploy-site.yml` and
 deployment is part of the release lifecycle; the development pipeline is
 reserved for PR-time CI checks.
 
+The `deploy-site` job restores a CircleCI cache of `.sst` (keyed on
+`sst.config.ts`) before running the deploy script, so the ~470 MB pulumi
+providers are restored rather than redownloaded. Step 3b's `bun sst install`
+then just verifies the cached providers. See the "Caches" section in
+`.circleci/AGENTS.md` for the full key rationale.
+
 ## Scripts
 
 | Script    | CircleCI Job  | Purpose                                                    |

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -34,15 +34,6 @@ const steps: Step[] = [
   },
 ]
 
-// TODO: sst provider install failed due to weird network shit...maybe we should take it out of the pipeline and
-//  cache the providers heavily?
-// if (!process.env.CI) {
-//   steps.push({
-//     label: 'sst types',
-//     run: () => $`bun sst install`.quiet().then(() => undefined),
-//   })
-// }
-
 for (const step of steps) {
   try {
     await step.run()


### PR DESCRIPTION
### Why

CI jobs were redownloading mise tools (~580 MB), facets, and SST pulumi providers (~470 MB) on every run because no caches existed for them. The SST cache that did exist was over-invalidating because its key included `bun.lock`, meaning any unrelated dependency bump busted the 470 MB provider download even when provider versions hadn't changed.

### Details

**New caches added to `setup-mise`** (shared across all seven jobs that call it):

- **mise tools** — cached to `~/.local/share/mise/installs` and `~/.local/share/mise/downloads`, keyed on `MISE_ENV` + checksums of both `mise.toml` and `mise.development.toml`. The `MISE_ENV` namespace keeps CI jobs (which load both toml files and include the `circleci` tool) in a separate cache slot from release jobs (which load only `mise.toml`). The restore happens before `mise install` so it becomes a near-instant no-op on a hit.
- **facets** — cached to `~/.facet/cache`, keyed on `facets.lock` rather than `facets.json`. Since `facets.json` can reference mutable git sources (e.g. `viper-plans#main`), the lockfile is the correct invalidation signal — it records the resolved commit, so the cache busts when `#main` moves while pinned facets stay cached.

**SST provider cache fixed in `deploy-site`**:

- Key changed from `v2-sst-{{ checksum "bun.lock" }}-{{ checksum "sst.config.ts" }}` to `v3-sst-{{ checksum "sst.config.ts" }}`. Provider versions are pinned in `sst.config.ts`, so that file alone is the correct invalidation input. The version prefix was bumped to `v3` to retire stale entries.
- `when: always` changed to `when: on_success` so a failed deploy can't persist a half-written `.sst` directory and poison subsequent runs.

The commented-out `bun sst install` block in `scripts/postinstall.ts` was also removed since it was dead code.

### Verification

CI — the cache save/restore steps will be exercised on the next pipeline run.