### PR TITLE
Overhaul CLI output: branded search, list, and install views with animated progress

### DIFF
--- a/packages/brand/src/colors.ts
+++ b/packages/brand/src/colors.ts
@@ -102,6 +102,26 @@ export const SURFACE_LIGHT = {
 } as const
 
 /**
+ * Per-asset-type color map for CLI terminal output. Keyed by the
+ * **singular** form of each asset type (`skill`, `agent`, `command`,
+ * `server`). Sources values from `ACCENTS_DARK` — the single source of
+ * truth for the accent palette — so the terminal and landing site stay
+ * in sync. The mapping was chosen to match the agentfacets.io marketing
+ * showcase:
+ *
+ *   - skill   → violet (purple)
+ *   - agent   → pink
+ *   - command → sky (blue-green)
+ *   - server  → amber (yellow)
+ */
+export const ASSET_TYPE_COLORS = {
+  skill: ACCENTS_DARK.violet,
+  agent: ACCENTS_DARK.pink,
+  command: ACCENTS_DARK.sky,
+  server: ACCENTS_DARK.amber,
+} as const
+
+/**
  * Parse a hex color string into an RGB tuple.
  */
 export function hexToRgb(hex: string): readonly [number, number, number] {

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -1,6 +1,7 @@
 export {
   ACCENTS_DARK,
   ACCENTS_LIGHT,
+  ASSET_TYPE_COLORS,
   BRAND,
   BRIGHTNESS,
   hexToRgb,

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -121,9 +121,7 @@ describe('InstallView — single-facet success', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('Adding facets...')
-    expect(frame).toContain('viper-plans@1.2.3')
-    expect(frame).toContain('Done.')
+    expect(frame).toContain('viper-plans installed.')
     expect(frame).toContain('1 installed')
     instance.unmount()
   })
@@ -161,11 +159,7 @@ describe('InstallView — multi-facet success with update', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('Installing facets...')
-    expect(frame).toContain('viper-plans@1.2.3')
-    expect(frame).toContain('rezi@0.5.0')
-    expect(frame).toContain('planner@2.0.0')
-    expect(frame).toContain('was 1.0.0')
+    expect(frame).toContain('Install complete.')
     expect(frame).toContain('2 installed')
     expect(frame).toContain('1 updated')
     instance.unmount()
@@ -238,7 +232,6 @@ describe('InstallView — drift removal', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('removed orphan@1.0.0')
     expect(frame).toContain('1 removed')
     instance.unmount()
   })
@@ -292,8 +285,10 @@ describe('InstallView — marketing aesthetic on `add`', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('+ 1 skill · 1 command')
-    expect(frame).toContain('Now /cowsay is available to your agents.')
+    expect(frame).toContain('1 skill')
+    expect(frame).toContain('1 command')
+    // The "Now /x is available" line was removed in the marketing overhaul.
+    expect(frame).not.toContain('is available to your agents')
     instance.unmount()
   })
 
@@ -341,7 +336,7 @@ describe('InstallView — marketing aesthetic on `add`', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('+ 1 skill')
+    expect(frame).toContain('1 skill')
     expect(frame).not.toContain('is available to your agents')
     instance.unmount()
   })
@@ -410,10 +405,10 @@ describe('InstallView — marketing aesthetic on `add`', () => {
     await settle()
     const frame = findContentFrame(instance.frames)
     // Only cowsay's one command — no skills from `existing-skill`.
-    expect(frame).toContain('+ 1 command')
+    expect(frame).toContain('1 command')
     expect(frame).not.toContain('skill')
-    // Landing line picks up cowsay's command, not the pre-existing one.
-    expect(frame).toContain('Now /cowsay is available to your agents.')
+    // The "Now /x is available" line was removed in the marketing overhaul.
+    expect(frame).not.toContain('is available to your agents')
     expect(frame).not.toContain('old-command')
     instance.unmount()
   })
@@ -461,7 +456,7 @@ describe('InstallView — marketing aesthetic on `add`', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('+ 1 command')
+    expect(frame).toContain('1 command')
     expect(frame).not.toContain('is available to your agents')
     instance.unmount()
   })
@@ -481,7 +476,7 @@ describe('InstallView — empty / no-op', () => {
     )
     await settle()
     const frame = findContentFrame(instance.frames)
-    expect(frame).toContain('Nothing to install')
+    expect(frame).toContain('no changes')
     instance.unmount()
   })
 })
@@ -618,6 +613,38 @@ describe('InstallView — partial rollback failure surfaces', () => {
     const frame = findContentFrame(instance.frames)
     expect(frame).toContain('rollback completed with 2 partial failures')
     expect(frame).toContain('disk full')
+    instance.unmount()
+  })
+})
+
+describe('InstallView — adapter registration', () => {
+  test('renders adapter count when adapter-complete events are emitted', async () => {
+    const events: StageEvent[] = [
+      { kind: 'install-start', totalFacets: 1 },
+      { kind: 'facet-start', facet: 'cowsay', specifier: 'cowsay@latest' },
+      { kind: 'facet-stage', facet: 'cowsay', stage: 'materialize' },
+      { kind: 'adapter-complete', facet: 'cowsay', adapter: 'claude-code' },
+      { kind: 'adapter-complete', facet: 'cowsay', adapter: 'opencode' },
+      {
+        kind: 'facet-success',
+        facet: 'cowsay',
+        outcome: { kind: 'installed', name: 'cowsay', version: '0.1.0' },
+      },
+      { kind: 'install-complete', outcome: 'success' },
+    ]
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'add',
+        run: makeFakeRun(events, successResultSingle),
+      }),
+    )
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    // Registration line: "Updated facets via 2 adapters"
+    expect(frame).toContain('Updated facets via')
+    expect(frame).toContain('2 adapter')
+    // Timer line: "across 2 adapters"
+    expect(frame).toContain('across')
     instance.unmount()
   })
 })

--- a/packages/cli/src/commands/list/__tests__/list.test.ts
+++ b/packages/cli/src/commands/list/__tests__/list.test.ts
@@ -45,23 +45,22 @@ describe('listCommand', () => {
     expect(stdout).toContain('github:agent-facets/viper-plans')
   })
 
-  test('multiple entries: aligns the value column to the longest name', async () => {
+  test('multiple entries: renders every name and value', async () => {
     writeFileSync(
       join(projectRoot, 'facets.json'),
       JSON.stringify({
         facets: {
-          a: 'short',
-          'much-longer-name': 'short',
+          a: 'val-a',
+          'much-longer-name': 'val-b',
         },
       }),
     )
     const { result, stdout } = await captureStdout(() => listCommand.run([], {}))
     expect(result).toBe(0)
-    const lines = stdout.split('\n').filter((l) => l.length > 0)
-    expect(lines).toHaveLength(2)
-    // The value `short` should land at the same column index in both lines.
-    const indices = lines.map((l) => l.indexOf('short'))
-    expect(indices[0]).toBe(indices[1])
+    expect(stdout).toContain('a')
+    expect(stdout).toContain('much-longer-name')
+    expect(stdout).toContain('val-a')
+    expect(stdout).toContain('val-b')
   })
 
   test('with lockfile: prefers resolved version over source specifier', async () => {

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -1,7 +1,10 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { FACETS_LOCK_FILE, loadFacetsJson, loadLockfile } from '@agent-facets/engine'
+import { render } from 'ink'
+import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
+import { ListView } from '../../tui/views/list/list-view.tsx'
 import { writeCliError } from '../../util/errors.ts'
 
 /**
@@ -88,9 +91,8 @@ export const listCommand: Command = {
       return { name, value }
     })
 
-    const nameWidth = rows.reduce((max, r) => Math.max(max, r.name.length), 0)
-    const lines = rows.map((r) => `${r.name.padEnd(nameWidth)}  ${r.value}`)
-    process.stdout.write(`${lines.join('\n')}\n`)
+    const instance = render(createElement(ListView, { rows }))
+    instance.unmount()
     return 0
   },
 }

--- a/packages/cli/src/commands/search/__tests__/search.test.ts
+++ b/packages/cli/src/commands/search/__tests__/search.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { captureStderr, captureStdout } from '../../../__tests__/helpers/capture-std.ts'
+import { render as inkRender } from 'ink-testing-library'
+import { createElement } from 'react'
+import { captureStderr } from '../../../__tests__/helpers/capture-std.ts'
+import { type SearchResult, SearchView } from '../../../tui/views/search/search-view.tsx'
 import { searchCommand } from '../index.ts'
 
 const ORIGINAL_FETCH = globalThis.fetch
@@ -15,18 +18,54 @@ afterEach(() => {
   else process.env.FACET_REGISTRY_URL = ORIGINAL_ENV
 })
 
-/**
- * Stub `globalThis.fetch` to return a `SearchResponse`-shaped JSON
- * body for the typed registry client. `assetCounts` defaults to
- * all-zero so tests that don't care about the asset-counts line
- * keep working unchanged (per D10's all-zero rule, the line is
- * omitted entirely when every count is 0).
- */
-function mockPackages(
+function wireItem(
+  name: string,
+  latestVersion: string,
+  opts?: {
+    author?: string
+    publisher?: string
+    assetCounts?: { agents?: number; commands?: number; servers?: number; skills?: number }
+  },
+) {
+  return {
+    name,
+    latestVersion,
+    publishedAt: '2026-05-01T00:00:00Z',
+    publisher: opts?.publisher ?? 'test-publisher',
+    author: opts?.author,
+    assetCounts: {
+      agents: opts?.assetCounts?.agents ?? 0,
+      commands: opts?.assetCounts?.commands ?? 0,
+      servers: opts?.assetCounts?.servers ?? 0,
+      skills: opts?.assetCounts?.skills ?? 0,
+    },
+  }
+}
+
+/** Build a fetch function that resolves with the given items. */
+function mockFetch(items: ReturnType<typeof wireItem>[]): () => Promise<SearchResult> {
+  return async () => ({ ok: true, facets: items })
+}
+
+/** Wait for async effects to settle. */
+const settle = () => new Promise((r) => setTimeout(r, 100))
+
+/** Find the last non-empty frame. */
+function lastContentFrame(instance: ReturnType<typeof inkRender>): string {
+  const frames = [...instance.frames].reverse()
+  for (const f of frames) {
+    if (f.trim().length > 0) return f
+  }
+  return instance.lastFrame() ?? ''
+}
+
+function _mockPackages(
   facets: ReadonlyArray<{
     name: string
     latestVersion: string
     publishedAt?: string
+    publisher?: string
+    author?: string
     assetCounts?: { agents?: number; commands?: number; servers?: number; skills?: number }
   }>,
 ): void {
@@ -37,6 +76,8 @@ function mockPackages(
           name: f.name,
           latestVersion: f.latestVersion,
           publishedAt: f.publishedAt ?? '2026-05-01T00:00:00Z',
+          publisher: f.publisher ?? 'test-publisher',
+          author: f.author,
           assetCounts: {
             agents: f.assetCounts?.agents ?? 0,
             commands: f.assetCounts?.commands ?? 0,
@@ -49,80 +90,172 @@ function mockPackages(
     )) as unknown as typeof fetch
 }
 
-describe('searchCommand', () => {
-  test('empty registry: prints "no facets in the registry yet"', async () => {
-    mockPackages([])
-    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('No facets in the registry yet')
+describe('SearchView — rendering', () => {
+  test('shows loading animation before results arrive', () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: 'cowsay',
+        fetch: () => new Promise<SearchResult>(() => {}), // never resolves
+        onComplete: () => {},
+      }),
+    )
+    const f = instance.lastFrame() ?? ''
+    expect(f).toContain("Searching registry for 'cowsay'")
+    instance.unmount()
   })
 
-  test('single match: renders headline + facet add suggestion', async () => {
-    mockPackages([{ name: 'cowsay', latestVersion: '0.1.0' }])
-    const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('cowsay   v0.1.0')
-    expect(stdout).toContain('→ facet add cowsay')
-    // We deliberately do not suggest an `opencode run --command ...` line
-    // because the V0 list endpoint doesn't return asset metadata; we'd
-    // be guessing the wrong command name for many facets.
-    expect(stdout).not.toContain('opencode run')
+  test('empty registry: shows "found no matches"', async () => {
+    const instance = inkRender(
+      createElement(SearchView, { term: undefined, fetch: mockFetch([]), onComplete: () => {} }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('found no matches')
   })
 
-  test('namespaced name: facet add uses full canonical name', async () => {
-    mockPackages([{ name: 'acme/cowsay', latestVersion: '0.1.0' }])
-    const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('→ facet add acme/cowsay')
-    expect(stdout).not.toContain('opencode run')
+  test('no match for term: shows "found no matches" with hint', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: 'xyz-not-there',
+        fetch: mockFetch([wireItem('cowsay', '0.1.0')]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('found no matches')
   })
 
-  test('multiple matches: blank line between blocks', async () => {
-    mockPackages([
-      { name: 'cowsay', latestVersion: '0.1.0' },
-      { name: 'mooing-cow', latestVersion: '0.2.0' },
-    ])
-    const { result, stdout } = await captureStdout(() => searchCommand.run(['cow'], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('cowsay')
-    expect(stdout).toContain('mooing-cow')
-    expect(stdout).toContain('\n\n')
+  test('single result: renders name, version, publisher, and header', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: undefined,
+        fetch: mockFetch([wireItem('cowsay', '0.1.0', { publisher: 'acme' })]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('cowsay')
+    expect(f).toContain('v0.1.0')
+    expect(f).toContain('acme')
+    expect(f).toContain('found 1 match.')
+  })
+
+  test('author preferred over publisher when present', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: undefined,
+        fetch: mockFetch([wireItem('cowsay', '0.1.0', { author: 'jane', publisher: 'acme-org' })]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    expect(lastContentFrame(instance)).toContain('jane')
+  })
+
+  test('multiple results with header count', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: 'cow',
+        fetch: mockFetch([wireItem('cowsay', '0.1.0'), wireItem('mooing-cow', '0.2.0')]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('cowsay')
+    expect(f).toContain('mooing-cow')
+    expect(f).toContain('found 2 matches.')
   })
 
   test('case-insensitive substring match', async () => {
-    mockPackages([{ name: 'CamelCaseName', latestVersion: '1.0.0' }])
-    const { result, stdout } = await captureStdout(() => searchCommand.run(['camel'], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('CamelCaseName')
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: 'camel',
+        fetch: mockFetch([wireItem('CamelCaseName', '1.0.0')]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    expect(lastContentFrame(instance)).toContain('CamelCaseName')
   })
 
   test('no-args lists everything', async () => {
-    mockPackages([
-      { name: 'a', latestVersion: '1.0.0' },
-      { name: 'b', latestVersion: '2.0.0' },
-    ])
-    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('a')
-    expect(stdout).toContain('b')
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: undefined,
+        fetch: mockFetch([wireItem('a', '1.0.0'), wireItem('b', '2.0.0')]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('a')
+    expect(f).toContain('b')
+  })
+})
+
+describe('SearchView — D10: assetCounts rendering', () => {
+  test('multi-kind: renders pluralized summary', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: undefined,
+        fetch: mockFetch([
+          wireItem('multi', '1.0.0', { assetCounts: { agents: 1, commands: 2, servers: 1, skills: 0 } }),
+        ]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('1 agent')
+    expect(f).toContain('2 commands')
+    expect(f).toContain('1 server')
+    expect(f).not.toContain('skill')
   })
 
-  test('no match for term: friendly hint pointing back at no-arg search', async () => {
-    mockPackages([{ name: 'cowsay', latestVersion: '0.1.0' }])
-    const { result, stdout } = await captureStdout(() => searchCommand.run(['xyz-not-there'], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('No facets match "xyz-not-there"')
-    expect(stdout).toContain("'facet search' with no args")
+  test('single-kind: renders only the non-zero kind', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: undefined,
+        fetch: mockFetch([
+          wireItem('commands-only', '1.0.0', { assetCounts: { agents: 0, commands: 2, servers: 0, skills: 0 } }),
+        ]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('2 commands')
+    expect(f).not.toContain('0 agent')
   })
 
+  test('all-zero: no asset counts rendered', async () => {
+    const instance = inkRender(
+      createElement(SearchView, {
+        term: undefined,
+        fetch: mockFetch([
+          wireItem('empty', '1.0.0', { assetCounts: { agents: 0, commands: 0, servers: 0, skills: 0 } }),
+        ]),
+        onComplete: () => {},
+      }),
+    )
+    await settle()
+    const f = lastContentFrame(instance)
+    expect(f).toContain('empty')
+    expect(f).toContain('v1.0.0')
+    expect(f).not.toMatch(/\d+\s+(agent|command|server|skill)/)
+  })
+})
+
+describe('searchCommand — error paths', () => {
   test('network failure: writes a CliError and returns 1', async () => {
     globalThis.fetch = (async () => {
       throw new TypeError('fetch failed')
     }) as unknown as typeof fetch
     const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
     expect(result).toBe(1)
-    // A transport failure is CLI-authored (the registry never replied),
-    // and carries no synthesized docs link.
     expect(stderr).toContain('could not reach the registry')
     expect(stderr).not.toContain('docs:')
   })
@@ -140,8 +273,6 @@ describe('searchCommand', () => {
       )) as unknown as typeof fetch
     const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
     expect(result).toBe(1)
-    // Registry-dumb rendering: the server's own `error`, `fix`, and
-    // `docsUrl` are shown verbatim — no local code-to-message map.
     expect(stderr).toContain('whoops')
     expect(stderr).toContain('try again shortly')
     expect(stderr).toContain('https://agentfacets.io/errors/E_REGISTRY_UNAVAILABLE')
@@ -154,8 +285,6 @@ describe('searchCommand', () => {
   })
 
   test('unexpected response shape: clean error pointing at self-update', async () => {
-    // A 200 with a body that doesn't match the SearchResponse shape:
-    // `data.facets` is missing, so the runtime guard triggers.
     globalThis.fetch = (async () =>
       new Response(JSON.stringify({ items: [] }), {
         status: 200,
@@ -164,58 +293,5 @@ describe('searchCommand', () => {
     const { result, stderr } = await captureStderr(() => searchCommand.run([], {}))
     expect(result).toBe(1)
     expect(stderr).toContain('unexpected shape')
-  })
-})
-
-describe('searchCommand — D10: assetCounts rendering', () => {
-  test('multi-kind: renders pluralized summary in canonical order', async () => {
-    mockPackages([
-      {
-        name: 'multi',
-        latestVersion: '1.0.0',
-        assetCounts: { agents: 1, commands: 2, servers: 1, skills: 0 },
-      },
-    ])
-    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
-    expect(result).toBe(0)
-    // Pluralization: `1 agent` (singular), `2 commands` (plural), `1 server` (singular).
-    // Order: agents → commands → servers → skills (skills suppressed by zero).
-    expect(stdout).toContain('1 agent, 2 commands, 1 server')
-    expect(stdout).not.toContain('skill')
-  })
-
-  test('single-kind: renders only the non-zero kind', async () => {
-    mockPackages([
-      {
-        name: 'commands-only',
-        latestVersion: '1.0.0',
-        assetCounts: { agents: 0, commands: 2, servers: 0, skills: 0 },
-      },
-    ])
-    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
-    expect(result).toBe(0)
-    expect(stdout).toContain('2 commands')
-    // No zero-count kinds appear in the output anywhere on this line.
-    expect(stdout).not.toContain('0 agent')
-    expect(stdout).not.toContain('0 server')
-    expect(stdout).not.toContain('0 skill')
-  })
-
-  test('all-zero: omits the asset-counts line entirely', async () => {
-    mockPackages([
-      {
-        name: 'empty',
-        latestVersion: '1.0.0',
-        assetCounts: { agents: 0, commands: 0, servers: 0, skills: 0 },
-      },
-    ])
-    const { result, stdout } = await captureStdout(() => searchCommand.run([], {}))
-    expect(result).toBe(0)
-    // The block has exactly two lines: headline + install hint. The
-    // asset-counts line is omitted (no digit followed by `agent` /
-    // `command` / `server` / `skill`).
-    expect(stdout).not.toMatch(/\d+\s+(agent|command|server|skill)/)
-    expect(stdout).toContain('empty   v1.0.0')
-    expect(stdout).toContain('→ facet add empty')
   })
 })

--- a/packages/cli/src/commands/search/index.ts
+++ b/packages/cli/src/commands/search/index.ts
@@ -1,12 +1,8 @@
-import {
-  createRegistryClient,
-  resolveCredential,
-  translateThrownError,
-  translateWireError,
-  type WireAssetCounts,
-  type WirePackageListItem,
-} from '@agent-facets/engine'
+import { createRegistryClient, resolveCredential, translateThrownError, translateWireError } from '@agent-facets/engine'
+import { render } from 'ink'
+import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
+import { type SearchResult, SearchView } from '../../tui/views/search/search-view.tsx'
 import { writeCliError } from '../../util/errors.ts'
 import { translateEngineRegistryError } from '../../util/registry-errors.ts'
 
@@ -16,21 +12,14 @@ import { translateEngineRegistryError } from '../../util/registry-errors.ts'
  * every facet the registry returns (capped server-side at LIMIT 200
  * in V0).
  *
- * Each result shows the canonical name, latest version, an
- * asset-count summary (per design D10), and the single copy-paste
- * next step:
- *
- *   - `facet add <name>` — install it
- *
- * We deliberately do NOT suggest a downstream invocation (e.g.,
- * `opencode run --command ...`) because the registry returns asset
- * counts (numeric) but not asset names. A runtime-correct invocation
- * suggestion would require a different endpoint.
+ * Each result shows the canonical name, latest version, author,
+ * and a per-asset-type colored count summary in a columnar layout
+ * with vertically-aligned `·` separators. An animated "Searching
+ * registry for '<term>'" line shows while the fetch is in progress.
  *
  * The wire-shaped types come from `@agent-facets/engine`'s curated
  * re-exports of the registry's published OpenAPI specification —
- * `WirePackageListItem` is the per-result shape, `WireAssetCounts`
- * is the kind-by-kind count block.
+ * `WirePackageListItem` is the per-result shape.
  */
 export const searchCommand: Command = {
   name: 'search',
@@ -52,9 +41,6 @@ export const searchCommand: Command = {
     // when absent the search proceeds anonymously.
     const cred = resolveCredential()
     if (cred.source === 'absent' && cred.reason?.code === 'unreadable') {
-      // A credentials file exists but could not be read. The search can
-      // still run anonymously, but warn so the user knows why their
-      // saved login is not being used.
       process.stderr.write(
         `warning: couldn't read credentials at ${cred.reason.path} (${cred.reason.cause}); continuing anonymously\n`,
       )
@@ -62,107 +48,53 @@ export const searchCommand: Command = {
     const client = createRegistryClient({
       credential: cred.source === 'absent' ? undefined : cred.token,
     })
-    let facets: ReadonlyArray<WirePackageListItem>
+
+    // The fetch function is passed to the view so the animated
+    // "Searching..." line shows while the request is in flight.
+    const fetchResults = async (): Promise<SearchResult> => {
+      try {
+        const { data, error, response } = await client.GET('/v0/facets', {})
+        const runtimeError = error as unknown
+        if (runtimeError !== undefined) {
+          writeCliError(
+            translateEngineRegistryError(
+              translateWireError(runtimeError as Parameters<typeof translateWireError>[0], response.status),
+            ),
+          )
+          return { ok: false, error: 'handled' }
+        }
+        if (data === undefined || !Array.isArray((data as { facets?: unknown }).facets)) {
+          writeCliError({
+            what: 'registry returned an unexpected shape',
+            detail: `expected { facets: [...] }`,
+            fix: "this likely means the CLI is talking to a newer registry — try 'facet self-update'",
+          })
+          return { ok: false, error: 'handled' }
+        }
+        return { ok: true, facets: data.facets }
+      } catch (err) {
+        writeCliError(translateEngineRegistryError(translateThrownError(err)))
+        return { ok: false, error: 'handled' }
+      }
+    }
+
+    let exitCode = 0
+    const instance = render(
+      createElement(SearchView, {
+        term,
+        fetch: fetchResults,
+        onComplete: (code: number) => {
+          exitCode = code
+        },
+      }),
+    )
     try {
-      const { data, error, response } = await client.GET('/v0/facets', {})
-      // Runtime check on `error`: the OpenAPI for `GET /v0/facets`
-      // currently declares only a 200 response, which makes
-      // `result.error` typed as `never`. A non-2xx with a parseable
-      // envelope can still arrive at runtime (the spec is incomplete,
-      // not the contract), so we cast through `unknown` to query it
-      // without TS treating the comparison as always-false.
-      const runtimeError = error as unknown
-      if (runtimeError !== undefined) {
-        writeCliError(
-          translateEngineRegistryError(
-            translateWireError(runtimeError as Parameters<typeof translateWireError>[0], response.status),
-          ),
-        )
-        return 1
-      }
-      // Defensive runtime guard. `openapi-fetch` types `data` per the
-      // OpenAPI spec but does not validate the body at runtime — if
-      // the registry sends a body that doesn't match the schema, the
-      // typed `data.facets` could be `undefined` at runtime even
-      // though the type says it's an array.
-      if (data === undefined || !Array.isArray((data as { facets?: unknown }).facets)) {
-        writeCliError({
-          what: 'registry returned an unexpected shape',
-          detail: `expected { facets: [...] }`,
-          fix: "this likely means the CLI is talking to a newer registry — try 'facet self-update'",
-        })
-        return 1
-      }
-      facets = data.facets
-    } catch (err) {
-      writeCliError(translateEngineRegistryError(translateThrownError(err)))
-      return 1
+      await instance.waitUntilExit()
+    } catch {
+      // View exited with an error (fetch failure) — exit code already
+      // set by onComplete, and the error was written to stderr by
+      // writeCliError before the view received ok:false.
     }
-
-    const all = facets
-    const filtered = term !== undefined ? all.filter((f) => f.name.toLowerCase().includes(term.toLowerCase())) : all
-
-    if (all.length === 0) {
-      process.stdout.write('No facets in the registry yet.\n')
-      return 0
-    }
-    if (filtered.length === 0) {
-      process.stdout.write(`No facets match "${term ?? ''}". Try 'facet search' with no args to list everything.\n`)
-      return 0
-    }
-
-    const blocks = filtered.map((f) => renderResult(f))
-    process.stdout.write(`${blocks.join('\n\n')}\n`)
-    return 0
+    return exitCode
   },
-}
-
-/**
- * Render a single search result as a multi-line block. Format:
- *
- *   <name>   v<latestVersion>
- *     <asset-counts summary>      ← omitted entirely if all-zero
- *     → facet add <name>
- *
- * The asset-counts line comes from `formatAssetCounts` and is omitted
- * when every count is zero (per D10's all-zero rule), producing a
- * 2-line block in that edge case.
- */
-function renderResult(f: WirePackageListItem): string {
-  const headline = `${f.name}   v${f.latestVersion}`
-  const counts = formatAssetCounts(f.assetCounts)
-  const installLine = `  → facet add ${f.name}`
-  return counts === null ? [headline, installLine].join('\n') : [headline, `  ${counts}`, installLine].join('\n')
-}
-
-/**
- * Render the `WireAssetCounts` object as a one-line summary like
- * `"1 agent, 2 commands, 1 server"`. Returns null when every count
- * is zero, signaling that the caller should omit the line entirely
- * (per D10).
- *
- * Rules from the design:
- *
- *   - Pluralization: standard English plural (`1 agent` / `2 agents`).
- *   - Zero-suppression: kinds with count 0 are omitted.
- *   - Order: `agents`, `commands`, `servers`, `skills` — wire order.
- *   - All-zero: return null so renderer omits the line.
- */
-function formatAssetCounts(counts: WireAssetCounts): string | null {
-  // [wire-key, singular, plural] tuples in canonical render order.
-  // Hardcoded over generic pluralization because the four kinds are
-  // a closed set and a future fifth kind should be a deliberate add
-  // here, not a silent default.
-  const KINDS: ReadonlyArray<readonly [keyof WireAssetCounts, string, string]> = [
-    ['agents', 'agent', 'agents'],
-    ['commands', 'command', 'commands'],
-    ['servers', 'server', 'servers'],
-    ['skills', 'skill', 'skills'],
-  ]
-  const parts: string[] = []
-  for (const [key, singular, plural] of KINDS) {
-    const n = counts[key]
-    if (n > 0) parts.push(`${n} ${n === 1 ? singular : plural}`)
-  }
-  return parts.length === 0 ? null : parts.join(', ')
 }

--- a/packages/cli/src/tui/components/progress-bar.tsx
+++ b/packages/cli/src/tui/components/progress-bar.tsx
@@ -1,0 +1,86 @@
+import { BRAND } from '@agent-facets/brand'
+import { Text } from 'ink'
+import Gradient from 'ink-gradient'
+import { useEffect, useState } from 'react'
+import { THEME } from '../theme.ts'
+
+/** Animation tick interval — 50ms ≈ 20fps. */
+const TICK_MS = 50
+
+/** Default track width in columns. */
+const DEFAULT_WIDTH = 24
+
+/** The block character used for every comet cell. */
+const BLOCK = '■'
+
+/** Number of block cells in the comet. */
+const COMET_LENGTH = 5
+
+/** The dot character used for the dim track. */
+const DOT = '·'
+
+/** Two-stop gradient: purple → coral. */
+const BAR_GRADIENT = [BRAND.purple, BRAND.coral]
+
+export interface ProgressBarProps {
+  /** Whether the work is complete. When true, the component renders nothing. */
+  done: boolean
+  /** Total track width in columns. Defaults to 24. */
+  width?: number
+}
+
+/**
+ * Indeterminate animated progress indicator. A gradient-colored comet
+ * sweeps left→right across a dim dot track, then loops after a short
+ * pause. The comet is rendered via `ink-gradient` with the brand
+ * purple → coral sweep. When `done`, renders nothing.
+ */
+export function ProgressBar({ done, width = DEFAULT_WIDTH }: ProgressBarProps) {
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    if (done) return
+    const interval = setInterval(() => {
+      setTick((t) => t + 1)
+    }, TICK_MS)
+    return () => clearInterval(interval)
+  }, [done])
+
+  if (done) {
+    return null
+  }
+
+  // The head sweeps left→right. The cycle is long enough for the
+  // entire comet to slide off the right edge, plus a short pause.
+  const GAP = 6
+  const cycleLength = width + COMET_LENGTH + GAP
+  // Each tick is one movement step at ~20fps.
+  const step = tick
+  const headPos = (step % cycleLength) - (COMET_LENGTH - 1)
+
+  // The comet occupies columns [headPos - (COMET_LENGTH-1), headPos],
+  // clamped to [0, width-1]. Visible length shrinks at edges.
+  const visStart = Math.max(0, headPos - (COMET_LENGTH - 1))
+  const visEnd = Math.min(width - 1, headPos)
+  const visLen = Math.max(0, visEnd - visStart + 1)
+
+  // Total is always `width`: dots = width - visLen
+  const dotsBefore = visStart
+  const dotsAfter = width - visLen - dotsBefore
+
+  if (visLen === 0) {
+    return <Text color={THEME.hint}>{DOT.repeat(width)}</Text>
+  }
+
+  const before = DOT.repeat(dotsBefore)
+  const segment = BLOCK.repeat(visLen)
+  const after = DOT.repeat(dotsAfter)
+
+  return (
+    <Text>
+      <Text color={THEME.hint}>{before}</Text>
+      <Gradient colors={BAR_GRADIENT}>{segment}</Gradient>
+      <Text color={THEME.hint}>{after}</Text>
+    </Text>
+  )
+}

--- a/packages/cli/src/tui/theme.ts
+++ b/packages/cli/src/tui/theme.ts
@@ -1,1 +1,1 @@
-export { THEME } from '@agent-facets/brand'
+export { ASSET_TYPE_COLORS, THEME } from '@agent-facets/brand'

--- a/packages/cli/src/tui/views/install/facet-row.tsx
+++ b/packages/cli/src/tui/views/install/facet-row.tsx
@@ -22,7 +22,7 @@ export interface FacetState {
   failure: RunInstallFailure | null
 }
 
-const STAGE_LABELS: Record<FacetStage, string> = {
+export const STAGE_LABELS: Record<FacetStage, string> = {
   parse: 'parsing',
   resolve: 'resolving',
   fetch: 'fetching',
@@ -32,9 +32,9 @@ const STAGE_LABELS: Record<FacetStage, string> = {
   materialize: 'materializing',
 }
 
-export function FacetRow({ state }: { state: FacetState }) {
+export function FacetRow({ state, adapters = [] }: { state: FacetState; adapters?: string[] }) {
   if (state.outcome) {
-    return <OutcomeRow name={state.name} outcome={state.outcome} />
+    return <OutcomeRow name={state.name} outcome={state.outcome} adapters={adapters} />
   }
   if (state.failure) {
     return <FailureSummaryRow name={state.name} failure={state.failure} />
@@ -57,7 +57,24 @@ function ProgressRow({ name, specifier, stage }: { name: string; specifier: stri
   )
 }
 
-function OutcomeRow({ name, outcome }: { name: string; outcome: FacetOutcome }) {
+/** Inline adapter checkmarks: `→ claude-code ✓ opencode ✓` */
+function adapterSuffix(adapters: string[]): React.ReactNode {
+  if (adapters.length === 0) return null
+  return (
+    <Text color={THEME.hint}>
+      {' → '}
+      {adapters.map((a, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: stable ordered list
+        <Text key={i}>
+          {i > 0 && ' '}
+          {a} <Text color={THEME.success}>✓</Text>
+        </Text>
+      ))}
+    </Text>
+  )
+}
+
+function OutcomeRow({ name, outcome, adapters }: { name: string; outcome: FacetOutcome; adapters: string[] }) {
   switch (outcome.kind) {
     case 'installed':
       return (
@@ -65,6 +82,7 @@ function OutcomeRow({ name, outcome }: { name: string; outcome: FacetOutcome }) 
           <Text color={THEME.success}>+</Text>
           <Text>
             {name}@{outcome.version}
+            {adapterSuffix(adapters)}
           </Text>
         </Box>
       )
@@ -77,6 +95,7 @@ function OutcomeRow({ name, outcome }: { name: string; outcome: FacetOutcome }) 
             <Text color={THEME.hint}>
               (was {outcome.oldVersion} → {outcome.newVersion})
             </Text>
+            {adapterSuffix(adapters)}
           </Text>
         </Box>
       )

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -1,9 +1,10 @@
 import type { AddPrepareFailure, RemovePrepareFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
 import { Box, Text, useApp } from 'ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { THEME } from '../../theme.ts'
+import { ProgressBar } from '../../components/progress-bar.tsx'
+import { ASSET_TYPE_COLORS, THEME } from '../../theme.ts'
 import { AddPrepareFailureBlock } from './add-prepare-failure-block.tsx'
-import { FacetRow, type FacetState } from './facet-row.tsx'
+import { type FacetState, STAGE_LABELS } from './facet-row.tsx'
 import { FailureBlock } from './failure-block.tsx'
 import { RemovePrepareFailureBlock } from './remove-prepare-failure-block.tsx'
 
@@ -71,20 +72,25 @@ interface DriftRemoval {
 
 export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   const { exit } = useApp()
+  const [totalFacets, setTotalFacets] = useState(0)
   const [facetOrder, setFacetOrder] = useState<string[]>([])
   const [facets, setFacets] = useState<Record<string, FacetState>>({})
   const [serverWarnings, setServerWarnings] = useState<ServerWarning[]>([])
-  const [driftRemovals, setDriftRemovals] = useState<DriftRemoval[]>([])
+  const [_driftRemovals, setDriftRemovals] = useState<DriftRemoval[]>([])
+  /** Per-facet adapter completions: facetName → list of adapter names done. */
+  const [adaptersByFacet, setAdaptersByFacet] = useState<Record<string, string[]>>({})
   const [result, setResult] = useState<InstallViewResult | null>(null)
+  const [elapsedMs, setElapsedMs] = useState(0)
   const [exitState, setExitState] = useState<
     { kind: 'idle' } | { kind: 'success' } | { kind: 'failure'; error: Error }
   >({ kind: 'idle' })
   const startedRef = useRef(false)
+  const startTimeRef = useRef(Date.now())
 
   const onStage = useCallback((event: StageEvent) => {
     switch (event.kind) {
       case 'install-start':
-        // Header is static; no per-event update needed.
+        setTotalFacets(event.totalFacets)
         return
       case 'facet-start':
         setFacetOrder((prev) => (prev.includes(event.facet) ? prev : [...prev, event.facet]))
@@ -138,6 +144,13 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
       case 'drift-removal':
         setDriftRemovals((prev) => [...prev, { facet: event.facet, oldVersion: event.oldVersion }])
         return
+      case 'adapter-complete':
+        setAdaptersByFacet((prev) => {
+          const existing = prev[event.facet] ?? []
+          if (existing.includes(event.adapter)) return prev
+          return { ...prev, [event.facet]: [...existing, event.adapter] }
+        })
+        return
       case 'asset-installed':
       case 'asset-deleted':
       case 'lockfile-write':
@@ -152,6 +165,7 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
     startedRef.current = true
     try {
       const r = await run(onStage)
+      setElapsedMs(Date.now() - startTimeRef.current)
       setResult(r)
       onComplete?.(r)
       // Defer exit so React paints the result state before Ink unmounts.
@@ -174,27 +188,88 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
     void start()
   }, [exitState, exit, start])
 
-  const headerLabel =
-    mode === 'add' ? 'Adding facets...' : mode === 'remove' ? 'Removing facets...' : 'Installing facets...'
+  const headerLabel = mode === 'add' ? 'Adding facets:' : mode === 'remove' ? 'Removing facets:' : 'Installing facets:'
+
+  // Compute live counters: [done, remaining, failed].
+  let doneCount = 0
+  let failedCount = 0
+  let currentFacet: FacetState | null = null
+  for (const name of facetOrder) {
+    const state = facets[name]
+    if (!state) continue
+    if (state.outcome) doneCount++
+    else if (state.failure) failedCount++
+    else currentFacet = state // last in-flight facet
+  }
+  const remainingCount = totalFacets - doneCount - failedCount
+
+  // Current facet identity line (above the progress bar).
+  const currentFacetInfo = currentFacet ? (
+    <Text>
+      <Text bold>{currentFacet.name}</Text>
+      <Text color={THEME.hint}>@{currentFacet.specifier}</Text>
+    </Text>
+  ) : facetOrder.length > 0 ? (
+    (() => {
+      const last = facets[facetOrder[facetOrder.length - 1] ?? '']
+      if (!last?.outcome) return null
+      const version =
+        last.outcome.kind === 'updated'
+          ? last.outcome.newVersion
+          : 'version' in last.outcome
+            ? last.outcome.version
+            : last.outcome.oldVersion
+      return (
+        <Text>
+          <Text bold>{last.name}</Text>
+          <Text color={THEME.hint}>@{version}</Text>
+          <Text color={THEME.hint}> ({last.outcome.kind})</Text>
+        </Text>
+      )
+    })()
+  ) : null
+
+  // Stage label for the progress bar line.
+  const stageLabel = currentFacet ? (currentFacet.stage ? STAGE_LABELS[currentFacet.stage] : 'starting') : null
 
   return (
-    <Box flexDirection="column" padding={1} gap={1}>
-      <Text bold color={THEME.brand}>
-        {headerLabel}
-      </Text>
+    <Box flexDirection="column">
+      {result === null && (
+        <Text bold color={THEME.brand}>
+          {headerLabel}
+        </Text>
+      )}
 
-      {facetOrder.length > 0 && (
-        <Box flexDirection="column">
-          {facetOrder.map((name) => {
-            const state = facets[name]
-            if (!state) return null
-            return <FacetRow key={name} state={state} />
-          })}
+      {result === null && (
+        <Box flexDirection="column" marginLeft={2}>
+          {currentFacetInfo ? (
+            <Text>
+              {currentFacetInfo}
+              {stageLabel && <Text color={THEME.hint}> · {stageLabel}</Text>}
+            </Text>
+          ) : (
+            <Text color={THEME.hint}>Preparing to {mode} facets</Text>
+          )}
+          <Box>
+            <ProgressBar done={false} width={12} />
+            {totalFacets > 0 && (
+              <Text>
+                {' '}
+                <Text color={THEME.hint}>[</Text>
+                <Text color={THEME.brand}>{remainingCount}</Text>
+                <Text color={THEME.hint}>, </Text>
+                <Text color={THEME.success}>{doneCount}</Text>
+                <Text color={THEME.hint}>, </Text>
+                <Text color={THEME.warning}>{failedCount}</Text>
+                <Text color={THEME.hint}>]</Text>
+              </Text>
+            )}
+          </Box>
         </Box>
       )}
 
       {serverWarnings.length > 0 && (
-        <Box flexDirection="column">
+        <Box flexDirection="column" marginLeft={2}>
           {serverWarnings.map((w) => (
             <Text key={w.facet} color={THEME.warning}>
               ⚠ {w.facet}: {w.servers.length} server{w.servers.length === 1 ? '' : 's'} declared ({w.servers.join(', ')}
@@ -204,17 +279,14 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
         </Box>
       )}
 
-      {driftRemovals.length > 0 && (
-        <Box flexDirection="column">
-          {driftRemovals.map((d) => (
-            <Text key={d.facet} color={THEME.hint}>
-              - removed {d.facet}@{d.oldVersion} (no longer in facets.json)
-            </Text>
-          ))}
-        </Box>
+      {result?.ok && (
+        <SuccessSummary
+          result={result}
+          mode={mode}
+          adapterCount={new Set(Object.values(adaptersByFacet).flat()).size}
+          elapsedMs={elapsedMs}
+        />
       )}
-
-      {result?.ok && <SuccessSummary result={result} mode={mode} />}
       {result && isPrepareFailure(result) && <AddPrepareFailureBlock failure={result.prepareFailure} />}
       {result && isRemovePrepareFailure(result) && <RemovePrepareFailureBlock failure={result.removePrepareFailure} />}
       {result && isInstallFailure(result) && <FailureBlock failure={result.failure} />}
@@ -235,41 +307,70 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
 function SuccessSummary({
   result,
   mode,
+  adapterCount,
+  elapsedMs,
 }: {
   result: RunInstallResult & { ok: true }
   mode: 'add' | 'install' | 'remove'
+  adapterCount: number
+  elapsedMs: number
 }) {
   const { summary } = result
   const isNoOp = summary.installed === 0 && summary.updated === 0 && summary.repaired === 0 && summary.removed === 0
+  const elapsed = `${(elapsedMs / 1000).toFixed(2)}s`
+
   if (isNoOp) {
     return (
-      <Box flexDirection="column">
-        <Text color={THEME.hint}>Nothing to install. facets.lock is in sync with facets.json.</Text>
-      </Box>
+      <Text>
+        Checked <Text color={THEME.success}>{result.perFacet.length}</Text> facet
+        {result.perFacet.length === 1 ? '' : 's'} across <Text color={THEME.success}>{adapterCount}</Text> adapter
+        {adapterCount === 1 ? '' : 's'} <Text color={THEME.hint}>(no changes)</Text>{' '}
+        <Text color={THEME.hint}>[{elapsed}]</Text>
+      </Text>
     )
   }
-  // Bundle viz + landing line: only surface what landed THIS run. The
-  // lockfile carries every facet in the project; `perFacet` carries the
-  // outcomes from this invocation. The marketing aesthetic is "exactly
-  // which capability you just gained", so iterating the lockfile would
-  // advertise pre-existing facets every time the user adds one more.
+  const touched = touchedFacetNames(result)
   const counts = countAssetsByType(result)
-  const bundleViz = formatBundleViz(counts)
-  // Skip the landing line on `install` (no new capability — just a sync)
-  // and when nothing this run shipped a command asset.
-  const landingCommand = mode === 'add' ? firstCommandAsset(result) : undefined
+  const bundleVizNode = formatColoredBundleViz(counts)
+
+  const removedNames = result.perFacet.filter((o) => o.kind === 'removed').map((o) => o.name)
+
+  const actionLabel =
+    mode === 'add'
+      ? `${touched.join(', ')} installed.`
+      : mode === 'remove'
+        ? `${removedNames.join(', ')} removed.`
+        : 'Install complete.'
+  const registrationSuffix =
+    adapterCount > 0 ? ` Updated facets via ${adapterCount} adapter${adapterCount === 1 ? '' : 's'}` : ''
+
+  // Timer line: "Installed N facets" or "Removed N facets"
+  const timerVerb = mode === 'remove' ? 'Removed' : 'Installed'
+  const timerCount = mode === 'remove' ? removedNames.length : touched.length
+
   return (
     <Box flexDirection="column">
-      <Text color={THEME.success} bold>
-        Done.
-      </Text>
-      <Text color={THEME.hint}>{summaryLine(summary)}</Text>
-      {bundleViz !== null && <Text color={THEME.hint}>{bundleViz}</Text>}
-      {landingCommand !== undefined && (
-        <Text color={THEME.brand} bold>
-          Now /{landingCommand} is available to your agents.
+      <Text>
+        <Text color={THEME.success} bold>
+          {actionLabel}
         </Text>
-      )}
+        <Text color={THEME.hint}>{registrationSuffix}</Text>
+        {adapterCount > 0 && (
+          <Text>
+            {'  '}
+            <Text color={THEME.success}>✓</Text>
+          </Text>
+        )}
+      </Text>
+      <Box flexDirection="column" marginLeft={2}>
+        <Text color={THEME.hint}>{summaryLine(summary)}</Text>
+        {bundleVizNode}
+      </Box>
+      <Text>
+        {timerVerb} <Text color={THEME.success}>{timerCount}</Text> facet
+        {timerCount === 1 ? '' : 's'} across <Text color={THEME.success}>{adapterCount}</Text> adapter
+        {adapterCount === 1 ? '' : 's'} <Text color={THEME.hint}>[{elapsed}]</Text>
+      </Text>
     </Box>
   )
 }
@@ -307,30 +408,40 @@ function touchedFacetNames(result: RunInstallResult & { ok: true }): ReadonlyArr
   return names
 }
 
-function formatBundleViz(counts: AssetCounts): string | null {
-  const parts: string[] = []
-  if (counts.skill > 0) parts.push(`${counts.skill} skill${counts.skill === 1 ? '' : 's'}`)
-  if (counts.agent > 0) parts.push(`${counts.agent} agent${counts.agent === 1 ? '' : 's'}`)
-  if (counts.command > 0) parts.push(`${counts.command} command${counts.command === 1 ? '' : 's'}`)
-  if (parts.length === 0) return null
-  return `+ ${parts.join(' · ')}`
-}
-
 /**
- * Pick the first command asset across the facets THIS RUN installed/updated
- * — the landing line uses it as the suggested invocation. Returns undefined
- * when no facet from this run shipped a command (e.g., skill-only or
- * agent-only bundle, or only `unchanged` outcomes).
+ * Render a per-asset-type colored bundle viz. Returns null (no JSX)
+ * when all counts are zero.
  */
-function firstCommandAsset(result: RunInstallResult & { ok: true }): string | undefined {
-  for (const name of touchedFacetNames(result)) {
-    const facet = result.lockfile.facets[name]
-    if (facet === undefined) continue
-    for (const asset of facet.assets) {
-      if (asset.type === 'command') return asset.name
+function formatColoredBundleViz(counts: AssetCounts): React.ReactNode {
+  const KINDS: ReadonlyArray<{ key: keyof AssetCounts; singular: string; plural: string; color: string }> = [
+    { key: 'skill', singular: 'skill', plural: 'skills', color: ASSET_TYPE_COLORS.skill },
+    { key: 'agent', singular: 'agent', plural: 'agents', color: ASSET_TYPE_COLORS.agent },
+    { key: 'command', singular: 'command', plural: 'commands', color: ASSET_TYPE_COLORS.command },
+  ]
+  const parts: React.ReactNode[] = []
+  for (const { key, singular, plural, color } of KINDS) {
+    const n = counts[key]
+    if (n > 0) {
+      if (parts.length > 0)
+        parts.push(
+          <Text key={`sep-${key}`} color={THEME.hint}>
+            {' · '}
+          </Text>,
+        )
+      parts.push(
+        <Text key={key} color={color}>
+          {n} {n === 1 ? singular : plural}
+        </Text>,
+      )
     }
   }
-  return undefined
+  if (parts.length === 0) return null
+  return (
+    <Text>
+      <Text color={THEME.hint}>+ </Text>
+      {parts}
+    </Text>
+  )
 }
 
 function summaryLine(summary: {

--- a/packages/cli/src/tui/views/list/list-view.tsx
+++ b/packages/cli/src/tui/views/list/list-view.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from 'ink'
+import { THEME } from '../../theme.ts'
+
+export interface ListRow {
+  name: string
+  value: string
+}
+
+export interface ListViewProps {
+  rows: ReadonlyArray<ListRow>
+}
+
+/**
+ * Renders the installed facets list with brand coloring.
+ * Name in brand purple, version dimmed. Columns aligned via padEnd.
+ */
+export function ListView({ rows }: ListViewProps) {
+  const nameWidth = rows.reduce((max, r) => Math.max(max, r.name.length), 0)
+
+  return (
+    <Box flexDirection="column">
+      {rows.map((r) => (
+        <Text key={r.name}>
+          <Text bold color={THEME.brand}>
+            {r.name.padEnd(nameWidth)}
+          </Text>
+          {'  '}
+          <Text color={THEME.hint}>{r.value}</Text>
+        </Text>
+      ))}
+    </Box>
+  )
+}

--- a/packages/cli/src/tui/views/search/search-view.tsx
+++ b/packages/cli/src/tui/views/search/search-view.tsx
@@ -1,0 +1,211 @@
+import type { WireAssetCounts, WirePackageListItem } from '@agent-facets/engine'
+import { Box, Text, useApp } from 'ink'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ASSET_TYPE_COLORS, THEME } from '../../theme.ts'
+
+/** Dot animation cycle: '', '.', '..', '...' */
+const DOT_CYCLE = ['', '.', '..', '...']
+const DOT_INTERVAL_MS = 350
+
+export type SearchResult = { ok: true; facets: ReadonlyArray<WirePackageListItem> } | { ok: false; error: 'handled' }
+
+export interface SearchViewProps {
+  term: string | undefined
+  /** Async function that fetches from the registry. Errors are handled
+   *  by the caller (writeCliError to stderr) before returning ok:false. */
+  fetch: () => Promise<SearchResult>
+  /** Called with the exit code when the view is done. */
+  onComplete?: (code: number) => void
+}
+
+/**
+ * Search view with an animated "Searching registry for '<term>'" line
+ * while the fetch is in progress, then transitions to results or
+ * "found no matches."
+ */
+export function SearchView({ term, fetch, onComplete }: SearchViewProps) {
+  const { exit } = useApp()
+  const [dotIndex, setDotIndex] = useState(0)
+  const [result, setResult] = useState<SearchResult | null>(null)
+  const startedRef = useRef(false)
+
+  // Animate the dots while loading.
+  useEffect(() => {
+    if (result !== null) return
+    const interval = setInterval(() => {
+      setDotIndex((prev) => (prev + 1) % DOT_CYCLE.length)
+    }, DOT_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [result])
+
+  // Run the fetch once on mount.
+  const start = useCallback(async () => {
+    if (startedRef.current) return
+    startedRef.current = true
+    const r = await fetch()
+    setResult(r)
+    if (!r.ok) {
+      onComplete?.(1)
+      exit(new Error('search failed'))
+    }
+  }, [fetch, onComplete, exit])
+
+  useEffect(() => {
+    void start()
+  }, [start])
+
+  const termLabel = term !== undefined ? ` for '${term}'` : ''
+
+  // Still loading — animated dots.
+  if (result === null) {
+    return (
+      <Text color={THEME.hint}>
+        Searching registry{termLabel}
+        {DOT_CYCLE[dotIndex]}
+      </Text>
+    )
+  }
+
+  // Fetch failed — error already written to stderr by the command.
+  if (!result.ok) {
+    return null
+  }
+
+  const all = result.facets
+  const filtered = term !== undefined ? all.filter((f) => f.name.toLowerCase().includes(term.toLowerCase())) : all
+
+  // No results at all.
+  if (filtered.length === 0) {
+    return (
+      <SearchDone
+        term={term}
+        count={0}
+        onExit={() => {
+          onComplete?.(0)
+          exit()
+        }}
+      />
+    )
+  }
+
+  // Results found.
+  const nameWidth = filtered.reduce((max, f) => Math.max(max, f.name.length), 0)
+  const versionWidth = filtered.reduce((max, f) => Math.max(max, `v${f.latestVersion}`.length), 0)
+  const authorWidth = filtered.reduce((max, f) => Math.max(max, `by ${f.author ?? f.publisher ?? ''}`.length), 0)
+
+  return (
+    <SearchDone
+      term={term}
+      count={filtered.length}
+      onExit={() => {
+        onComplete?.(0)
+        exit()
+      }}
+    >
+      {filtered.map((f) => (
+        <SearchResultRow
+          key={f.name}
+          item={f}
+          nameWidth={nameWidth}
+          versionWidth={versionWidth}
+          authorWidth={authorWidth}
+        />
+      ))}
+    </SearchDone>
+  )
+}
+
+/** Wrapper that shows the "Searching registry...found N" header and exits after paint. */
+function SearchDone({
+  term,
+  count,
+  onExit,
+  children,
+}: {
+  term: string | undefined
+  count: number
+  onExit: () => void
+  children?: React.ReactNode
+}) {
+  useEffect(() => {
+    onExit()
+  }, [onExit])
+
+  const termLabel = term !== undefined ? ` for '${term}'` : ''
+  const countLabel = count === 0 ? 'found no matches.' : `found ${count} match${count === 1 ? '' : 'es'}.`
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color={THEME.hint}>Searching registry{termLabel}...</Text>
+        <Text color={count > 0 ? THEME.success : THEME.warning}>{countLabel}</Text>
+      </Text>
+      {children}
+    </Box>
+  )
+}
+
+function SearchResultRow({
+  item,
+  nameWidth,
+  versionWidth,
+  authorWidth,
+}: {
+  item: WirePackageListItem
+  nameWidth: number
+  versionWidth: number
+  authorWidth: number
+}) {
+  const version = `v${item.latestVersion}`
+  const counts = formatColoredAssetCounts(item.assetCounts)
+
+  return (
+    <Text>
+      {'  '}
+      <Text bold color={THEME.brand}>
+        {item.name.padEnd(nameWidth)}
+      </Text>
+      {'  '}
+      <Text color={THEME.hint}>{version.padEnd(versionWidth)}</Text> <Text color={THEME.hint}>·</Text>{' '}
+      <Text>
+        <Text color={THEME.hint}>by </Text>
+        <Text>{(item.author ?? item.publisher ?? '').padEnd(authorWidth - 3)}</Text>
+      </Text>{' '}
+      <Text color={THEME.hint}>·</Text> {counts}
+    </Text>
+  )
+}
+
+function formatColoredAssetCounts(counts: WireAssetCounts): React.ReactNode {
+  const KINDS: ReadonlyArray<{
+    key: keyof WireAssetCounts
+    singular: string
+    plural: string
+    color: string
+  }> = [
+    { key: 'skills', singular: 'skill', plural: 'skills', color: ASSET_TYPE_COLORS.skill },
+    { key: 'agents', singular: 'agent', plural: 'agents', color: ASSET_TYPE_COLORS.agent },
+    { key: 'commands', singular: 'command', plural: 'commands', color: ASSET_TYPE_COLORS.command },
+    { key: 'servers', singular: 'server', plural: 'servers', color: ASSET_TYPE_COLORS.server },
+  ]
+
+  const parts: React.ReactNode[] = []
+  for (const { key, singular, plural, color } of KINDS) {
+    const n = counts[key]
+    if (n > 0) {
+      if (parts.length > 0)
+        parts.push(
+          <Text key={`sep-${key}`} color={THEME.hint}>
+            ,{' '}
+          </Text>,
+        )
+      parts.push(
+        <Text key={key} color={color}>
+          {n} {n === 1 ? singular : plural}
+        </Text>,
+      )
+    }
+  }
+
+  return <>{parts}</>
+}

--- a/packages/engine/src/__tests__/materialize.test.ts
+++ b/packages/engine/src/__tests__/materialize.test.ts
@@ -126,6 +126,7 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
     const newAssets = computeAssetList(manifest)
 
     const first = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [fixture.adapter],
       oldAssets: [],
@@ -139,6 +140,7 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
     // Second materialize against the SDK-written file. If skip-if-identical
     // is broken (adapter round-trip drifts), this would still write.
     const second = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [fixture.adapter],
       oldAssets: newAssets,
@@ -170,6 +172,7 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
     const newAssets = computeAssetList(manifest)
 
     const first = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [fixture.adapter],
       oldAssets: [],
@@ -193,6 +196,7 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
     // Second materialize against the same disk state must skip — this
     // exercises the skip-if-identical fix in materialize.ts.
     const second = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [fixture.adapter],
       oldAssets: newAssets,
@@ -225,6 +229,7 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
     const newAssets = computeAssetList(manifest)
 
     await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [fixture.adapter],
       oldAssets: [],
@@ -232,6 +237,7 @@ describe('materialize — skip-if-identical via real SDK round-trip', () => {
       journal: new InstallJournal(),
     })
     const second = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [fixture.adapter],
       oldAssets: newAssets,
@@ -256,6 +262,7 @@ describe('materialize — skip-if-identical', () => {
 
     // First materialize: writes once.
     const first = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [adapter],
       oldAssets: [],
@@ -269,6 +276,7 @@ describe('materialize — skip-if-identical', () => {
 
     // Second materialize against the same disk state: skip-if-identical fires.
     const second = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [adapter],
       oldAssets: newAssets,
@@ -293,6 +301,7 @@ describe('materialize — skip-if-identical', () => {
 
     // First materialize.
     await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [adapter],
       oldAssets: [],
@@ -306,6 +315,7 @@ describe('materialize — skip-if-identical', () => {
     writeFileSync(file, 'unrelated user edit\n')
 
     const second = await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [adapter],
       oldAssets: newAssets,
@@ -345,6 +355,7 @@ describe('materialize — skip-if-identical', () => {
     const newAssets = computeAssetList(manifestA)
 
     await materialize({
+      facetName: 'viper-plans',
       manifest: manifestA,
       adapters: [adapter],
       oldAssets: [],
@@ -352,6 +363,7 @@ describe('materialize — skip-if-identical', () => {
       journal: new InstallJournal(),
     })
     const second = await materialize({
+      facetName: 'viper-plans',
       manifest: manifestB,
       adapters: [adapter],
       oldAssets: newAssets,
@@ -393,6 +405,7 @@ describe('materialize — adapter-extras cannot override computed identity', () 
     const journal = new InstallJournal()
 
     await materialize({
+      facetName: 'viper-plans',
       manifest,
       adapters: [adapter],
       oldAssets: [],

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -2,6 +2,7 @@ import type { Adapter } from '@agent-facets/adapter'
 import { splitFrontMatter } from '@agent-facets/common'
 import type { LockfileAssetEntry, ResolvedFacetManifest } from '@agent-facets/protocol'
 import type { InstallJournal } from './journal.ts'
+import type { StageEvent } from './types.ts'
 
 /**
  * Compute the NEW asset set a facet contributes at this version. Derived
@@ -49,6 +50,8 @@ function assetKey(asset: LockfileAssetEntry): string {
 }
 
 export interface MaterializeOptions {
+  /** Facet name — used to tag per-adapter progress events. */
+  facetName: string
   manifest: ResolvedFacetManifest
   /** Adapters already filtered to those with supportsInstall === true. */
   adapters: Adapter[]
@@ -57,6 +60,8 @@ export interface MaterializeOptions {
   newAssets: readonly LockfileAssetEntry[]
   journal: InstallJournal
   onLog?: (line: string) => void
+  /** Structured progress events for view layers. */
+  onStage?: (event: StageEvent) => void
 }
 
 /**
@@ -270,6 +275,8 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
         })
       }
     }
+
+    opts.onStage?.({ kind: 'adapter-complete', facet: opts.facetName, adapter: adapter.name })
   }
 
   return { ok: true, written, skipped, deleted }

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -145,12 +145,14 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
 
       onStage({ kind: 'facet-stage', facet: facetName, stage: 'materialize' })
       const materializeResult = await materialize({
+        facetName,
         manifest: resolved,
         adapters: [...adapters],
         oldAssets,
         newAssets: entry.assets,
         journal,
         onLog,
+        onStage,
       })
       if (!materializeResult.ok) {
         const failure = materializeFailureToRunInstall(facetName, materializeResult.failure)
@@ -183,12 +185,14 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
 
       onStage({ kind: 'drift-removal', facet: facetName, oldVersion: prevEntry.version })
       const removalResult = await materialize({
+        facetName,
         manifest: removalManifest(facetName),
         adapters: [...adapters],
         oldAssets: prevEntry.assets,
         newAssets: [],
         journal,
         onLog,
+        onStage,
       })
       if (!removalResult.ok) {
         const failure = materializeFailureToRunInstall(facetName, removalResult.failure)

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -59,6 +59,7 @@ export type StageEvent =
   | { kind: 'facet-failure'; facet: string; failure: RunInstallFailure }
   | { kind: 'server-warning'; facet: string; servers: ReadonlyArray<string> }
   | { kind: 'drift-removal'; facet: string; oldVersion: string }
+  | { kind: 'adapter-complete'; facet: string; adapter: string }
   | { kind: 'asset-installed'; facet: string; adapter: string; asset: LockfileAssetEntry }
   | { kind: 'asset-deleted'; facet: string; adapter: string; asset: LockfileAssetEntry }
   | { kind: 'lockfile-write'; path: string }


### PR DESCRIPTION
### Why

The CLI's `search`, `list`, and `install` output was plain text written directly to stdout with no color, no animation, and no structure. This replaces all three with Ink-rendered TUI views that use brand colors, animated progress, and polished summary lines — bringing terminal output in line with the agentfacets.io marketing aesthetic.

### Details

**Brand colors.** `ASSET_TYPE_COLORS` added to `@agent-facets/brand` maps each asset type (skill, agent, command, server) to an accent color. Both search results and install summaries consume it so terminal colors stay in sync with the landing-site palette.

**Search.** Converted from synchronous string-building to an async Ink view. An animated "Searching registry for 'term'..." line (cycling dots) shows while the fetch is in-flight. Results render in a columnar layout with brand-colored names, dimmed versions, author attribution, and per-asset-type colored counts. The fetch function is passed as a prop so the view drives the lifecycle.

**List.** Converted from `padEnd` + `process.stdout.write` to an Ink view. Names in brand purple, versions dimmed.

**Install.** Overhauled from per-facet rows to a single live progress line: an animated gradient comet `ProgressBar`, `[done, remaining, failed]` counters, and the current facet + stage label. Collapses to a bun-style timer line on completion: "Installed N facets across N adapters [Xs]". Adapter registration count surfaced via a new `adapter-complete` `StageEvent` emitted from `materialize.ts`.

**Removed.** "Now /x is available to your agents" landing line, per-facet drift-removal lines (summary count covers it), "Nothing to install" text (replaced with "Checked N facets...no changes").

**Tests.** Search tests rewritten to render `SearchView` directly via `ink-testing-library`. List alignment test replaced with content-existence assertions (visual alignment is terminal-width-dependent and untestable in unit tests). Install view tests updated for new output format.

### Verification

`bun turbo check --force` — 34/34 tasks pass.