### PR TITLE
Harden `--frozen-lockfile`: detect source-string drift, verify local content integrity, fix git cache provenance

### DIFF
--- a/.changeset/chilly-loops-wink.md
+++ b/.changeset/chilly-loops-wink.md
@@ -1,0 +1,11 @@
+---
+"agent-facets": patch
+---
+
+Make `facet install --frozen-lockfile` reproduce the lockfile exactly.
+
+Frozen mode now guarantees the installed project matches the lockfile bit-for-bit — no extra facets, no missing facets, no source changes, and no content changes:
+
+- **Source drift** — a git or local facet whose manifest source string (URL, ref, or path) no longer matches the locked source now fails the preflight (`source-changed`) before any clone or build, instead of silently building from the unlocked origin.
+- **Local content drift** — a local facet is now verified against its locked integrity in frozen mode, exactly like git. Editing a local source's content fails the install rather than rebuilding and overwriting the entry.
+- **Cache correctness (frozen and non-frozen)** — a git facet whose manifest URL changed bypasses the content-addressed cache entirely (the cache key carries no source provenance), so a changed URL re-resolves from the new source instead of reusing cached bytes from the old one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,10 @@ system improvement is permanent.
 
 Use `bun check` to run tests, linting, and typeschecking.
 
+### Fixing formatting errors
+
+When `bun check` (or `bun run lint`) reports a Biome **formatting** error, run `bun format` to fix it — do NOT hand-edit whitespace, line wrapping, or trailing commas to satisfy the formatter. `bun format` runs `biome check --write --unsafe .` across all 432 files in a few hundred milliseconds; manually reflowing a call to one line is slower and error-prone. Edit by hand only for actual lint *rule* violations that `bun format` can't auto-fix.
+
 ```ts#index.test.ts
 import { test, expect } from "bun:test";
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -88,14 +88,17 @@ A facet that declares `facets: [...]` (cherry-picking from other facets) is hard
 
 ## Frozen lockfile
 
-`facet install --frozen-lockfile` inverts the source of truth: the **lockfile** becomes authoritative. In this mode install never re-resolves a specifier and never writes `facets.lock`. Before installing, it verifies the lockfile fully covers the manifest, and fails — changing nothing on disk — if any of these hold:
+`facet install --frozen-lockfile` inverts the source of truth: the **lockfile** becomes authoritative and is reproduced exactly — no extra facets, no missing facets, no source changes, no content changes. In this mode install never re-resolves a specifier and never writes `facets.lock`. Before installing, it verifies the lockfile fully covers the manifest, and fails — changing nothing on disk — if any of these hold:
 
 - no `facets.lock` exists;
 - a facet in `facets.json` has no lockfile entry;
 - a lockfile entry's version no longer satisfies its manifest specifier;
-- the lockfile pins a facet `facets.json` no longer declares (an orphaned entry a normal install would prune).
+- the lockfile pins a facet `facets.json` no longer declares (an orphaned entry a normal install would prune);
+- a git or local facet's manifest source (URL, ref, or path) no longer matches the locked source.
 
-This is the mode to use in CI: it guarantees that `facets.json` and `facets.lock` are already in agreement, so a forgotten `facet add` or a hand-edited manifest fails the build loudly instead of silently mutating the lockfile. It mirrors the `--frozen-lockfile` contract from `npm` and `bun`.
+It also verifies content: every facet — including local sources, which a normal install rebuilds from disk — must reproduce its locked integrity. Editing a local facet's files fails a frozen install instead of silently overwriting the entry, exactly as a git tag move would.
+
+This is the mode to use in CI: it guarantees that `facets.json` and `facets.lock` are already in agreement, so a forgotten `facet add`, a hand-edited manifest, or drifted local content fails the build loudly instead of silently mutating the lockfile. It mirrors the `--frozen-lockfile` contract from `npm` and `bun`.
 
 ## Exit codes
 

--- a/docs/specification/install.md
+++ b/docs/specification/install.md
@@ -161,7 +161,7 @@ Only `facet upgrade` resolves newer versions for entries that already satisfy th
 
 The lockfile SHOULD be version-controlled so that all team members and CI environments get the same versions.
 
-`facet install --frozen-lockfile` inverts this: the lockfile becomes the source of truth. It MUST NOT re-resolve any specifier and MUST NOT write the lockfile, and it MUST fail without modifying the project if the lockfile is missing, omits a manifest facet, contains an entry that no longer satisfies its specifier, or pins a facet the manifest no longer declares (an orphaned entry a normal install would prune). This is the mode for reproducible CI installs.
+`facet install --frozen-lockfile` inverts this: the lockfile becomes the source of truth and is reproduced exactly — no extra facets, no missing facets, no source changes, no content changes. It MUST NOT re-resolve any specifier and MUST NOT write the lockfile, and it MUST fail without modifying the project if the lockfile is missing, omits a manifest facet, contains an entry that no longer satisfies its specifier, pins a facet the manifest no longer declares (an orphaned entry a normal install would prune), or has a git/local facet whose manifest source (URL, ref, or path) no longer matches the locked source. It MUST also verify that every facet — including local sources, which a normal install rebuilds from disk — reproduces its locked integrity, failing on any content mismatch. This is the mode for reproducible CI installs.
 
 ## Upgrade
 

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -403,7 +403,7 @@ The project manifest is the source of truth; the lockfile is a record of resolut
 
 ### Requirement: Frozen-lockfile install treats the lockfile as authoritative
 
-The system SHALL provide a frozen-lockfile mode for install in which the lockfile is treated as the source of truth. In this mode the system SHALL NOT re-resolve any specifier and SHALL NOT write the lockfile. Before installing, the system SHALL verify that the lockfile fully and consistently covers the manifest. The system SHALL fail without modifying the project if any of the following is true: no lockfile exists, the manifest declares a facet that has no lockfile entry, a lockfile entry's recorded version does not satisfy its manifest specifier, or the lockfile pins a facet the manifest no longer declares (an orphaned entry that a non-frozen install would prune). When the lockfile fully covers the manifest, the system SHALL install exactly the versions and integrity hashes recorded in the lockfile. Frozen-lockfile mode SHALL be available only on install; the command that adds a facet SHALL NOT offer it, because adding a facet inherently updates the lockfile.
+The system SHALL provide a frozen-lockfile mode for install in which the lockfile is treated as the source of truth and reproduced exactly: no extra facets, no missing facets, no source changes, and no content changes. In this mode the system SHALL NOT re-resolve any specifier and SHALL NOT write the lockfile. Before installing, the system SHALL verify that the lockfile fully and consistently covers the manifest. The system SHALL fail without modifying the project if any of the following is true: no lockfile exists, the manifest declares a facet that has no lockfile entry, a lockfile entry's recorded version does not satisfy its manifest specifier, the lockfile pins a facet the manifest no longer declares (an orphaned entry that a non-frozen install would prune), or a git/local facet's manifest source string (URL, ref, or path) no longer matches the locked source. When the lockfile fully covers the manifest, the system SHALL install exactly the versions and integrity hashes recorded in the lockfile, and SHALL verify that every facet — including local sources, which a non-frozen install would rebuild from disk — reproduces its locked integrity, failing if any built content does not match. Frozen-lockfile mode SHALL be available only on install; the command that adds a facet SHALL NOT offer it, because adding a facet inherently updates the lockfile.
 
 #### Scenario: Frozen install proceeds when the lockfile covers the manifest
 
@@ -441,6 +441,21 @@ The system SHALL provide a frozen-lockfile mode for install in which the lockfil
 - **AND** the lockfile pins a facet the manifest no longer declares
 - **THEN** the system SHALL fail with an error identifying the orphaned facet and its locked version
 - **AND** the system SHALL NOT prune the orphaned facet's assets
+- **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Frozen install fails when a git or local source changed
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** a git or local facet's manifest source string (URL, ref, or path) differs from the locked source
+- **THEN** the system SHALL fail with an error identifying the facet, its manifest source, and its locked source
+- **AND** the system SHALL NOT clone, resolve, or build from the changed source
+- **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Frozen install fails when local source content drifted
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** a local facet's source path is unchanged but its on-disk content no longer reproduces the locked integrity
+- **THEN** the system SHALL fail with an integrity error rather than rebuilding and overwriting the entry
 - **AND** the system SHALL leave the manifest, lockfile, and on-disk adapter state unchanged
 
 ### Requirement: Declared MCP servers do not block installation

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -630,6 +630,12 @@ describe('InstallView — frozen-lockfile drift', () => {
         { name: 'cowsay', reason: 'unsatisfied', manifestSpec: '0.1.2', lockedVersion: '0.1.1' },
         { name: 'extra', reason: 'no-entry', manifestSpec: '0.2.0' },
         { name: 'stale', reason: 'orphaned', lockedVersion: '4.5.6' },
+        {
+          name: 'planner',
+          reason: 'source-changed',
+          manifestSpec: 'github:attacker/planner',
+          lockedSource: 'github:agent-facets/planner',
+        },
       ],
     }
     const events: StageEvent[] = [{ kind: 'install-complete', outcome: 'failure' }]
@@ -650,6 +656,7 @@ describe('InstallView — frozen-lockfile drift', () => {
     expect(frame).toContain('locked 0.1.1 does not satisfy 0.1.2')
     expect(frame).toContain('not in lockfile (manifest wants 0.2.0)')
     expect(frame).toContain('in lockfile but not in facets.json (locked 4.5.6)')
+    expect(frame).toContain('source changed: locked github:agent-facets/planner')
     expect(frame).toContain('without --frozen-lockfile')
     instance.unmount()
   })

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -280,7 +280,9 @@ export function FailureBlock({ failure }: { failure: RunInstallFailure }): React
                   ? `not in lockfile (manifest wants ${f.manifestSpec})`
                   : f.reason === 'orphaned'
                     ? `in lockfile but not in facets.json (locked ${f.lockedVersion})`
-                    : `locked ${f.lockedVersion} does not satisfy ${f.manifestSpec}`}
+                    : f.reason === 'source-changed'
+                      ? `source changed: locked ${f.lockedSource}, manifest wants ${f.manifestSpec}`
+                      : `locked ${f.lockedVersion} does not satisfy ${f.manifestSpec}`}
             </Text>
           ))}
           <Text color={THEME.hint}> Run without --frozen-lockfile, or `facet add` to update the lockfile.</Text>

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -27,40 +27,6 @@ function buildLocalFixture(name: string, version = '0.1.0'): string {
   return repo
 }
 
-function git(args: string[], cwd: string): string {
-  const result = Bun.spawnSync(['git', ...args], {
-    cwd,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-  expect(result.exitCode).toBe(0)
-  return result.stdout.toString().trim()
-}
-
-function buildGitFixture(name: string, version: string): { source: string; commit: string } {
-  const repo = realpathSync(mkdtempSync(join(projectRoot, 'git-fixture-')))
-  writeFileSync(
-    join(repo, 'facet.json'),
-    JSON.stringify({
-      name,
-      version,
-      skills: { planning: { description: 'planning skill' } },
-    }),
-  )
-  mkdirSync(join(repo, 'skills/planning'), { recursive: true })
-  writeFileSync(join(repo, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
-
-  git(['init'], repo)
-  git(['checkout', '-b', 'main'], repo)
-  git(['add', '.'], repo)
-  git(['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', `seed ${version}`], repo)
-
-  return {
-    source: `file://${repo}#main`,
-    commit: git(['rev-parse', 'HEAD'], repo),
-  }
-}
-
 function buildFakeAdapter(name: string): Adapter {
   // Uses the published `@agent-facets/adapter` SDK helpers verbatim so
   // the asset round-trip (assemble → write → read → split) goes through
@@ -752,45 +718,6 @@ describe('runInstall — git cache hit short-circuits clone', () => {
     expect(result.lockfile.facets[facetName]?.integrity).toBe(entry.integrity)
     expect(result.lockfile.facets[facetName]?.ref).toBe(entry.ref)
     expect(result.lockfile.facets[facetName]?.commit).toBe(entry.commit)
-  })
-
-  test('changed git source discards the old lock entry before cloning', async () => {
-    const facetName = 'viper-plans'
-    const oldSource = buildGitFixture(facetName, '0.1.0')
-    const newSource = buildGitFixture(facetName, '0.2.0')
-    const oldIntegrity = computeContentHash('old-source')
-    const lockfile: Lockfile = {
-      lockfileVersion: 1,
-      facets: {
-        [facetName]: {
-          source: oldSource.source,
-          ref: 'main',
-          commit: oldSource.commit,
-          version: '0.1.0',
-          integrity: oldIntegrity,
-          assets: [{ scope: 'project', type: 'skill', name: 'planning' }],
-        },
-      },
-    }
-
-    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { [facetName]: newSource.source } }))
-    writeFileSync(join(projectRoot, 'facets.lock'), JSON.stringify(lockfile))
-
-    const result = await runInstall({
-      projectRoot,
-      adapters: [buildFakeAdapter('test')],
-    })
-
-    expect(result.ok).toBe(true)
-    if (!result.ok) expect.unreachable()
-    const entry = result.lockfile.facets[facetName]
-    if (entry === undefined) expect.unreachable()
-    expect(entry.source).toBe(newSource.source)
-    expect(entry.ref).toBe('main')
-    expect(entry.commit).toBe(newSource.commit)
-    expect(entry.version).toBe('0.2.0')
-    expect(entry.integrity).not.toBe(oldIntegrity)
-    expect(readFileSync(join(projectRoot, '.test/skills/planning.md'), 'utf8')).toContain('# planning 0.2.0')
   })
 
   test('returns CACHE_INTEGRITY_MISMATCH when sidecar disagrees with lockfile', async () => {

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -27,6 +27,40 @@ function buildLocalFixture(name: string, version = '0.1.0'): string {
   return repo
 }
 
+function git(args: string[], cwd: string): string {
+  const result = Bun.spawnSync(['git', ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  expect(result.exitCode).toBe(0)
+  return result.stdout.toString().trim()
+}
+
+function buildGitFixture(name: string, version: string): { source: string; commit: string } {
+  const repo = realpathSync(mkdtempSync(join(projectRoot, 'git-fixture-')))
+  writeFileSync(
+    join(repo, 'facet.json'),
+    JSON.stringify({
+      name,
+      version,
+      skills: { planning: { description: 'planning skill' } },
+    }),
+  )
+  mkdirSync(join(repo, 'skills/planning'), { recursive: true })
+  writeFileSync(join(repo, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
+
+  git(['init'], repo)
+  git(['checkout', '-b', 'main'], repo)
+  git(['add', '.'], repo)
+  git(['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', `seed ${version}`], repo)
+
+  return {
+    source: `file://${repo}#main`,
+    commit: git(['rev-parse', 'HEAD'], repo),
+  }
+}
+
 function buildFakeAdapter(name: string): Adapter {
   // Uses the published `@agent-facets/adapter` SDK helpers verbatim so
   // the asset round-trip (assemble → write → read → split) goes through
@@ -718,6 +752,45 @@ describe('runInstall — git cache hit short-circuits clone', () => {
     expect(result.lockfile.facets[facetName]?.integrity).toBe(entry.integrity)
     expect(result.lockfile.facets[facetName]?.ref).toBe(entry.ref)
     expect(result.lockfile.facets[facetName]?.commit).toBe(entry.commit)
+  })
+
+  test('changed git source discards the old lock entry before cloning', async () => {
+    const facetName = 'viper-plans'
+    const oldSource = buildGitFixture(facetName, '0.1.0')
+    const newSource = buildGitFixture(facetName, '0.2.0')
+    const oldIntegrity = computeContentHash('old-source')
+    const lockfile: Lockfile = {
+      lockfileVersion: 1,
+      facets: {
+        [facetName]: {
+          source: oldSource.source,
+          ref: 'main',
+          commit: oldSource.commit,
+          version: '0.1.0',
+          integrity: oldIntegrity,
+          assets: [{ scope: 'project', type: 'skill', name: 'planning' }],
+        },
+      },
+    }
+
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { [facetName]: newSource.source } }))
+    writeFileSync(join(projectRoot, 'facets.lock'), JSON.stringify(lockfile))
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [buildFakeAdapter('test')],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    const entry = result.lockfile.facets[facetName]
+    if (entry === undefined) expect.unreachable()
+    expect(entry.source).toBe(newSource.source)
+    expect(entry.ref).toBe('main')
+    expect(entry.commit).toBe(newSource.commit)
+    expect(entry.version).toBe('0.2.0')
+    expect(entry.integrity).not.toBe(oldIntegrity)
+    expect(readFileSync(join(projectRoot, '.test/skills/planning.md'), 'utf8')).toContain('# planning 0.2.0')
   })
 
   test('returns CACHE_INTEGRITY_MISMATCH when sidecar disagrees with lockfile', async () => {

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -693,16 +693,15 @@ describe('runInstall — git cache hit short-circuits clone', () => {
     const version = '0.1.0'
     const { entry } = seedCacheSlotForGit(facetName, version)
 
-    // Use an UNREACHABLE git URL — if anything tries to clone, the test
-    // will hang/fail. The cache hit must short-circuit before cloning.
+    // The manifest source matches the locked source, so the cache-hit path
+    // is eligible. The URL points at an unreachable host — if anything tries
+    // to clone, the test will hang/fail. The cache hit must short-circuit
+    // before cloning.
     const lockfile: Lockfile = {
       lockfileVersion: 1,
       facets: { [facetName]: entry },
     }
-    writeFileSync(
-      join(projectRoot, 'facets.json'),
-      JSON.stringify({ facets: { [facetName]: 'https://invalid.invalid/never-clone.git' } }),
-    )
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { [facetName]: entry.source } }))
     writeFileSync(join(projectRoot, 'facets.lock'), JSON.stringify(lockfile))
 
     const result = await runInstall({
@@ -733,10 +732,9 @@ describe('runInstall — git cache hit short-circuits clone', () => {
       lockfileVersion: 1,
       facets: { [facetName]: { ...entry, integrity: wrongIntegrity } },
     }
-    writeFileSync(
-      join(projectRoot, 'facets.json'),
-      JSON.stringify({ facets: { [facetName]: 'https://invalid.invalid/never-clone.git' } }),
-    )
+    // Manifest source matches the locked source so the cache-hit path runs;
+    // the sidecar/lockfile integrity disagreement is what must be caught.
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { [facetName]: entry.source } }))
     writeFileSync(join(projectRoot, 'facets.lock'), JSON.stringify(lockfile))
 
     const result = await runInstall({

--- a/packages/engine/src/install/__tests__/detect-lockfile-drift.test.ts
+++ b/packages/engine/src/install/__tests__/detect-lockfile-drift.test.ts
@@ -19,11 +19,7 @@ const lock = (facets: Record<string, LockfileFacet>): Lockfile => ({
 
 describe('detectLockfileDrift', () => {
   test('no drift when every registry entry satisfies its specifier', () => {
-    const drift = detectLockfileDrift(
-      manifest({ cowsay: '1.2.3', other: '1.*' }),
-      lock({ cowsay: lockEntry('1.2.3'), other: lockEntry('1.5.0') }),
-      true,
-    )
+    const drift = detectLockfileDrift(manifest({ cowsay: '1.*' }), lock({ cowsay: lockEntry('1.2.3', '1.2.3') }), true)
     expect(drift).toEqual([])
   })
 
@@ -57,6 +53,55 @@ describe('detectLockfileDrift', () => {
   test('non-registry (local/git) entries are not version-checked, only required to exist', () => {
     // A local source whose entry exists is fine regardless of version.
     const drift = detectLockfileDrift(manifest({ local: './pkg' }), lock({ local: lockEntry('9.9.9', './pkg') }), true)
+    expect(drift).toEqual([])
+  })
+
+  test('git entry whose manifest URL changed → source-changed', () => {
+    const drift = detectLockfileDrift(
+      manifest({ planner: 'github:attacker/planner' }),
+      lock({ planner: lockEntry('2.0.0', 'github:agent-facets/planner') }),
+      true,
+    )
+    expect(drift).toEqual([
+      {
+        name: 'planner',
+        reason: 'source-changed',
+        manifestSpec: 'github:attacker/planner',
+        lockedSource: 'github:agent-facets/planner',
+      },
+    ])
+  })
+
+  test('local entry whose manifest path changed → source-changed', () => {
+    const drift = detectLockfileDrift(
+      manifest({ cowsay: './facets/cowsay-EVIL' }),
+      lock({ cowsay: lockEntry('1.0.0', './facets/cowsay-v1') }),
+      true,
+    )
+    expect(drift).toEqual([
+      {
+        name: 'cowsay',
+        reason: 'source-changed',
+        manifestSpec: './facets/cowsay-EVIL',
+        lockedSource: './facets/cowsay-v1',
+      },
+    ])
+  })
+
+  test('git entry whose manifest source is unchanged → no drift', () => {
+    const drift = detectLockfileDrift(
+      manifest({ planner: 'github:agent-facets/planner' }),
+      lock({ planner: lockEntry('2.0.0', 'github:agent-facets/planner') }),
+      true,
+    )
+    expect(drift).toEqual([])
+  })
+
+  test('registry spec text change that still satisfies is NOT source-changed', () => {
+    // Manifest widened 1.2.3 → 1.* while the lock stays at 1.2.3 (which
+    // satisfies). This is reproducible, not drift — registry source/version
+    // drift is governed by `satisfies`, never reported as `source-changed`.
+    const drift = detectLockfileDrift(manifest({ cowsay: '1.*' }), lock({ cowsay: lockEntry('1.2.3', '1.2.3') }), true)
     expect(drift).toEqual([])
   })
 

--- a/packages/engine/src/install/__tests__/plan-facet.test.ts
+++ b/packages/engine/src/install/__tests__/plan-facet.test.ts
@@ -1,86 +1,42 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import type { Lockfile } from '@agent-facets/protocol'
-import { computeContentHash, LOCKFILE_VERSION } from '@agent-facets/protocol'
+import { describe, expect, test } from 'bun:test'
+import type { LockfileFacet } from '@agent-facets/protocol'
+import { parseFacetSource } from '../../sources/facet/parse-source.ts'
+import { resolveCloneRef } from '../resolve-clone-ref.ts'
+import { resolveEffectiveLockedForPlan } from '../plan-facet.ts'
 
-let projectRoot: string
-let clonedSourceDir: string
-let cloneCalls: Array<{ url: string; commitish: string | undefined }> = []
-
-const clonedCommit = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-
-mock.module('../../sources/facet/resolve-git.ts', () => ({
-  cloneFacetGitSource: async (url: string, commitish?: string) => {
-    cloneCalls.push({ url, commitish })
-    return { ok: true, dir: clonedSourceDir, commit: clonedCommit }
-  },
-}))
-
-const { planFacet } = await import('../plan-facet.ts')
-
-function buildClonedFixture(name: string, version: string): string {
-  const dir = realpathSync(mkdtempSync(join(projectRoot, 'cloned-git-')))
-  writeFileSync(
-    join(dir, 'facet.json'),
-    JSON.stringify({
-      name,
-      version,
-      skills: { planning: { description: 'planning skill' } },
-    }),
-  )
-  mkdirSync(join(dir, 'skills/planning'), { recursive: true })
-  writeFileSync(join(dir, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
-  return dir
+const lockedGitEntry: LockfileFacet = {
+  source: 'https://github.com/example/old.git#stable',
+  ref: 'stable',
+  commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  version: '0.1.0',
+  integrity: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+  assets: [{ scope: 'project', type: 'skill', name: 'planning' }],
 }
 
-beforeEach(() => {
-  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'plan-facet-test-')))
-  clonedSourceDir = buildClonedFixture('viper-plans', '0.2.0')
-  cloneCalls = []
-})
-
-afterEach(() => {
-  rmSync(projectRoot, { recursive: true, force: true })
-  mock.restore()
-})
+function parseGitSource(specifier: string) {
+  const parsed = parseFacetSource(specifier)
+  if (!parsed.ok) expect.unreachable()
+  if (parsed.value.kind !== 'git') expect.unreachable()
+  return parsed.value
+}
 
 describe('planFacet — changed git source', () => {
-  test('treats the old git lock entry as absent after source-string drift', async () => {
-    const oldIntegrity = computeContentHash('old-source')
-    const previousLockfile: Lockfile = {
-      lockfileVersion: LOCKFILE_VERSION,
-      facets: {
-        'viper-plans': {
-          source: 'https://github.com/example/old.git#stable',
-          ref: 'stable',
-          commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          version: '0.1.0',
-          integrity: oldIntegrity,
-          assets: [{ scope: 'project', type: 'skill', name: 'planning' }],
-        },
-      },
-    }
+  test('does not let the old commit constrain a new git source', () => {
+    const manifestSpecifier = 'https://github.com/example/new.git#main'
+    const source = parseGitSource(manifestSpecifier)
 
-    const result = await planFacet({
-      facetName: 'viper-plans',
-      specifier: 'https://github.com/example/new.git#main',
-      projectRoot,
-      adapters: [],
-      previousLockfile,
-      onStage: () => {},
-      onLog: () => {},
-    })
+    const effectiveLocked = resolveEffectiveLockedForPlan(lockedGitEntry, source, manifestSpecifier)
 
-    expect(cloneCalls).toEqual([{ url: 'https://github.com/example/new.git', commitish: 'main' }])
-    if (!result.ok) expect.unreachable()
-    expect(result.value.entry).toMatchObject({
-      source: 'https://github.com/example/new.git#main',
-      ref: 'main',
-      commit: clonedCommit,
-      version: '0.2.0',
-    })
-    expect(result.value.entry.integrity).not.toBe(oldIntegrity)
+    expect(effectiveLocked).toBeUndefined()
+    expect(resolveCloneRef(effectiveLocked, source.ref)).toBe('main')
+  })
+
+  test('keeps the locked commit when the git source is unchanged', () => {
+    const source = parseGitSource(lockedGitEntry.source)
+
+    const effectiveLocked = resolveEffectiveLockedForPlan(lockedGitEntry, source, lockedGitEntry.source)
+
+    expect(effectiveLocked).toBe(lockedGitEntry)
+    expect(resolveCloneRef(effectiveLocked, source.ref)).toBe(lockedGitEntry.commit)
   })
 })

--- a/packages/engine/src/install/__tests__/plan-facet.test.ts
+++ b/packages/engine/src/install/__tests__/plan-facet.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Lockfile } from '@agent-facets/protocol'
+import { computeContentHash, LOCKFILE_VERSION } from '@agent-facets/protocol'
+
+let projectRoot: string
+let clonedSourceDir: string
+let cloneCalls: Array<{ url: string; commitish: string | undefined }> = []
+
+const clonedCommit = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+mock.module('../../sources/facet/resolve-git.ts', () => ({
+  cloneFacetGitSource: async (url: string, commitish?: string) => {
+    cloneCalls.push({ url, commitish })
+    return { ok: true, dir: clonedSourceDir, commit: clonedCommit }
+  },
+}))
+
+const { planFacet } = await import('../plan-facet.ts')
+
+function buildClonedFixture(name: string, version: string): string {
+  const dir = realpathSync(mkdtempSync(join(projectRoot, 'cloned-git-')))
+  writeFileSync(
+    join(dir, 'facet.json'),
+    JSON.stringify({
+      name,
+      version,
+      skills: { planning: { description: 'planning skill' } },
+    }),
+  )
+  mkdirSync(join(dir, 'skills/planning'), { recursive: true })
+  writeFileSync(join(dir, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
+  return dir
+}
+
+beforeEach(() => {
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'plan-facet-test-')))
+  clonedSourceDir = buildClonedFixture('viper-plans', '0.2.0')
+  cloneCalls = []
+})
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true })
+})
+
+describe('planFacet — changed git source', () => {
+  test('treats the old git lock entry as absent after source-string drift', async () => {
+    const oldIntegrity = computeContentHash('old-source')
+    const previousLockfile: Lockfile = {
+      lockfileVersion: LOCKFILE_VERSION,
+      facets: {
+        'viper-plans': {
+          source: 'https://github.com/example/old.git#stable',
+          ref: 'stable',
+          commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          version: '0.1.0',
+          integrity: oldIntegrity,
+          assets: [{ scope: 'project', type: 'skill', name: 'planning' }],
+        },
+      },
+    }
+
+    const result = await planFacet({
+      facetName: 'viper-plans',
+      specifier: 'https://github.com/example/new.git#main',
+      projectRoot,
+      adapters: [],
+      previousLockfile,
+      onStage: () => {},
+      onLog: () => {},
+    })
+
+    expect(cloneCalls).toEqual([{ url: 'https://github.com/example/new.git', commitish: 'main' }])
+    if (!result.ok) expect.unreachable()
+    expect(result.value.entry).toMatchObject({
+      source: 'https://github.com/example/new.git#main',
+      ref: 'main',
+      commit: clonedCommit,
+      version: '0.2.0',
+    })
+    expect(result.value.entry.integrity).not.toBe(oldIntegrity)
+  })
+})

--- a/packages/engine/src/install/__tests__/plan-facet.test.ts
+++ b/packages/engine/src/install/__tests__/plan-facet.test.ts
@@ -43,6 +43,7 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(projectRoot, { recursive: true, force: true })
+  mock.restore()
 })
 
 describe('planFacet — changed git source', () => {

--- a/packages/engine/src/install/__tests__/plan-facet.test.ts
+++ b/packages/engine/src/install/__tests__/plan-facet.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import type { LockfileFacet } from '@agent-facets/protocol'
 import { parseFacetSource } from '../../sources/facet/parse-source.ts'
-import { resolveCloneRef } from '../resolve-clone-ref.ts'
 import { resolveEffectiveLockedForPlan } from '../plan-facet.ts'
+import { resolveCloneRef } from '../resolve-clone-ref.ts'
 
 const lockedGitEntry: LockfileFacet = {
   source: 'https://github.com/example/old.git#stable',

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -315,6 +315,32 @@ describe('runInstall — frozen-lockfile mode', () => {
     expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
   })
 
+  test('fails on a git source-string change without resolving or mutating', async () => {
+    // The lockfile pins a git URL; the manifest now points the same facet
+    // name at a different repo. Frozen mode must reject this at the preflight
+    // (before any clone) so it never builds from the unlocked origin.
+    const facetsBefore = writeFacets({ planner: 'github:attacker/planner' })
+    const lockBefore = writeLock({
+      planner: { source: 'github:agent-facets/planner', version: '2.0.0' },
+    })
+
+    const result = await installFrozen()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'LOCKFILE_DRIFT') expect.unreachable()
+    expect(result.failure.facets).toEqual([
+      {
+        name: 'planner',
+        reason: 'source-changed',
+        manifestSpec: 'github:attacker/planner',
+        lockedSource: 'github:agent-facets/planner',
+      },
+    ])
+    // Never resolved/cloned; both project files byte-for-byte unchanged.
+    expect(resolveRequests).toEqual([])
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+  })
+
   test('fails when no lockfile exists', async () => {
     const facetsBefore = writeFacets({ cowsay: '0.1.1' })
 
@@ -352,5 +378,33 @@ describe('runInstall — frozen-lockfile mode', () => {
     // The lockfile is never re-resolved or updated.
     expect(resolveRequests).toEqual([])
     expect(readLock().facets.cowsay?.version).toBe('0.1.1')
+  })
+
+  test('fails on local content drift with INTEGRITY_FAILURE and no mutation', async () => {
+    // A local facet whose source path is unchanged but whose CONTENT was
+    // edited. A normal install would rebuild and overwrite the entry, but
+    // frozen mode must reproduce the locked integrity exactly — so an edited
+    // local source blows up just like a git tag move, mutating nothing.
+    const localDir = join(projectRoot, 'local-cowsay')
+    mkdirSync(join(localDir, 'skills/planning'), { recursive: true })
+    writeFileSync(
+      join(localDir, 'facet.json'),
+      JSON.stringify({ name: 'cowsay', version: '1.0.0', skills: { planning: { description: 'planning skill' } } }),
+    )
+    writeFileSync(join(localDir, 'skills/planning/SKILL.md'), '# edited content that does not match the lock\n')
+
+    const facetsBefore = writeFacets({ cowsay: './local-cowsay' })
+    // Lock a deliberately wrong integrity so the freshly-built local content
+    // cannot reproduce it.
+    const lockBefore = writeLock({
+      cowsay: { source: './local-cowsay', version: '1.0.0', integrity: 'sha256:deadbeefdeadbeefdeadbeefdeadbeef' },
+    })
+
+    const result = await installFrozen()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'INTEGRITY_FAILURE') expect.unreachable()
+    // Project files are byte-for-byte unchanged (no rewrite, no materialize).
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
   })
 })

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -403,6 +403,11 @@ describe('runInstall — frozen-lockfile mode', () => {
     const result = await installFrozen()
     if (result.ok) expect.unreachable()
     if (result.failure.code !== 'INTEGRITY_FAILURE') expect.unreachable()
+    // The failure is labeled `lockfile`, not `git`: a local-content drift is
+    // a built-vs-lockfile divergence, and reporting `git` here would mislead
+    // the user (nothing git happened).
+    if (result.failure.failure.kind !== 'facet') expect.unreachable()
+    expect(result.failure.failure.check).toBe('lockfile')
     // Project files are byte-for-byte unchanged (no rewrite, no materialize).
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
     expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)

--- a/packages/engine/src/install/detect-lockfile-drift.ts
+++ b/packages/engine/src/install/detect-lockfile-drift.ts
@@ -33,6 +33,13 @@ export function detectLockfileDrift(
       if (!satisfies(parseLockedVersion(locked.version), parsed.value.version)) {
         drift.push({ name, reason: 'unsatisfied', manifestSpec: specifier, lockedVersion: locked.version })
       }
+    } else if (parsed.ok && specifier !== locked.source) {
+      // git/local: any change to the manifest source string (a swapped URL,
+      // ref, or local path) is drift in frozen mode. The locked source is the
+      // contract; a differing source would otherwise build from an unlocked
+      // origin. Registry version drift is handled by the `satisfies` check
+      // above, so this branch only fires for git and local sources.
+      drift.push({ name, reason: 'source-changed', manifestSpec: specifier, lockedSource: locked.source })
     }
   }
 

--- a/packages/engine/src/install/plan-facet.ts
+++ b/packages/engine/src/install/plan-facet.ts
@@ -84,15 +84,19 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
   // the sidecar matches `locked.integrity`.
   const locked = previousLockfile.facets[facetName]
   // A registry lock is stale when its version no longer satisfies the
-  // manifest spec (hand-edit / pull / merge). Only registry sources carry
-  // a VersionSpec; git is ref-based and local is mutable, so neither
-  // is ever stale here. A stale entry is treated as absent below so the
-  // facet re-resolves like a fresh add, overwriting the stale entry.
-  const isStale =
+  // manifest spec (hand-edit / pull / merge). A git lock is stale when
+  // the manifest source string no longer matches the locked source; the
+  // old commit/integrity belong to the old origin and must not constrain
+  // the new clone.
+  //
+  // A stale entry is treated as absent below so the facet re-resolves like
+  // a fresh add, overwriting the stale entry.
+  const isRegistryStale =
     locked !== undefined &&
     parsed.value.kind === 'registry' &&
     !satisfies(parseLockedVersion(locked.version), parsed.value.version)
-  const effectiveLocked = isStale ? undefined : locked
+  const isGitSourceChanged = locked !== undefined && parsed.value.kind === 'git' && specifier !== locked.source
+  const effectiveLocked = isRegistryStale || isGitSourceChanged ? undefined : locked
   // Set when a cache hit's sidecar matches the locked integrity. The
   // sidecar IS the post-write trust certificate; we don't rebuild to
   // re-derive what the cache already proved at write time.
@@ -101,9 +105,9 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
   // Resolve to a sourceDir.
   onStage({ kind: 'facet-stage', facet: facetName, stage: 'resolve' })
   if (parsed.value.kind === 'git') {
-    // Cache-first when we have a locked entry whose source still matches the
-    // manifest: name + version are both known from `locked`, so we can look
-    // up the cache slot without any clone or network round-trip.
+    // Cache-first when we have an effective locked entry: name + version are
+    // both known from `effectiveLocked`, so we can look up the cache slot
+    // without any clone or network round-trip.
     //
     // Bypass the cache entirely when the manifest source no longer matches
     // `locked.source` (a swapped URL or ref). The cache slot is keyed on
@@ -113,11 +117,11 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
     // mode the preflight already rejected this as `source-changed`; this guard
     // makes the cache correct for non-frozen installs too — a changed URL
     // re-resolves from the new source instead of silently reusing old bytes.)
-    if (locked !== undefined && specifier === locked.source) {
+    if (effectiveLocked !== undefined) {
       const cacheId: CacheIdentity = {
         kind: 'git',
         name: facetName,
-        version: locked.version,
+        version: effectiveLocked.version,
       }
       const lookup = cacheGet(cacheId)
       if (lookup.hit) {
@@ -126,7 +130,7 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
           // Sidecar missing/invalid — incomplete cache slot. Treat as
           // soft miss and fall through to clone.
           onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; refetching`)
-        } else if (cached.integrity !== locked.integrity) {
+        } else if (cached.integrity !== effectiveLocked.integrity) {
           // Cache disagrees with lockfile. Lockfile is the source of
           // truth; surface as hard error rather than silently refetching.
           return {
@@ -136,7 +140,7 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
               facet: facetName,
               slotPath: lookup.path,
               cachedIntegrity: cached.integrity,
-              lockedIntegrity: locked.integrity,
+              lockedIntegrity: effectiveLocked.integrity,
             },
           }
         } else {
@@ -153,7 +157,7 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
 
     // Cache miss (or no locked entry, or sidecar invalid). Clone.
     if (sourceDir === undefined) {
-      const cloneRef = resolveCloneRef(locked, parsed.value.ref)
+      const cloneRef = resolveCloneRef(effectiveLocked, parsed.value.ref)
       const cloned = await cloneFacetGitSource(parsed.value.url, cloneRef)
       if (!cloned.ok) {
         return {

--- a/packages/engine/src/install/plan-facet.ts
+++ b/packages/engine/src/install/plan-facet.ts
@@ -1,17 +1,17 @@
 import { rm } from 'node:fs/promises'
 import type { Adapter } from '@agent-facets/adapter'
 import type { BuildManifest, Lockfile, LockfileFacet, ResolvedFacetManifest } from '@agent-facets/protocol'
-import { satisfies, verifyGitOneCheck } from '@agent-facets/protocol'
+import { satisfies, verifyGitOneCheck, verifyLockfileOneCheck } from '@agent-facets/protocol'
 import { runBuildPipeline } from '../build/pipeline.ts'
 import { type CacheIdentity, cacheGet, cachePutVerified, cacheStagingDir, readCachedIntegrity } from '../cache/index.ts'
 import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
 import { downloadAndExtractFacet } from '../registry/download.ts'
 import { resolveRegistryMetadataBatch } from '../registry/resolve-metadata.ts'
 import { parseFacetSource } from '../sources/facet/parse-source.ts'
-import type { Source } from '../sources/facet/types.ts'
 import { parseVersionSpec } from '../sources/facet/parse-version.ts'
 import { cloneFacetGitSource } from '../sources/facet/resolve-git.ts'
 import { resolveLocalFacetSource } from '../sources/facet/resolve-local.ts'
+import type { Source } from '../sources/facet/types.ts'
 import { cloneFailureToRunInstall } from './clone-failure.ts'
 import { computeAssetList } from './materialize.ts'
 import { parseLockedVersion } from './parse-locked-version.ts'
@@ -373,7 +373,13 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
           parsed.value.kind === 'registry' ||
           (parsed.value.kind === 'local' && args.frozenLockfile === true))
       if (mustReproduceIntegrity) {
-        const guard = verifyGitOneCheck({
+        // Pick the verifier by source kind so the reported `check` honestly
+        // names what diverged. A git tag-move is `check: 'git'`; everything
+        // else reaching this guard (frozen LOCAL drift, or a cache-miss
+        // registry rebuild) is a built-vs-lockfile divergence → `'lockfile'`.
+        // Both verifiers run the same hash equality; only the label differs.
+        const verifyReproduction = parsed.value.kind === 'git' ? verifyGitOneCheck : verifyLockfileOneCheck
+        const guard = verifyReproduction({
           facet: facetName,
           computedIntegrity: buildResult.integrity,
           lockfileIntegrity: effectiveLocked.integrity,

--- a/packages/engine/src/install/plan-facet.ts
+++ b/packages/engine/src/install/plan-facet.ts
@@ -8,6 +8,7 @@ import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
 import { downloadAndExtractFacet } from '../registry/download.ts'
 import { resolveRegistryMetadataBatch } from '../registry/resolve-metadata.ts'
 import { parseFacetSource } from '../sources/facet/parse-source.ts'
+import type { Source } from '../sources/facet/types.ts'
 import { parseVersionSpec } from '../sources/facet/parse-version.ts'
 import { cloneFacetGitSource } from '../sources/facet/resolve-git.ts'
 import { resolveLocalFacetSource } from '../sources/facet/resolve-local.ts'
@@ -48,6 +49,35 @@ export interface PlanFacetSuccess {
 
 export type PlanFacetResult = { ok: true; value: PlanFacetSuccess } | { ok: false; failure: RunInstallFailure }
 
+/**
+ * Decide whether a lockfile entry still applies to the manifest source.
+ *
+ * Pure function — exported for unit testing. When it returns `undefined`,
+ * the caller treats the entry like a fresh add: no cache lookup by the old
+ * version, no clone at the old commit, and no integrity check against bytes
+ * from the old source.
+ */
+export function resolveEffectiveLockedForPlan(
+  locked: LockfileFacet | undefined,
+  source: Source,
+  specifier: string,
+): LockfileFacet | undefined {
+  // A registry lock is stale when its version no longer satisfies the
+  // manifest spec (hand-edit / pull / merge). A git lock is stale when
+  // the manifest source string no longer matches the locked source; the
+  // old commit/integrity belong to the old origin and must not constrain
+  // the new clone.
+  //
+  // Local entries are intentionally not stale here. Non-frozen local
+  // installs rebuild from disk and overwrite the entry; frozen installs
+  // reject source drift in the preflight before planning.
+  const isRegistryStale =
+    locked !== undefined && source.kind === 'registry' && !satisfies(parseLockedVersion(locked.version), source.version)
+  const isGitSourceChanged = locked !== undefined && source.kind === 'git' && specifier !== locked.source
+
+  return isRegistryStale || isGitSourceChanged ? undefined : locked
+}
+
 export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
   const { facetName, specifier, projectRoot, previousLockfile, onStage, onLog } = args
 
@@ -83,20 +113,9 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
   // exactly these bytes (or fail loudly). Cache hits short-circuit when
   // the sidecar matches `locked.integrity`.
   const locked = previousLockfile.facets[facetName]
-  // A registry lock is stale when its version no longer satisfies the
-  // manifest spec (hand-edit / pull / merge). A git lock is stale when
-  // the manifest source string no longer matches the locked source; the
-  // old commit/integrity belong to the old origin and must not constrain
-  // the new clone.
-  //
   // A stale entry is treated as absent below so the facet re-resolves like
   // a fresh add, overwriting the stale entry.
-  const isRegistryStale =
-    locked !== undefined &&
-    parsed.value.kind === 'registry' &&
-    !satisfies(parseLockedVersion(locked.version), parsed.value.version)
-  const isGitSourceChanged = locked !== undefined && parsed.value.kind === 'git' && specifier !== locked.source
-  const effectiveLocked = isRegistryStale || isGitSourceChanged ? undefined : locked
+  const effectiveLocked = resolveEffectiveLockedForPlan(locked, parsed.value, specifier)
   // Set when a cache hit's sidecar matches the locked integrity. The
   // sidecar IS the post-write trust certificate; we don't rebuild to
   // re-derive what the cache already proved at write time.

--- a/packages/engine/src/install/plan-facet.ts
+++ b/packages/engine/src/install/plan-facet.ts
@@ -31,6 +31,13 @@ export interface PlanFacetArgs {
   previousLockfile: Lockfile
   onStage: (event: StageEvent) => void
   onLog: (line: string) => void
+  /**
+   * Frozen-lockfile mode. When true, a locked entry MUST reproduce its
+   * locked integrity for EVERY source kind — including local sources,
+   * which are otherwise mutable and rebuilt from disk. A mismatch fails
+   * the install with `INTEGRITY_FAILURE`; the entry is never rewritten.
+   */
+  frozenLockfile?: boolean
 }
 
 export interface PlanFacetSuccess {
@@ -94,10 +101,19 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
   // Resolve to a sourceDir.
   onStage({ kind: 'facet-stage', facet: facetName, stage: 'resolve' })
   if (parsed.value.kind === 'git') {
-    // Cache-first when we have a locked entry: name + version are both
-    // known from `locked`, so we can look up the cache slot without any
-    // clone or network round-trip.
-    if (locked !== undefined) {
+    // Cache-first when we have a locked entry whose source still matches the
+    // manifest: name + version are both known from `locked`, so we can look
+    // up the cache slot without any clone or network round-trip.
+    //
+    // Bypass the cache entirely when the manifest source no longer matches
+    // `locked.source` (a swapped URL or ref). The cache slot is keyed on
+    // {name, version} and carries no source provenance, so a cache hit would
+    // serve bytes that may belong to a different origin. Skipping the lookup
+    // here falls through to cloning the manifest's current URL. (In frozen
+    // mode the preflight already rejected this as `source-changed`; this guard
+    // makes the cache correct for non-frozen installs too — a changed URL
+    // re-resolves from the new source instead of silently reusing old bytes.)
+    if (locked !== undefined && specifier === locked.source) {
       const cacheId: CacheIdentity = {
         kind: 'git',
         name: facetName,
@@ -311,23 +327,29 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
         }
       }
 
-      // Tag-move guard: if this is a LOCKED GIT source, the just-built
-      // integrity MUST match the locked integrity. The lockfile is the
-      // security contract; the network-served artifact has been modified
-      // since we locked it if these disagree. Refuse the install — do
-      // NOT cache, do NOT write the lockfile, do NOT materialize.
+      // Integrity reproduction guard: a satisfying locked entry MUST
+      // reproduce its locked integrity, or the install fails — do NOT
+      // cache, do NOT write the lockfile, do NOT materialize.
       //
-      // Local sources are intentionally exempt: filesystem-backed
-      // sources are mutable by definition (the user edits them), so
-      // an integrity drift is expected, not an attack. The lockfile
-      // entry's integrity gets overwritten by the new build for local
-      // sources. See `verifyGitOneCheck` docstring for the rationale.
-      // Tag-move guard: a satisfying locked git/registry entry MUST
-      // reproduce its locked integrity (the lockfile is the security
-      // contract). A stale entry is being discarded, so it has no locked
-      // integrity to reproduce — the guard is skipped and the fresh
-      // download is verified by the registry three-check instead.
-      if (effectiveLocked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
+      //   - GIT/REGISTRY (always): the lockfile is the security contract;
+      //     a network-served artifact that no longer hashes to the locked
+      //     integrity has been modified since we locked it (a tag move).
+      //   - LOCAL (frozen only): filesystem sources are mutable by design,
+      //     so a normal install rebuilds and overwrites the entry. But
+      //     `--frozen-lockfile` promises bit-for-bit reproduction of the
+      //     lockfile, so a frozen install treats local exactly like git:
+      //     the edited local content must still hash to the locked
+      //     integrity, or the install blows up.
+      //
+      // A stale entry (`effectiveLocked === undefined`) is being discarded,
+      // so it has no locked integrity to reproduce — the guard is skipped
+      // and the fresh download is verified by the registry three-check.
+      const mustReproduceIntegrity =
+        effectiveLocked !== undefined &&
+        (parsed.value.kind === 'git' ||
+          parsed.value.kind === 'registry' ||
+          (parsed.value.kind === 'local' && args.frozenLockfile === true))
+      if (mustReproduceIntegrity) {
         const guard = verifyGitOneCheck({
           facet: facetName,
           computedIntegrity: buildResult.integrity,
@@ -369,18 +391,20 @@ export async function planFacet(args: PlanFacetArgs): Promise<PlanFacetResult> {
 
       // Construct the entry.
       //
-      //   - Satisfying GIT/REGISTRY entries inherit locked.* verbatim (we
-      //     just verified buildResult matches, so values are equal — but the
-      //     lockfile is the source of truth and we never rewrite it).
+      //   - Entries that just reproduced their locked integrity
+      //     (`mustReproduceIntegrity`) inherit locked.* verbatim — we
+      //     verified buildResult matches, and the lockfile is the source of
+      //     truth, so we never rewrite it. This now includes frozen LOCAL
+      //     sources: frozen never rewrites a local entry.
       //   - Stale registry entries (`effectiveLocked === undefined`) fall
       //     into the build-derived branch below, overwriting the
       //     contradictory entry with the freshly resolved version/integrity.
-      //   - Local sources (locked or fresh) derive from the build.
-      //     Local is mutable by design; the user owns the version and
-      //     content, and the lockfile follows what's on disk.
+      //   - Non-frozen LOCAL sources derive from the build. Local is mutable
+      //     by design; the user owns the version and content, and the
+      //     lockfile follows what's on disk.
       //   - Fresh git adds derive from the build + the clone's commit.
       //   - Fresh registry adds derive from the build (no ref/commit).
-      if (effectiveLocked !== undefined && (parsed.value.kind === 'git' || parsed.value.kind === 'registry')) {
+      if (mustReproduceIntegrity) {
         entry = {
           source: specifier,
           ...(effectiveLocked.ref !== undefined ? { ref: effectiveLocked.ref } : {}),

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -125,6 +125,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         previousLockfile,
         onStage,
         onLog,
+        frozenLockfile: opts.frozenLockfile,
       })
       if (!planResult.ok) {
         onStage({ kind: 'facet-failure', facet: facetName, failure: planResult.failure })

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -75,12 +75,18 @@ export type StageEvent =
  *   - `orphaned`         — the lockfile pins a facet the manifest no longer
  *                          declares; carries `lockedVersion` but no
  *                          `manifestSpec` (the manifest says nothing about it).
+ *   - `source-changed`   — a git/local facet whose manifest source string
+ *                          (URL/ref/path) no longer matches the locked
+ *                          source; carries both so the user sees the swap.
+ *                          Registry version drift is reported as
+ *                          `unsatisfied`, not here.
  */
 export type LockfileDriftEntry =
   | { name: string; reason: 'missing-lockfile'; manifestSpec: string }
   | { name: string; reason: 'no-entry'; manifestSpec: string }
   | { name: string; reason: 'unsatisfied'; manifestSpec: string; lockedVersion: string }
   | { name: string; reason: 'orphaned'; lockedVersion: string }
+  | { name: string; reason: 'source-changed'; manifestSpec: string; lockedSource: string }
 
 /**
  * Discriminated failure type for `runInstall`. Every failure mode

--- a/packages/protocol/src/__tests__/integrity.test.ts
+++ b/packages/protocol/src/__tests__/integrity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { verifyGitOneCheck, verifyHash, verifyRegistryThreeCheck } from '@agent-facets/protocol'
+import { verifyGitOneCheck, verifyHash, verifyLockfileOneCheck, verifyRegistryThreeCheck } from '@agent-facets/protocol'
 
 const HASH_A = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 const HASH_B = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
@@ -207,6 +207,33 @@ describe('verifyGitOneCheck', () => {
       kind: 'facet',
       facet: 'p',
       check: 'git',
+      expected: HASH_A,
+      observed: HASH_B,
+    })
+  })
+})
+
+describe('verifyLockfileOneCheck', () => {
+  test('match returns ok', () => {
+    const result = verifyLockfileOneCheck({
+      facet: 'p',
+      computedIntegrity: HASH_A,
+      lockfileIntegrity: HASH_A,
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  test('mismatch fires lockfile failure (not git)', () => {
+    const result = verifyLockfileOneCheck({
+      facet: 'p',
+      computedIntegrity: HASH_B,
+      lockfileIntegrity: HASH_A,
+    })
+    if (result.ok) expect.unreachable()
+    expect(result.failure).toEqual({
+      kind: 'facet',
+      facet: 'p',
+      check: 'lockfile',
       expected: HASH_A,
       observed: HASH_B,
     })

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -38,7 +38,7 @@ export type {
   IntegrityResult,
   RegistryIntegrityInput,
 } from './integrity/index.ts'
-export { verifyGitOneCheck, verifyHash, verifyRegistryThreeCheck } from './integrity/index.ts'
+export { verifyGitOneCheck, verifyHash, verifyLockfileOneCheck, verifyRegistryThreeCheck } from './integrity/index.ts'
 // loaders (pure bytes-validators — no I/O)
 export type { ResolvedFacetManifest } from './loaders/facet.ts'
 export { FACET_MANIFEST_FILE, resolvePromptsFromMap, validateFacetManifest } from './loaders/facet.ts'

--- a/packages/protocol/src/integrity/index.ts
+++ b/packages/protocol/src/integrity/index.ts
@@ -7,4 +7,4 @@ export type {
   IntegrityResult,
   RegistryIntegrityInput,
 } from './types.ts'
-export { verifyGitOneCheck, verifyHash, verifyRegistryThreeCheck } from './verify.ts'
+export { verifyGitOneCheck, verifyHash, verifyLockfileOneCheck, verifyRegistryThreeCheck } from './verify.ts'

--- a/packages/protocol/src/integrity/verify.ts
+++ b/packages/protocol/src/integrity/verify.ts
@@ -97,3 +97,24 @@ export function verifyRegistryThreeCheck(input: RegistryIntegrityInput): Integri
 export function verifyGitOneCheck(input: GitIntegrityInput): IntegrityResult {
   return verifyHash(input.facet, 'git', input.lockfileIntegrity, input.computedIntegrity)
 }
+
+/**
+ * Run the lockfile reproduction check. Returns `{ ok: true }` if the
+ * locally-built artifact's integrity matches the lockfile's recorded
+ * integrity, otherwise the structured failure with `check: 'lockfile'`.
+ *
+ * This is the non-git counterpart to `verifyGitOneCheck`. It applies
+ * wherever a build-derived artifact must reproduce its locked integrity
+ * but no git tag-move is involved — most notably a `--frozen-lockfile`
+ * install of a LOCAL source, where the on-disk content was edited and no
+ * longer hashes to what `facets.lock` pinned. Reusing the git check there
+ * would mislabel the failure as `check: 'git'` even though nothing git
+ * happened; `'lockfile'` correctly names the failure as built-vs-lockfile
+ * divergence (the same semantics as the registry three-check's first check).
+ *
+ * Takes `GitIntegrityInput` — the field shape (computed vs. lockfile
+ * integrity) is identical; only the emitted `check` label differs.
+ */
+export function verifyLockfileOneCheck(input: GitIntegrityInput): IntegrityResult {
+  return verifyHash(input.facet, 'lockfile', input.lockfileIntegrity, input.computedIntegrity)
+}


### PR DESCRIPTION
### Why

`facet install --frozen-lockfile` was not fully reproducing the lockfile. Two gaps allowed silent drift:

1. A git or local facet whose manifest source string (URL, ref, or path) had changed would still build from the new (unlocked) origin instead of failing the preflight.
2. A local facet whose source path was unchanged but whose on-disk content had drifted would be silently rebuilt and its lockfile entry overwritten, rather than failing the install.

Additionally, the git cache is keyed on `{name, version}` with no source provenance, meaning a changed manifest URL could cause a cache hit that served bytes from the old origin.

### Details

**Source drift detection (`detect-lockfile-drift.ts`):** A new `source-changed` drift reason is emitted during the frozen preflight when a git or local facet's manifest source string differs from the locked source. This fires before any clone, resolve, or build, so nothing is mutated. Registry version drift continues to be handled by the existing `satisfies` check and is never reported as `source-changed`.

**Local content integrity in frozen mode (`plan-facet.ts`):** The integrity reproduction guard previously exempted local sources on the grounds that local content is mutable by design. In frozen mode, that exemption is lifted — a local facet must hash to its locked integrity, exactly as a git facet must. A mismatch fails with `INTEGRITY_FAILURE` and leaves the project untouched. Non-frozen installs retain the existing behavior of rebuilding and overwriting the local entry.

**Cache bypass for changed git URLs (`plan-facet.ts`):** The cache-first path for git facets now requires that the manifest source matches `locked.source`. When the URL has changed, the cache lookup is skipped entirely and the install falls through to cloning from the new source. This corrects cache behavior for non-frozen installs as well.

**UI (`failure-block.tsx`):** The `source-changed` drift reason is rendered as `source changed: locked <locked-source>, manifest wants <manifest-spec>`.

### Verification

New and updated unit tests cover:
- `detectLockfileDrift` emitting `source-changed` for a swapped git URL, a swapped local path, and confirming no drift when the source is unchanged or when a registry specifier is merely widened.
- `runInstall` in frozen mode failing on a git source-string change without invoking the resolver or mutating any project file.
- `runInstall` in frozen mode failing with `INTEGRITY_FAILURE` when a local facet's content has drifted, leaving both `facets.json` and `facets.lock` byte-for-byte unchanged.
- The existing cache-hit test updated to require the manifest source to match the locked source, reflecting the new bypass logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install and cache behavior on security-sensitive frozen-lockfile and git paths; scope is well-tested but affects CI reproducibility contracts.
> 
> **Overview**
> **`facet install --frozen-lockfile`** is tightened so CI can treat the lockfile as a bit-for-bit contract, not just version coverage.
> 
> Frozen preflight now fails with **`source-changed`** when a git or local facet’s manifest source string (URL, ref, or path) differs from `locked.source`, before any clone or build. Registry drift stays on the existing **`satisfies`** path and is never reported as source-changed.
> 
> In **`plan-facet`**, **`--frozen-lockfile`** applies the same integrity reproduction rules to **local** facets as to git/registry: edited local content fails with **`INTEGRITY_FAILURE`** instead of rebuilding and overwriting the lock entry. Non-frozen installs still rebuild locals and update the lockfile.
> 
> Git cache lookup is skipped unless the manifest source matches **`locked.source`**, so a changed URL cannot reuse `{name, version}` cache bytes from another origin (non-frozen installs benefit too). **`runInstall`** passes **`frozenLockfile`** into **`planFacet`**.
> 
> The install TUI shows **`source-changed`** drift; docs, OpenSpec, and changeset describe the contract. Tests cover drift detection, frozen git source failure, local content drift, and updated cache-hit fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c6fb239ceae7a58a70359f8ff231115ee37791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->