### PR TITLE
Rename machine-local install record to "receipt", add `DELTA_CONFLICT` guard, and harden path traversal across archive validation and cache operations

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,19 +18,19 @@ allows you to install the exact versions you want of **facets** and their depend
 The following are the most common `facet` commands. See the [roadmap](/roadmap) for planned commands.
 
 <Columns cols={2}>
-  <Card title={<Badge>facet create</Badge>}>
+  <Card title={<Badge>facet create</Badge>} href="/cli/authoring/create">
     Scaffolds a new **facet** project with an interactive wizard  -- name, description, version, and initial assets
   </Card>
-  <Card title={<Badge>facet edit</Badge>}>
+  <Card title={<Badge>facet edit</Badge>} href="/cli/authoring/edit">
     Full authoring workbench  -- edit identity, manage assets, reconcile disk vs manifest
   </Card>
-  <Card title={<Badge>facet build</Badge>}>
+  <Card title={<Badge>facet build</Badge>} href="/cli/authoring/build">
     Validates and packages your **facet** into a distributable archive with integrity hashes
   </Card>
   <Card title={<Badge>facet add</Badge>} href="/cli/add">
     Add a **facet** to the project  -- resolve from a source, download, and install in one step
   </Card>
-  <Card title={<Badge>facet publish</Badge>} href="/roadmap">
+  <Card title={<Badge>facet publish</Badge>} href="/cli/authoring/publish">
     Publish a built **facet** to the registry
   </Card>
   <Card title={<Badge>facet self-update</Badge>} href="/cli/self-update">

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -17,19 +17,19 @@ allows you to install the exact versions you want of **facets** and their depend
 The following are the most common `facet` commands. See the [roadmap](/roadmap) for planned commands.
 
 <Columns cols={2}>
-  <Card title={<Badge>facet create</Badge>}>
+  <Card title={<Badge>facet create</Badge>} href="/cli/authoring/create">
     Scaffolds a new **facet** project with an interactive wizard  -- name, description, version, and initial assets
   </Card>
-  <Card title={<Badge>facet edit</Badge>}>
+  <Card title={<Badge>facet edit</Badge>} href="/cli/authoring/edit">
     Full authoring workbench  -- edit identity, manage assets, reconcile disk vs manifest
   </Card>
-  <Card title={<Badge>facet build</Badge>}>
+  <Card title={<Badge>facet build</Badge>} href="/cli/authoring/build">
     Validates and packages your **facet** into a distributable archive with integrity hashes
   </Card>
   <Card title={<Badge>facet add</Badge>} href="/cli/add">
     Add a **facet** to the project  -- resolve from a source, download, and install in one step
   </Card>
-  <Card title={<Badge>facet publish</Badge>} href="/roadmap">
+  <Card title={<Badge>facet publish</Badge>} href="/cli/authoring/publish">
     Publish a built **facet** to the registry
   </Card>
   <Card title={<Badge>facet self-update</Badge>} href="/cli/self-update">

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -227,13 +227,14 @@ When no manifest entry for the facet exists, or the existing entry's value is no
 - **AND** the system SHALL record `name@MAJOR.MINOR.PATCH` in the project manifest
 - **AND** the system SHALL NOT record the facet name as the version value
 
-#### Scenario: @latest tag is equivalent to a bare name
+#### Scenario: Explicit @latest tag records "latest" in the manifest
 
 - **WHEN** a user adds a registry facet using the literal `name@latest` form
-- **AND** no entry for that facet exists in the project manifest
 - **THEN** the system SHALL resolve the latest published version
-- **AND** the system SHALL record `name@MAJOR.MINOR.PATCH` in the project manifest
-- **AND** the resulting manifest, lockfile, and on-disk state SHALL be identical to what would have been produced by the bare-name form
+- **AND** the system SHALL record `latest` as the version specifier in the project manifest (preserving the user's explicit intent to float)
+- **AND** the system SHALL record the resolved exact version in the lockfile
+
+> **Note:** This differs from the bare-name form, which pins to the resolved exact version. A bare name is shorthand for "give me the latest and pin it"; `name@latest` is an explicit floating specifier, analogous to `name@1.*`.
 
 #### Scenario: Wildcard-resolved version is recorded as exact version
 
@@ -311,7 +312,7 @@ The system performs three distinct network operations when installing a registry
 
 An exact version that is already cached SHALL require neither version resolution nor content download. A request whose exact version is already known (an exact specifier, or a satisfying lockfile entry) SHALL NOT trigger version resolution. The presence of a cached copy SHALL NOT, by itself, avoid version resolution when the exact version is not yet known, and SHALL NOT avoid integrity confirmation when a lockfile entry is being created.
 
-#### Scenario: Exact specifier with warm cache and satisfying lockfile entry contacts the network for nothing
+#### Scenario: Exact specifier with warm cache and satisfying lockfile entry requires no network access
 
 - **WHEN** a user adds a facet by an exact version whose content is already in the cache
 - **AND** the lockfile already records that exact version with its integrity
@@ -350,7 +351,7 @@ An exact version that is already cached SHALL require neither version resolution
 
 ### Requirement: An explicit add request is resolved fresh, independent of the lockfile
 
-When a user explicitly adds a facet, the system SHALL treat that request as authoritative and SHALL NOT consult the lockfile to satisfy it. The system SHALL distinguish a facet the user is **explicitly adding** from a facet **already recorded in the manifest** that is merely being reproduced, and SHALL trust the lockfile only for the latter.
+When a user explicitly adds a facet, the system SHALL treat that request as authoritative and SHALL NOT consult the lockfile for version resolution. The system MAY still use a satisfying lockfile entry's recorded integrity as a trust anchor (see the offline re-add scenario below). The system SHALL distinguish a facet the user is **explicitly adding** from a facet **already recorded in the manifest** that is merely being reproduced, and SHALL trust the lockfile only for the latter.
 
 For an explicit add:
 
@@ -390,46 +391,46 @@ For an explicit add:
 
 ### Requirement: A machine-local record tracks what each project has materialized
 
-The system SHALL maintain a machine-local record of what it has materialized into each project's adapter trees, separate from the lockfile. Because the lockfile is shared and version-controlled, it cannot reliably describe what a particular machine has on disk — a change pulled from version control can remove a lockfile entry while that facet's assets remain materialized in the working copy. The machine-local record SHALL persist outside the project's version-controlled files and SHALL survive operations that rewrite the lockfile from outside the system. Each project SHALL have its own record, identified by the project's canonical on-disk location, so that two distinct projects never share a record and concurrent operations in different projects never contend on one. For each materialized facet the record SHALL retain enough information — at minimum the asset set it contributed — to remove that facet's assets later without consulting the cache or the network. A project that has no such record yet SHALL have one created from the current lockfile on the next operation.
+The system SHALL maintain a machine-local install record — the **receipt** — of what it has materialized into each project's adapter trees, separate from the lockfile. Because the lockfile is shared and version-controlled, it cannot reliably describe what a particular machine has on disk — a change pulled from version control can remove a lockfile entry while that facet's assets remain materialized in the working copy. The receipt SHALL persist outside the project's version-controlled files and SHALL survive operations that rewrite the lockfile from outside the system. Each project SHALL have its own receipt, identified by the project's canonical on-disk location, so that two distinct projects never share a receipt and concurrent operations in different projects never contend on one. For each materialized facet the receipt SHALL retain enough information — at minimum the asset set it contributed — to remove that facet's assets later without consulting the cache or the network. A project that has no receipt yet SHALL have one created from the current lockfile on the next operation.
 
-The system SHALL treat this record, not the on-disk lockfile, as the description of what is currently materialized when deciding which assets to remove. When a facet is recorded as materialized but is no longer wanted (absent from the manifest and not being added), the system SHALL delete that facet's recorded assets from every selected adapter and SHALL drop the facet from both the lockfile and the machine-local record. This removal SHALL succeed without any network access and without any cached content, because the record itself carries the asset set to delete.
+The system SHALL treat the receipt, not the on-disk lockfile, as the description of what is currently materialized when deciding which assets to remove. When a facet is recorded as materialized but is no longer wanted (absent from the manifest and not being added), the system SHALL delete that facet's recorded assets from every selected adapter and SHALL drop the facet from both the lockfile and the receipt. This removal SHALL succeed without any network access and without any cached content, because the receipt itself carries the asset set to delete. In frozen-lockfile mode, this cleanup applies only after the frozen consistency check passes; an orphaned lockfile entry that the consistency check rejects SHALL cause the operation to fail before any cleanup occurs (see the frozen-lockfile requirement).
 
-The record SHALL be treated as untrusted input. Before acting on a record, the system SHALL verify it corresponds to the project being operated on; a record that does not (corruption, collision, or tampering) SHALL be ignored and recreated rather than acted upon. When deleting assets named by the record, the system SHALL delete only files that resolve to locations inside the project's adapter trees; a recorded path that resolves outside them SHALL NOT be deleted, and the system SHALL report it. A corrupted record MAY cause a cleanup to be skipped; it SHALL NOT cause deletion outside the project's adapter trees.
+The receipt SHALL be treated as untrusted input. Before acting on a receipt, the system SHALL verify it corresponds to the project being operated on; a receipt that does not (corruption, collision, or tampering) SHALL be ignored and recreated rather than acted upon. When deleting assets named by the receipt, the system SHALL delete only files that resolve to locations inside the project's adapter trees; a recorded path that resolves outside them SHALL NOT be deleted, and the system SHALL report it. A corrupted receipt MAY cause a cleanup to be skipped; it SHALL NOT cause deletion outside the project's adapter trees.
 
 #### Scenario: A pulled change that drops a lockfile entry still cleans up its assets
 
 - **WHEN** a change pulled from version control removes a facet from both the manifest and the lockfile
 - **AND** that facet's assets were previously materialized on this machine
 - **AND** the user runs install
-- **THEN** the system SHALL detect the facet as materialized but no longer wanted via the machine-local record
+- **THEN** the system SHALL detect the facet as materialized but no longer wanted via the receipt
 - **AND** the system SHALL delete that facet's assets from every selected adapter
 - **AND** the system SHALL NOT leave the facet's assets orphaned on disk
 
 #### Scenario: Removal needs neither cache nor network
 
 - **WHEN** a user removes a facet whose content is absent from the cache and whose registry is unreachable
-- **THEN** the system SHALL still delete that facet's assets using the asset set recorded in the machine-local record
+- **THEN** the system SHALL still delete that facet's assets using the asset set recorded in the receipt
 - **AND** the removal SHALL succeed
 
-#### Scenario: A project without a record bootstraps one
+#### Scenario: A project without a receipt bootstraps one
 
-- **WHEN** the system operates on a project that has a lockfile but no machine-local record yet
-- **THEN** the system SHALL create the record from the current lockfile's entries
-- **AND** subsequent operations SHALL use the record as the description of what is materialized
+- **WHEN** the system operates on a project that has a lockfile but no receipt yet
+- **THEN** the system SHALL create the receipt from the current lockfile's entries
+- **AND** subsequent operations SHALL use the receipt as the description of what is materialized
 
-#### Scenario: A record naming a path outside the project never causes deletion there
+#### Scenario: A receipt naming a path outside the project never causes deletion there
 
-- **WHEN** the machine-local record contains an asset path that resolves outside the project's adapter trees (for example via `..` segments, an absolute path elsewhere, or a symlink)
+- **WHEN** the receipt contains an asset path that resolves outside the project's adapter trees (for example via `..` segments, an absolute path elsewhere, or a symlink)
 - **AND** the system would otherwise remove that facet's assets
 - **THEN** the system SHALL NOT delete the escaping path
 - **AND** the system SHALL report the invalid entry
 - **AND** valid asset paths inside the adapter trees SHALL still be processed normally
 
-#### Scenario: A record that does not match its project is ignored, not acted on
+#### Scenario: A receipt that does not match its project is ignored, not acted on
 
-- **WHEN** the system loads a machine-local record whose recorded project identity does not match the project being operated on
-- **THEN** the system SHALL NOT delete any assets based on that record
-- **AND** the system SHALL recreate the record from the current lockfile as if none existed
+- **WHEN** the system loads a receipt whose recorded project identity does not match the project being operated on
+- **THEN** the system SHALL NOT delete any assets based on that receipt
+- **AND** the system SHALL recreate the receipt from the current lockfile as if none existed
 
 ### Requirement: Resolved facet content is cached locally
 
@@ -591,7 +592,7 @@ The project manifest is the source of truth; the lockfile is a record of resolut
 
 The system SHALL provide a frozen-lockfile mode for install in which the lockfile is treated as the source of truth and reproduced exactly: no extra facets, no missing facets, no source changes, and no content changes. In this mode the system SHALL NOT perform version resolution for any facet and SHALL NOT write the lockfile; content download for a locked exact version absent from the cache SHALL remain permitted, because downloading already-locked bytes is reproduction, not drift. Because adding or removing a facet changes the locked set, the system SHALL reject a frozen-lockfile operation that carries any explicit add or removal, before inspecting the lockfile. Before installing, the system SHALL verify that the lockfile fully and consistently covers the manifest. The system SHALL fail without modifying the project if any of the following is true: the operation carries an explicit add or removal, no lockfile exists, the lockfile cannot be read or does not satisfy the published schema, the manifest declares a facet that has no lockfile entry, a lockfile entry's recorded version does not satisfy its manifest specifier, the lockfile pins a facet the manifest no longer declares (an orphaned entry that a non-frozen install would prune), or a git or local facet's manifest source string (URL, ref, or path) no longer matches the recorded git or local source provenance. When the lockfile fully covers the manifest, the system SHALL install exactly the versions and integrity hashes recorded in the lockfile, downloading any whose content is not cached, and SHALL verify that every facet — including cached content and local sources, which a non-frozen install would rebuild from disk — reproduces its recorded integrity, failing if any content does not match. Because frozen mode never creates a lockfile entry, it SHALL NOT require integrity confirmation against the registry; its only permitted network activity is downloading already-locked content.
 
-Frozen mode constrains the locked set, not the machine's materialized state: assets that the machine-local record shows as materialized but that the lockfile-covered manifest no longer wants SHALL still be removed, and the machine-local record SHALL be updated to match — while the lockfile and manifest SHALL still never be written.
+Frozen mode constrains the locked set, not the machine's materialized state: assets that the receipt shows as materialized but that the lockfile-covered manifest no longer wants SHALL still be removed, and the receipt SHALL be updated to match — while the lockfile and manifest SHALL still never be written.
 
 #### Scenario: Frozen install proceeds when the lockfile covers the manifest
 
@@ -619,11 +620,11 @@ Frozen mode constrains the locked set, not the machine's materialized state: ass
 #### Scenario: Frozen mode still cleans up a facet dropped by a pulled change
 
 - **WHEN** a change pulled from version control removes a facet from both the manifest and the lockfile
-- **AND** the machine-local record shows that facet's assets as materialized on this machine
+- **AND** the receipt shows that facet's assets as materialized on this machine
 - **AND** a user runs install in frozen-lockfile mode
 - **THEN** the frozen consistency check SHALL pass (the manifest and lockfile agree)
-- **AND** the system SHALL delete that facet's assets using the machine-local record
-- **AND** the system SHALL update the machine-local record so it no longer lists the facet
+- **AND** the system SHALL delete that facet's assets using the receipt
+- **AND** the system SHALL update the receipt so it no longer lists the facet
 - **AND** the system SHALL NOT write the lockfile or the manifest
 
 #### Scenario: Frozen mode rejects an explicit add or removal
@@ -736,39 +737,39 @@ When a facet declares dependencies on other facets (composition), the system SHA
 
 ### Requirement: Failed installs leave the project unchanged
 
-The project manifest, the lockfile, and the machine-local install record SHALL be written together as a single transactional commit at the end of a successful operation. The system SHALL NOT write the manifest ahead of resolving and materializing a change. When an install, add, or remove operation fails for any reason, the manifest, the lockfile, and the install record on disk SHALL all remain exactly as they were before the operation. The user SHALL NOT be left with a project whose manifest references a facet that was never installed, nor with a lockfile or install record that records a state that was never materialized.
+The project manifest, the lockfile, and the receipt SHALL be written together as a single transactional commit at the end of a successful operation. The system SHALL NOT write the manifest ahead of resolving and materializing a change. When an install, add, or remove operation fails for any reason, the manifest, the lockfile, and the receipt on disk SHALL all remain exactly as they were before the operation. The user SHALL NOT be left with a project whose manifest references a facet that was never installed, nor with a lockfile or receipt that records a state that was never materialized.
 
-#### Scenario: Add failure leaves manifest, lockfile, and install record unchanged
+#### Scenario: Add failure leaves manifest, lockfile, and receipt unchanged
 
 - **WHEN** a user adds a facet
 - **AND** any step (resolution, download, integrity, materialization, or the final write) fails
 - **THEN** the manifest on disk SHALL match its pre-operation contents
 - **AND** the lockfile on disk SHALL match its pre-operation contents
-- **AND** the machine-local install record on disk SHALL match its pre-operation contents
+- **AND** the receipt on disk SHALL match its pre-operation contents
 - **AND** the system SHALL surface the failure to the user
 
-#### Scenario: Manifest, lockfile, and install record are written together on success
+#### Scenario: Manifest, lockfile, and receipt are written together on success
 
 - **WHEN** an add, remove, or install operation succeeds
-- **THEN** the system SHALL write the updated manifest, lockfile, and install record as one commit
+- **THEN** the system SHALL write the updated manifest, lockfile, and receipt as one commit
 - **AND** no one of the three files SHALL be left written while another is not
 
 ### Requirement: Removing a facet uninstalls it
 
-When a user removes a facet from a project, the system SHALL drop the facet from the project manifest, delete the facet's materialized assets from every selected adapter, and update the lockfile and the machine-local install record so neither records the facet — all in a single operation. A user SHALL NOT need to run a separate install step after removing. The asset set to delete SHALL be taken from the machine-local install record, so removal SHALL require neither the cache nor the network.
+When a user removes a facet from a project, the system SHALL drop the facet from the project manifest, delete the facet's materialized assets from every selected adapter, and update the lockfile and the receipt so neither records the facet — all in a single operation. A user SHALL NOT need to run a separate install step after removing. The asset set to delete SHALL be taken from the receipt, so removal SHALL require neither the cache nor the network.
 
 #### Scenario: Removing a declared facet uninstalls it
 
 - **WHEN** a user removes a facet that is declared in the project manifest
 - **THEN** the system SHALL remove the facet's entry from the project manifest
-- **AND** the system SHALL delete every asset the facet contributed from every selected adapter, using the asset set recorded in the machine-local install record
-- **AND** the system SHALL update the lockfile and the machine-local install record so neither records the facet
+- **AND** the system SHALL delete every asset the facet contributed from every selected adapter, using the asset set recorded in the receipt
+- **AND** the system SHALL update the lockfile and the receipt so neither records the facet
 - **AND** the operation SHALL complete in a single command invocation
 
 #### Scenario: Other facets are left intact
 
 - **WHEN** a user removes one facet from a project that declares several facets
-- **THEN** the system SHALL leave every other declared facet's manifest entry, lockfile entry, install-record entry, and materialized assets unchanged
+- **THEN** the system SHALL leave every other declared facet's manifest entry, lockfile entry, receipt entry, and materialized assets unchanged
 
 #### Scenario: Removing the last facet leaves an empty project
 
@@ -778,12 +779,12 @@ When a user removes a facet from a project, the system SHALL drop the facet from
 
 ### Requirement: Removing multiple declared facets is transactional
 
-When a user removes more than one facet in a single invocation, the system SHALL remove all of the declared facets together. If the removal of any declared facet fails (asset deletion, lockfile update, or manifest write), the system SHALL remove none of them and SHALL leave the project unchanged. Names that are not declared in the project manifest SHALL be silently ignored and SHALL NOT cause the operation to fail.
+When a user removes more than one facet in a single invocation, the system SHALL remove all of the declared facets together. If the removal of any declared facet fails (asset deletion or the final commit of the manifest, lockfile, and receipt), the system SHALL remove none of them and SHALL leave the manifest, lockfile, receipt, and adapter state unchanged. Names that are not declared in the project manifest SHALL be silently ignored and SHALL NOT cause the operation to fail.
 
 #### Scenario: All declared facets are removed together
 
 - **WHEN** a user removes two or more facets that are all declared in the project manifest
-- **THEN** the system SHALL remove every named facet's manifest entry, assets, and lockfile entry
+- **THEN** the system SHALL remove every named facet's manifest entry, assets, lockfile entry, and receipt entry
 - **AND** the operation SHALL succeed only if every declared facet was removed
 
 #### Scenario: Undeclared names are ignored in a multi-facet removal
@@ -795,12 +796,12 @@ When a user removes more than one facet in a single invocation, the system SHALL
 
 ### Requirement: Removing an undeclared facet is a silent no-op
 
-When a user removes a facet that is not declared in the project manifest, the system SHALL silently ignore the name. The project manifest, lockfile, and adapter state SHALL remain unchanged for that name. When every requested name is undeclared, the system SHALL exit successfully and SHALL report that no changes were made.
+When a user removes a facet that is not declared in the project manifest, the system SHALL silently ignore the name. The project manifest, lockfile, receipt, and adapter state SHALL remain unchanged for that name. When every requested name is undeclared, the system SHALL exit successfully and SHALL report that no changes were made.
 
 #### Scenario: Removing a facet that is not declared
 
 - **WHEN** a user removes a facet whose name does not appear in the project manifest
-- **THEN** the system SHALL leave the project manifest, lockfile, and adapter state unchanged
+- **THEN** the system SHALL leave the project manifest, lockfile, receipt, and adapter state unchanged
 - **AND** the system SHALL NOT fail with an error
 
 #### Scenario: All requested names are undeclared
@@ -811,16 +812,13 @@ When a user removes a facet that is not declared in the project manifest, the sy
 
 ### Requirement: Failed removals leave the project unchanged
 
-When a remove operation fails for any reason after the project manifest has been modified, the system SHALL restore the manifest to its pre-operation state. The user SHALL NOT be left with a project whose manifest no longer references a facet whose assets were never removed.
+When a remove operation fails for any reason, the manifest, lockfile, and receipt on disk SHALL all remain exactly as they were before the operation. The user SHALL NOT be left with a project whose manifest no longer references a facet whose assets were never removed, nor with a lockfile or receipt that records a state that was never materialized.
 
-#### Scenario: Removal failure rolls back the manifest
+#### Scenario: Removal failure leaves manifest, lockfile, and receipt unchanged
 
-- **WHEN** the system has removed a facet's entry from the project manifest as part of a remove operation
-- **AND** a subsequent step (asset deletion or lockfile update) fails
-- **THEN** the system SHALL restore the manifest to its exact pre-operation contents
+- **WHEN** a user removes a facet
+- **AND** any step (asset deletion or the final commit of the manifest, lockfile, and receipt) fails
+- **THEN** the manifest on disk SHALL match its pre-operation contents
+- **AND** the lockfile on disk SHALL match its pre-operation contents
+- **AND** the receipt on disk SHALL match its pre-operation contents
 - **AND** the system SHALL surface the failure to the user
-
-#### Scenario: Removal failure leaves the lockfile unchanged
-
-- **WHEN** a remove operation fails before the lockfile update is committed
-- **THEN** the lockfile on disk SHALL match its pre-operation contents

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -322,6 +322,22 @@ export function FailureBlock({ failure }: { failure: RunInstallFailure }): React
           <Text color={THEME.hint}> Run without --frozen-lockfile to modify the locked set.</Text>
         </Box>
       )
+    case 'DELTA_CONFLICT':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ internal error: delta conflict
+          </Text>
+          <Text> facet "{failure.facet}" appears in both additions and removals</Text>
+          <Text color={THEME.hint}>
+            {' '}
+            This is a bug — please file an issue @{' '}
+            <Text color={THEME.brand} bold>
+              https://github.com/agent-facets/facets/issues/new
+            </Text>
+          </Text>
+        </Box>
+      )
     default: {
       // Exhaustiveness guard: any new `RunInstallFailure` variant must
       // get a `case` arm above. Without this, an un-rendered failure

--- a/packages/engine/src/__tests__/cache.test.ts
+++ b/packages/engine/src/__tests__/cache.test.ts
@@ -16,6 +16,7 @@ import {
   cacheSlot,
   cacheSlotIsDir,
   cacheStagingDir,
+  computeDirIntegrity,
   evictCacheSlot,
   readCachedIntegrity,
   resolveCacheRoot,
@@ -539,5 +540,105 @@ describe('evictCacheSlot', () => {
     expect(cacheGet(id).hit).toBe(true)
     evictCacheSlot(slotPath)
     expect(cacheGet(id).hit).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Path traversal hardening (#28)
+// ---------------------------------------------------------------------------
+
+describe('computeDirIntegrity path traversal defense', () => {
+  test('rejects a relative traversal path (../../../../etc/passwd)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dir-integrity-traversal-'))
+    try {
+      const result = computeDirIntegrity(dir, ['../../../../etc/passwd'])
+      expect(result.ok).toBe(false)
+      if (result.ok) expect.unreachable()
+      expect(result.reason).toBe('unsafe-path')
+      expect(result.path).toBe('../../../../etc/passwd')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects an absolute path (/etc/passwd)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dir-integrity-abs-'))
+    try {
+      const result = computeDirIntegrity(dir, ['/etc/passwd'])
+      expect(result.ok).toBe(false)
+      if (result.ok) expect.unreachable()
+      expect(result.reason).toBe('unsafe-path')
+      expect(result.path).toBe('/etc/passwd')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a backslash path segment', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dir-integrity-backslash-'))
+    try {
+      const result = computeDirIntegrity(dir, ['foo\\bar'])
+      expect(result.ok).toBe(false)
+      if (result.ok) expect.unreachable()
+      expect(result.reason).toBe('unsafe-path')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('cachePutVerified path traversal defense', () => {
+  test('rejects a traversal path in buildManifest.assets', () => {
+    const id: CacheIdentity = { kind: 'registry', name: 'traversal', version: '1.0.0' }
+    const staging = cacheStagingDir()
+    writeFileSync(join(staging, 'facet.json'), '{"name":"traversal","version":"1.0.0"}')
+    const manifest: BuildManifest = {
+      facetVersion: 0.1,
+      archive: 'archive.tar.gz',
+      integrity: 'sha256:fake',
+      assets: {
+        '../../../../etc/passwd': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+      },
+    }
+
+    const result = cachePutVerified(id, staging, manifest, manifest.integrity, 'traversal')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (!('integrity' in result)) expect.unreachable()
+    expect(result.integrity.kind).toBe('asset')
+    if (result.integrity.kind !== 'asset') expect.unreachable()
+    expect(result.integrity.observed).toBe('<unsafe-path>')
+    expect(result.integrity.path).toBe('../../../../etc/passwd')
+
+    // Cache slot was NOT created; staging is intact.
+    expect(cacheSlotIsDir(id)).toBe(false)
+    expect(existsSync(staging)).toBe(true)
+    rmSync(staging, { recursive: true, force: true })
+  })
+
+  test('rejects an absolute path in buildManifest.assets', () => {
+    const id: CacheIdentity = { kind: 'registry', name: 'abs-path', version: '1.0.0' }
+    const staging = cacheStagingDir()
+    writeFileSync(join(staging, 'facet.json'), '{"name":"abs-path","version":"1.0.0"}')
+    const manifest: BuildManifest = {
+      facetVersion: 0.1,
+      archive: 'archive.tar.gz',
+      integrity: 'sha256:fake',
+      assets: {
+        '/etc/passwd': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+      },
+    }
+
+    const result = cachePutVerified(id, staging, manifest, manifest.integrity, 'abs-path')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    if (!('integrity' in result)) expect.unreachable()
+    expect(result.integrity.kind).toBe('asset')
+    if (result.integrity.kind !== 'asset') expect.unreachable()
+    expect(result.integrity.observed).toBe('<unsafe-path>')
+
+    rmSync(staging, { recursive: true, force: true })
   })
 })

--- a/packages/engine/src/__tests__/registry.test.ts
+++ b/packages/engine/src/__tests__/registry.test.ts
@@ -3,8 +3,13 @@ import { createHash } from 'node:crypto'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { assembleOuterTar, computeContentHash } from '@agent-facets/protocol'
-import { createTar } from 'nanotar'
+import {
+  assembleOuterTar,
+  assembleTar,
+  computeAssetHashes,
+  computeContentHash,
+  INNER_ARCHIVE_NAME,
+} from '@agent-facets/protocol'
 import {
   describeVersionSpec,
   downloadAndExtractFacet,
@@ -169,25 +174,27 @@ describe('downloadAndExtractFacet', () => {
     rmSync(dest, { recursive: true, force: true })
   })
 
-  // Build a two-layer `.facet` archive (outer tar wrapping
-  // build-manifest.json + archive.tar.gz) and its sha256 so the
-  // integrity check exercises the actual happy path.
-  function buildArchive(entries: Array<{ name: string; data: string }>): {
+  // Re-wrap a Bun gzip output into a Uint8Array<ArrayBuffer> for protocol helpers.
+  const intoArrayBuffer = <B extends ArrayBufferLike>(bytes: Uint8Array<B>): Uint8Array<ArrayBuffer> =>
+    new Uint8Array(bytes)
+  const gz = (input: Uint8Array): Uint8Array => intoArrayBuffer(Bun.gzipSync(intoArrayBuffer(input)))
+
+  // Build a two-layer `.facet` archive using protocol's canonical helpers
+  // so the result passes `validateFacetArchive`'s full verification pipeline.
+  function buildArchive(entries: Array<{ path: string; content: string }>): {
     bytes: Uint8Array
     integrity: string
   } {
-    const innerTar = createTar(entries.map((e) => ({ name: e.name, data: e.data }))) as Uint8Array<ArrayBuffer>
-    const innerGz = new Uint8Array(Bun.gzipSync(innerTar))
+    const sorted = [...entries].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+    const assetHashes = computeAssetHashes(sorted)
+    const innerTar = assembleTar(sorted)
     const contentHash = computeContentHash(innerTar)
-    const assets: Record<string, string> = {}
-    for (const e of entries) {
-      assets[e.name] = computeContentHash(e.data)
-    }
+    const innerGz = gz(innerTar)
     const buildManifest = JSON.stringify({
-      facetVersion: 1,
-      archive: 'cowsay-0.1.0.facet',
+      facetVersion: 0.1,
+      archive: INNER_ARCHIVE_NAME,
       integrity: contentHash,
-      assets,
+      assets: assetHashes,
     })
     const outerTar = assembleOuterTar(buildManifest, innerGz)
     const integrity = `sha256:${createHash('sha256').update(outerTar).digest('hex')}`
@@ -224,9 +231,14 @@ describe('downloadAndExtractFacet', () => {
   }
 
   test('happy path: resolves the 302, downloads from S3, verifies sha256, extracts files', async () => {
+    const facetJson = JSON.stringify(
+      { name: 'cowsay', version: '0.1.0', commands: { cowsay: { description: 'Say moo' } } },
+      null,
+      2,
+    )
     const { bytes, integrity } = buildArchive([
-      { name: 'facet.json', data: '{"name":"cowsay","version":"0.1.0"}' },
-      { name: 'commands/cowsay.md', data: '# cowsay\n' },
+      { path: 'facet.json', content: facetJson },
+      { path: 'commands/cowsay.md', content: '# cowsay\n' },
     ])
     const { urls } = stubArchiveDownload(new Response(bytes, { status: 200 }))
     const result = await downloadAndExtractFacet({ ...META, transportHash: integrity }, dest)
@@ -240,7 +252,7 @@ describe('downloadAndExtractFacet', () => {
   })
 
   test('sha256 mismatch: returns NETWORK_ERROR with hash detail and writes nothing', async () => {
-    const { bytes } = buildArchive([{ name: 'facet.json', data: '{}' }])
+    const { bytes } = buildArchive([{ path: 'facet.json', content: JSON.stringify({ name: 'x', version: '0.1.0' }) }])
     stubArchiveDownload(new Response(bytes, { status: 200 }))
     const result = await downloadAndExtractFacet({ ...META, transportHash: 'sha256:0000' }, dest)
     expect(result.ok).toBe(false)

--- a/packages/engine/src/cache/operations.ts
+++ b/packages/engine/src/cache/operations.ts
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
+import { validateAssetName } from '@agent-facets/common'
 import type {
   AssetIntegrityFailure,
   BuildManifest,
@@ -276,6 +277,17 @@ export function cachePutVerified(
 ): CachePutVerifiedResult {
   // 1. Per-asset audit.
   for (const [path, expected] of Object.entries(buildManifest.assets)) {
+    const nameCheck = validateAssetName(path)
+    if (!nameCheck.ok) {
+      const failure: AssetIntegrityFailure = {
+        kind: 'asset',
+        facet,
+        path,
+        expected,
+        observed: '<unsafe-path>',
+      }
+      return { ok: false, integrity: failure }
+    }
     let observed: string
     try {
       const bytes = readFileSync(join(sourceDir, path))
@@ -369,6 +381,7 @@ export function readCachedIntegrity(slotPath: string): CacheIntegrity | null {
 export type DirIntegrityResult =
   | { ok: true; integrity: string; assetHashes: Record<string, string> }
   | { ok: false; reason: 'unreadable'; path: string }
+  | { ok: false; reason: 'unsafe-path'; path: string }
 
 /**
  * Genuinely recompute a directory's canonical integrity from its bytes.
@@ -387,6 +400,10 @@ export function computeDirIntegrity(dir: string, assetPaths: ReadonlyArray<strin
   const entries: ArchiveEntry[] = []
   const assetHashes: Record<string, string> = {}
   for (const path of assetPaths) {
+    const nameCheck = validateAssetName(path)
+    if (!nameCheck.ok) {
+      return { ok: false, reason: 'unsafe-path', path }
+    }
     let content: string
     try {
       content = readFileSync(join(dir, path), 'utf8')

--- a/packages/engine/src/install/__tests__/receipt.test.ts
+++ b/packages/engine/src/install/__tests__/receipt.test.ts
@@ -171,6 +171,14 @@ describe('loadReceipt', () => {
     expect(result.receipt.facets.cowsay?.version).toBe('0.0.1')
     expect(result.receipt.facets.cowsay?.assets).toHaveLength(1)
   })
+
+  test('returns corrupt (not throw) on an unresolvable project path (#19)', () => {
+    const nonexistent = join(projectDir, 'this-does-not-exist')
+    const result = loadReceipt(nonexistent)
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('corrupt')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -215,6 +223,25 @@ describe('writeReceipt', () => {
     expect(Object.keys(result.receipt.facets)).toHaveLength(2)
     expect(result.receipt.facets.cowsay?.assets).toHaveLength(2)
     expect(result.receipt.facets.hello?.assets).toHaveLength(1)
+  })
+
+  test('normalizes receipt.path so a stale path does not cause path-mismatch (#20)', () => {
+    const canonical = realpathSync(projectDir)
+    const receipt: Receipt = {
+      version: 1,
+      path: '/some/other/path', // intentionally wrong
+      facets: {
+        cowsay: {
+          version: '0.0.1',
+          assets: [{ scope: 'project', type: 'skill', name: 'cowsay' }],
+        },
+      },
+    }
+    writeReceipt(projectDir, receipt)
+    const result = loadReceipt(projectDir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.receipt.path).toBe(canonical)
   })
 })
 

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -229,6 +229,32 @@ afterEach(() => {
   rmSync(fakeHome, { recursive: true, force: true })
 })
 
+describe('runInstall — DELTA_CONFLICT (#23)', () => {
+  test('a delta with the same facet in additions and removals fails before any mutation', async () => {
+    writeFacets({ cowsay: '0.1.0' })
+    const adapters = await loadInstalledAdapters()
+    const result = await runInstall({
+      projectRoot,
+      adapters: adapters.filter((a) => a.supportsInstall === true),
+      delta: {
+        additions: [
+          {
+            facetName: 'cowsay',
+            specifier: 'cowsay@0.1.0',
+            source: { kind: 'registry', name: 'cowsay', version: { kind: 'exact', major: 0, minor: 1, patch: 0 } },
+          },
+        ],
+        removals: [{ facetName: 'cowsay' }],
+      },
+    })
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('DELTA_CONFLICT')
+    if (result.failure.code !== 'DELTA_CONFLICT') expect.unreachable()
+    expect(result.failure.facet).toBe('cowsay')
+    expect(result.rollback.kind).toBe('not-needed')
+  })
+})
+
 describe('runInstall — exact manifest pin differing from the lockfile', () => {
   test('re-resolves to the manifest version and reports updated', async () => {
     // Fixtures exist for both versions; the lock pins 0.1.1, manifest bumps to 0.1.2.

--- a/packages/engine/src/install/commit/tri-write.ts
+++ b/packages/engine/src/install/commit/tri-write.ts
@@ -74,22 +74,46 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
     capturePreImage(receiptPath(projectRoot)),
   ]
 
-  try {
-    const newManifest: FacetsJson = { ...args.facetsJson, facets: { ...args.desiredFacets } }
-    writeFacetsJson(projectRoot, newManifest)
-    writeLockfile(projectRoot, args.newLockfile)
-    writeReceipt(projectRoot, newReceipt)
-  } catch (error) {
-    for (const image of preImages) {
-      restorePreImage(image)
-    }
-    return {
-      ok: false,
-      failure: {
-        code: 'LOCKFILE_WRITE_FAILED',
-        path: join(projectRoot, FACETS_LOCK_FILE),
-        cause: error instanceof Error ? error.message : String(error),
+  // Each write is wrapped individually so a mid-trio failure identifies
+  // which file threw. The pre-image restore always runs for all three
+  // files regardless of which one failed, preserving the all-or-nothing
+  // guarantee.
+  const writes: Array<{ file: 'manifest' | 'lockfile' | 'receipt'; path: string; fn: () => void }> = [
+    {
+      file: 'manifest',
+      path: join(projectRoot, 'facets.json'),
+      fn: () => {
+        const newManifest: FacetsJson = { ...args.facetsJson, facets: { ...args.desiredFacets } }
+        writeFacetsJson(projectRoot, newManifest)
       },
+    },
+    {
+      file: 'lockfile',
+      path: join(projectRoot, FACETS_LOCK_FILE),
+      fn: () => writeLockfile(projectRoot, args.newLockfile),
+    },
+    {
+      file: 'receipt',
+      path: receiptPath(projectRoot),
+      fn: () => writeReceipt(projectRoot, newReceipt),
+    },
+  ]
+
+  for (const write of writes) {
+    try {
+      write.fn()
+    } catch (error) {
+      for (const image of preImages) {
+        restorePreImage(image)
+      }
+      return {
+        ok: false,
+        failure: {
+          code: 'LOCKFILE_WRITE_FAILED',
+          path: write.path,
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      }
     }
   }
   return { ok: true }

--- a/packages/engine/src/install/receipt.ts
+++ b/packages/engine/src/install/receipt.ts
@@ -137,8 +137,17 @@ export function canonicalProjectPath(projectDir: string): string {
  * Never throws.
  */
 export function loadReceipt(projectDir: string): LoadReceiptResult {
-  const canonical = realpathSync(projectDir)
-  const filePath = receiptPath(projectDir)
+  let canonical: string
+  let filePath: string
+  try {
+    canonical = realpathSync(projectDir)
+    filePath = receiptPath(projectDir)
+  } catch {
+    // realpathSync throws when the path doesn't exist or is otherwise
+    // unresolvable (dangling symlink, permission denied). Treat the
+    // same as a missing receipt — the caller will bootstrap a fresh one.
+    return { ok: false, reason: 'corrupt' }
+  }
 
   if (!existsSync(filePath)) {
     return { ok: false, reason: 'missing' }
@@ -198,13 +207,21 @@ export function loadReceipt(projectDir: string): LoadReceiptResult {
 
 /**
  * Write a receipt atomically. Creates the receipts directory if needed.
+ *
+ * The embedded `path` field is always normalized to `canonicalProjectPath(projectDir)`
+ * regardless of what the passed `receipt` carries — this ensures the
+ * receipt's self-identification matches what `loadReceipt` computes,
+ * so a receipt can never round-trip to a spurious `path-mismatch`.
+ *
  * Never throws on ENOENT for the parent directory.
  */
 export function writeReceipt(projectDir: string, receipt: Receipt): void {
   const dir = facetReceiptsDir()
   mkdirSync(dir, { recursive: true })
   const filePath = receiptPath(projectDir)
-  atomicWriteFileSync(filePath, `${JSON.stringify(receipt, null, 2)}\n`)
+  const canonical = canonicalProjectPath(projectDir)
+  const normalized: Receipt = { ...receipt, path: canonical }
+  atomicWriteFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -90,6 +90,15 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       }
     }
 
+    // 3b. Delta conflict check. The same facet name in both additions
+    //     and removals is an illegal state the CLI should never produce;
+    //     this check is defense-in-depth, run before the install lock.
+    const additionNames = new Set(delta.additions.map((a) => a.facetName))
+    const conflict = delta.removals.find((r) => additionNames.has(r.facetName))
+    if (conflict !== undefined) {
+      return failureNoMutation({ code: 'DELTA_CONFLICT', facet: conflict.facetName })
+    }
+
     // 4. Frozen-lockfile gates. A frozen commit with a non-empty delta is
     //    rejected immediately — add/remove can never run frozen. The
     //    drift preflight runs before any mutation/journal entry so drift

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -205,6 +205,12 @@ export type RunInstallFailure =
       cause: string
     }
   | { code: 'FROZEN_WITH_DELTA' }
+  /**
+   * The install delta contains the same facet name in both `additions`
+   * and `removals`. This is an illegal state the CLI should never
+   * produce; the check exists as defense-in-depth.
+   */
+  | { code: 'DELTA_CONFLICT'; facet: string }
   | { code: 'ABORTED' }
 
 /**

--- a/packages/engine/src/registry/download.ts
+++ b/packages/engine/src/registry/download.ts
@@ -1,17 +1,17 @@
 import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, isAbsolute, join, normalize, relative } from 'node:path'
-import { type BuildManifest, parseFacetArchive } from '@agent-facets/protocol'
-import { parseTarGzip } from 'nanotar'
+import { dirname, join } from 'node:path'
+import { type BuildManifest, validateFacetArchive } from '@agent-facets/protocol'
 import type { Client } from 'openapi-fetch'
 import { createRegistryClient, translateWireError } from './client.ts'
 import { resolveCredential } from './credentials.ts'
 import type { paths } from './generated/registry-api.ts'
+import { uncappedGunzip } from './gunzip.ts'
 import type { RegistryMetadata, RegistryResult } from './types.ts'
 
 /**
- * Download a `.tar.gz` archive from the registry and extract its contents
- * into `dest`.
+ * Download a `.facet` archive from the registry and extract its verified
+ * contents into `dest`.
  *
  * The archive is fetched in two hops, both resolved here just-in-time
  * from the metadata's `name` + `version`:
@@ -30,20 +30,17 @@ import type { RegistryMetadata, RegistryResult } from './types.ts'
  *      client: a presigned S3 URL points at a different system and is
  *      never a registry endpoint in the OpenAPI spec.
  *
- * The downloaded bytes are a `.facet` archive — an uncompressed outer
- * tar containing `build-manifest.json` and `archive.tar.gz` (the
- * gzipped inner tar of source files). Both layers are unpacked here
- * to extract the source files into `dest`.
- *
- * Verification: the registry's `transportHash` (sha256 of the
- * tarball-as-uploaded) is checked against the bytes we just downloaded.
- * Mismatch is a hard error — the tarball was tampered with in transit
- * or the registry's record is corrupt; either way, refuse to extract.
- *
- * Path safety: tar entry names that would escape `dest` (absolute paths,
- * `../` segments, leading slashes) are rejected. A single bad entry
- * fails the entire extraction so we never end up with a half-written
- * directory containing some malicious files.
+ * Verification is two-layered:
+ *   - **Transport**: sha256 of the downloaded bytes must match the
+ *     registry's `transportHash`. Mismatch is a hard error — the
+ *     tarball was tampered with in transit or the registry's record is
+ *     corrupt; either way, refuse to extract.
+ *   - **Content**: the downloaded bytes are passed through
+ *     `validateFacetArchive` which runs the full end-to-end verification
+ *     pipeline: outer-tar parsing, inner-archive decompression, per-asset
+ *     hash reconciliation, path safety (`validateAssetName`), facet.json
+ *     schema validation, outer-exclusivity (no undeclared extra files),
+ *     and build-rule validation. Only verified assets are extracted.
  *
  * Always returns; never throws.
  */
@@ -125,12 +122,15 @@ export async function downloadAndExtractFacet(
     }
   }
 
-  // The registry stores `.facet` archives — an uncompressed outer tar
-  // containing `build-manifest.json` + `archive.tar.gz` (the gzipped
-  // inner tar of source files). Unpack both layers to reach the entries.
-  const outerResult = parseFacetArchive(bytes)
-  if (!outerResult.ok) {
-    const msg = outerResult.errors.map((e) => e.message).join('; ')
+  // Run the full end-to-end archive verification pipeline. This replaces
+  // the former ad-hoc parseFacetArchive + parseTarGzip + sanitizeEntryName
+  // extraction loop with the canonical validateFacetArchive, which runs
+  // path-safety validation (validateAssetName), per-asset hash
+  // reconciliation, outer-exclusivity (no undeclared extra files), and
+  // build-rule validation. Only verified assets are extracted.
+  const archiveResult = await validateFacetArchive(bytes, { gunzip: uncappedGunzip })
+  if (!archiveResult.ok) {
+    const msg = archiveResult.errors.map((e) => e.message).join('; ')
     return {
       ok: false,
       error: {
@@ -141,71 +141,20 @@ export async function downloadAndExtractFacet(
     }
   }
 
-  let entries: ReadonlyArray<{ name: string; data?: Uint8Array }>
-  try {
-    entries = await parseTarGzip(outerResult.data.innerArchiveBytes)
-  } catch (err) {
-    return {
-      ok: false,
-      error: {
-        code: 'NETWORK_ERROR',
-        cause: `inner archive is not a valid gzipped tar: ${err instanceof Error ? err.message : String(err)}`,
-        attempts: 1,
-      },
-    }
-  }
+  const { buildManifest, assets } = archiveResult.data
 
-  // Two-pass extraction to honor the all-or-nothing contract:
-  //   Pass 1 — validate every entry's path. No filesystem writes. If any
-  //            entry is unsafe, return immediately; `dest` is untouched.
-  //   Pass 2 — only after every entry has cleared sanitization, mkdir
-  //            `dest` and write the files.
-  // Without the split, a malicious tar with a safe entry followed by an
-  // unsafe one would land the safe entry on disk before we noticed.
-  interface PreparedEntry {
-    target: string
-    data: Uint8Array
-  }
-  const prepared: PreparedEntry[] = []
-  for (const entry of entries) {
-    if (entry.data === undefined) continue // directory entry; recreated as we write files
-    const safeName = sanitizeEntryName(entry.name)
-    if (safeName === null) {
-      return {
-        ok: false,
-        error: {
-          code: 'NETWORK_ERROR',
-          cause: `archive contains an unsafe path: "${entry.name}"`,
-          attempts: 1,
-        },
-      }
-    }
-    const target = join(dest, safeName)
-    // Defense-in-depth: ensure the resolved path is still under dest after
-    // join+normalize. `sanitizeEntryName` should have caught this, but
-    // a second check costs nothing.
-    const rel = relative(dest, target)
-    if (rel.startsWith('..') || rel.startsWith('/')) {
-      return {
-        ok: false,
-        error: {
-          code: 'NETWORK_ERROR',
-          cause: `archive entry "${entry.name}" resolves outside the extraction directory`,
-          attempts: 1,
-        },
-      }
-    }
-    prepared.push({ target, data: entry.data })
-  }
-
-  // All entries cleared sanitization — now it's safe to touch the filesystem.
+  // Extract verified assets to dest. All paths have been validated by
+  // validateFacetArchive (via validateAssetName) so they are safe
+  // relative paths. Extract all-or-nothing: mkdir + write only after
+  // full verification.
   await mkdir(dest, { recursive: true })
-  for (const { target, data } of prepared) {
+  for (const asset of assets) {
+    const target = join(dest, asset.path)
     await mkdir(dirname(target), { recursive: true })
-    await writeFile(target, data)
+    await writeFile(target, asset.bytes)
   }
 
-  return { ok: true, value: outerResult.data.buildManifest }
+  return { ok: true, value: buildManifest }
 }
 
 /**
@@ -295,37 +244,4 @@ export async function resolveArchiveUrl(
     ok: false,
     error: translateWireError(wireError as Parameters<typeof translateWireError>[0], response.status),
   }
-}
-
-/**
- * Reject tar entry names that would escape the extraction directory.
- * Returns the safe relative form, or null if the entry should be refused.
- *
- *   - Reject empty names.
- *   - Strip a leading `./`; if nothing remains, reject (no useful target).
- *   - Reject any platform-absolute path (`/foo`, `C:\foo`, `\\?\foo`,
- *     `\\server\share`). On POSIX `isAbsolute('C:\\...')` is false, so
- *     we also explicitly reject Windows-style drive letters and UNC
- *     prefixes — defense in depth in case a malicious tar is unpacked
- *     on a Windows host.
- *   - Reject any segment equal to `..` (parent traversal).
- *   - Reject `.` after normalization (entry would target `dest` itself,
- *     which `writeFile` cannot do because `dest` is a directory).
- */
-function sanitizeEntryName(name: string): string | null {
-  if (name.length === 0) return null
-  let cleaned = name
-  if (cleaned.startsWith('./')) cleaned = cleaned.slice(2)
-  if (cleaned.length === 0) return null
-  if (isAbsolute(cleaned)) return null
-  // Windows drive letters and UNC, even on POSIX hosts where `isAbsolute`
-  // returns false for them. (`C:\path`, `C:/path`, `\\server\share`.)
-  if (/^[A-Za-z]:[\\/]/.test(cleaned)) return null
-  if (cleaned.startsWith('\\\\')) return null
-  if (cleaned.startsWith('/')) return null
-  const normalized = normalize(cleaned)
-  if (normalized === '.' || normalized === '..') return null
-  const segments = normalized.split('/')
-  if (segments.some((s) => s === '..')) return null
-  return normalized
 }

--- a/packages/engine/src/registry/resolve-metadata.ts
+++ b/packages/engine/src/registry/resolve-metadata.ts
@@ -64,8 +64,10 @@ export async function resolveRegistryMetadataBatch(
  * The wire→internal mapping is intentional and load-bearing:
  *
  *   - `body.content_hash` becomes `transportHash`. It is the sha256 of
- *     the gzipped tarball as uploaded; `download.ts` uses it for the
- *     raw-bytes transport check.
+ *     the uploaded `.facet` archive (the uncompressed outer tar
+ *     carrying `build-manifest.json` + the gzipped inner
+ *     `archive.tar.gz`); `download.ts` uses it for the raw-bytes
+ *     transport check.
  *   - `body.content_integrity` becomes `contentFingerprint`. It is the
  *     sha256 of the canonical archive (inner uncompressed tar) — the
  *     domain the sidecar, lockfile, and build-manifest all record. Fed

--- a/packages/engine/src/registry/types.ts
+++ b/packages/engine/src/registry/types.ts
@@ -7,9 +7,12 @@ import type { VersionSpec } from '@agent-facets/protocol'
  *   - `version`: the exact resolved version (e.g., `"1.2.3"`). When the
  *     caller passed a wildcard or `latest`, this is the version the
  *     registry chose.
- *   - `transportHash`: sha256 of the uploaded `.facet` tarball (the
- *     gzipped delivery bytes). Used only by `download.ts` for the
- *     raw-bytes transport check after downloading.
+ *   - `transportHash`: sha256 of the uploaded `.facet` archive (the
+ *     uncompressed outer tar containing `build-manifest.json` and the
+ *     gzipped inner `archive.tar.gz`; the wire `Content-Type` is
+ *     `application/gzip` but these bytes are the outer tar itself).
+ *     Used only by `download.ts` for the raw-bytes transport check
+ *     after downloading.
  *   - `contentFingerprint`: sha256 of the canonical archive (the inner
  *     uncompressed tar). This is the domain the cache sidecar, the
  *     lockfile, and `build-manifest.json` all record. Fed to the

--- a/packages/protocol/src/__tests__/validate-archive.test.ts
+++ b/packages/protocol/src/__tests__/validate-archive.test.ts
@@ -432,6 +432,115 @@ describe('validateFacetArchive', () => {
     })
   })
 
+  describe('path traversal defense (Step 4b)', () => {
+    test('a traversal path in buildManifest.assets is rejected', async () => {
+      // Craft an archive whose build manifest declares a traversal path as
+      // an asset key. Steps 1–4 should pass, but Step 4b (path safety)
+      // should reject before any hashing work.
+      const facetJson = JSON.stringify(
+        {
+          name: 'test-facet',
+          version: '1.0.0',
+          skills: { 'code-review': { description: 'Review code' } },
+        },
+        null,
+        2,
+      )
+      const entries = [
+        { path: FACET_MANIFEST_FILE, content: facetJson },
+        { path: 'skills/code-review/SKILL.md', content: '# Code Review\n\nReview the diff.' },
+        { path: '../../../../etc/passwd', content: 'root:x:0:0:root:/root:/bin/bash' },
+      ]
+      entries.sort((a, b) => (a.path < b.path ? -1 : 1))
+      const assetHashes = computeAssetHashes(entries)
+      const innerTar = assembleTar(entries)
+      const integrity = computeContentHash(innerTar)
+      const innerGz = gz(innerTar)
+      const buildManifestJson = JSON.stringify(
+        { facetVersion: 0.1, archive: INNER_ARCHIVE_NAME, integrity, assets: assetHashes },
+        null,
+        2,
+      )
+      const outerBytes = assembleOuterTar(buildManifestJson, innerGz)
+
+      const result = await validateFacetArchive(outerBytes, { gunzip: okGunzip })
+
+      if (result.ok) expect.unreachable()
+      expect(result.errors.some((e) => e.path === '../../../../etc/passwd')).toBe(true)
+      expect(result.errors.some((e) => e.message.includes('path safety'))).toBe(true)
+    })
+
+    test('an absolute path in an inner-tar entry name is rejected', async () => {
+      const facetJson = JSON.stringify(
+        {
+          name: 'test-facet',
+          version: '1.0.0',
+          skills: { 'code-review': { description: 'Review code' } },
+        },
+        null,
+        2,
+      )
+      const entries = [
+        { path: FACET_MANIFEST_FILE, content: facetJson },
+        { path: 'skills/code-review/SKILL.md', content: '# Code Review\n\nReview the diff.' },
+      ]
+      // We need to craft an inner tar with a bad entry name. Since assembleTar
+      // accepts entries as-is, we add a poisoned entry before packing.
+      const poisonedEntries = [...entries, { path: '/etc/passwd', content: 'root:x:0:0:root:/root:/bin/bash' }]
+      poisonedEntries.sort((a, b) => (a.path < b.path ? -1 : 1))
+      const assetHashes = computeAssetHashes(poisonedEntries)
+      const innerTar = assembleTar(poisonedEntries)
+      const integrity = computeContentHash(innerTar)
+      const innerGz = gz(innerTar)
+      const buildManifestJson = JSON.stringify(
+        { facetVersion: 0.1, archive: INNER_ARCHIVE_NAME, integrity, assets: assetHashes },
+        null,
+        2,
+      )
+      const outerBytes = assembleOuterTar(buildManifestJson, innerGz)
+
+      const result = await validateFacetArchive(outerBytes, { gunzip: okGunzip })
+
+      if (result.ok) expect.unreachable()
+      expect(result.errors.some((e) => e.path === '/etc/passwd')).toBe(true)
+      expect(result.errors.some((e) => e.message.includes('path safety'))).toBe(true)
+    })
+
+    test('a backslash path in the build manifest is rejected', async () => {
+      const facetJson = JSON.stringify(
+        {
+          name: 'test-facet',
+          version: '1.0.0',
+          skills: { 'code-review': { description: 'Review code' } },
+        },
+        null,
+        2,
+      )
+      const entries = [
+        { path: FACET_MANIFEST_FILE, content: facetJson },
+        { path: 'skills/code-review/SKILL.md', content: '# Code Review\n\nReview the diff.' },
+        { path: 'foo\\bar', content: 'windows-style path' },
+      ]
+      entries.sort((a, b) => (a.path < b.path ? -1 : 1))
+      const assetHashes = computeAssetHashes(entries)
+      const innerTar = assembleTar(entries)
+      const integrity = computeContentHash(innerTar)
+      const innerGz = gz(innerTar)
+      const buildManifestJson = JSON.stringify(
+        { facetVersion: 0.1, archive: INNER_ARCHIVE_NAME, integrity, assets: assetHashes },
+        null,
+        2,
+      )
+      const outerBytes = assembleOuterTar(buildManifestJson, innerGz)
+
+      const result = await validateFacetArchive(outerBytes, { gunzip: okGunzip })
+
+      if (result.ok) expect.unreachable()
+      expect(result.errors.some((e) => e.path === 'foo\\bar')).toBe(true)
+      expect(result.errors.some((e) => e.message.includes('path safety'))).toBe(true)
+    })
+  })
+
   describe('contract invariants', () => {
     test('never throws on any failure mode', async () => {
       // Combine multiple failure-triggering inputs and assert no throw.

--- a/packages/protocol/src/integrity/validate-archive.ts
+++ b/packages/protocol/src/integrity/validate-archive.ts
@@ -1,4 +1,4 @@
-import type { Validated, ValidationError } from '@agent-facets/common'
+import { type Validated, type ValidationError, validateAssetName } from '@agent-facets/common'
 import { computeContentHash, INNER_ARCHIVE_NAME, parseFacetArchive, parseInnerArchive } from '../build/content-hash.ts'
 import { detectNamingCollisions } from '../build/detect-collisions.ts'
 import { validateContentFiles } from '../build/validate-content.ts'
@@ -170,6 +170,38 @@ export async function validateFacetArchive(
     }
   }
   const innerEntries = innerResult.entries
+
+  // Step 4b: validate all path names are safe before reconciliation.
+  // Defense-in-depth: reject traversal paths (../, absolute, backslash)
+  // in both the build manifest's asset keys and the inner tar's entry
+  // names before any hashing work. A malicious archive that smuggles an
+  // unsafe path through either channel is stopped here.
+  const pathSafetyErrors: ValidationError[] = []
+  for (const key of Object.keys(buildManifest.assets)) {
+    const check = validateAssetName(key)
+    if (!check.ok) {
+      pathSafetyErrors.push({
+        path: key,
+        message: `Build manifest asset key fails path safety validation: ${check.reason}`,
+        expected: 'safe relative path',
+        actual: key,
+      })
+    }
+  }
+  for (const entry of innerEntries) {
+    const check = validateAssetName(entry.name)
+    if (!check.ok) {
+      pathSafetyErrors.push({
+        path: entry.name,
+        message: `Inner archive entry name fails path safety validation: ${check.reason}`,
+        expected: 'safe relative path',
+        actual: entry.name,
+      })
+    }
+  }
+  if (pathSafetyErrors.length > 0) {
+    return { ok: false, errors: pathSafetyErrors }
+  }
 
   // Step 5: per-asset hash reconciliation
   const assetErrors: ValidationError[] = []


### PR DESCRIPTION
### Why

Several correctness and security gaps needed to be closed together:

- `name@latest` was incorrectly treated as equivalent to a bare name (pinning to the resolved exact version). The intent of an explicit `@latest` specifier is to float, not pin.
- The machine-local install record lacked a consistent name ("receipt") across the spec and codebase, making the terminology ambiguous.
- Path traversal attacks were possible through unsafe asset names in build manifests and inner tar entries — neither `validateFacetArchive` nor `cachePutVerified` nor `computeDirIntegrity` rejected paths like `../../../../etc/passwd`, `/etc/passwd`, or `foo\bar`.
- A delta carrying the same facet in both `additions` and `removals` had no guard, leaving the engine in an undefined state.
- `loadReceipt` would throw (rather than return a structured error) when `realpathSync` failed on a non-existent project path.
- `writeReceipt` did not normalize the embedded `path` field, allowing a stale or mismatched path to survive a round-trip and trigger spurious `path-mismatch` failures.
- The failed-removal rollback requirement only covered the manifest; the spec and implementation now treat the manifest, lockfile, and receipt as an atomic unit for both add and remove failures.
- `downloadAndExtractFacet` used an ad-hoc extraction loop with its own `sanitizeEntryName` instead of the canonical `validateFacetArchive` pipeline.

### Details

**`@latest` semantics:** The spec scenario is renamed and rewritten. A bare name pins to the resolved exact version; `name@latest` records `latest` as the version specifier in the manifest and the resolved exact version only in the lockfile, analogous to a wildcard specifier.

**Receipt terminology:** All references to "machine-local record" or "machine-local install record" in the spec are replaced with "receipt" for consistency with the code.

**Path traversal hardening:** `validateAssetName` (from `@agent-facets/common`) is now called in three places: `validateFacetArchive` (Step 4b, before hash reconciliation), `cachePutVerified` (before per-asset reads), and `computeDirIntegrity` (before file reads). The `DirIntegrityResult` union gains an `unsafe-path` variant. The old `sanitizeEntryName` function in `download.ts` is deleted; `downloadAndExtractFacet` now delegates entirely to `validateFacetArchive` and only writes files after full verification passes.

**Delta conflict check:** `runInstall` now checks for a facet appearing in both `additions` and `removals` before acquiring the install lock or touching any state, returning a `DELTA_CONFLICT` failure with the offending facet name. The CLI renders this as an internal error with a bug-report link.

**Receipt robustness:** `loadReceipt` wraps `realpathSync` in a try/catch and returns `{ ok: false, reason: 'corrupt' }` on failure instead of throwing. `writeReceipt` always overwrites the embedded `path` field with `canonicalProjectPath(projectDir)`, so a receipt can never round-trip to a path-mismatch.

**Atomic failure handling:** The spec's failed-removal requirement is tightened to match the add-failure requirement — all three files (manifest, lockfile, receipt) must remain unchanged if any step fails. `commitProjectFiles` now wraps each write individually so a mid-trio failure identifies the offending file while still restoring all three pre-images.

**`downloadAndExtractFacet` refactor:** The two-pass extraction loop and `sanitizeEntryName` are removed. The function now calls `validateFacetArchive` (which runs path safety, per-asset hash reconciliation, outer-exclusivity, and build-rule validation) and writes only the verified `assets` array to disk. Test helpers are updated to use `assembleTar`, `computeAssetHashes`, and `INNER_ARCHIVE_NAME` from the protocol package so the constructed archives pass the full verification pipeline.

### Verification

New and updated tests cover:
- `computeDirIntegrity` rejecting relative traversal, absolute, and backslash paths.
- `cachePutVerified` rejecting traversal and absolute paths in `buildManifest.assets`, confirming the cache slot is not created.
- `validateFacetArchive` Step 4b rejecting traversal paths in build manifest asset keys, absolute paths in inner tar entry names, and backslash paths.
- `runInstall` returning `DELTA_CONFLICT` before any mutation when the same facet appears in both additions and removals.
- `loadReceipt` returning `corrupt` (not throwing) for a non-existent project path.
- `writeReceipt` normalizing the embedded path so a stale path does not survive a round-trip.