### PR TITLE
Add `tsdown` build pipeline to `@agent-facets/brand`

### DIFF
--- a/.changeset/good-words-pay.md
+++ b/.changeset/good-words-pay.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/brand": patch
+---
+
+Add `tsdown` build pipeline to `@agent-facets/brand`

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,10 @@
     "packages/brand": {
       "name": "@agent-facets/brand",
       "version": "0.5.3",
+      "devDependencies": {
+        "tsdown": "^0.22.0",
+        "typescript": "^6.0.3",
+      },
       "peerDependencies": {
         "typescript": "^5 || ^6",
       },

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -8,24 +8,33 @@
   "version": "0.5.3",
   "type": "module",
   "files": [
-    "src",
-    "!src/**/__tests__",
-    "!src/**/*.test.ts"
+    "dist"
   ],
   "exports": {
     ".": "./src/index.ts"
   },
   "scripts": {
+    "build": "tsdown",
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
     "types": "tsc --noEmit",
     "test": "bun test"
+  },
+  "devDependencies": {
+    "tsdown": "^0.22.0",
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "typescript": "^5 || ^6"
   },
   "publishConfig": {
     "access": "public",
-    "provenance": false
+    "provenance": false,
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "types": "./dist/index.d.mts"
+      }
+    }
   }
 }

--- a/packages/brand/tsdown.config.ts
+++ b/packages/brand/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { eager: true },
+  clean: true,
+})


### PR DESCRIPTION
### Why

The `@agent-facets/brand` package was shipping raw TypeScript source files, which requires consumers to handle compilation themselves. Building to a proper `dist` output makes the package consumable as a standard ESM package.

### Details

`tsdown` is introduced as the build tool, configured to compile `src/index.ts` to ESM with eager type declarations. The published `files` field now points to `dist` instead of `src`, and the `publishConfig` exports map resolves to the compiled `.mjs` and `.d.mts` files.

### Verification

CI, plus verifying the published package resolves correctly via the `import` and `types` export conditions.