### PR TITLE
Add `facet remove` (aliased `rm`); extract shared `ensureAdapters`; add remove engine orchestrator with manifest snapshot/restore

### DIFF
--- a/.changeset/violet-hands-build.md
+++ b/.changeset/violet-hands-build.md
@@ -1,0 +1,12 @@
+---
+"agent-facets": minor
+---
+
+Add the `facet remove` command (aliased `rm`) — the inverse of `facet add`.
+
+`facet remove <facet> [more facets...]` takes one or more facets back out of a project in a single command: it removes them from `facets.json`, deletes their assets from every connected adapter, and rewrites `facets.lock` without them.
+
+- **Transactional** — removal reuses the same install pipeline as `facet add`, so any failure restores `facets.json` byte-for-byte and leaves the project unchanged.
+- **All-or-nothing** — when removing multiple facets, if any name is not declared in `facets.json`, nothing is removed.
+- **Strict** — removing a facet that is not declared fails with a clear error instead of silently succeeding. Every facet you don't name is left untouched.
+- **`--verbose`** — emits detailed step output on stderr, matching `facet add`/`facet install`.

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -4,6 +4,37 @@ description: What's new in Agent Facets
 rss: true
 ---
 
+<Update label="2026-06-06" description="New facet remove command (aliased rm)" tags={["CLI", "New Feature"]} rss={{
+  title: "New command: facet remove",
+  description: "facet remove (aliased rm) takes one or more facets out of a project: it removes them from facets.json, deletes their assets from every connected adapter, and rewrites facets.lock without them, in a single command. It is the inverse of facet add and reuses the same install pipeline, so removal is transactional — any failure restores facets.json byte-for-byte. Removing multiple facets is all-or-nothing, and removing a facet that is not declared fails without changing anything."
+}}>
+  ## New command: `facet remove`
+
+  `facet remove <facet> [more facets...]` is the inverse of `facet add`: it
+  takes facets back out of a project. In one command it removes the named
+  facets from `facets.json`, deletes their assets from every connected
+  adapter, and rewrites `facets.lock` without them.
+
+  ```bash
+  # Remove a single facet.
+  facet remove viper-plans
+
+  # rm is an alias.
+  facet rm viper-plans
+
+  # Remove several at once.
+  facet remove viper-plans rezi
+  ```
+
+  Removal reuses the same install pipeline as `facet add`, so it is
+  **transactional**: any failure restores `facets.json` byte-for-byte and
+  leaves the project unchanged. Removing multiple facets is all-or-nothing —
+  if any name is not declared in `facets.json`, nothing is removed. Every
+  facet you don't name is left untouched.
+
+  See the [`facet remove`](/cli/remove) reference for details.
+</Update>
+
 <Update label="2026-06-05" description="Bearer-token auth for the registry; new login/whoami/logout commands; FACET_REGISTRY_API_KEY removed; install now re-resolves a stale lockfile; new --frozen-lockfile flag" tags={["CLI", "Breaking", "New Feature", "Fix"]} rss={{
   title: "Registry auth moves to bearer tokens; new login/whoami/logout commands; install honors manifest edits",
   description: "The facet CLI now authenticates to the registry with a personal access token sent as a bearer credential, replacing the old FACET_REGISTRY_API_KEY API key. FACET_REGISTRY_API_KEY has been removed with no shim. Provide a token via the FACET_TOKEN environment variable or by running the new `facet login` command, which verifies the token and saves it to ~/.facet/credentials. Two more new commands: `facet whoami` prints the signed-in identity, and `facet logout` clears the saved credential. `facet publish` now also accepts an optional directory argument. Registry errors are now rendered using the registry's own message and suggested fix. Bug fix: editing a facet's version in facets.json now takes effect — facet install re-resolves a lockfile entry that no longer satisfies the manifest, and fails if the requested version does not exist, instead of silently keeping the old version. New flag: facet install --frozen-lockfile treats the lockfile as the source of truth and fails on any manifest/lockfile drift, for reproducible CI installs."

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -8,11 +8,47 @@ tag: facet remove
 ## Usage
 
 ```sh
-facet remove <facet>
+facet remove <facet> [more facets...]
 ```
 
-WIP
+Removes one or more facets from `facets.json`, deletes their assets from every connected adapter, and rewrites `facets.lock` without them — in a single command. The inverse of [`facet add`](/cli/add). Aliased as `facet rm`.
 
 ## What it does
 
-WIP
+1. **Load `facets.json`.** A missing or invalid manifest fails before any change.
+2. **Validate every name is declared.** If any named facet is not in `facets.json`, the command fails and changes nothing — removing multiple facets is all-or-nothing.
+3. **Snapshot `facets.json`** byte-for-byte for rollback.
+4. **Remove the named entries** from `facets.json`.
+5. **Run the install pipeline.** The removed facets are now absent from the manifest, so drift removal deletes their assets from every adapter and rewrites the lockfile without them. Every other facet is left untouched.
+6. **On any failure**, restore the `facets.json` snapshot. The project is left exactly as it was before the command ran.
+
+## Examples
+
+```sh
+# Remove a single facet.
+facet remove viper-plans
+
+# rm is an alias.
+facet rm viper-plans
+
+# Remove several at once (all-or-nothing).
+facet remove viper-plans rezi
+```
+
+## Flags
+
+| Flag        | Description                          |
+| ----------- | ------------------------------------ |
+| `--verbose` | Show detailed step output on stderr. |
+
+## Exit codes
+
+| Code | Meaning                                                                              |
+| ---- | ------------------------------------------------------------------------------------ |
+| `0`  | Removal succeeded.                                                                   |
+| `1`  | Failed (no names given, a named facet not in `facets.json`, install failure, etc.). `facets.json` is restored byte-for-byte on every failure path. |
+
+## See also
+
+- [`facet add`](/cli/add) — the inverse: add a facet to `facets.json` and install it in one step.
+- [`facet install`](/cli/install) — reapply `facets.json` and the lockfile.

--- a/docs/roadmap/beta.md
+++ b/docs/roadmap/beta.md
@@ -16,6 +16,13 @@ These commands are implemented and ready to use:
 | `facet build`   | Validate and package a **facet** into a distributable archive                                |
 | `facet add`     | Add a **facet** to the project — resolve from a source, download, and install in one step    |
 | `facet install` | Reapply `facets.json` and `facets.lock`; bootstrap the lockfile on first run                 |
+| `facet remove`  | Remove a **facet** from the project, delete its assets, and update the lockfile              |
+| `facet search`  | Search the registry for **facets**                                                           |
+| `facet list`    | List installed **facets**                                                                    |
+| `facet publish` | Publish a built **facet** to the registry                                                    |
+| `facet login`   | Sign in to the registry with a personal access token                                         |
+| `facet logout`  | Clear the saved registry credential                                                          |
+| `facet whoami`  | Show the signed-in registry identity                                                         |
 
 ## Planned
 
@@ -23,8 +30,5 @@ These commands are registered in the CLI but not yet implemented:
 
 | Command         | Description                                                                  |
 | --------------- | ---------------------------------------------------------------------------- |
-| `facet remove`  | Remove a **facet** from the project and update the lockfile                  |
 | `facet upgrade` | Interactive upgrade wizard for installed **facets**                          |
-| `facet publish` | Publish a built **facet** to the registry                                   |
-| `facet info`    | Show information about a **facet** from the registry                        |
-| `facet list`    | List installed **facets**                                                   |
+| `facet info`    | Show information about a **facet** from the registry                         |

--- a/docs/specification/install.md
+++ b/docs/specification/install.md
@@ -205,9 +205,9 @@ The lockfile SHOULD be version-controlled so that all team members and CI enviro
 
 6. **Write the updated lockfile.** Record the new versions, content hashes, and API surface hashes for all updated artifacts.
 
-## Uninstall
+## Remove
 
-`facet uninstall` removes a facet and its managed assets.
+`facet remove` removes a facet and its managed assets.
 
 ### Steps
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -820,3 +820,83 @@ The CLI SHALL register a `logout` command that removes the saved credentials fil
 - **WHEN** a user runs `logout` with no saved credentials file present
 - **THEN** the CLI SHALL report that there were no saved credentials to remove
 - **AND** the process SHALL exit with code 0
+
+### Requirement: Remove command is registered
+
+The system SHALL register a `remove` command that removes one or more facets from the project manifest and uninstalls them in a single operation. The command SHALL accept one or more facet names as positional arguments. The system SHALL also accept `rm` as an alias of the same command, so users with muscle memory for either name succeed; both names SHALL invoke identical behavior.
+
+#### Scenario: Remove command is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the help output SHALL list the `remove` command with its description
+- **AND** the help output SHALL list `rm` as an alias of the same command
+
+#### Scenario: rm alias produces identical behavior
+
+- **WHEN** a user runs `rm` with the same arguments and flags as a corresponding `remove` invocation
+- **THEN** the system SHALL produce the same output, side effects, and exit code as `remove`
+
+#### Scenario: Remove command requires at least one name
+
+- **WHEN** a user runs `remove` with no positional arguments
+- **THEN** the system SHALL print a usage error
+- **AND** the process SHALL exit with code 1
+
+#### Scenario: Remove command accepts multiple names
+
+- **WHEN** a user runs `remove` with two or more facet names
+- **THEN** the system SHALL remove each named facet
+- **AND** the operation SHALL succeed only if every named facet is removed successfully
+
+### Requirement: Remove renders the unified progress view
+
+The `remove` command SHALL present progress through the same shared rendering used by the commands that add and install facets. A user watching `remove` SHALL see a per-facet section that names each removed facet and indicates whether its removal succeeded or failed, followed by a final summary that lists each affected facet on its own line.
+
+#### Scenario: Single-facet removal shows per-facet detail
+
+- **WHEN** a user runs `remove` with exactly one facet to remove
+- **THEN** the rendered view SHALL show the facet's name and its removal progress
+- **AND** on completion the view SHALL show a one-line summary identifying the removed facet
+
+#### Scenario: Multi-facet removal shows aggregate progress
+
+- **WHEN** a user runs `remove` with multiple facets to remove
+- **THEN** the rendered view SHALL show progress for each facet
+- **AND** on completion the view SHALL show one summary line per affected facet
+
+### Requirement: Remove reports an undeclared facet clearly
+
+When `remove` is asked to remove a facet that is not declared in the project, the system SHALL identify the undeclared facet by name and SHALL exit with a non-zero code without modifying the project.
+
+#### Scenario: Removing an undeclared facet is reported
+
+- **WHEN** a user runs `remove` with a name that is not declared in the project manifest
+- **THEN** the system SHALL print an error identifying the undeclared facet by name
+- **AND** the project manifest, lockfile, and adapter state SHALL be unchanged
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: Remove reports rollback outcome on failure
+
+When a remove operation fails after the project manifest has been modified, the rendered view SHALL indicate whether the project was fully restored to its pre-operation state or whether some state may remain, and the process SHALL exit with a non-zero code.
+
+#### Scenario: Failed removal that fully rolls back
+
+- **WHEN** a remove operation fails and the system fully restores the project to its pre-operation state
+- **THEN** the rendered view SHALL indicate that the project state is unchanged
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Failed removal that cannot fully roll back
+
+- **WHEN** a remove operation fails and the system cannot fully restore the project
+- **THEN** the rendered view SHALL warn the user that some state may remain
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: Remove accepts verbose output
+
+The `remove` command SHALL accept a `--verbose` flag that emits additional diagnostic output. The verbose output SHALL be written to stderr so that it does not interfere with the rendered view on stdout.
+
+#### Scenario: Verbose flag emits diagnostics on stderr
+
+- **WHEN** a user runs `remove` with `--verbose`
+- **THEN** the rendered view SHALL appear on stdout as usual
+- **AND** additional diagnostic output SHALL appear on stderr

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -565,3 +565,69 @@ When an install operation fails for any reason after the manifest has been modif
 
 - **WHEN** an install operation fails before the lockfile is committed
 - **THEN** the lockfile on disk SHALL match its pre-operation contents
+
+### Requirement: Removing a facet uninstalls it
+
+When a user removes a facet from a project, the system SHALL drop the facet from the project manifest, delete the facet's materialized assets from every selected adapter, and update the lockfile so it no longer records the facet — all in a single operation. A user SHALL NOT need to run a separate install step after removing.
+
+#### Scenario: Removing a declared facet uninstalls it
+
+- **WHEN** a user removes a facet that is declared in the project manifest
+- **THEN** the system SHALL remove the facet's entry from the project manifest
+- **AND** the system SHALL delete every asset the facet contributed from every selected adapter
+- **AND** the system SHALL update the lockfile so it no longer records the facet
+- **AND** the operation SHALL complete in a single command invocation
+
+#### Scenario: Other facets are left intact
+
+- **WHEN** a user removes one facet from a project that declares several facets
+- **THEN** the system SHALL leave every other declared facet's manifest entry, lockfile entry, and materialized assets unchanged
+
+#### Scenario: Removing the last facet leaves an empty project
+
+- **WHEN** a user removes the only facet declared in the project
+- **THEN** the system SHALL leave the project manifest declaring no facets
+- **AND** the system SHALL leave a valid lockfile that records no facets
+
+### Requirement: Removing multiple facets is a single all-or-nothing operation
+
+When a user removes more than one facet in a single invocation, the system SHALL remove all of the named facets together. If any named facet cannot be removed, the system SHALL remove none of them and SHALL leave the project unchanged.
+
+#### Scenario: All named facets are removed together
+
+- **WHEN** a user removes two or more facets that are all declared in the project manifest
+- **THEN** the system SHALL remove every named facet's manifest entry, assets, and lockfile entry
+- **AND** the operation SHALL succeed only if every named facet was removed
+
+#### Scenario: One absent name aborts the whole removal
+
+- **WHEN** a user removes two or more facets and at least one of them is not declared in the project manifest
+- **THEN** the system SHALL NOT remove any of the named facets
+- **AND** the system SHALL leave the project manifest, lockfile, and adapter state unchanged
+
+### Requirement: Removing an undeclared facet fails
+
+When a user removes a facet that is not declared in the project manifest, the system SHALL fail with an error identifying the facet and SHALL leave the project unchanged. The system SHALL NOT treat the removal of an undeclared facet as a silent success.
+
+#### Scenario: Removing a facet that is not declared
+
+- **WHEN** a user removes a facet whose name does not appear in the project manifest
+- **THEN** the system SHALL fail with an error identifying the facet by name
+- **AND** the system SHALL leave the project manifest, lockfile, and adapter state unchanged
+- **AND** the system SHALL exit with a non-zero status
+
+### Requirement: Failed removals leave the project unchanged
+
+When a remove operation fails for any reason after the project manifest has been modified, the system SHALL restore the manifest to its pre-operation state. The user SHALL NOT be left with a project whose manifest no longer references a facet whose assets were never removed.
+
+#### Scenario: Removal failure rolls back the manifest
+
+- **WHEN** the system has removed a facet's entry from the project manifest as part of a remove operation
+- **AND** a subsequent step (asset deletion or lockfile update) fails
+- **THEN** the system SHALL restore the manifest to its exact pre-operation contents
+- **AND** the system SHALL surface the failure to the user
+
+#### Scenario: Removal failure leaves the lockfile unchanged
+
+- **WHEN** a remove operation fails before the lockfile update is committed
+- **THEN** the lockfile on disk SHALL match its pre-operation contents

--- a/packages/cli/src/__tests__/cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/cli.e2e.test.ts
@@ -28,13 +28,14 @@ const IMPLEMENTED_COMMAND_NAMES = [
   'login',
   'logout',
   'publish',
+  'remove',
   'search',
   'self-update',
   'whoami',
 ]
 // Stubs — invocable (to surface "did you mean…" suggestions) but hidden from
 // the global help listing (Adjustment K).
-const STUB_COMMAND_NAMES = ['info', 'remove', 'upgrade']
+const STUB_COMMAND_NAMES = ['info', 'upgrade']
 
 type ExecResult = {
   stdout: string

--- a/packages/cli/src/__tests__/remove.e2e.test.ts
+++ b/packages/cli/src/__tests__/remove.e2e.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+/**
+ * End-to-end tests for `facet remove` that spawn the compiled `./dist/facet`
+ * binary as a subprocess. These cover the CLI surface — argv parsing, help
+ * listing + `rm` alias, and usage errors — that the engine unit tests
+ * cannot exercise.
+ *
+ * The full remove transaction (manifest mutation, asset pruning, lockfile
+ * regeneration, undeclared-facet failure, multi-name atomicity, and
+ * install-failure rollback) is covered end-to-end against real
+ * materialization by the engine's `run-remove.test.ts`. Driving those paths
+ * through the compiled binary would require a working installed adapter
+ * (and a seeded facet), which the engine suite already exercises directly,
+ * so this file stays focused on argv/help/usage behavior.
+ */
+
+const CLI_PATH = resolve(import.meta.dir, '../../dist/facet')
+
+if (!existsSync(CLI_PATH)) {
+  throw new Error(
+    `[e2e] dist/facet not found at ${CLI_PATH}.\n` +
+      `Build the CLI first:\n` +
+      `  bun run --cwd packages/cli build\n` +
+      `Or run the full check pipeline:\n` +
+      `  bun check`,
+  )
+}
+
+type ExecResult = { stdout: string; stderr: string; exitCode: number }
+
+async function runCli(args: string[], opts?: { cwd?: string; env?: Record<string, string> }): Promise<ExecResult> {
+  const proc = Bun.spawn([CLI_PATH, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    cwd: opts?.cwd,
+    env: { ...process.env, ...opts?.env },
+  })
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  const exitCode = await proc.exited
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode }
+}
+
+// --- Help / alias ---
+
+describe('facet remove — help', () => {
+  test('--help lists remove with its rm alias', async () => {
+    const result = await runCli(['--help'])
+    expect(result.exitCode).toBe(0)
+    // remove is implemented, so it appears in global help, comma-joined with rm.
+    expect(result.stdout).toMatch(/^\s+remove,\s*rm\s/m)
+    expect(result.stderr).toBe('')
+  })
+
+  test('remove --help shows usage and --verbose flag', async () => {
+    const result = await runCli(['remove', '--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('facet remove')
+    expect(result.stdout).toContain('[more facets...]')
+    expect(result.stdout).toContain('--verbose')
+    expect(result.stderr).toBe('')
+  })
+})
+
+// --- Usage error ---
+
+describe('facet remove — usage', () => {
+  test('no arguments prints usage error and exits 1', async () => {
+    const result = await runCli(['remove'])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('missing facet name')
+    expect(result.stdout).toBe('')
+  })
+
+  test('rm alias with no arguments also errors', async () => {
+    const result = await runCli(['rm'])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('missing facet name')
+  })
+})
+
+// --- Validation ordering: facet checks run before adapter discovery ---
+
+describe('facet remove — validates before adapter discovery', () => {
+  let projectRoot: string
+  let fakeHome: string
+
+  beforeEach(() => {
+    projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-rm-e2e-')))
+    fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-rm-home-')))
+    // An empty adapters dir → zero installed adapters.
+    mkdirSync(join(fakeHome, '.facet', 'adapters'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true })
+    rmSync(fakeHome, { recursive: true, force: true })
+  })
+
+  test('removing an undeclared facet with no adapters reports the facet error, not the adapter error', async () => {
+    // Valid manifest that declares one facet — but NOT the one we remove.
+    const before = `${JSON.stringify({ facets: { cowsay: '0.1.1' } }, null, 2)}\n`
+    writeFileSync(join(projectRoot, 'facets.json'), before)
+
+    const result = await runCli(['remove', 'ghost'], {
+      cwd: projectRoot,
+      env: { HOME: fakeHome, FACET_DIR: join(fakeHome, '.facet') },
+    })
+
+    expect(result.exitCode).toBe(1)
+    // The undeclared-facet error wins because validation runs before adapter
+    // discovery. The old ordering would have reported the adapter error here.
+    expect(result.stderr).toContain('not declared in facets.json')
+    expect(result.stderr).toContain('ghost')
+    expect(result.stderr).not.toContain('no adapters installed')
+    // Nothing was removed: the manifest is byte-for-byte unchanged.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(before)
+  })
+})

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -8,6 +8,7 @@ import { listCommand } from './commands/list/index.ts'
 import { loginCommand } from './commands/login/index.ts'
 import { logoutCommand } from './commands/logout/index.ts'
 import { publishCommand } from './commands/publish/index.ts'
+import { removeCommand } from './commands/remove/index.ts'
 import { searchCommand } from './commands/search/index.ts'
 import { selfUpdateCommand } from './commands/self-update.ts'
 import { whoamiCommand } from './commands/whoami/index.ts'
@@ -62,7 +63,7 @@ export const commands: Record<string, Command> = {
   login: loginCommand,
   logout: logoutCommand,
   publish: publishCommand,
-  remove: stubCommand('remove', 'Remove a facet from the project'),
+  remove: removeCommand,
   search: searchCommand,
   'self-update': selfUpdateCommand,
   upgrade: stubCommand('upgrade', 'Upgrade installed facets'),

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -1,8 +1,6 @@
-import type { Adapter } from '@agent-facets/adapter'
 import {
   type AddPrepareFailure,
   type AddSource,
-  loadInstalledAdapters,
   type ParseError,
   parseFacetSource,
   type RunAddResult,
@@ -13,7 +11,7 @@ import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
 import { writeCliError } from '../../util/errors.ts'
-import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
+import { ensureAdapters } from '../shared/ensure-adapters.ts'
 
 /**
  * `facet add <source> [more sources...]` — adds one or more facets to
@@ -149,53 +147,6 @@ export const addCommand: Command = {
     })
     return 1
   },
-}
-
-/**
- * Discover installable adapters. If none, auto-launch the picker on
- * TTY; on non-TTY return null with a CLI error already written.
- */
-async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
-  const adapters = await loadInstalledAdapters()
-  const installable = adapters.filter((a) => a.supportsInstall === true)
-  if (installable.length > 0) return installable
-
-  if (adapters.length > 0) {
-    const stale = adapters.map((a) => a.name).join(', ')
-    writeCliError({
-      what: `installed adapters do not support install yet: ${stale}`,
-      detail: 'these adapters were bundled before install support shipped; the capability flag is missing',
-      fix: "update each with 'facet adapter install <name>' to pull a version with install support",
-    })
-    return null
-  }
-
-  // Zero installable adapters. TTY → picker; non-TTY → fail.
-  const result = await pickAndInstallAdapters()
-  if (result.ok) {
-    const installableAfter = result.adapters.filter((a) => a.supportsInstall === true)
-    if (installableAfter.length === 0) {
-      writeCliError({
-        what: 'no adapters with install support after picker',
-        detail: 'the selected adapter(s) bundled an old SDK without install support',
-        fix: 'pick a different adapter or update one with install support',
-      })
-      return null
-    }
-    return installableAfter
-  }
-
-  if (result.reason === 'non-tty') {
-    writeCliError({
-      what: 'no adapters installed',
-      detail: 'this is a non-interactive environment; the picker cannot run here',
-      fix: "run 'facet adapter install <name>' first (e.g. claude-code, opencode)",
-    })
-  } else if (result.reason === 'aborted') {
-    process.stderr.write('Aborted: no adapters installed.\n')
-  }
-  // 'install-failed': pickAndInstallAdapters wrote its own CLI error.
-  return null
 }
 
 function writeParseError(specifier: string, error: ParseError): void {

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -98,10 +98,11 @@ export const installCommand: Command = {
           return result
         },
         onComplete: (r) => {
-          // `install` never produces a prepare-phase failure; guard the
-          // wider InstallViewResult so the captured value stays a
-          // RunInstallResult. The `run` closure already set `captured`.
-          if (!('prepareFailure' in r)) captured = r
+          // `install` never produces a prepare-phase failure (add/remove
+          // only); guard the wider InstallViewResult so the captured value
+          // stays a RunInstallResult. The `run` closure already set
+          // `captured`.
+          if (!('prepareFailure' in r) && !('removePrepareFailure' in r)) captured = r
         },
       }),
     )

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -1,0 +1,177 @@
+import { prepareRemove, type RemovePrepareFailure, type RunRemoveResult, runRemove } from '@agent-facets/engine'
+import { render } from 'ink'
+import { createElement } from 'react'
+import type { Command } from '../../commands.ts'
+import { InstallView } from '../../tui/views/install/install-view.tsx'
+import { writeCliError } from '../../util/errors.ts'
+import { ensureAdapters } from '../shared/ensure-adapters.ts'
+
+/**
+ * `facet remove <facet> [more facets...]` — removes one or more facets
+ * from `facets.json` and uninstalls them in a single operation.
+ *
+ * This command is a thin caller over the engine `remove` orchestrator
+ * (`runRemove`), which owns the manifest transaction: validate every name
+ * is declared, snapshot `facets.json`, remove the entries, run the install
+ * pipeline (whose drift-removal deletes the facets' assets and rewrites
+ * the lockfile), and restore the snapshot on failure. This file only
+ * parses argv, ensures adapters, renders progress, and maps the result to
+ * an exit code + error block.
+ */
+export const removeCommand: Command = {
+  name: 'remove',
+  description: 'Remove a facet from facets.json and uninstall it',
+  usage: '<facet> [more facets...]',
+  aliases: ['rm'],
+  implemented: true,
+  flags: {
+    verbose: { type: 'boolean', description: 'Show detailed step output on stderr' },
+  },
+  run: async (args, flags) => {
+    if (args.length === 0) {
+      writeCliError({
+        what: 'missing facet name',
+        detail: 'facet remove requires at least one facet name',
+        fix: 'run: facet remove <facet>    (e.g. facet remove viper-plans)',
+      })
+      return 1
+    }
+
+    const verbose = flags.verbose === true
+    const onLog = verbose ? (line: string) => process.stderr.write(`${line}\n`) : undefined
+
+    const names = args
+    const projectRoot = process.cwd()
+
+    // Validate the manifest + names BEFORE discovering adapters. An
+    // undeclared facet or missing manifest must fail with the facet error
+    // and leave the project untouched — never launching the adapter picker
+    // or reporting "no adapters installed" (the contract per the CLI spec's
+    // "Remove reports an undeclared facet clearly"). The validated result is
+    // threaded into `runRemove` so validation runs exactly once.
+    const prepared = prepareRemove({ projectRoot, names })
+    if (!prepared.ok) {
+      writePrepareError(prepared.failure)
+      return 1
+    }
+
+    // Discover or pick adapters. Drift-removal calls `deleteAsset` on each
+    // selected adapter, so removal needs installable adapters just like add.
+    const adapters = await ensureAdapters()
+    if (adapters === null) {
+      // ensureAdapters already wrote the appropriate CLI error.
+      return 1
+    }
+
+    // Wire SIGINT to an AbortController so engine never installs a
+    // process-global signal handler. The view's deferred-exit pattern
+    // ensures the rollback render lands before unmount.
+    const controller = new AbortController()
+    const sigintHandler = () => {
+      process.stderr.write('\nInterrupted. Rolling back...\n')
+      controller.abort()
+    }
+    process.on('SIGINT', sigintHandler)
+
+    let captured: RunRemoveResult | undefined
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'remove',
+        run: async (onStage) => {
+          const result = await runRemove({
+            projectRoot,
+            names,
+            adapters,
+            prepared,
+            onStage,
+            ...(onLog ? { onLog } : {}),
+            signal: controller.signal,
+          })
+          captured = result
+          // The view renders from a RunInstallResult-shaped value. Map
+          // runRemove's result into what the view expects: install success
+          // and install failures pass through verbatim; a prepare-phase
+          // failure surfaces via the dedicated remove prepare-failure arm.
+          if (result.ok) return result.install
+          if (result.phase === 'install') return result.install
+          return { ok: false, removePrepareFailure: result.failure }
+        },
+        onComplete: (r) => {
+          // `onComplete` receives the view-shaped result; `captured` is
+          // already the richer RunRemoveResult set in `run`.
+          void r
+        },
+      }),
+    )
+
+    try {
+      await instance.waitUntilExit()
+    } catch {
+      // Ink rejects on view-level failure; we have the captured result.
+    } finally {
+      process.off('SIGINT', sigintHandler)
+    }
+
+    if (!captured) {
+      writeCliError({
+        what: 'remove failed',
+        detail: 'the remove pipeline returned no result',
+        fix: 'this is a bug; please file an issue with the verbose log',
+      })
+      return 1
+    }
+
+    if (captured.ok) return 0
+
+    if (captured.phase === 'prepare') {
+      writePrepareError(captured.failure)
+      return 1
+    }
+
+    // Install-phase failure. The orchestrator restored the manifest
+    // snapshot; branch the guidance on whether restore succeeded and
+    // whether the install rollback was partial.
+    const rollback = captured.install.rollback
+    const partialFailureCount = rollback.kind === 'partial-failure' ? rollback.failures : 0
+    const rollbackFailed = partialFailureCount > 0 || !captured.manifestRestored
+    writeCliError({
+      what: 'remove failed',
+      detail: `code=${captured.install.failure.code}`,
+      fix: rollbackFailed
+        ? `partial rollback: some state may remain (manifest restored: ${captured.manifestRestored}). Inspect and clean manually before re-running 'facet remove'.`
+        : "rollback complete; project state unchanged. Fix the underlying issue and re-run 'facet remove'.",
+    })
+    return 1
+  },
+}
+
+/**
+ * Map a `RemovePrepareFailure` (engine) to the canonical CLI error block
+ * on stderr. The view already rendered a richer block on stdout; this
+ * keeps stderr grep-friendly and gives each failure a precise fix line.
+ */
+function writePrepareError(failure: RemovePrepareFailure): void {
+  switch (failure.reason) {
+    case 'manifest-read':
+      writeCliError({
+        what: 'could not read facets.json',
+        detail: failure.error,
+        fix: 'run this command inside a project with a valid facets.json',
+      })
+      return
+    case 'not-declared':
+      writeCliError({
+        what: `facet ${failure.names.length === 1 ? 'is' : 'are'} not declared in facets.json`,
+        detail: failure.names.join(', '),
+        fix: 'check the name(s) against facets.json; nothing was removed',
+      })
+      return
+    case 'manifest-write':
+      writeCliError({
+        what: 'could not write facets.json',
+        detail: failure.error,
+        fix: 'check file permissions and available disk space; nothing was removed',
+      })
+      return
+  }
+}

--- a/packages/cli/src/commands/shared/ensure-adapters.ts
+++ b/packages/cli/src/commands/shared/ensure-adapters.ts
@@ -1,0 +1,57 @@
+import type { Adapter } from '@agent-facets/adapter'
+import { loadInstalledAdapters } from '@agent-facets/engine'
+import { writeCliError } from '../../util/errors.ts'
+import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
+
+/**
+ * Discover install-capable adapters for commands that materialize or
+ * delete assets (`add`, `remove`). If none are installable, auto-launch
+ * the picker on a TTY; on a non-TTY return `null` with a CLI error
+ * already written.
+ *
+ * Shared by `add` and `remove` because both drive the install pipeline,
+ * which writes (`add`) or deletes (`remove`) assets across every selected
+ * adapter — the adapter-discovery contract is identical for both.
+ */
+export async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
+  const adapters = await loadInstalledAdapters()
+  const installable = adapters.filter((a) => a.supportsInstall === true)
+  if (installable.length > 0) return installable
+
+  if (adapters.length > 0) {
+    const stale = adapters.map((a) => a.name).join(', ')
+    writeCliError({
+      what: `installed adapters do not support install yet: ${stale}`,
+      detail: 'these adapters were bundled before install support shipped; the capability flag is missing',
+      fix: "update each with 'facet adapter install <name>' to pull a version with install support",
+    })
+    return null
+  }
+
+  // Zero installable adapters. TTY → picker; non-TTY → fail.
+  const result = await pickAndInstallAdapters()
+  if (result.ok) {
+    const installableAfter = result.adapters.filter((a) => a.supportsInstall === true)
+    if (installableAfter.length === 0) {
+      writeCliError({
+        what: 'no adapters with install support after picker',
+        detail: 'the selected adapter(s) bundled an old SDK without install support',
+        fix: 'pick a different adapter or update one with install support',
+      })
+      return null
+    }
+    return installableAfter
+  }
+
+  if (result.reason === 'non-tty') {
+    writeCliError({
+      what: 'no adapters installed',
+      detail: 'this is a non-interactive environment; the picker cannot run here',
+      fix: "run 'facet adapter install <name>' first (e.g. claude-code, opencode)",
+    })
+  } else if (result.reason === 'aborted') {
+    process.stderr.write('Aborted: no adapters installed.\n')
+  }
+  // 'install-failed': pickAndInstallAdapters wrote its own CLI error.
+  return null
+}

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -1,19 +1,24 @@
-import type { AddPrepareFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
+import type { AddPrepareFailure, RemovePrepareFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
 import { Box, Text, useApp } from 'ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { THEME } from '../../theme.ts'
 import { AddPrepareFailureBlock } from './add-prepare-failure-block.tsx'
 import { FacetRow, type FacetState } from './facet-row.tsx'
 import { FailureBlock } from './failure-block.tsx'
+import { RemovePrepareFailureBlock } from './remove-prepare-failure-block.tsx'
 
 /**
  * Driver result. The `install` flow returns a `RunInstallResult`. The
- * `add` flow may instead fail in its pre-install (prepare) phase — name
- * resolution / manifest read — which has no `RunInstallResult` shape, so
- * it surfaces as a distinct `prepare-failure` arm the view renders via
- * {@link AddPrepareFailureBlock}.
+ * `add` and `remove` flows may instead fail in a pre-install (prepare)
+ * phase — `add`: name resolution / manifest read; `remove`: manifest read
+ * / undeclared facet — which has no `RunInstallResult` shape, so it
+ * surfaces as a distinct `prepare-failure` arm. The arm is tagged by which
+ * flow produced it so the view renders the matching block.
  */
-export type InstallViewResult = RunInstallResult | { ok: false; prepareFailure: AddPrepareFailure }
+export type InstallViewResult =
+  | RunInstallResult
+  | { ok: false; prepareFailure: AddPrepareFailure }
+  | { ok: false; removePrepareFailure: RemovePrepareFailure }
 
 export interface InstallViewProps {
   /**
@@ -24,9 +29,10 @@ export interface InstallViewProps {
   run: (onStage: (event: StageEvent) => void) => Promise<InstallViewResult>
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
-   * renders "Installing facets...". Functional behavior is identical.
+   * renders "Installing facets..."; `'remove'` renders "Removing
+   * facets...". Functional behavior is identical.
    */
-  mode: 'add' | 'install'
+  mode: 'add' | 'install' | 'remove'
   /**
    * Fires once when the install completes, before Ink unmounts. Lets
    * the caller capture the result for exit-code mapping.
@@ -37,6 +43,20 @@ export interface InstallViewProps {
 /** Type guard: a driver result that is an add prepare-phase failure. */
 function isPrepareFailure(r: InstallViewResult): r is { ok: false; prepareFailure: AddPrepareFailure } {
   return !r.ok && 'prepareFailure' in r
+}
+
+/** Type guard: a driver result that is a remove prepare-phase failure. */
+function isRemovePrepareFailure(r: InstallViewResult): r is { ok: false; removePrepareFailure: RemovePrepareFailure } {
+  return !r.ok && 'removePrepareFailure' in r
+}
+
+/**
+ * Type guard: a driver result that is an install-pipeline failure (a
+ * `RunInstallResult` with `ok: false`), as opposed to a prepare-phase
+ * failure. Narrows so `.failure` and `.rollback` are accessible.
+ */
+function isInstallFailure(r: InstallViewResult): r is Extract<RunInstallResult, { ok: false }> {
+  return !r.ok && !isPrepareFailure(r) && !isRemovePrepareFailure(r)
 }
 
 interface ServerWarning {
@@ -154,7 +174,8 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
     void start()
   }, [exitState, exit, start])
 
-  const headerLabel = mode === 'add' ? 'Adding facets...' : 'Installing facets...'
+  const headerLabel =
+    mode === 'add' ? 'Adding facets...' : mode === 'remove' ? 'Removing facets...' : 'Installing facets...'
 
   return (
     <Box flexDirection="column" padding={1} gap={1}>
@@ -195,8 +216,9 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
 
       {result?.ok && <SuccessSummary result={result} mode={mode} />}
       {result && isPrepareFailure(result) && <AddPrepareFailureBlock failure={result.prepareFailure} />}
-      {result && !result.ok && !isPrepareFailure(result) && <FailureBlock failure={result.failure} />}
-      {result && !result.ok && !isPrepareFailure(result) && result.rollback.kind === 'partial-failure' && (
+      {result && isRemovePrepareFailure(result) && <RemovePrepareFailureBlock failure={result.removePrepareFailure} />}
+      {result && isInstallFailure(result) && <FailureBlock failure={result.failure} />}
+      {result && isInstallFailure(result) && result.rollback.kind === 'partial-failure' && (
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.warning}>
             ⚠ rollback completed with {result.rollback.failures} partial failure
@@ -210,7 +232,13 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   )
 }
 
-function SuccessSummary({ result, mode }: { result: RunInstallResult & { ok: true }; mode: 'add' | 'install' }) {
+function SuccessSummary({
+  result,
+  mode,
+}: {
+  result: RunInstallResult & { ok: true }
+  mode: 'add' | 'install' | 'remove'
+}) {
   const { summary } = result
   const isNoOp = summary.installed === 0 && summary.updated === 0 && summary.repaired === 0 && summary.removed === 0
   if (isNoOp) {

--- a/packages/cli/src/tui/views/install/remove-prepare-failure-block.tsx
+++ b/packages/cli/src/tui/views/install/remove-prepare-failure-block.tsx
@@ -1,0 +1,57 @@
+import type { RemovePrepareFailure } from '@agent-facets/engine'
+import { Box, Text } from 'ink'
+import type React from 'react'
+import { THEME } from '../../theme.ts'
+
+/**
+ * Renders the structured failure detail for the `remove` flow's
+ * pre-install (prepare) phase — manifest read and undeclared-facet
+ * validation. These failures occur before the install pipeline runs, so
+ * they have no `RunInstallFailure` shape; the `remove` orchestrator
+ * reports them as `RemovePrepareFailure` and the view renders them here.
+ *
+ * The explicit return type + `assertNever` default arm makes any new
+ * `RemovePrepareFailure` variant a compile-time error here, mirroring
+ * {@link AddPrepareFailureBlock}.
+ */
+export function RemovePrepareFailureBlock({ failure }: { failure: RemovePrepareFailure }): React.JSX.Element {
+  switch (failure.reason) {
+    case 'manifest-read':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ could not read facets.json
+          </Text>
+          <Text> {failure.error}</Text>
+        </Box>
+      )
+    case 'not-declared': {
+      const count = failure.names.length
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ {count === 1 ? 'facet is not declared' : 'facets are not declared'} in facets.json
+          </Text>
+          <Text> {failure.names.join(', ')}</Text>
+          <Text color={THEME.hint}> nothing was removed; check the name(s) against facets.json</Text>
+        </Box>
+      )
+    }
+    case 'manifest-write':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ could not write facets.json
+          </Text>
+          <Text> {failure.error}</Text>
+          <Text color={THEME.hint}> nothing was removed; check file permissions and disk space</Text>
+        </Box>
+      )
+    default: {
+      // Exhaustiveness guard: any new `RemovePrepareFailure` variant must
+      // get a `case` arm above.
+      const _exhaustive: never = failure
+      return _exhaustive
+    }
+  }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -87,6 +87,14 @@ export type { AddPrepareFailure, AddSource, RunAddOptions, RunAddResult } from '
 export { runAdd } from './install/run-add.ts'
 // install orchestrator
 export { runInstall } from './install/run-install.ts'
+// remove orchestrator (owns the facet remove manifest transaction)
+export type {
+  RemovePrepareFailure,
+  RemovePrepareResult,
+  RunRemoveOptions,
+  RunRemoveResult,
+} from './install/run-remove.ts'
+export { prepareRemove, runRemove } from './install/run-remove.ts'
 export type {
   FacetOutcome,
   FacetStage,

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Tests for the `facet remove` orchestrator (`runRemove`).
+ *
+ * Each test first seeds project state by running `runAdd` (which installs a
+ * facet, writing the manifest, lockfile, and materialized assets) and then
+ * exercises `runRemove`. The registry resolve + download path is stubbed via
+ * `mock.module` exactly as in run-add.test.ts so no live registry is needed;
+ * everything downstream (build, content-hash, materialize, drift-removal,
+ * lockfile) runs for real.
+ */
+
+// --- Registry mock state (mutated per-test before calling runAdd) ---------
+
+let registryFixtureDir: string | null = null
+let registryResolvedVersion = '0.1.1'
+
+mock.module('../../registry/resolve-metadata.ts', () => ({
+  resolveRegistryMetadataBatch: async (specs: ReadonlyArray<{ name: string }>) => ({
+    ok: true,
+    value: specs.map((s) => ({
+      name: s.name,
+      version: registryResolvedVersion,
+      expectedIntegrity: 'sha256:stub',
+    })),
+  }),
+}))
+
+mock.module('../../registry/download.ts', () => ({
+  downloadAndExtractFacet: async (_meta: { name: string }, dest: string) => {
+    if (registryFixtureDir === null) {
+      return { ok: false, error: { code: 'NETWORK_ERROR', cause: 'no fixture set', attempts: 1 } }
+    }
+    cpSync(registryFixtureDir, dest, { recursive: true })
+    return { ok: true, value: undefined }
+  },
+}))
+
+// Imported AFTER the mocks are registered so run-install picks up the stubs.
+const { runAdd } = await import('../run-add.ts')
+const { runRemove, prepareRemove } = await import('../run-remove.ts')
+const { parseFacetSource } = await import('../../sources/facet/parse-source.ts')
+const { loadInstalledAdapters } = await import('../../adapters/loader.ts')
+
+let projectRoot: string
+let originalCwd: string
+let fakeHome: string
+let originalHome: string | undefined
+let originalFacetDir: string | undefined
+let adaptersDir: string
+
+/** Build a facet fixture directory (a `facet.json` + one skill). */
+function buildFixture(parent: string, name: string, version: string): string {
+  const repo = realpathSync(mkdtempSync(join(parent, 'fixture-')))
+  writeFileSync(
+    join(repo, 'facet.json'),
+    JSON.stringify({ name, version, skills: { [name]: { description: `${name} skill` } } }),
+  )
+  mkdirSync(join(repo, `skills/${name}`), { recursive: true })
+  writeFileSync(join(repo, `skills/${name}/SKILL.md`), `# ${name} ${version}\n`)
+  return repo
+}
+
+function installFakeAdapter(baseDir: string, name: string): void {
+  const dir = join(baseDir, name)
+  mkdirSync(dir, { recursive: true })
+  const assetFsImport = require.resolve('@agent-facets/adapter')
+  writeFileSync(
+    join(dir, 'adapter.js'),
+    `
+import { installAssetFile, readAssetFile, deleteAssetFile } from '${assetFsImport}'
+import { join } from 'node:path'
+function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
+export default {
+  name: '${name}',
+  supportsInstall: true,
+  buildAssetMetadata(data) { return { ok: true, data: data || {} } },
+  async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
+  async readAsset(scope, type, name) { return readAssetFile({ file: path(type, name) }) },
+  async deleteAsset(scope, type, name) { await deleteAssetFile({ file: path(type, name) }) },
+}
+`,
+  )
+}
+
+function readFacets(): Record<string, string> {
+  return JSON.parse(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).facets
+}
+
+function readLockfileFacets(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).facets
+}
+
+function assetPath(adapter: string, facet: string): string {
+  // Mirrors the fake adapter's path(): .<adapter>/skills/<facet>.md
+  return join(projectRoot, `.${adapter}`, 'skills', `${facet}.md`)
+}
+
+async function installFacet(name: string, version: string): Promise<void> {
+  registryResolvedVersion = version
+  registryFixtureDir = buildFixture(fakeHome, name, version)
+  const parsed = parseFacetSource(`${name}@${version}`)
+  if (!parsed.ok) throw new Error(`test bug: unparseable specifier ${name}@${version}`)
+  const adapters = (await loadInstalledAdapters()).filter((a) => a.supportsInstall === true)
+  const result = await runAdd({
+    projectRoot,
+    sources: [{ specifier: `${name}@${version}`, source: parsed.value }],
+    adapters,
+  })
+  if (!result.ok) throw new Error(`test bug: failed to seed facet ${name}`)
+}
+
+async function remove(names: string[]) {
+  const adapters = (await loadInstalledAdapters()).filter((a) => a.supportsInstall === true)
+  return runRemove({ projectRoot, names, adapters })
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-runremove-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-home-')))
+  const facetDir = join(fakeHome, '.facet')
+  adaptersDir = join(facetDir, 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+  process.env.HOME = fakeHome
+  process.env.FACET_DIR = facetDir
+  process.chdir(projectRoot)
+  installFakeAdapter(adaptersDir, 'test-adapter')
+  registryFixtureDir = null
+  registryResolvedVersion = '0.1.1'
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('runRemove — single-facet removal', () => {
+  test('removes the facet from manifest, lockfile, and adapter', async () => {
+    await installFacet('cowsay', '0.1.1')
+    expect(readFacets().cowsay).toBe('0.1.1')
+    expect(readLockfileFacets().cowsay).toBeDefined()
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(true)
+
+    const result = await remove(['cowsay'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+
+    expect(readFacets().cowsay).toBeUndefined()
+    expect(readLockfileFacets().cowsay).toBeUndefined()
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(false)
+    // The removed facet is surfaced as a `removed` outcome.
+    expect(result.install.perFacet.some((o) => o.kind === 'removed' && o.name === 'cowsay')).toBe(true)
+  })
+})
+
+describe('runRemove — multi-facet removal', () => {
+  test('removes all named facets in one operation', async () => {
+    await installFacet('cowsay', '0.1.1')
+    await installFacet('fortune', '0.2.0')
+
+    const result = await remove(['cowsay', 'fortune'])
+    expect(result.ok).toBe(true)
+
+    expect(readFacets().cowsay).toBeUndefined()
+    expect(readFacets().fortune).toBeUndefined()
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(false)
+    expect(existsSync(assetPath('test-adapter', 'fortune'))).toBe(false)
+  })
+
+  test('leaves other facets intact', async () => {
+    await installFacet('cowsay', '0.1.1')
+    await installFacet('fortune', '0.2.0')
+
+    const result = await remove(['cowsay'])
+    expect(result.ok).toBe(true)
+
+    expect(readFacets().cowsay).toBeUndefined()
+    expect(readFacets().fortune).toBe('0.2.0')
+    expect(readLockfileFacets().fortune).toBeDefined()
+    expect(existsSync(assetPath('test-adapter', 'fortune'))).toBe(true)
+  })
+
+  test('one absent name aborts the whole operation, leaving the project unchanged', async () => {
+    await installFacet('cowsay', '0.1.1')
+    const beforeFacets = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+    const beforeLock = readFileSync(join(projectRoot, 'facets.lock'), 'utf8')
+
+    const result = await remove(['cowsay', 'does-not-exist'])
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (result.phase !== 'prepare') expect.unreachable()
+    if (result.failure.reason !== 'not-declared') expect.unreachable()
+    expect(result.failure.names).toEqual(['does-not-exist'])
+
+    // Nothing removed.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(beforeFacets)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(beforeLock)
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(true)
+  })
+})
+
+describe('runRemove — undeclared facet', () => {
+  test('fails with not-declared and leaves the project unchanged', async () => {
+    await installFacet('cowsay', '0.1.1')
+    const beforeFacets = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+
+    const result = await remove(['ghost'])
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (result.phase !== 'prepare') expect.unreachable()
+    if (result.failure.reason !== 'not-declared') expect.unreachable()
+    expect(result.failure.names).toEqual(['ghost'])
+
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(beforeFacets)
+  })
+
+  test('fails with manifest-read when no facets.json exists', async () => {
+    // Fresh project root, no facets.json written.
+    const result = await remove(['anything'])
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (result.phase !== 'prepare') expect.unreachable()
+    expect(result.failure.reason).toBe('manifest-read')
+  })
+})
+
+describe('runRemove — last facet', () => {
+  test('removing the only facet leaves an empty manifest and valid empty lockfile', async () => {
+    await installFacet('cowsay', '0.1.1')
+
+    const result = await remove(['cowsay'])
+    expect(result.ok).toBe(true)
+
+    expect(Object.keys(readFacets())).toHaveLength(0)
+    expect(Object.keys(readLockfileFacets())).toHaveLength(0)
+    // Lockfile is still structurally valid (declares a version).
+    const lock = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    expect(lock.lockfileVersion).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('prepareRemove — read-only validation', () => {
+  test('returns not-declared for an undeclared name without mutating disk', async () => {
+    await installFacet('cowsay', '0.1.1')
+    const beforeFacets = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+    const beforeLock = readFileSync(join(projectRoot, 'facets.lock'), 'utf8')
+
+    const result = prepareRemove({ projectRoot, names: ['ghost'] })
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'not-declared') expect.unreachable()
+    expect(result.failure.names).toEqual(['ghost'])
+
+    // Pure validation: nothing on disk changed.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(beforeFacets)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(beforeLock)
+  })
+
+  test('collects all absent names (all-or-nothing) when several are undeclared', async () => {
+    await installFacet('cowsay', '0.1.1')
+
+    const result = prepareRemove({ projectRoot, names: ['cowsay', 'ghost', 'phantom'] })
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'not-declared') expect.unreachable()
+    expect(result.failure.names).toEqual(['ghost', 'phantom'])
+  })
+
+  test('returns manifest-read when no facets.json exists', () => {
+    // Fresh project root, no facets.json written.
+    const result = prepareRemove({ projectRoot, names: ['anything'] })
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.failure.reason).toBe('manifest-read')
+  })
+
+  test('returns the parsed manifest and a snapshot when every name is declared', async () => {
+    await installFacet('cowsay', '0.1.1')
+
+    const result = prepareRemove({ projectRoot, names: ['cowsay'] })
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.json.facets.cowsay).toBe('0.1.1')
+    // Snapshot captures the on-disk bytes for rollback.
+    expect(result.snapshot).not.toBeNull()
+    expect(result.snapshot?.toString('utf8')).toBe(readFileSync(join(projectRoot, 'facets.json'), 'utf8'))
+  })
+})
+
+describe('runRemove — install-failure restore', () => {
+  test('restores facets.json byte-for-byte when install fails', async () => {
+    await installFacet('cowsay', '0.1.1')
+    const before = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+
+    // Force a runInstall failure: hold the install lock so runRemove's
+    // runInstall call fails with LOCK_HELD AFTER the provisional manifest
+    // write, exercising the snapshot restore path.
+    const { acquireInstallLock } = await import('../lockfile-guard.ts')
+    const lock = acquireInstallLock(projectRoot)
+    if (!lock.ok) expect.unreachable()
+
+    try {
+      const result = await remove(['cowsay'])
+      expect(result.ok).toBe(false)
+      if (result.ok) expect.unreachable()
+      if (result.phase !== 'install') expect.unreachable()
+      expect(result.manifestRestored).toBe(true)
+    } finally {
+      await lock.lock.release()
+    }
+
+    // facets.json restored to its exact pre-command bytes.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(before)
+  })
+})

--- a/packages/engine/src/install/run-remove.ts
+++ b/packages/engine/src/install/run-remove.ts
@@ -1,0 +1,223 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
+import type { FacetsJson } from '@agent-facets/protocol'
+import { FACETS_JSON_FILE, removeFacetFromManifest } from '../manifest/mutations.ts'
+import { loadFacetsJson, writeFacetsJson } from '../manifest/project-files.ts'
+import { runInstall } from './run-install.ts'
+import type { RunInstallResult, StageEvent } from './types.ts'
+
+/**
+ * The `facet remove` orchestrator. Owns the manifest transaction for the
+ * remove flow on a developer's machine, mirroring {@link runAdd}:
+ *
+ *   1. Prepare: load `facets.json`, validate every named facet is declared,
+ *      and snapshot the manifest. A missing/invalid manifest or an
+ *      undeclared name fails here, before any mutation (there is nothing to
+ *      remove). Extracted into {@link prepareRemove} so the CLI can run this
+ *      read-only validation *before* discovering adapters — an undeclared
+ *      facet must fail with the facet error and leave state untouched, never
+ *      launching the adapter picker or reporting "no adapters installed".
+ *   2. Remove every named entry; write the manifest.
+ *   3. Run the install pipeline. The removed facets are now orphaned
+ *      lockfile entries, so the existing drift-removal loop deletes their
+ *      assets from every adapter and rewrites the lockfile without them.
+ *   4. On install failure, restore the manifest snapshot byte-for-byte.
+ *
+ * Asset deletion and lockfile regeneration are NOT reimplemented here —
+ * they are the install pipeline's existing drift-removal behavior. The
+ * manifest snapshot/restore is an engine concern (filesystem mutation),
+ * not CLI presentation. The CLI is a thin caller that renders this result.
+ *
+ * Never throws. Failures are reported via the discriminated result — the
+ * snapshot read (in `prepareRemove`) and the manifest write are both guarded
+ * and surface as a `manifest-write` prepare failure.
+ */
+
+export interface RunRemoveOptions {
+  projectRoot: string
+  /** Facet names (the `facets.json` keys) to remove — not source specifiers. */
+  names: ReadonlyArray<string>
+  adapters: ReadonlyArray<Adapter>
+  /**
+   * Pre-validated state from {@link prepareRemove}. The CLI calls
+   * `prepareRemove` before adapter discovery and threads the result in here
+   * so validation runs exactly once. When omitted (e.g. direct engine
+   * callers and tests), `runRemove` prepares internally — so it remains
+   * correct standalone.
+   */
+  prepared?: Extract<RemovePrepareResult, { ok: true }>
+  onStage?: (event: StageEvent) => void
+  onLog?: (line: string) => void
+  signal?: AbortSignal
+}
+
+/**
+ * Structured failure for the pre-install phase of `runRemove`. Tagged on
+ * `reason` so each arm carries exactly the fields that reason implies:
+ *   - `manifest-read`  — `facets.json` is missing, unreadable, or invalid;
+ *                        there is nothing to remove.
+ *   - `not-declared`   — one or more named facets are not declared in the
+ *                        manifest. Carries every absent name so the CLI can
+ *                        report them all in one shot (all-or-nothing).
+ *   - `manifest-write` — reading the snapshot or writing the mutated
+ *                        manifest hit an I/O error (permissions, disk full,
+ *                        a race). The original `facets.json` is left intact
+ *                        (the snapshot read never mutates; the write is
+ *                        atomic — tmp + rename — so a throw leaves the
+ *                        target untouched), so no install ran and nothing
+ *                        needs restoring.
+ */
+export type RemovePrepareFailure =
+  | { reason: 'manifest-read'; error: string }
+  | { reason: 'not-declared'; names: ReadonlyArray<string> }
+  | { reason: 'manifest-write'; error: string }
+
+/**
+ * Result of {@link prepareRemove}: the read-only validation + snapshot phase
+ * of a remove. On success carries the parsed manifest to mutate and the
+ * byte-for-byte snapshot used to restore on a later install failure.
+ */
+export type RemovePrepareResult =
+  | { ok: true; json: FacetsJson; snapshot: Buffer | null }
+  | { ok: false; failure: RemovePrepareFailure }
+
+/**
+ * Result of `runRemove`. Discriminated by `ok`.
+ *
+ *   - `{ ok: true; install }` — removal succeeded; the manifest no longer
+ *     declares the removed facets and the lockfile has been rewritten.
+ *   - `{ ok: false; phase: 'prepare'; failure }` — failed before any disk
+ *     mutation (manifest read, or an undeclared name).
+ *   - `{ ok: false; phase: 'install'; install; manifestRestored }` —
+ *     install failed; the manifest snapshot has been restored.
+ *     `install` is the underlying `runInstall` failure for the CLI to
+ *     render; `manifestRestored` reports whether restore succeeded.
+ */
+export type RunRemoveResult =
+  | { ok: true; install: Extract<RunInstallResult, { ok: true }> }
+  | { ok: false; phase: 'prepare'; failure: RemovePrepareFailure }
+  | {
+      ok: false
+      phase: 'install'
+      install: Extract<RunInstallResult, { ok: false }>
+      manifestRestored: boolean
+    }
+
+/**
+ * The read-only validation + snapshot phase of a remove. Loads `facets.json`,
+ * checks that every named facet is declared (collecting all absent names for
+ * an all-or-nothing error), and snapshots the manifest for rollback.
+ *
+ * Extracted from `runRemove` so the CLI can run it *before* discovering
+ * adapters: an undeclared facet or missing manifest must fail with the facet
+ * error and leave the project untouched, never launching the adapter picker
+ * or reporting "no adapters installed". Performs no mutation.
+ *
+ * Never throws — the snapshot read is guarded and surfaces as `manifest-write`.
+ */
+export function prepareRemove(opts: { projectRoot: string; names: ReadonlyArray<string> }): RemovePrepareResult {
+  const { projectRoot, names } = opts
+
+  // 1. Load facets.json. A missing or invalid manifest means there is
+  //    nothing to remove — fail before any mutation.
+  const loaded = loadFacetsJson(projectRoot)
+  if (!loaded.ok) {
+    return { ok: false, failure: { reason: 'manifest-read', error: loaded.error } }
+  }
+  if (!loaded.existed) {
+    return { ok: false, failure: { reason: 'manifest-read', error: `no ${FACETS_JSON_FILE} found` } }
+  }
+  const json = loaded.data
+
+  // 2. Validate every name is declared. Collect all absent names so the
+  //    user sees the full set in one error (all-or-nothing — Decision 2/3).
+  const absent = names.filter((name) => json.facets[name] === undefined)
+  if (absent.length > 0) {
+    return { ok: false, failure: { reason: 'not-declared', names: absent } }
+  }
+
+  // 3. Snapshot facets.json for rollback. Guard the read so an I/O error
+  //    surfaces as a structured failure instead of escaping the function.
+  const facetsJsonPath = join(projectRoot, FACETS_JSON_FILE)
+  try {
+    const snapshot: Buffer | null = existsSync(facetsJsonPath) ? readFileSync(facetsJsonPath) : null
+    return { ok: true, json, snapshot }
+  } catch (err) {
+    return {
+      ok: false,
+      failure: { reason: 'manifest-write', error: err instanceof Error ? err.message : String(err) },
+    }
+  }
+}
+
+export async function runRemove(opts: RunRemoveOptions): Promise<RunRemoveResult> {
+  const { projectRoot, names, adapters, signal } = opts
+  const onStage = opts.onStage
+  const onLog = opts.onLog
+
+  // 1. Use the caller's pre-validated state, or prepare now. Threading
+  //    `prepared` in from the CLI means validation runs exactly once;
+  //    omitting it keeps `runRemove` correct for direct callers and tests.
+  const prep = opts.prepared ?? prepareRemove({ projectRoot, names })
+  if (!prep.ok) {
+    return { ok: false, phase: 'prepare', failure: prep.failure }
+  }
+  const { json, snapshot } = prep
+  const facetsJsonPath = join(projectRoot, FACETS_JSON_FILE)
+
+  // 2. Remove every named entry and write the manifest. Guard the write so
+  //    an I/O error surfaces as `manifest-write` rather than escaping. The
+  //    write is atomic (tmp + rename) and no install has run yet, so a throw
+  //    leaves the original `facets.json` intact — nothing to restore.
+  for (const name of names) {
+    removeFacetFromManifest(json, name)
+    onLog?.(`[verbose]   removed "${name}" from ${FACETS_JSON_FILE}`)
+  }
+  try {
+    writeFacetsJson(projectRoot, json)
+  } catch (err) {
+    return {
+      ok: false,
+      phase: 'prepare',
+      failure: { reason: 'manifest-write', error: err instanceof Error ? err.message : String(err) },
+    }
+  }
+
+  // 3. Run install. The removed facets are now orphaned lockfile entries;
+  //    drift-removal deletes their assets and rewrites the lockfile.
+  const install = await runInstall({
+    projectRoot,
+    adapters,
+    ...(onStage ? { onStage } : {}),
+    ...(onLog ? { onLog } : {}),
+    ...(signal ? { signal } : {}),
+  })
+
+  // 4. Restore on failure; report whether the restore succeeded.
+  if (!install.ok) {
+    const manifestRestored = restoreSnapshot(facetsJsonPath, snapshot)
+    return { ok: false, phase: 'install', install, manifestRestored }
+  }
+
+  return { ok: true, install }
+}
+
+/**
+ * Restore the manifest snapshot. Returns whether the restore succeeded so
+ * the CLI can warn the user when the project may be in a partial state.
+ * Mirrors `runAdd`'s helper; the snapshot is non-null in practice because
+ * `runRemove` requires the manifest to exist before mutating.
+ */
+function restoreSnapshot(path: string, snapshot: Buffer | null): boolean {
+  try {
+    if (snapshot === null) {
+      if (existsSync(path)) rmSync(path)
+      return true
+    }
+    writeFileSync(path, snapshot)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
### Why

`facet remove` was previously a stub. Users had no way to take a facet back out of a project without manually editing `facets.json`, deleting assets, and rewriting the lockfile by hand.

### Details

`runRemove` in the engine owns the full manifest transaction:

1. Load and validate `facets.json` — a missing or invalid manifest fails before any mutation.
2. Check that every named facet is declared. All absent names are collected and reported at once; if any are missing, nothing is changed (all-or-nothing).
3. Snapshot `facets.json` byte-for-byte for rollback.
4. Remove the named entries and write the updated manifest.
5. Run the existing install pipeline. The removed facets become orphaned lockfile entries, so the pipeline's existing drift-removal loop deletes their assets from every adapter and rewrites the lockfile without them — no new deletion logic was needed.
6. On install failure, restore the manifest snapshot and report whether the restore succeeded.

The `ensureAdapters` helper that was previously inlined in the `add` command has been extracted to `commands/shared/ensure-adapters.ts` and is now shared by both `add` and `remove`, since both drive the install pipeline and need installable adapters.

The `InstallView` gains a `'remove'` mode (renders "Removing facets...") and a new `RemovePrepareFailureBlock` component that handles the two prepare-phase failure cases (`manifest-read` and `not-declared`) with exhaustiveness checking. The `isInstallFailure` type guard was added to correctly narrow install-pipeline failures away from both prepare-failure shapes.

`rm` is registered as an alias for `remove`.

### Verification

Engine behavior is covered by `run-remove.test.ts`, which seeds real project state via `runAdd` against a stubbed registry and exercises: single-facet removal, multi-facet removal, intact bystander facets, all-or-nothing abort on an absent name, undeclared-facet failure, last-facet removal leaving a valid empty project, and manifest restore on install failure (by holding the install lock). CLI surface (help listing, `rm` alias, usage error on no arguments) is covered by `remove.e2e.test.ts` against the compiled binary.