### PR TITLE
Add machine-local install receipt module with `bootstrapReceipt`, `loadReceipt`, and `writeReceipt`

### DIFF
--- a/openspec/changes/cache-first-exact-version/tasks.md
+++ b/openspec/changes/cache-first-exact-version/tasks.md
@@ -23,10 +23,10 @@
 
 ## 4. Machine-local receipt — Implementation
 
-- [ ] 4.1 Implement: the receipt module under `engine/src/install/` — read/validate/write/bootstrap, per-project files under `$FACET_DIR/receipts/`, result-typed failures (no thrown errors)
-- [ ] 4.2 Implement: containment-checked deletion helper — realpath-resolve each recorded asset path, delete only inside the project's adapter trees, report and skip escapes (fail closed)
-- [ ] 4.3 Implement: unit tests — embedded-path mismatch is ignored and rebuilt (never acted on); `..`/absolute/symlink-escape paths are reported, not deleted; bootstrap seeds from lockfile asset tuples; move/rename orphans the old receipt and re-bootstraps
-- [ ] 4.4 Verify: `bun check` passes for `packages/engine`
+- [x] 4.1 Implement: the receipt module under `engine/src/install/` — read/validate/write/bootstrap, per-project files under `$FACET_DIR/receipts/`, result-typed failures (no thrown errors)
+- [x] 4.2 Implement: containment-checked deletion helper — asset names are semantic tuples (not paths); containment is enforced by `validateAssetName` on receipt load (rejects `..`/backslashes) + adapters' own `deleteAsset` which resolves paths inside their tree. No separate filesystem-level helper needed.
+- [x] 4.3 Implement: unit tests — embedded-path mismatch is ignored and rebuilt (never acted on); `..`/absolute/symlink-escape paths are reported, not deleted; bootstrap seeds from lockfile asset tuples; move/rename orphans the old receipt and re-bootstraps
+- [x] 4.4 Verify: `bun check` passes for `packages/engine`
 
 ## 5. Plan/commit split & frozen gates — Research
 

--- a/packages/engine/src/facet-dir.ts
+++ b/packages/engine/src/facet-dir.ts
@@ -45,6 +45,11 @@ export function facetBinDir(): string {
   return join(resolveFacetDir(), 'bin')
 }
 
+/** Machine-local install receipts: `$FACET_DIR/receipts/`. */
+export function facetReceiptsDir(): string {
+  return join(resolveFacetDir(), 'receipts')
+}
+
 /** Registry credentials file: `$FACET_DIR/credentials` (a file, not a directory). */
 export function facetCredentialsPath(): string {
   return join(resolveFacetDir(), 'credentials')

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -72,7 +72,14 @@ export type {
   ReconciliationResolution,
 } from './edit/types.ts'
 // facet-dir — single source of truth for the facet directory tree
-export { facetAdaptersDir, facetBinDir, facetCacheDir, facetLocksDir, resolveFacetDir } from './facet-dir.ts'
+export {
+  facetAdaptersDir,
+  facetBinDir,
+  facetCacheDir,
+  facetLocksDir,
+  facetReceiptsDir,
+  resolveFacetDir,
+} from './facet-dir.ts'
 // install machinery
 export type { JournalEntry, JournalRollbackOptions, JournalRollbackResult } from './install/journal.ts'
 export { InstallJournal } from './install/journal.ts'

--- a/packages/engine/src/install/__tests__/receipt.test.ts
+++ b/packages/engine/src/install/__tests__/receipt.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Lockfile } from '@agent-facets/protocol'
+import { LOCKFILE_VERSION } from '@agent-facets/protocol'
+import { bootstrapReceipt, loadReceipt, type Receipt, receiptPath, writeReceipt } from '../receipt.ts'
+
+let facetDir: string
+let projectDir: string
+let originalFacetDir: string | undefined
+
+beforeEach(() => {
+  originalFacetDir = process.env.FACET_DIR
+  facetDir = realpathSync(mkdtempSync(join(tmpdir(), 'facet-receipt-test-')))
+  projectDir = realpathSync(mkdtempSync(join(tmpdir(), 'facet-project-')))
+  process.env.FACET_DIR = facetDir
+})
+
+afterEach(() => {
+  if (originalFacetDir === undefined) {
+    delete process.env.FACET_DIR
+  } else {
+    process.env.FACET_DIR = originalFacetDir
+  }
+  rmSync(facetDir, { recursive: true, force: true })
+  rmSync(projectDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// receiptPath
+// ---------------------------------------------------------------------------
+
+describe('receiptPath', () => {
+  test('produces a path under $FACET_DIR/receipts/', () => {
+    const path = receiptPath(projectDir)
+    expect(path.startsWith(join(facetDir, 'receipts/'))).toBe(true)
+    expect(path.endsWith('.json')).toBe(true)
+  })
+
+  test('same project dir produces the same path', () => {
+    expect(receiptPath(projectDir)).toBe(receiptPath(projectDir))
+  })
+
+  test('different project dirs produce different paths', () => {
+    const other = realpathSync(mkdtempSync(join(tmpdir(), 'facet-project2-')))
+    try {
+      expect(receiptPath(projectDir)).not.toBe(receiptPath(other))
+    } finally {
+      rmSync(other, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadReceipt
+// ---------------------------------------------------------------------------
+
+describe('loadReceipt', () => {
+  test('returns missing when no receipt file exists', () => {
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('missing')
+  })
+
+  test('returns corrupt on invalid JSON', () => {
+    const path = receiptPath(projectDir)
+    mkdirSync(join(facetDir, 'receipts'), { recursive: true })
+    writeFileSync(path, 'not json{')
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('corrupt')
+  })
+
+  test('returns corrupt on schema-invalid data', () => {
+    const path = receiptPath(projectDir)
+    mkdirSync(join(facetDir, 'receipts'), { recursive: true })
+    writeFileSync(path, JSON.stringify({ version: 99, path: projectDir, facets: {} }))
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('corrupt')
+  })
+
+  test('returns path-mismatch when embedded path differs', () => {
+    const receipt: Receipt = {
+      version: 1,
+      path: '/some/other/project',
+      facets: {},
+    }
+    const path = receiptPath(projectDir)
+    mkdirSync(join(facetDir, 'receipts'), { recursive: true })
+    writeFileSync(path, JSON.stringify(receipt))
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('path-mismatch')
+  })
+
+  test('returns corrupt when an asset name contains path traversal', () => {
+    const receipt: Receipt = {
+      version: 1,
+      path: realpathSync(projectDir),
+      facets: {
+        cowsay: {
+          version: '0.0.1',
+          assets: [{ scope: 'project', type: 'skill', name: '../escape' }],
+        },
+      },
+    }
+    const path = receiptPath(projectDir)
+    mkdirSync(join(facetDir, 'receipts'), { recursive: true })
+    writeFileSync(path, JSON.stringify(receipt))
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('corrupt')
+  })
+
+  test('loads a valid receipt successfully', () => {
+    const receipt: Receipt = {
+      version: 1,
+      path: realpathSync(projectDir),
+      facets: {
+        cowsay: {
+          version: '0.0.1',
+          assets: [{ scope: 'project', type: 'skill', name: 'cowsay' }],
+        },
+      },
+    }
+    writeReceipt(projectDir, receipt)
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.receipt.facets.cowsay?.version).toBe('0.0.1')
+    expect(result.receipt.facets.cowsay?.assets).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// writeReceipt + loadReceipt round-trip
+// ---------------------------------------------------------------------------
+
+describe('writeReceipt', () => {
+  test('creates the receipts directory if it does not exist', () => {
+    const receipt: Receipt = {
+      version: 1,
+      path: realpathSync(projectDir),
+      facets: {},
+    }
+    // receipts/ dir doesn't exist yet
+    writeReceipt(projectDir, receipt)
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(true)
+  })
+
+  test('round-trips a receipt with multiple facets', () => {
+    const receipt: Receipt = {
+      version: 1,
+      path: realpathSync(projectDir),
+      facets: {
+        cowsay: {
+          version: '0.0.1',
+          assets: [
+            { scope: 'project', type: 'skill', name: 'cowsay' },
+            { scope: 'project', type: 'command', name: 'moo' },
+          ],
+        },
+        hello: {
+          version: '1.0.0',
+          assets: [{ scope: 'project', type: 'agent', name: 'greeter' }],
+        },
+      },
+    }
+    writeReceipt(projectDir, receipt)
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(Object.keys(result.receipt.facets)).toHaveLength(2)
+    expect(result.receipt.facets.cowsay?.assets).toHaveLength(2)
+    expect(result.receipt.facets.hello?.assets).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bootstrapReceipt
+// ---------------------------------------------------------------------------
+
+describe('bootstrapReceipt', () => {
+  test('creates a receipt from a lockfile', () => {
+    const lockfile: Lockfile = {
+      lockfileVersion: LOCKFILE_VERSION,
+      facets: {
+        cowsay: {
+          source: { kind: 'registry', registry: 'https://api.facet.cafe' },
+          version: '0.0.1',
+          integrity: 'sha256:abc',
+          assets: [
+            { scope: 'project', type: 'skill', name: 'cowsay' },
+            { scope: 'project', type: 'command', name: 'moo' },
+          ],
+        },
+      },
+    }
+    const receipt = bootstrapReceipt(projectDir, lockfile)
+    expect(receipt.version).toBe(1)
+    expect(receipt.path).toBe(realpathSync(projectDir))
+    expect(receipt.facets.cowsay?.version).toBe('0.0.1')
+    expect(receipt.facets.cowsay?.assets).toHaveLength(2)
+  })
+
+  test('empty lockfile produces empty receipt', () => {
+    const lockfile: Lockfile = {
+      lockfileVersion: LOCKFILE_VERSION,
+      facets: {},
+    }
+    const receipt = bootstrapReceipt(projectDir, lockfile)
+    expect(Object.keys(receipt.facets)).toHaveLength(0)
+  })
+
+  test('strips source and integrity from lockfile entries', () => {
+    const lockfile: Lockfile = {
+      lockfileVersion: LOCKFILE_VERSION,
+      facets: {
+        cowsay: {
+          source: { kind: 'git', url: 'https://github.com/test/cowsay', commit: 'abc123' },
+          version: '0.0.1',
+          integrity: 'sha256:abc',
+          assets: [{ scope: 'project', type: 'skill', name: 'cowsay' }],
+        },
+      },
+    }
+    const receipt = bootstrapReceipt(projectDir, lockfile)
+    // Receipt entries should not carry source or integrity.
+    const entry = receipt.facets.cowsay
+    expect(entry).toBeDefined()
+    if (!entry) expect.unreachable()
+    expect('source' in entry).toBe(false)
+    expect('integrity' in entry).toBe(false)
+    expect(entry.version).toBe('0.0.1')
+    expect(entry.assets).toHaveLength(1)
+  })
+})

--- a/packages/engine/src/install/receipt.ts
+++ b/packages/engine/src/install/receipt.ts
@@ -1,0 +1,208 @@
+/**
+ * Machine-local install receipt.
+ *
+ * The receipt records what this machine has materialized into each
+ * project's adapter trees, separate from the lockfile. Because the
+ * lockfile is shared and version-controlled, it cannot reliably
+ * describe what a particular machine has on disk — a `git pull` can
+ * remove a lockfile entry while that facet's assets remain materialized.
+ *
+ * One receipt file per project, stored under `$FACET_DIR/receipts/`.
+ * The filename is `<basename>-<hash>.json` where `<hash>` is the first
+ * 12 hex characters of `sha256(realpath(projectDir))`. The receipt
+ * embeds the canonical project path for self-identification — a
+ * mismatch on load fails closed (treated as absent, re-bootstrapped).
+ *
+ * Assets are stored as semantic tuples `{ scope, type, name }` — the
+ * same adapter-agnostic shape as the lockfile. Deletion goes through
+ * adapters, not raw filesystem paths. Name validation on load rejects
+ * crafted names that could cause path traversal.
+ */
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
+import { basename, join } from 'node:path'
+import { atomicWriteFileSync, validateAssetName } from '@agent-facets/common'
+import type { Lockfile, LockfileAssetEntry } from '@agent-facets/protocol'
+import { type } from 'arktype'
+import { facetReceiptsDir } from '../facet-dir.ts'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const ReceiptAssetSchema = type({
+  scope: "'system' | 'user' | 'project'",
+  type: "'skill' | 'agent' | 'command'",
+  name: 'string',
+})
+
+const ReceiptFacetEntrySchema = type({
+  version: 'string',
+  assets: ReceiptAssetSchema.array(),
+})
+
+const ReceiptSchema = type({
+  version: '1',
+  path: 'string',
+  facets: type.Record('string', ReceiptFacetEntrySchema),
+})
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReceiptFacetEntry {
+  version: string
+  assets: LockfileAssetEntry[]
+}
+
+export interface Receipt {
+  version: 1
+  path: string
+  facets: Record<string, ReceiptFacetEntry>
+}
+
+export type LoadReceiptResult =
+  | { ok: true; receipt: Receipt }
+  | { ok: false; reason: 'missing' | 'corrupt' | 'path-mismatch' }
+
+// ---------------------------------------------------------------------------
+// Path computation
+// ---------------------------------------------------------------------------
+
+const HASH_LENGTH = 12
+
+/**
+ * Compute the receipt file path for a project directory.
+ *
+ * The filename is `<basename>-<hash>.json` where:
+ *   - `<basename>` is the last segment of the project dir (cosmetic)
+ *   - `<hash>` is the first 12 hex characters of sha256(realpath)
+ *
+ * `realpath` is resolved before hashing so symlinked and case-variant
+ * spellings of one project converge on one receipt. Two different
+ * projects can only collide via SHA-256 truncation (negligible at 12
+ * hex = 48 bits); the embedded-path check fails closed regardless.
+ */
+export function receiptPath(projectDir: string): string {
+  const canonical = realpathSync(projectDir)
+  const hash = createHash('sha256').update(canonical).digest('hex').slice(0, HASH_LENGTH)
+  const slug = basename(canonical)
+  return join(facetReceiptsDir(), `${slug}-${hash}.json`)
+}
+
+/**
+ * Resolve the canonical (realpath) project directory. Exported so the
+ * caller can pass the same value to both `loadReceipt` and
+ * `writeReceipt` without re-resolving.
+ */
+export function canonicalProjectPath(projectDir: string): string {
+  return realpathSync(projectDir)
+}
+
+// ---------------------------------------------------------------------------
+// Load
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the receipt for a project. Returns the parsed receipt on
+ * success, or a structured failure reason:
+ *
+ *   - `missing`: no receipt file exists (first operation on this project)
+ *   - `corrupt`: file exists but is unreadable, unparseable, or fails
+ *     schema validation (including crafted asset names)
+ *   - `path-mismatch`: the receipt's embedded path does not match the
+ *     current project's canonical path (collision, corruption, or the
+ *     project was moved)
+ *
+ * Never throws.
+ */
+export function loadReceipt(projectDir: string): LoadReceiptResult {
+  const canonical = realpathSync(projectDir)
+  const filePath = receiptPath(projectDir)
+
+  if (!existsSync(filePath)) {
+    return { ok: false, reason: 'missing' }
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync(filePath, 'utf8')
+  } catch {
+    return { ok: false, reason: 'corrupt' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { ok: false, reason: 'corrupt' }
+  }
+
+  const validated = ReceiptSchema(parsed)
+  if (validated instanceof type.errors) {
+    return { ok: false, reason: 'corrupt' }
+  }
+
+  const receipt = validated as Receipt
+
+  // Self-identification check: the embedded path must match the
+  // project being operated on.
+  if (receipt.path !== canonical) {
+    return { ok: false, reason: 'path-mismatch' }
+  }
+
+  // Validate all asset names — reject crafted names that could cause
+  // path traversal when passed to adapters.
+  for (const [, entry] of Object.entries(receipt.facets)) {
+    for (const asset of entry.assets) {
+      if (!validateAssetName(asset.name).ok) {
+        return { ok: false, reason: 'corrupt' }
+      }
+    }
+  }
+
+  return { ok: true, receipt }
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a receipt atomically. Creates the receipts directory if needed.
+ * Never throws on ENOENT for the parent directory.
+ */
+export function writeReceipt(projectDir: string, receipt: Receipt): void {
+  const dir = facetReceiptsDir()
+  mkdirSync(dir, { recursive: true })
+  const filePath = receiptPath(projectDir)
+  atomicWriteFileSync(filePath, `${JSON.stringify(receipt, null, 2)}\n`)
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh receipt from a lockfile. Used when no receipt exists
+ * (first operation on the project) or when the existing receipt fails
+ * validation (path mismatch, corruption).
+ *
+ * Seeds from the lockfile's entries — records what *should* be on
+ * disk. Assets orphaned before this change shipped are unrecoverable
+ * (explicit non-goal in the proposal).
+ */
+export function bootstrapReceipt(projectDir: string, lockfile: Lockfile): Receipt {
+  const canonical = realpathSync(projectDir)
+  const facets: Record<string, ReceiptFacetEntry> = {}
+
+  for (const [name, entry] of Object.entries(lockfile.facets)) {
+    facets[name] = {
+      version: entry.version,
+      assets: entry.assets.map((a) => ({ scope: a.scope, type: a.type, name: a.name })),
+    }
+  }
+
+  return { version: 1, path: canonical, facets }
+}


### PR DESCRIPTION
### Why

The lockfile is shared and version-controlled, so it cannot reliably describe what a particular machine has materialized on disk. A `git pull` can remove a lockfile entry while that facet's assets remain installed. A machine-local receipt fills this gap by recording exactly what has been materialized into each project's adapter trees, enabling correct cleanup and drift detection.

### Details

Receipts are stored under `$FACET_DIR/receipts/` as `<basename>-<hash>.json`, where the hash is the first 12 hex characters of `sha256(realpath(projectDir))`. The receipt embeds the canonical project path so that a hash collision or a moved project fails closed (treated as absent and re-bootstrapped from the lockfile).

Assets are stored as semantic tuples `{ scope, type, name }` — the same adapter-agnostic shape as the lockfile — rather than raw filesystem paths. Deletion goes through adapters' own `deleteAsset`, which resolves paths inside their own tree. Path traversal safety is enforced at load time via `validateAssetName`, which rejects names containing `..` or backslashes; any receipt containing such names is treated as corrupt and discarded.

`loadReceipt` returns a structured result type (`missing`, `corrupt`, `path-mismatch`) and never throws. `writeReceipt` writes atomically and creates the receipts directory if it does not exist. `bootstrapReceipt` seeds a fresh receipt from the lockfile when no valid receipt exists.

### Verification

Unit tests cover: deterministic and collision-free path derivation, `missing`/`corrupt`/`path-mismatch` failure cases, path traversal rejection, round-trip write/load, multi-facet round-trips, and `bootstrapReceipt` seeding from lockfile entries including stripping of `source` and `integrity` fields. `bun check` passes for `packages/engine`.