### PR TITLE
Bump `cowsay` from 0.1.1 to 0.1.2

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
     "viper-plans": "github:agent-facets/viper-plans",
-    "cowsay": "0.1.1"
+    "cowsay": "0.1.2"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -37,8 +37,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.1.1",
-      "integrity": "sha256:dfbc7a5521ae40579e89abbd6958fa597e9eadd926110f6aad90adf37406f2fa",
+      "version": "0.1.2",
+      "integrity": "sha256:622b64920cc729a4c6af213708ac52aa48b4bc9cff7ce3c23876fd3a4a437176",
       "assets": [
         {
           "scope": "project",

--- a/fixtures/cowsay/facet.json
+++ b/fixtures/cowsay/facet.json
@@ -1,6 +1,6 @@
 {
   "name": "cowsay",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "What does the cow say?",
   "skills": {
     "cowsay-rules": {


### PR DESCRIPTION
### Why

Bumps the `cowsay` facet from version `0.1.1` to `0.1.2`, updating the lock file integrity hash accordingly.