### PR TITLE
Remove WAF from all stages (static site has no server-side attack surface)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,9 @@ account is shared with the sibling `facet-cafe` repo.
 | App name       | `agent-facets`                                     |
 | AWS profile    | `facet-cafe` (shared account)                      |
 | Node runtime   | `nodejs24.x` (matches `mise.toml` — single source) |
-| Main stage     | `main` → `agentfacets.io` (apex) + WAF             |
-| Preview stage  | `${stage}` → `${stage}.agentfacets.io`, no WAF     |
-| Personal stage | `${user}` → `${user}.agentfacets.io`, no WAF       |
+| Main stage     | `main` → `agentfacets.io` (apex)                   |
+| Preview stage  | `${stage}` → `${stage}.agentfacets.io`              |
+| Personal stage | `${user}` → `${user}.agentfacets.io`                |
 
 ### Prerequisites
 

--- a/infra/site.ts
+++ b/infra/site.ts
@@ -7,23 +7,20 @@
  * - `docs.agentfacets.io` serves Mintlify content; the CNAME pointing it at
  *   Mintlify's edge (`cname.mintlify-dns.com`) is defined in `infra/dns.ts`.
  *   The docs themselves are hosted by Mintlify, not by anything in this stack.
- * - WAF is enabled on the `main` stage only (SST's built-in managed rules +
- *   default rate limit). Preview and personal stages run without WAF to keep
- *   iteration cheap.
+ * - No WAF: the site is static CloudFront-hosted content with no server-side
+ *   attack surface (no backend, DB, or user input), so WAF filtering adds
+ *   cost without value.
  * - `www.agentfacets.io` 301-redirects to the apex via SST's native
  *   `domain.redirects` on the main stage.
  */
 
 import { SITE_DOMAIN, SITE_REDIRECTS } from './helpers/domain'
 
-const isMain = $app.stage === 'main'
-
 const siteRouter = new sst.aws.Router('AgentFacetsSite', {
   domain: {
     name: SITE_DOMAIN,
     redirects: SITE_REDIRECTS,
   },
-  waf: isMain ? true : undefined,
   invalidation: {
     paths: ['/*'],
     wait: false,


### PR DESCRIPTION
### Why

WAF was enabled on the `main` stage, but the site is fully static content served via CloudFront with no backend, database, or user input. There is no server-side attack surface for WAF to protect against, so the cost provides no value.

### Details

The `isMain` flag and conditional `waf` attachment have been removed from the router configuration. All stages now deploy identically without WAF.