### PR TITLE
Add `cowsay` 0.1.3 facet dependency

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,5 +1,6 @@
 {
   "facets": {
-    "viper-plans": "github:agent-facets/viper-plans"
+    "viper-plans": "github:agent-facets/viper-plans",
+    "cowsay": "0.1.3"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -31,6 +31,36 @@
           "name": "viper-run"
         }
       ]
+    },
+    "cowsay": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.julian.facet.cafe"
+      },
+      "version": "0.1.3",
+      "integrity": "sha256:7086c8cd6eaff5625c161ebf82fca7fbde0f7bc4fd3a6749b1fb539f2d819b26",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "cowsay-rules"
+        },
+        {
+          "scope": "project",
+          "type": "agent",
+          "name": "cowsay"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "cowchat"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "cowsay"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Why

Adds the `cowsay` facet (version `0.1.3`) as a dependency to the project.

### Details

The `cowsay` facet is sourced from the registry at `https://api.julian.facet.cafe` and includes the following assets:

- **Skill:** `cowsay-rules`
- **Agent:** `cowsay`
- **Commands:** `cowchat`, `cowsay`