### PR TITLE
Treat undeclared facets in `facet remove` as silent no-ops instead of errors

### DIFF
--- a/.changeset/fair-queens-joke.md
+++ b/.changeset/fair-queens-joke.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": minor
+---
+
+UI updates for all facet management commands and `remove` will now silently ignore undeclared facets

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -16,7 +16,7 @@ Removes one or more facets from `facets.json`, deletes their assets from every c
 ## What it does
 
 1. **Load `facets.json`.** A missing or invalid manifest fails before any change.
-2. **Validate every name is declared.** If any named facet is not in `facets.json`, the command fails and changes nothing — removing multiple facets is all-or-nothing.
+2. **Filter to declared names.** Names not in `facets.json` are silently ignored. If every name is absent, the command exits successfully with no changes.
 3. **Snapshot `facets.json`** byte-for-byte for rollback.
 4. **Remove the named entries** from `facets.json`.
 5. **Run the install pipeline.** The removed facets are now absent from the manifest, so drift removal deletes their assets from every adapter and rewrites the lockfile without them. Every other facet is left untouched.
@@ -31,7 +31,7 @@ facet remove viper-plans
 # rm is an alias.
 facet rm viper-plans
 
-# Remove several at once (all-or-nothing).
+# Remove several at once.
 facet remove viper-plans rezi
 ```
 
@@ -45,8 +45,8 @@ facet remove viper-plans rezi
 
 | Code | Meaning                                                                              |
 | ---- | ------------------------------------------------------------------------------------ |
-| `0`  | Removal succeeded.                                                                   |
-| `1`  | Failed (no names given, a named facet not in `facets.json`, install failure, etc.). `facets.json` is restored byte-for-byte on every failure path. |
+| `0`  | Removal succeeded, or all requested names were already absent from `facets.json` (no-op). |
+| `1`  | Failed (no names given, install failure, etc.). `facets.json` is restored byte-for-byte on every failure path. |
 
 ## See also
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -658,8 +658,9 @@ The system SHALL register a `remove` command that removes one or more facets fro
 #### Scenario: Remove command accepts multiple names
 
 - **WHEN** a user runs `remove` with two or more facet names
-- **THEN** the system SHALL remove each named facet
-- **AND** the operation SHALL succeed only if every named facet is removed successfully
+- **THEN** the system SHALL remove each declared facet
+- **AND** the system SHALL silently ignore any undeclared names
+- **AND** the operation SHALL succeed if every declared facet is removed successfully
 
 ### Requirement: Remove renders the unified progress view
 
@@ -677,16 +678,23 @@ The `remove` command SHALL present progress through the same shared rendering us
 - **THEN** the rendered view SHALL show progress for each facet
 - **AND** on completion the view SHALL show one summary line per affected facet
 
-### Requirement: Remove reports an undeclared facet clearly
+### Requirement: Remove handles undeclared names gracefully
 
-When `remove` is asked to remove a facet that is not declared in the project, the system SHALL identify the undeclared facet by name and SHALL exit with a non-zero code without modifying the project.
+When `remove` is given a name that is not declared in the project, the system SHALL silently ignore it. When every requested name is undeclared, the rendered view SHALL report that no changes were made and the process SHALL exit with code 0.
 
-#### Scenario: Removing an undeclared facet is reported
+#### Scenario: Removing only undeclared names shows no-op summary
 
-- **WHEN** a user runs `remove` with a name that is not declared in the project manifest
-- **THEN** the system SHALL print an error identifying the undeclared facet by name
-- **AND** the project manifest, lockfile, and adapter state SHALL be unchanged
-- **AND** the process SHALL exit with a non-zero code
+- **WHEN** a user runs `remove` with one or more names that are not declared in the project manifest
+- **AND** no requested name is declared
+- **THEN** the rendered view SHALL show a summary indicating no changes
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Mix of declared and undeclared names removes the declared ones
+
+- **WHEN** a user runs `remove` with names where some are declared and some are not
+- **THEN** the system SHALL remove the declared facets
+- **AND** the system SHALL silently ignore the undeclared names
+- **AND** the process SHALL exit with code 0 if all declared facets were removed successfully
 
 ### Requirement: Remove reports rollback outcome on failure
 

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -589,32 +589,38 @@ When a user removes a facet from a project, the system SHALL drop the facet from
 - **THEN** the system SHALL leave the project manifest declaring no facets
 - **AND** the system SHALL leave a valid lockfile that records no facets
 
-### Requirement: Removing multiple facets is a single all-or-nothing operation
+### Requirement: Removing multiple declared facets is transactional
 
-When a user removes more than one facet in a single invocation, the system SHALL remove all of the named facets together. If any named facet cannot be removed, the system SHALL remove none of them and SHALL leave the project unchanged.
+When a user removes more than one facet in a single invocation, the system SHALL remove all of the declared facets together. If the removal of any declared facet fails (asset deletion, lockfile update, or manifest write), the system SHALL remove none of them and SHALL leave the project unchanged. Names that are not declared in the project manifest SHALL be silently ignored and SHALL NOT cause the operation to fail.
 
-#### Scenario: All named facets are removed together
+#### Scenario: All declared facets are removed together
 
 - **WHEN** a user removes two or more facets that are all declared in the project manifest
 - **THEN** the system SHALL remove every named facet's manifest entry, assets, and lockfile entry
-- **AND** the operation SHALL succeed only if every named facet was removed
+- **AND** the operation SHALL succeed only if every declared facet was removed
 
-#### Scenario: One absent name aborts the whole removal
+#### Scenario: Undeclared names are ignored in a multi-facet removal
 
 - **WHEN** a user removes two or more facets and at least one of them is not declared in the project manifest
-- **THEN** the system SHALL NOT remove any of the named facets
-- **AND** the system SHALL leave the project manifest, lockfile, and adapter state unchanged
+- **THEN** the system SHALL remove every *declared* facet in the request
+- **AND** the system SHALL silently ignore the undeclared names
+- **AND** the operation SHALL succeed if every declared facet was removed successfully
 
-### Requirement: Removing an undeclared facet fails
+### Requirement: Removing an undeclared facet is a silent no-op
 
-When a user removes a facet that is not declared in the project manifest, the system SHALL fail with an error identifying the facet and SHALL leave the project unchanged. The system SHALL NOT treat the removal of an undeclared facet as a silent success.
+When a user removes a facet that is not declared in the project manifest, the system SHALL silently ignore the name. The project manifest, lockfile, and adapter state SHALL remain unchanged for that name. When every requested name is undeclared, the system SHALL exit successfully and SHALL report that no changes were made.
 
 #### Scenario: Removing a facet that is not declared
 
 - **WHEN** a user removes a facet whose name does not appear in the project manifest
-- **THEN** the system SHALL fail with an error identifying the facet by name
-- **AND** the system SHALL leave the project manifest, lockfile, and adapter state unchanged
-- **AND** the system SHALL exit with a non-zero status
+- **THEN** the system SHALL leave the project manifest, lockfile, and adapter state unchanged
+- **AND** the system SHALL NOT fail with an error
+
+#### Scenario: All requested names are undeclared
+
+- **WHEN** a user removes one or more facets and none of them are declared in the project manifest
+- **THEN** the system SHALL exit successfully
+- **AND** the system SHALL report that no changes were made
 
 ### Requirement: Failed removals leave the project unchanged
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -39,8 +39,8 @@ function findContentFrame(frames: ReadonlyArray<string | undefined>): string {
 function makeFakeRun(
   events: ReadonlyArray<StageEvent>,
   result: RunInstallResult,
-): (onStage: (e: StageEvent) => void) => Promise<RunInstallResult> {
-  return async (onStage) => {
+): (onStage: (e: StageEvent) => void, onLog?: (line: string) => void) => Promise<RunInstallResult> {
+  return async (onStage, _onLog) => {
     for (const event of events) {
       onStage(event)
     }

--- a/packages/cli/src/__tests__/remove.e2e.test.ts
+++ b/packages/cli/src/__tests__/remove.e2e.test.ts
@@ -100,7 +100,7 @@ describe('facet remove — validates before adapter discovery', () => {
     rmSync(fakeHome, { recursive: true, force: true })
   })
 
-  test('removing an undeclared facet with no adapters reports the facet error, not the adapter error', async () => {
+  test('removing an undeclared facet prints no-op summary without discovering adapters', async () => {
     // Valid manifest that declares one facet — but NOT the one we remove.
     const before = `${JSON.stringify({ facets: { cowsay: '0.1.1' } }, null, 2)}\n`
     writeFileSync(join(projectRoot, 'facets.json'), before)
@@ -110,11 +110,13 @@ describe('facet remove — validates before adapter discovery', () => {
       env: { HOME: fakeHome, FACET_DIR: join(fakeHome, '.facet') },
     })
 
-    expect(result.exitCode).toBe(1)
-    // The undeclared-facet error wins because validation runs before adapter
-    // discovery. The old ordering would have reported the adapter error here.
-    expect(result.stderr).toContain('not declared in facets.json')
-    expect(result.stderr).toContain('ghost')
+    expect(result.exitCode).toBe(0)
+    // No-op summary printed — the one declared facet is counted.
+    expect(result.stdout).toContain('Checked 1 facet')
+    expect(result.stdout).toContain('no changes')
+    // No error output — undeclared facets are silently ignored, and
+    // adapter discovery is skipped entirely (no "no adapters installed").
+    expect(result.stderr).not.toContain('not declared')
     expect(result.stderr).not.toContain('no adapters installed')
     // Nothing was removed: the manifest is byte-for-byte unchanged.
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(before)

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -45,7 +45,6 @@ export const addCommand: Command = {
     }
 
     const verbose = flags.verbose === true
-    const onLog = verbose ? (line: string) => process.stderr.write(`${line}\n`) : undefined
 
     // Parse every source up front. No I/O happens here; any parse error
     // aborts before mounting the view or touching disk.
@@ -82,13 +81,13 @@ export const addCommand: Command = {
     const instance = render(
       createElement(InstallView, {
         mode: 'add',
-        run: async (onStage) => {
+        run: async (onStage, onLog) => {
           const result = await runAdd({
             projectRoot,
             sources,
             adapters,
             onStage,
-            ...(onLog ? { onLog } : {}),
+            ...(verbose && onLog ? { onLog } : {}),
             signal: controller.signal,
           })
           captured = result

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -42,7 +42,6 @@ export const installCommand: Command = {
 
     const verbose = flags.verbose === true
     const frozenLockfile = flags['frozen-lockfile'] === true
-    const onLog = verbose ? (line: string) => process.stderr.write(`${line}\n`) : undefined
 
     const projectRoot = process.cwd()
 
@@ -85,12 +84,12 @@ export const installCommand: Command = {
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
-        run: async (onStage) => {
+        run: async (onStage, onLog) => {
           const result = await runInstall({
             projectRoot,
             adapters: installable,
             onStage,
-            onLog,
+            ...(verbose && onLog ? { onLog } : {}),
             signal: controller.signal,
             frozenLockfile,
           })

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -1,7 +1,8 @@
 import { prepareRemove, type RemovePrepareFailure, type RunRemoveResult, runRemove } from '@agent-facets/engine'
-import { render } from 'ink'
+import { Box, render, Text } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
+import { THEME } from '../../tui/theme.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
 import { writeCliError } from '../../util/errors.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
@@ -37,8 +38,8 @@ export const removeCommand: Command = {
       return 1
     }
 
+    const startTime = performance.now()
     const verbose = flags.verbose === true
-    const onLog = verbose ? (line: string) => process.stderr.write(`${line}\n`) : undefined
 
     const names = args
     const projectRoot = process.cwd()
@@ -53,6 +54,33 @@ export const removeCommand: Command = {
     if (!prepared.ok) {
       writePrepareError(prepared.failure)
       return 1
+    }
+
+    // If every requested name was absent from facets.json, there is nothing
+    // to remove. Print the no-op summary and exit without discovering
+    // adapters — avoids a misleading "no adapters installed" error when the
+    // user removes a facet that was never declared.
+    if (prepared.names.length === 0) {
+      const facetCount = Object.keys(prepared.json.facets).length
+      const elapsed = `${((performance.now() - startTime) / 1000).toFixed(2)}s`
+      const instance = render(
+        createElement(
+          Box,
+          null,
+          createElement(
+            Text,
+            null,
+            'Checked ',
+            createElement(Text, { color: THEME.success }, facetCount),
+            ` facet${facetCount === 1 ? '' : 's'} `,
+            createElement(Text, { color: THEME.hint }, '(no changes)'),
+            ' ',
+            createElement(Text, { color: THEME.hint }, `[${elapsed}]`),
+          ),
+        ),
+      )
+      instance.unmount()
+      return 0
     }
 
     // Discover or pick adapters. Drift-removal calls `deleteAsset` on each
@@ -77,14 +105,14 @@ export const removeCommand: Command = {
     const instance = render(
       createElement(InstallView, {
         mode: 'remove',
-        run: async (onStage) => {
+        run: async (onStage, onLog) => {
           const result = await runRemove({
             projectRoot,
             names,
             adapters,
             prepared,
             onStage,
-            ...(onLog ? { onLog } : {}),
+            ...(verbose && onLog ? { onLog } : {}),
             signal: controller.signal,
           })
           captured = result
@@ -157,13 +185,6 @@ function writePrepareError(failure: RemovePrepareFailure): void {
         what: 'could not read facets.json',
         detail: failure.error,
         fix: 'run this command inside a project with a valid facets.json',
-      })
-      return
-    case 'not-declared':
-      writeCliError({
-        what: `facet ${failure.names.length === 1 ? 'is' : 'are'} not declared in facets.json`,
-        detail: failure.names.join(', '),
-        fix: 'check the name(s) against facets.json; nothing was removed',
       })
       return
     case 'manifest-write':

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -1,5 +1,5 @@
 import type { AddPrepareFailure, RemovePrepareFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
-import { Box, Text, useApp } from 'ink'
+import { Box, Text, useApp, useStderr } from 'ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ProgressBar } from '../../components/progress-bar.tsx'
 import { ASSET_TYPE_COLORS, THEME } from '../../theme.ts'
@@ -24,10 +24,13 @@ export type InstallViewResult =
 export interface InstallViewProps {
   /**
    * Driver: caller supplies `runInstall`-equivalent closure that takes
-   * an `onStage` callback and returns the result. The view runs it once
-   * on mount and surfaces its events / outcome.
+   * an `onStage` callback and an optional `onLog` callback, and returns
+   * the result. The view runs it once on mount and surfaces its events /
+   * outcome. When verbose output is enabled, the caller should thread
+   * `onLog` into the engine call; the view routes it through Ink's
+   * stderr writer so it doesn't race the progress bar repaint.
    */
-  run: (onStage: (event: StageEvent) => void) => Promise<InstallViewResult>
+  run: (onStage: (event: StageEvent) => void, onLog?: (line: string) => void) => Promise<InstallViewResult>
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
    * renders "Installing facets..."; `'remove'` renders "Removing
@@ -72,6 +75,7 @@ interface DriftRemoval {
 
 export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   const { exit } = useApp()
+  const { write: writeToStderr } = useStderr()
   const [totalFacets, setTotalFacets] = useState(0)
   const [facetOrder, setFacetOrder] = useState<string[]>([])
   const [facets, setFacets] = useState<Record<string, FacetState>>({})
@@ -160,11 +164,25 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
     }
   }, [])
 
+  /**
+   * Verbose-log writer coordinated with Ink's rendering. Callers thread
+   * this into the engine's `onLog` so verbose lines reach stderr without
+   * racing the progress-bar repaint. `useStderr().write()` is Ink's
+   * equivalent of `<Static>` for strings: it writes once, in order,
+   * above the live region, on the stderr stream.
+   */
+  const onLog = useCallback(
+    (line: string) => {
+      writeToStderr(`${line}\n`)
+    },
+    [writeToStderr],
+  )
+
   const start = useCallback(async () => {
     if (startedRef.current) return
     startedRef.current = true
     try {
-      const r = await run(onStage)
+      const r = await run(onStage, onLog)
       setElapsedMs(Date.now() - startTimeRef.current)
       setResult(r)
       onComplete?.(r)
@@ -174,7 +192,7 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
       const err = error instanceof Error ? error : new Error(String(error))
       setExitState({ kind: 'failure', error: err })
     }
-  }, [run, onStage, onComplete])
+  }, [run, onStage, onLog, onComplete])
 
   useEffect(() => {
     if (exitState.kind === 'success') {

--- a/packages/cli/src/tui/views/install/remove-prepare-failure-block.tsx
+++ b/packages/cli/src/tui/views/install/remove-prepare-failure-block.tsx
@@ -5,10 +5,10 @@ import { THEME } from '../../theme.ts'
 
 /**
  * Renders the structured failure detail for the `remove` flow's
- * pre-install (prepare) phase — manifest read and undeclared-facet
- * validation. These failures occur before the install pipeline runs, so
- * they have no `RunInstallFailure` shape; the `remove` orchestrator
- * reports them as `RemovePrepareFailure` and the view renders them here.
+ * pre-install (prepare) phase — manifest read and write failures.
+ * These failures occur before the install pipeline runs, so they have
+ * no `RunInstallFailure` shape; the `remove` orchestrator reports them
+ * as `RemovePrepareFailure` and the view renders them here.
  *
  * The explicit return type + `assertNever` default arm makes any new
  * `RemovePrepareFailure` variant a compile-time error here, mirroring
@@ -25,18 +25,6 @@ export function RemovePrepareFailureBlock({ failure }: { failure: RemovePrepareF
           <Text> {failure.error}</Text>
         </Box>
       )
-    case 'not-declared': {
-      const count = failure.names.length
-      return (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color={THEME.warning} bold>
-            ✕ {count === 1 ? 'facet is not declared' : 'facets are not declared'} in facets.json
-          </Text>
-          <Text> {failure.names.join(', ')}</Text>
-          <Text color={THEME.hint}> nothing was removed; check the name(s) against facets.json</Text>
-        </Box>
-      )
-    }
     case 'manifest-write':
       return (
         <Box flexDirection="column" marginTop={1}>

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -192,37 +192,28 @@ describe('runRemove — multi-facet removal', () => {
     expect(existsSync(assetPath('test-adapter', 'fortune'))).toBe(true)
   })
 
-  test('one absent name aborts the whole operation, leaving the project unchanged', async () => {
+  test('absent names are silently ignored — only declared facets are removed', async () => {
     await installFacet('cowsay', '0.1.1')
-    const beforeFacets = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
-    const beforeLock = readFileSync(join(projectRoot, 'facets.lock'), 'utf8')
 
     const result = await remove(['cowsay', 'does-not-exist'])
-    expect(result.ok).toBe(false)
-    if (result.ok) expect.unreachable()
-    if (result.phase !== 'prepare') expect.unreachable()
-    if (result.failure.reason !== 'not-declared') expect.unreachable()
-    expect(result.failure.names).toEqual(['does-not-exist'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
 
-    // Nothing removed.
-    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(beforeFacets)
-    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(beforeLock)
-    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(true)
+    // cowsay was removed; does-not-exist was silently ignored.
+    expect(Object.keys(readFacets())).not.toContain('cowsay')
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(false)
   })
 })
 
 describe('runRemove — undeclared facet', () => {
-  test('fails with not-declared and leaves the project unchanged', async () => {
+  test('removing only undeclared facets succeeds as a no-op', async () => {
     await installFacet('cowsay', '0.1.1')
     const beforeFacets = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
 
     const result = await remove(['ghost'])
-    expect(result.ok).toBe(false)
-    if (result.ok) expect.unreachable()
-    if (result.phase !== 'prepare') expect.unreachable()
-    if (result.failure.reason !== 'not-declared') expect.unreachable()
-    expect(result.failure.names).toEqual(['ghost'])
+    expect(result.ok).toBe(true)
 
+    // Nothing was removed — cowsay is still installed.
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(beforeFacets)
   })
 
@@ -252,30 +243,30 @@ describe('runRemove — last facet', () => {
 })
 
 describe('prepareRemove — read-only validation', () => {
-  test('returns not-declared for an undeclared name without mutating disk', async () => {
+  test('filters out undeclared names without mutating disk', async () => {
     await installFacet('cowsay', '0.1.1')
     const beforeFacets = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
     const beforeLock = readFileSync(join(projectRoot, 'facets.lock'), 'utf8')
 
     const result = prepareRemove({ projectRoot, names: ['ghost'] })
-    expect(result.ok).toBe(false)
-    if (result.ok) expect.unreachable()
-    if (result.failure.reason !== 'not-declared') expect.unreachable()
-    expect(result.failure.names).toEqual(['ghost'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    // ghost is absent — filtered out; names list is empty.
+    expect(result.names).toEqual([])
 
     // Pure validation: nothing on disk changed.
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(beforeFacets)
     expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(beforeLock)
   })
 
-  test('collects all absent names (all-or-nothing) when several are undeclared', async () => {
+  test('filters absent names and keeps only declared ones', async () => {
     await installFacet('cowsay', '0.1.1')
 
     const result = prepareRemove({ projectRoot, names: ['cowsay', 'ghost', 'phantom'] })
-    expect(result.ok).toBe(false)
-    if (result.ok) expect.unreachable()
-    if (result.failure.reason !== 'not-declared') expect.unreachable()
-    expect(result.failure.names).toEqual(['ghost', 'phantom'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    // Only cowsay is declared; ghost and phantom are filtered out.
+    expect(result.names).toEqual(['cowsay'])
   })
 
   test('returns manifest-read when no facets.json exists', () => {
@@ -293,6 +284,8 @@ describe('prepareRemove — read-only validation', () => {
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
     expect(result.json.facets.cowsay).toBe('0.1.1')
+    // Filtered names contains every requested name (all declared).
+    expect(result.names).toEqual(['cowsay'])
     // Snapshot captures the on-disk bytes for rollback.
     expect(result.snapshot).not.toBeNull()
     expect(result.snapshot?.toString('utf8')).toBe(readFileSync(join(projectRoot, 'facets.json'), 'utf8'))

--- a/packages/engine/src/install/run-remove.ts
+++ b/packages/engine/src/install/run-remove.ts
@@ -11,14 +11,14 @@ import type { RunInstallResult, StageEvent } from './types.ts'
  * The `facet remove` orchestrator. Owns the manifest transaction for the
  * remove flow on a developer's machine, mirroring {@link runAdd}:
  *
- *   1. Prepare: load `facets.json`, validate every named facet is declared,
- *      and snapshot the manifest. A missing/invalid manifest or an
- *      undeclared name fails here, before any mutation (there is nothing to
- *      remove). Extracted into {@link prepareRemove} so the CLI can run this
- *      read-only validation *before* discovering adapters — an undeclared
- *      facet must fail with the facet error and leave state untouched, never
+ *   1. Prepare: load `facets.json`, filter the requested names to those
+ *      actually declared (silently ignoring absent names), and snapshot the
+ *      manifest. A missing/invalid manifest fails here, before any mutation.
+ *      Extracted into {@link prepareRemove} so the CLI can run this read-only
+ *      validation *before* discovering adapters — a missing manifest must
+ *      fail with the manifest error and leave state untouched, never
  *      launching the adapter picker or reporting "no adapters installed".
- *   2. Remove every named entry; write the manifest.
+ *   2. Remove every declared entry; write the manifest.
  *   3. Run the install pipeline. The removed facets are now orphaned
  *      lockfile entries, so the existing drift-removal loop deletes their
  *      assets from every adapter and rewrites the lockfile without them.
@@ -57,9 +57,6 @@ export interface RunRemoveOptions {
  * `reason` so each arm carries exactly the fields that reason implies:
  *   - `manifest-read`  — `facets.json` is missing, unreadable, or invalid;
  *                        there is nothing to remove.
- *   - `not-declared`   — one or more named facets are not declared in the
- *                        manifest. Carries every absent name so the CLI can
- *                        report them all in one shot (all-or-nothing).
  *   - `manifest-write` — reading the snapshot or writing the mutated
  *                        manifest hit an I/O error (permissions, disk full,
  *                        a race). The original `facets.json` is left intact
@@ -70,7 +67,6 @@ export interface RunRemoveOptions {
  */
 export type RemovePrepareFailure =
   | { reason: 'manifest-read'; error: string }
-  | { reason: 'not-declared'; names: ReadonlyArray<string> }
   | { reason: 'manifest-write'; error: string }
 
 /**
@@ -79,7 +75,7 @@ export type RemovePrepareFailure =
  * byte-for-byte snapshot used to restore on a later install failure.
  */
 export type RemovePrepareResult =
-  | { ok: true; json: FacetsJson; snapshot: Buffer | null }
+  | { ok: true; json: FacetsJson; snapshot: Buffer | null; names: ReadonlyArray<string> }
   | { ok: false; failure: RemovePrepareFailure }
 
 /**
@@ -106,13 +102,13 @@ export type RunRemoveResult =
 
 /**
  * The read-only validation + snapshot phase of a remove. Loads `facets.json`,
- * checks that every named facet is declared (collecting all absent names for
- * an all-or-nothing error), and snapshots the manifest for rollback.
+ * filters the requested names to those actually declared (silently ignoring
+ * absent names), and snapshots the manifest for rollback.
  *
  * Extracted from `runRemove` so the CLI can run it *before* discovering
- * adapters: an undeclared facet or missing manifest must fail with the facet
- * error and leave the project untouched, never launching the adapter picker
- * or reporting "no adapters installed". Performs no mutation.
+ * adapters: a missing manifest must fail with the manifest error and leave
+ * the project untouched, never launching the adapter picker or reporting
+ * "no adapters installed". Performs no mutation.
  *
  * Never throws — the snapshot read is guarded and surfaces as `manifest-write`.
  */
@@ -130,19 +126,19 @@ export function prepareRemove(opts: { projectRoot: string; names: ReadonlyArray<
   }
   const json = loaded.data
 
-  // 2. Validate every name is declared. Collect all absent names so the
-  //    user sees the full set in one error (all-or-nothing — Decision 2/3).
-  const absent = names.filter((name) => json.facets[name] === undefined)
-  if (absent.length > 0) {
-    return { ok: false, failure: { reason: 'not-declared', names: absent } }
-  }
+  // 2. Filter to names that are actually declared. Absent names are
+  //    silently ignored — removing a facet that isn't declared in
+  //    facets.json is a no-op, not an error. If every name is absent
+  //    the caller proceeds with an empty list, which produces a no-op
+  //    install ("no changes").
+  const present = names.filter((name) => Object.hasOwn(json.facets, name))
 
   // 3. Snapshot facets.json for rollback. Guard the read so an I/O error
   //    surfaces as a structured failure instead of escaping the function.
   const facetsJsonPath = join(projectRoot, FACETS_JSON_FILE)
   try {
     const snapshot: Buffer | null = existsSync(facetsJsonPath) ? readFileSync(facetsJsonPath) : null
-    return { ok: true, json, snapshot }
+    return { ok: true, json, snapshot, names: present }
   } catch (err) {
     return {
       ok: false,
@@ -163,14 +159,16 @@ export async function runRemove(opts: RunRemoveOptions): Promise<RunRemoveResult
   if (!prep.ok) {
     return { ok: false, phase: 'prepare', failure: prep.failure }
   }
-  const { json, snapshot } = prep
+  const { json, snapshot, names: filteredNames } = prep
   const facetsJsonPath = join(projectRoot, FACETS_JSON_FILE)
 
-  // 2. Remove every named entry and write the manifest. Guard the write so
-  //    an I/O error surfaces as `manifest-write` rather than escaping. The
-  //    write is atomic (tmp + rename) and no install has run yet, so a throw
-  //    leaves the original `facets.json` intact — nothing to restore.
-  for (const name of names) {
+  // 2. Remove every declared entry and write the manifest. Names that were
+  //    absent from facets.json were already filtered out by prepareRemove.
+  //    Guard the write so an I/O error surfaces as `manifest-write` rather
+  //    than escaping. The write is atomic (tmp + rename) and no install has
+  //    run yet, so a throw leaves the original `facets.json` intact —
+  //    nothing to restore.
+  for (const name of filteredNames) {
     removeFacetFromManifest(json, name)
     onLog?.(`[verbose]   removed "${name}" from ${FACETS_JSON_FILE}`)
   }


### PR DESCRIPTION
### Why

Removing a facet that was never declared in `facets.json` previously failed with a hard error (`not-declared`), which was confusing when the user's intent was already satisfied — the facet simply isn't there. This change makes that case a silent no-op instead, consistent with how most package managers handle idempotent remove operations.

### Details

`prepareRemove` previously collected all absent names and returned a `not-declared` failure, blocking the entire operation (all-or-nothing). It now filters the requested names down to only those actually declared in `facets.json`, silently dropping the rest. If every requested name is absent, the filtered list is empty and the CLI prints a no-op summary ("Checked N facets (no changes)") and exits 0 without ever discovering adapters — avoiding the misleading "no adapters installed" error that would otherwise surface.

The `not-declared` variant has been removed from `RemovePrepareFailure` and the corresponding error rendering in `RemovePrepareFailureBlock`. `RemovePrepareResult` now carries the filtered `names` array so callers use the already-validated list rather than the raw input.

### Verification

Existing and updated tests cover the key cases: removing only undeclared facets succeeds as a no-op with the manifest unchanged, removing a mix of declared and undeclared facets removes only the declared ones, and `prepareRemove` returns the correctly filtered names list in all scenarios. The e2e test confirms exit code 0, the no-op summary on stdout, and no error output.