### PR TITLE
Refactor create/edit wizards to render inline success views and replace `THEME.primary` focus color with `THEME.focus`

### DIFF
--- a/.changeset/modern-aliens-dress.md
+++ b/.changeset/modern-aliens-dress.md
@@ -1,0 +1,6 @@
+---
+"@agent-facets/brand": patch
+"agent-facets": patch
+---
+
+UI changes for the CLI

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "github:agent-facets/viper-plans",
-    "cowsay": "0.0.1"
+    "cowsay": "0.0.1",
+    "viper-plans": "0.1.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -1,37 +1,6 @@
 {
   "lockfileVersion": 1,
   "facets": {
-    "viper-plans": {
-      "source": {
-        "kind": "git",
-        "url": "https://github.com/agent-facets/viper-plans.git",
-        "commit": "b6816a6e010f0364a6d6308e6b4157c64d3ca143"
-      },
-      "version": "0.1.0",
-      "integrity": "sha256:4033523b90d098adadf23ecc725b9c71ec4e334f04a6cb8ab7851ba247321526",
-      "assets": [
-        {
-          "scope": "project",
-          "type": "skill",
-          "name": "viper-execution-rules"
-        },
-        {
-          "scope": "project",
-          "type": "skill",
-          "name": "viper-planning"
-        },
-        {
-          "scope": "project",
-          "type": "command",
-          "name": "viper-plan"
-        },
-        {
-          "scope": "project",
-          "type": "command",
-          "name": "viper-run"
-        }
-      ]
-    },
     "cowsay": {
       "source": {
         "kind": "registry",
@@ -59,6 +28,36 @@
           "scope": "project",
           "type": "command",
           "name": "cowsay"
+        }
+      ]
+    },
+    "viper-plans": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.facet.cafe"
+      },
+      "version": "0.1.0",
+      "integrity": "sha256:4033523b90d098adadf23ecc725b9c71ec4e334f04a6cb8ab7851ba247321526",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "viper-execution-rules"
+        },
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "viper-planning"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "viper-plan"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "viper-run"
         }
       ]
     }

--- a/fixtures/viper-plans/.gitignore
+++ b/fixtures/viper-plans/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.opencode/

--- a/fixtures/viper-plans/commands/viper-plan.md
+++ b/fixtures/viper-plans/commands/viper-plan.md
@@ -1,0 +1,19 @@
+Load the `viper-planning` skill for guidance on plan structure.
+
+If the user provided a goal as arguments, use it. Otherwise, ask what they'd like to do. Only use the `question` tool if you need to ask multiple choice questions.
+
+## Goal
+
+$ARGUMENTS
+
+## Workflow
+
+1. Think, read, search, and explore to understand the problem
+2. Ask the user clarifying questions — don't make large assumptions about intent
+3. Compose VIPER steps that match the shape of the change (not every change needs all 5 types)
+4. Display the plan to the user in full for review
+5. Use the `question` tool to ask the user to approve the plan before implementation. If they request changes, update the plan and ask again until approved.
+6. Once approved, persist the plan using the `viper-write-plan` tool
+7. Do not try to implement — planning and execution are separate concerns
+
+Tell the user they may use the `/viper-run` command to execute the newly created plan.

--- a/fixtures/viper-plans/commands/viper-run.md
+++ b/fixtures/viper-plans/commands/viper-run.md
@@ -1,0 +1,38 @@
+Load the `viper-execution-rules` skill for guidance on the VIPER execution protocol.
+
+Plan name (if provided): $ARGUMENTS
+
+## Workflow
+
+1. **Discover plans**: Use the `viper-list-plans` tool to discover available plans
+
+2. **Select a plan**:
+   - If a plan name was provided as an argument, use it (look for a plan directory with that name)
+   - If only one plan exists, auto-select it but confirm with the user using the `question` tool: "Found one plan: **<name>**. Review it?"
+   - If multiple plans exist, use the `question` tool to let the user select which plan to review and execute:
+      - Show the list of plan names for selection
+      - Allow only one selection
+   - If no plans exist, tell the user and suggest using `/viper-plan` to create one
+
+3. **Load the plan**: Read `.opencode/plans/<name>/plan.md` fully
+
+4. **Display the plan to the user**: Show the VIPER plan steps to the user
+
+5. **Confirm execution**:
+   - Use the `question` tool to ask the user to choose between: execute the plan, view the plan in full, or reject it
+   - Do not provide any other options
+   - If they choose to view the plan, show the full content of the plan file and then ask again if they want to execute it
+   - If they reject the plan, stop execution and ask if they want to delete the plan file
+
+6. **Execute**: Follow the viper-execution-rules skill protocol:
+   - Create one TODO per step heading
+   - Execute steps in order following the VIPER protocol
+   - Gate Propose and Review steps on user approval/feedback
+   - Stop on Verify failures
+   - Enforce hard rules (Explore→Propose before Implement, Verify after Implement)
+
+## Cleanup
+
+Once complete, ask the user if they want to delete the plan with the `question` tool using a simple yes/no binary.
+
+If they answer yes, use the `viper-delete-plan` tool to remove the plan.

--- a/fixtures/viper-plans/facet.json
+++ b/fixtures/viper-plans/facet.json
@@ -1,0 +1,21 @@
+{
+  "name": "viper-plans",
+  "version": "0.1.0",
+  "description": "VIPER planning and execution",
+  "skills": {
+    "viper-planning": {
+      "description": "How to construct well-formed plans using the VIPER step model"
+    },
+    "viper-execution-rules": {
+      "description": "Rules and constraints for executing VIPER plans"
+    }
+  },
+  "commands": {
+    "viper-plan": {
+      "description": "Create a structured VIPER plan for a goal"
+    },
+    "viper-run": {
+      "description": "Execute a VIPER plan from .opencode/plans/"
+    }
+  }
+}

--- a/fixtures/viper-plans/skills/viper-execution-rules/SKILL.md
+++ b/fixtures/viper-plans/skills/viper-execution-rules/SKILL.md
@@ -1,0 +1,106 @@
+# VIPER Plan Execution
+
+This skill describes how to execute plans that follow the VIPER step model. It covers loading plans, creating TODOs, and the step execution protocol.
+
+## Loading a Plan
+
+When executing a plan (from a file or inline):
+
+1. Read the plan fully before doing anything
+2. Look for the `## Step Types` legend — it defines how each step type must be executed
+3. Create TODOs from the step headings
+
+## TODO Creation Rules
+
+**Create exactly ONE TODO item per `### Step <N> - <Type>: <Description>` heading in the plan.**
+
+- The TODO content MUST match the step heading: `<Type>: <Description>`
+- NEVER combine steps into a single TODO
+- NEVER skip steps
+- Each TODO MUST maps to exactly one step heading
+- You MUST NOT include the step number in the TODO content — only the type and description
+
+### Example
+
+```
+CORRECT:
+- Explore: Understand the widget registry       [in_progress]
+- Propose: Add FooWidget to the registry         [pending]
+- Implement: Add FooWidget to the registry       [pending]
+- Verify: Lint and test the widget registry      [pending]
+
+WRONG:
+- Explore + Propose: Widget registry             [in_progress]
+- Implement and Verify: FooWidget                [pending]
+```
+
+## Step Execution Protocol
+
+Before executing ANY step, check its type prefix and follow the corresponding rules:
+
+### Explore Steps (READ-ONLY)
+
+1. Read files, search the codebase, investigate broadly
+2. **DO NOT write, edit, or create ANY files**
+3. Summarize findings — these inform subsequent Propose or Review steps
+4. Mark complete and proceed to the next step
+
+### Propose Steps (READ-ONLY + USER GATE)
+
+1. Read the relevant files mentioned in the step
+2. Show the user the current code and your intended changes
+3. Use `mcp_question` to ask for explicit approval
+4. **DO NOT write, edit, or create ANY files during a Propose step**
+5. **DO NOT proceed to the next step until the user approves**
+
+If the user rejects or requests changes, revise the proposal and ask again.
+
+### Implement Steps (WRITE)
+
+1. If a preceding Propose step exists for this change, it MUST have explicit user approval before proceeding
+2. Make the code changes described in the step (or in the approved proposal)
+3. Do not add, remove, or modify anything beyond what the step specifies
+
+### Review Steps (READ-ONLY + USER GATE)
+
+1. Analyze what was done or found — read code, examine changes, assess quality
+2. Present your findings and analysis to the user
+3. Use `mcp_question` to ask for feedback before proceeding
+4. **DO NOT write, edit, or create ANY files during a Review step**
+5. **DO NOT proceed to the next step until the user responds**
+
+If the user has concerns, address them before moving on.
+
+### Verify Steps (CHECK)
+
+1. Run the verification commands specified in the step (lint, tests, type checks, syntax checks)
+2. If ALL checks pass → mark complete, proceed to the next step
+3. If ANY check fails → **STOP immediately**, report the failure to the user, and wait for instructions
+
+## Hard Rule Enforcement
+
+During execution, enforce these constraints:
+
+1. **Explore → Propose before Implement**: If the current step is Implement and the most recent non-Implement step was Explore, STOP — this violates the hard rule. There must be a Propose (or Review) between Explore and Implement.
+2. **Verify after Implement**: If the current step is Explore, Propose, or Review, and there are preceding Implement steps without a Verify between them, STOP — the plan is malformed.
+
+If a hard rule violation is detected, notify the user and do not proceed.
+
+## Execution Order
+
+Steps MUST be executed in the order they appear in the plan. The general flow is:
+
+```
+Explore  →  Propose  →  Implement  →  Verify
+              ↑              ↓
+              └── Review ────┘
+```
+
+But the exact sequence depends on the plan. Follow document order.
+
+## General Rules
+
+- Mark each TODO as `in_progress` when you start it, `completed` when done
+- Only have ONE TODO `in_progress` at a time
+- If you encounter something unexpected or ambiguous, STOP and ask the user
+- Do not go beyond what the plan specifies — if something seems missing, ask the user

--- a/fixtures/viper-plans/skills/viper-planning/SKILL.md
+++ b/fixtures/viper-plans/skills/viper-planning/SKILL.md
@@ -1,0 +1,114 @@
+# VIPER Plan Construction
+
+This skill describes how to construct well-formed plans using the VIPER step model. VIPER gives plan authors five step types — **Verify**, **Implement**, **Propose**, **Explore**, **Review** — that can be composed flexibly to match the shape of each change.
+
+## Step Types
+
+Every plan MUST include a Step Types legend at the top so the executor can reference it. Copy this verbatim:
+
+```
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Show the user intended changes and ask for approval
+  using the `question` tool. Do not write anything. Do not proceed until the user approves.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Analyze what was done or found, present findings
+  to the user, and wait for feedback before proceeding.
+```
+
+## Hard Rules
+
+Plan authors MUST follow these constraints when composing steps:
+
+1. **Explore → Propose before Implement**: An Explore step MUST be followed by another Explore or a Propose step before any Implement step. Never go directly from Explore to Implement.
+2. **Verify after Implement**: There MUST be at least one Verify step after any Implement step(s). Multiple Implements can batch before a single Verify, but you cannot end a plan or start a new Explore/Propose cycle without verifying what was implemented.
+3. **Implement without Propose is allowed**: Not every Implement needs a preceding Propose. The plan author decides when user approval is needed based on the risk and complexity of the change.
+
+## Step Naming Convention
+
+Format: `### Step <N> - <Type>: <Description>`
+
+Where `<Type>` is one of: `Explore`, `Propose`, `Implement`, `Review`, `Verify` and `<N>` is the step number.
+
+Steps are executed in the order they appear in the plan.
+
+## One Step = One TODO
+
+**Every `### <Type>: <Description>` heading becomes exactly ONE TODO item during execution.** Sub-content within a step is description for that single TODO — it does NOT create separate TODOs. Every distinct action that should be tracked independently MUST be its own step heading.
+
+## When to Use Each Step Type
+
+| Step          | Use when...                                                                                    |
+|---------------|------------------------------------------------------------------------------------------------|
+| **Verify**    | You need to run automated checks — tests, lint, type checks, syntax validation                 |
+| **Implement** | You're ready to write, edit, or delete files                                                   |
+| **Propose**   | The change is non-trivial and the user should approve the approach before you write code       |
+| **Explore**   | You need to read code, search for patterns, understand architecture before deciding what to do |
+| **Review**    | You want to analyze work that was done (yours or existing), present findings, and get feedback |
+
+## Example Patterns
+
+### Pattern 1: Full cycle with user gate
+
+A non-trivial change where the user should approve before implementation:
+
+```
+### Explore: Understand the widget registry
+### Propose: Add FooWidget to the registry
+### Implement: Add FooWidget to the registry
+### Verify: Lint and test the widget registry
+```
+
+### Pattern 2: Batched implements with single verify
+
+Multiple related mechanical changes that don't need individual approval:
+
+```
+### Explore: Find all deprecated API calls
+### Propose: Replace deprecated API calls across 4 files
+### Implement: Update api_client.rb
+### Implement: Update webhook_handler.rb
+### Implement: Update batch_processor.rb
+### Implement: Update event_listener.rb
+### Verify: Run full test suite for API layer
+```
+
+### Pattern 3: Research-heavy with review
+
+Deep investigation before a targeted change:
+
+```
+### Explore: Map the authentication flow
+### Explore: Identify all session timeout paths
+### Review: Present findings on session handling gaps
+### Propose: Fix session timeout in OAuth callback
+### Implement: Fix session timeout in OAuth callback
+### Verify: Run auth test suite
+```
+
+### Pattern 4: Implement without propose
+
+A trivial/mechanical change where user approval isn't needed:
+
+```
+### Implement: Fix typo in error message
+### Verify: Run lint check
+```
+
+## TODO Naming Convention
+
+Each step's TODO content MUST match the step heading: `<Type>: <Description>`
+
+NEVER combine multiple steps into one TODO.
+
+## Common Mistakes
+
+- **Explore directly to Implement**: Going from Explore to Implement without a Propose in between. Explore MUST lead to Explore or Propose before Implement.
+- **Missing Verify after Implement**: Every Implement (or batch of Implements) MUST be followed by a Verify.
+- **Bundled phases**: Writing multiple step types as sub-content within a single step heading. Each phase MUST be its own step.
+- **Missing type prefix**: Writing "### Add FooWidget" without the Explore/Propose/Implement/Review/Verify type.
+- **Missing legend**: The Step Types legend MUST be included in the plan itself.

--- a/packages/brand/src/theme.ts
+++ b/packages/brand/src/theme.ts
@@ -1,4 +1,4 @@
-import { BRAND, BRIGHTNESS, hexToRgb } from './colors.ts'
+import { ACCENTS_DARK, BRAND, BRIGHTNESS, hexToRgb } from './colors.ts'
 
 /**
  * Semantic theme — all values are references to brand constants.
@@ -15,6 +15,7 @@ export const THEME = {
   // Semantic aliases (can diverge from brand later)
   success: BRAND.green,
   warning: BRAND.coral,
+  focus: ACCENTS_DARK.pink,
 
   // Text — structural
   hint: BRIGHTNESS.dim,

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -69,19 +69,16 @@ export const createCommand: Command = {
       }
     }
 
-    const opts = await runCreateWizardInk()
-    if (!opts) {
+    const buildArg = args[0] ? ` ${displayDir}` : ''
+    const completed = await runCreateWizardInk({
+      onScaffold: (scaffoldOpts) => writeScaffold(scaffoldOpts, targetDir),
+      buildArg,
+    })
+
+    if (!completed) {
       console.log('\nCancelled.')
       return 1
     }
-
-    const files = await writeScaffold(opts, targetDir)
-
-    console.log(`\nFacet created: ${opts.name} → ${displayDir}`)
-    for (const file of files) {
-      console.log(`  ${displayDir}/${file}`)
-    }
-    console.log(`\nRun "facet build${args[0] ? ` ${displayDir}` : ''}" to validate your facet.`)
 
     return 0
   },

--- a/packages/cli/src/commands/create/wizard.tsx
+++ b/packages/cli/src/commands/create/wizard.tsx
@@ -11,8 +11,19 @@ interface EditorRequest {
   description: string
 }
 
-export async function runCreateWizardInk(): Promise<CreateOptions | null> {
-  let result: CreateOptions | null = null
+export interface RunCreateWizardOptions {
+  /** Write the scaffold to disk and return the list of created file paths. */
+  onScaffold: (opts: CreateOptions) => Promise<string[]>
+  /** Argument suffix for the "facet build" hint (e.g. " my-dir" or ""). */
+  buildArg: string
+}
+
+/**
+ * Run the create wizard. Returns `true` if the scaffold was written
+ * (success), `false` if the user cancelled.
+ */
+export async function runCreateWizardInk(options: RunCreateWizardOptions): Promise<boolean> {
+  let completed = false
   let snapshot: WizardSnapshot | undefined
   let pendingEditor: EditorRequest | null = null
   let done = false
@@ -24,17 +35,20 @@ export async function runCreateWizardInk(): Promise<CreateOptions | null> {
       const instance = render(
         <CreateWizard
           snapshot={snapshot}
-          onComplete={(opts) => {
-            result = opts
+          onScaffold={options.onScaffold}
+          buildArg={options.buildArg}
+          onComplete={() => {
+            completed = true
           }}
           onCancel={() => {
-            result = null
+            completed = false
           }}
           onSnapshot={(s) => {
             snapshot = s
           }}
           onRequestEditor={(section, name, description) => {
             pendingEditor = { section, name, description }
+            instance.clear()
             instance.unmount()
           }}
         />,
@@ -71,5 +85,5 @@ export async function runCreateWizardInk(): Promise<CreateOptions | null> {
     }
   }
 
-  return result
+  return completed
 }

--- a/packages/cli/src/commands/edit/index.ts
+++ b/packages/cli/src/commands/edit/index.ts
@@ -1,4 +1,4 @@
-import { applyEditOperations, buildEditContext, type EditResult } from '@agent-facets/engine'
+import { applyEditOperations, buildEditContext } from '@agent-facets/engine'
 import type { Command } from '../../commands.ts'
 import { resolveTargetDir } from '../resolve-dir.ts'
 import { runEditWizardInk } from './wizard.tsx'
@@ -23,17 +23,16 @@ export const editCommand: Command = {
     })
     if (!loaded.ok) return loaded.exitCode
 
-    const result: EditResult = await runEditWizardInk(loaded.context)
+    const buildArg = args[0] ? ` ${displayDir}` : ''
+    const completed = await runEditWizardInk(loaded.context, {
+      onApply: (result) => applyEditOperations(result.manifest, result.operations, rootDir),
+      buildArg,
+    })
 
-    if (result.outcome === 'cancelled') {
+    if (!completed) {
       console.log('\nCancelled — no changes applied.')
       return 1
     }
-
-    await applyEditOperations(result.manifest, result.operations, rootDir)
-
-    console.log(`\nChanges applied to ${displayDir}`)
-    console.log(`Run "facet build${args[0] ? ` ${displayDir}` : ''}" to validate your facet.`)
 
     return 0
   },

--- a/packages/cli/src/commands/edit/wizard.tsx
+++ b/packages/cli/src/commands/edit/wizard.tsx
@@ -11,8 +11,19 @@ interface EditorRequest {
   description: string
 }
 
-export async function runEditWizardInk(context: EditContext): Promise<EditResult> {
-  let result: EditResult = { outcome: 'cancelled' }
+export interface RunEditWizardOptions {
+  /** Apply edit operations to disk. */
+  onApply: (result: EditResult & { outcome: 'applied' }) => Promise<void>
+  /** Argument suffix for the "facet build" hint (e.g. " my-dir" or ""). */
+  buildArg: string
+}
+
+/**
+ * Run the edit wizard. Returns `true` if changes were applied (success),
+ * `false` if the user cancelled.
+ */
+export async function runEditWizardInk(context: EditContext, options: RunEditWizardOptions): Promise<boolean> {
+  let completed = false
   let snapshot: EditWizardSnapshot | undefined
   let pendingEditor: EditorRequest | null = null
   let done = false
@@ -25,14 +36,17 @@ export async function runEditWizardInk(context: EditContext): Promise<EditResult
         <EditWizard
           context={context}
           snapshot={snapshot}
+          onApply={options.onApply}
+          buildArg={options.buildArg}
           onComplete={(r) => {
-            result = r
+            completed = r.outcome === 'applied'
           }}
           onSnapshot={(s) => {
             snapshot = s
           }}
           onRequestEditor={(section, name, description) => {
             pendingEditor = { section, name, description }
+            instance.clear()
             instance.unmount()
           }}
         />,
@@ -70,5 +84,5 @@ export async function runEditWizardInk(context: EditContext): Promise<EditResult
     }
   }
 
-  return result
+  return completed
 }

--- a/packages/cli/src/tui/components/asset-field-picker.tsx
+++ b/packages/cli/src/tui/components/asset-field-picker.tsx
@@ -38,10 +38,10 @@ export function AssetFieldPicker({
       <Box gap={1} marginLeft={2}>
         {field === 'name' ? (
           <>
-            <Text color={THEME.primary} bold>
+            <Text color={THEME.focus} bold>
               ▸
             </Text>
-            <Text color={THEME.primary}>{name}</Text>
+            <Text color={THEME.focus}>{name}</Text>
             <Text color={THEME.hint}>
               <Text color={THEME.keyword}>↑↓</Text> select · <Text color={THEME.keyword}>Enter</Text> edit ·{' '}
               <Text color={THEME.keyword}>Esc</Text> back
@@ -57,10 +57,10 @@ export function AssetFieldPicker({
       <Box gap={1} marginLeft={2}>
         {field === 'description' ? (
           <>
-            <Text color={THEME.primary} bold>
+            <Text color={THEME.focus} bold>
               ▸
             </Text>
-            <Text color={THEME.primary}>{description}</Text>
+            <Text color={THEME.focus}>{description}</Text>
             <Text color={THEME.hint}>
               <Text color={THEME.keyword}>↑↓</Text> select · <Text color={THEME.keyword}>Enter</Text> edit ·{' '}
               <Text color={THEME.keyword}>Esc</Text> back

--- a/packages/cli/src/tui/components/asset-inline-input.tsx
+++ b/packages/cli/src/tui/components/asset-inline-input.tsx
@@ -62,8 +62,8 @@ export function AssetInlineInput({
   )
 
   return (
-    <Box marginLeft={2} gap={1}>
-      <Text color={THEME.tertiary}>{'>'}</Text>
+    <Box gap={1}>
+      <Text color={THEME.tertiary}>{'  >'}</Text>
       <TextInput value={value} onChange={onChange} placeholder={placeholder} focus={isFocused} />
       {error ? (
         <Text color={THEME.warning}>· {error}</Text>

--- a/packages/cli/src/tui/components/asset-item.tsx
+++ b/packages/cli/src/tui/components/asset-item.tsx
@@ -3,12 +3,15 @@ import { THEME } from '../theme.ts'
 
 export function AssetItem({
   name,
+  bulletColor,
   isFocused,
   onEdit,
   onRemove,
 }: {
   id: string
   name: string
+  /** Color for the bullet dot when unfocused. */
+  bulletColor?: string
   isFocused: boolean
   onEdit: () => void
   onRemove: () => void
@@ -22,20 +25,21 @@ export function AssetItem({
   )
 
   return (
-    <Box gap={1} marginLeft={2}>
+    <Box gap={1}>
       {isFocused ? (
         <>
-          <Text color={THEME.primary} bold>
+          <Text color={THEME.focus} bold>
             ▸
           </Text>
-          <Text color={THEME.primary}>{name}</Text>
+          <Text color={THEME.focus}>{name}</Text>
           <Text color={THEME.hint}>
             <Text color={THEME.keyword}>Enter</Text> edit name · <Text color={THEME.keyword}>Del</Text> remove
           </Text>
         </>
       ) : (
         <>
-          <Text color={THEME.success}>•</Text>
+          <Text>{'  '}</Text>
+          <Text color={bulletColor ?? THEME.success}>•</Text>
           <Text>{name}</Text>
         </>
       )}

--- a/packages/cli/src/tui/components/asset-section.tsx
+++ b/packages/cli/src/tui/components/asset-section.tsx
@@ -1,9 +1,11 @@
+import { ASSET_TYPE_COLORS } from '@agent-facets/brand'
 import { Box, Text } from 'ink'
 import { useState } from 'react'
 import { useFocusMode } from '../context/focus-mode-context.ts'
 import { useFocusOrder } from '../context/focus-order-context.ts'
 import type { AssetSectionKey } from '../context/form-state-context.ts'
 import { useFormState } from '../context/form-state-context.ts'
+import { THEME } from '../theme.ts'
 import { AssetDescription, truncateDescription } from './asset-description.tsx'
 import type { AssetField } from './asset-field-picker.tsx'
 import { AssetFieldPicker } from './asset-field-picker.tsx'
@@ -33,6 +35,8 @@ export function AssetSection({
   const [inputValue, setInputValue] = useState('')
   const [error, setError] = useState('')
   const [selectedItem, setSelectedItem] = useState<string | null>(null)
+
+  const sectionHasFocus = focusedId === `add-${section}` || items.some((_, i) => focusedId === `item-${section}-${i}`)
 
   const startAdding = () => {
     setAssetAdding(section, true)
@@ -83,8 +87,12 @@ export function AssetSection({
 
   return (
     <Box flexDirection="column" gap={0}>
-      <Box gap={1}>
-        <Text bold dimColor={dimmed}>
+      <Box gap={1} marginLeft={2}>
+        <Text
+          bold={sectionHasFocus}
+          color={sectionHasFocus ? THEME.focus : undefined}
+          dimColor={dimmed && !sectionHasFocus}
+        >
           {label}
         </Text>
         {items.length === 0 && !adding && <Text dimColor>(none)</Text>}
@@ -147,6 +155,7 @@ export function AssetSection({
             <AssetItem
               id={itemId}
               name={item}
+              bulletColor={ASSET_TYPE_COLORS[section]}
               isFocused={isFocusedItem}
               onEdit={() => startEditing(item)}
               onRemove={() => handleRemove(item)}
@@ -173,18 +182,16 @@ export function AssetSection({
           onCancel={closeInput}
         />
       ) : (
-        <Box marginLeft={2}>
-          <Button
-            id={`add-${section}`}
-            label="+ Add"
-            hint={
-              <Text dimColor>
-                <Text>Enter</Text> to add
-              </Text>
-            }
-            onPress={startAdding}
-          />
-        </Box>
+        <Button
+          id={`add-${section}`}
+          label="+ Add"
+          hint={
+            <Text dimColor>
+              <Text>Enter</Text> to add
+            </Text>
+          }
+          onPress={startAdding}
+        />
       )}
     </Box>
   )

--- a/packages/cli/src/tui/components/button.tsx
+++ b/packages/cli/src/tui/components/button.tsx
@@ -82,7 +82,7 @@ export function Button({
 
   return (
     <Box gap={0}>
-      <Text color={isFocused ? (color ?? THEME.primary) : undefined} bold={isFocused}>
+      <Text color={isFocused ? (color ?? THEME.focus) : undefined} bold={isFocused}>
         {prefix}
         {label}
       </Text>

--- a/packages/cli/src/tui/components/editable-field.tsx
+++ b/packages/cli/src/tui/components/editable-field.tsx
@@ -122,8 +122,8 @@ export function EditableField({
 
   return (
     <Box flexDirection="column" gap={0}>
-      <Box gap={1}>
-        <Text color={isFocused ? THEME.primary : undefined} bold={isFocused} dimColor={dimmed && !isFocused}>
+      <Box gap={1} marginLeft={2}>
+        <Text color={isFocused ? THEME.focus : undefined} bold={isFocused} dimColor={dimmed && !isFocused}>
           {label}:
         </Text>
         {isEditing && error ? (
@@ -146,26 +146,35 @@ export function EditableField({
           <Text dimColor>(not set)</Text>
         ) : null}
       </Box>
-      <Box marginLeft={2}>
-        {isEditing ? (
-          <Box gap={1}>
-            <Text color={THEME.tertiary}>{'> '}</Text>
-            <TextInput value={value} onChange={(v) => setFieldValue(field, v)} placeholder={placeholder} focus />
-            <Text color={THEME.hint}>
-              · <Text color={THEME.keyword}>Enter</Text> to save
-            </Text>
-          </Box>
+      <Box>
+        {isFocused ? (
+          <Text color={THEME.focus} bold>
+            {'▸ '}
+          </Text>
         ) : (
-          <Box gap={1}>
-            <Text dimColor={dimmed && !isFocused}>{value || ' '}</Text>
-            {isFocused && value && (
-              <Text color={THEME.hint}>
-                · <Text color={THEME.keyword}>Enter</Text> to edit · <Text color={THEME.keyword}>c</Text> to clear and
-                edit
-              </Text>
-            )}
-          </Box>
+          <Text>{'  '}</Text>
         )}
+        <Box gap={1} marginLeft={2}>
+          {isEditing ? (
+            <Box gap={1}>
+              <Text color={THEME.tertiary}>{'> '}</Text>
+              <TextInput value={value} onChange={(v) => setFieldValue(field, v)} placeholder={placeholder} focus />
+              <Text color={THEME.hint}>
+                · <Text color={THEME.keyword}>Enter</Text> to save
+              </Text>
+            </Box>
+          ) : (
+            <Box gap={1}>
+              <Text dimColor={dimmed && !isFocused}>{value || ' '}</Text>
+              {isFocused && value && (
+                <Text color={THEME.hint}>
+                  · <Text color={THEME.keyword}>Enter</Text> to edit · <Text color={THEME.keyword}>c</Text> to clear and
+                  edit
+                </Text>
+              )}
+            </Box>
+          )}
+        </Box>
       </Box>
     </Box>
   )

--- a/packages/cli/src/tui/components/login-menu.tsx
+++ b/packages/cli/src/tui/components/login-menu.tsx
@@ -90,7 +90,7 @@ export function LoginMenu({ initialError, onSubmitToken, onCancel }: LoginMenuPr
         <Text>How would you like to sign in?</Text>
         <Box height={1} />
         <Box>
-          <Text color={THEME.primary}>▸ </Text>
+          <Text color={THEME.focus}>▸ </Text>
           <Text color={THEME.secondary}>● </Text>
           <Text>Paste a personal access token</Text>
         </Box>

--- a/packages/cli/src/tui/components/reconciliation-item.tsx
+++ b/packages/cli/src/tui/components/reconciliation-item.tsx
@@ -63,13 +63,13 @@ export function ReconciliationItemRow({
       <Box gap={2}>
         <Box gap={1}>
           {isFocused ? (
-            <Text color={THEME.primary} bold>
+            <Text color={THEME.focus} bold>
               ▸
             </Text>
           ) : (
             <Text> </Text>
           )}
-          <Text color={isFocused ? THEME.primary : undefined}>{description}</Text>
+          <Text color={isFocused ? THEME.focus : undefined}>{description}</Text>
         </Box>
 
         <Box gap={2}>

--- a/packages/cli/src/tui/components/select-prompt.tsx
+++ b/packages/cli/src/tui/components/select-prompt.tsx
@@ -96,7 +96,7 @@ function SelectRow({ label, focused }: { label: string; focused: boolean }) {
   const cursor = focused ? '▸' : ' '
   return (
     <Box>
-      <Text color={THEME.primary}>{cursor}</Text>
+      <Text color={THEME.focus}>{cursor}</Text>
       <Text> {label}</Text>
     </Box>
   )

--- a/packages/cli/src/tui/layouts/wizard-layout.tsx
+++ b/packages/cli/src/tui/layouts/wizard-layout.tsx
@@ -27,8 +27,8 @@ function AnimatedGradientText({ text }: { text: string }) {
 
 export function WizardLayout({ children }: { children: ReactNode }) {
   return (
-    <Box flexDirection="column" padding={1} gap={1}>
-      <Box borderStyle="round" borderColor={THEME.brand} paddingX={2} gap={1}>
+    <Box flexDirection="column">
+      <Box gap={1} marginBottom={1}>
         <Text bold color={THEME.brand}>
           Create a new
         </Text>

--- a/packages/cli/src/tui/views/create/confirm-view.tsx
+++ b/packages/cli/src/tui/views/create/confirm-view.tsx
@@ -1,19 +1,20 @@
+import { ASSET_TYPE_COLORS } from '@agent-facets/brand'
 import { type ScaffoldOptions as CreateOptions, previewScaffoldFiles } from '@agent-facets/engine'
 import { Box, Text } from 'ink'
 import { useEffect } from 'react'
+import { truncateDescription } from '../../components/asset-description.tsx'
 import { Button } from '../../components/button.tsx'
 import { useFocusOrder } from '../../context/focus-order-context.ts'
+import type { AssetSectionKey } from '../../context/form-state-context.ts'
+import { useFormState } from '../../context/form-state-context.ts'
 import { WizardLayout } from '../../layouts/wizard-layout.tsx'
 import { THEME } from '../../theme.ts'
 
-function SummaryField({ label, value }: { label: string; value: string }) {
-  return (
-    <Box gap={1}>
-      <Text color={THEME.success}>✓</Text>
-      <Text bold>{label}:</Text>
-      <Text>{value}</Text>
-    </Box>
-  )
+const ASSET_TYPES: AssetSectionKey[] = ['skill', 'command', 'agent']
+const ASSET_LABELS: Record<AssetSectionKey, string> = {
+  skill: 'Skills',
+  command: 'Commands',
+  agent: 'Agents',
 }
 
 export function ConfirmView({
@@ -26,6 +27,7 @@ export function ConfirmView({
   onBack: () => void
 }) {
   const files = previewScaffoldFiles(opts)
+  const { form } = useFormState()
   const { setFocusIds, focus, focusedId } = useFocusOrder()
 
   useEffect(() => {
@@ -35,21 +37,58 @@ export function ConfirmView({
 
   return (
     <WizardLayout>
-      <Box flexDirection="column" marginLeft={2}>
-        <SummaryField label="Name" value={opts.name} />
-        <SummaryField label="Description" value={opts.description} />
-        <SummaryField label="Version" value={opts.version} />
-        {opts.skills.length > 0 && <SummaryField label="Skills" value={opts.skills.join(', ')} />}
-        {opts.agents.length > 0 && <SummaryField label="Agents" value={opts.agents.join(', ')} />}
-        {opts.commands.length > 0 && <SummaryField label="Commands" value={opts.commands.join(', ')} />}
+      <Box flexDirection="column">
+        <Box gap={1}>
+          <Text bold>Name:</Text>
+          <Text>{form.fields.name.value || '(none)'}</Text>
+        </Box>
+        <Box gap={1}>
+          <Text bold>Description:</Text>
+          <Text>{truncateDescription(form.fields.description.value || '(none)')}</Text>
+        </Box>
+        <Box gap={1}>
+          <Text bold>Version:</Text>
+          <Text>{form.fields.version.value || '(none)'}</Text>
+        </Box>
       </Box>
 
-      <Box flexDirection="column" borderStyle="round" borderColor={THEME.success} paddingX={2} paddingY={1} gap={0}>
+      {ASSET_TYPES.map((type) => {
+        const section = form.assets[type]
+        return (
+          <Box key={type} flexDirection="column">
+            <Text bold>{ASSET_LABELS[type]}:</Text>
+            {section.items.length === 0 ? (
+              <Box marginLeft={2}>
+                <Text dimColor>(none)</Text>
+              </Box>
+            ) : (
+              section.items.map((item) => {
+                const desc = section.descriptions[item] ?? `A ${item} ${type}`
+                return (
+                  <Box key={item} flexDirection="column" marginLeft={2}>
+                    <Box gap={1}>
+                      <Text color={ASSET_TYPE_COLORS[type]}>●</Text>
+                      <Text>{item}</Text>
+                    </Box>
+                    <Box marginLeft={3}>
+                      <Text dimColor>{truncateDescription(desc)}</Text>
+                    </Box>
+                  </Box>
+                )
+              })
+            )}
+          </Box>
+        )
+      })}
+
+      <Box flexDirection="column" marginTop={1}>
         <Text bold color={THEME.success}>
           Files to create:
         </Text>
         {files.map((f) => (
-          <Text key={f}> {f}</Text>
+          <Box key={f} marginLeft={2}>
+            <Text color={THEME.hint}>{f}</Text>
+          </Box>
         ))}
       </Box>
 

--- a/packages/cli/src/tui/views/create/success-view.tsx
+++ b/packages/cli/src/tui/views/create/success-view.tsx
@@ -1,0 +1,22 @@
+import { Box, Text } from 'ink'
+import { THEME } from '../../theme.ts'
+
+export function CreateSuccessView({ name, files, buildArg }: { name: string; files: string[]; buildArg: string }) {
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color={THEME.success} bold>
+          {name} created.
+        </Text>
+      </Text>
+      <Box flexDirection="column" marginLeft={2}>
+        {files.map((f) => (
+          <Text key={f} color={THEME.hint}>
+            {f}
+          </Text>
+        ))}
+      </Box>
+      <Text color={THEME.hint}>Run "facet build{buildArg}" to validate your facet.</Text>
+    </Box>
+  )
+}

--- a/packages/cli/src/tui/views/create/wizard.tsx
+++ b/packages/cli/src/tui/views/create/wizard.tsx
@@ -9,6 +9,7 @@ import { useExitKeys } from '../../hooks/use-exit-keys.ts'
 import { useNavigationKeys } from '../../hooks/use-navigation-keys.ts'
 import { ConfirmView } from './confirm-view.tsx'
 import { CreateView } from './create-view.tsx'
+import { CreateSuccessView } from './success-view.tsx'
 
 export interface WizardSnapshot {
   form: FormState
@@ -23,23 +24,46 @@ export interface WizardSnapshot {
 export interface CreateWizardProps {
   onComplete: (opts: CreateOptions) => void
   onCancel: () => void
+  /** Write the scaffold to disk and return the list of created file paths. */
+  onScaffold?: (opts: CreateOptions) => Promise<string[]>
+  /** Argument suffix for the "facet build" hint (e.g. " my-dir" or ""). */
+  buildArg?: string
   snapshot?: WizardSnapshot
   onSnapshot?: (snapshot: WizardSnapshot) => void
   onRequestEditor?: (section: AssetSectionKey, name: string, description: string) => void
 }
 
-function CreateWizardInner({ onComplete, onCancel, snapshot, onSnapshot, onRequestEditor }: CreateWizardProps) {
+type Phase = 'editing' | 'confirming' | 'done'
+
+function CreateWizardInner({
+  onComplete,
+  onCancel,
+  onScaffold,
+  buildArg = '',
+  snapshot,
+  onSnapshot,
+  onRequestEditor,
+}: CreateWizardProps) {
   const { exit } = useApp()
   const { setMode } = useFocusMode()
   const { form, toCreateOptions } = useFormState()
   const { focusedId } = useFocusOrder()
 
-  const [confirming, setConfirming] = useState(false)
+  const [phase, setPhase] = useState<Phase>('editing')
+  const [doneFiles, setDoneFiles] = useState<string[]>([])
+  const [doneName, setDoneName] = useState('')
 
   // Keep the parent informed of current state for snapshot
   useEffect(() => {
     onSnapshot?.({ form, focusedId, selectedItem: snapshot?.selectedItem })
   }, [form, focusedId, onSnapshot, snapshot?.selectedItem])
+
+  // Defer exit so React paints the success view before Ink unmounts.
+  useEffect(() => {
+    if (phase === 'done') {
+      exit()
+    }
+  }, [phase, exit])
 
   const cancel = useCallback(() => {
     onCancel()
@@ -57,16 +81,30 @@ function CreateWizardInner({ onComplete, onCancel, snapshot, onSnapshot, onReque
     [form, onRequestEditor],
   )
 
-  if (confirming) {
+  const handleConfirm = useCallback(async () => {
+    const opts = toCreateOptions()
+    onComplete(opts)
+    if (onScaffold) {
+      const files = await onScaffold(opts)
+      setDoneName(opts.name)
+      setDoneFiles(files)
+      setPhase('done')
+    } else {
+      exit()
+    }
+  }, [toCreateOptions, onComplete, onScaffold, exit])
+
+  if (phase === 'done') {
+    return <CreateSuccessView name={doneName} files={doneFiles} buildArg={buildArg} />
+  }
+
+  if (phase === 'confirming') {
     return (
       <ConfirmView
         opts={toCreateOptions()}
-        onConfirm={() => {
-          onComplete(toCreateOptions())
-          exit()
-        }}
+        onConfirm={handleConfirm}
         onBack={() => {
-          setConfirming(false)
+          setPhase('editing')
           setMode('form-navigation')
         }}
       />
@@ -76,7 +114,7 @@ function CreateWizardInner({ onComplete, onCancel, snapshot, onSnapshot, onReque
   return (
     <CreateView
       onSubmit={() => {
-        setConfirming(true)
+        setPhase('confirming')
         setMode('form-confirmation')
       }}
       onEditDescription={handleEditDescription}

--- a/packages/cli/src/tui/views/edit/edit-confirm-view.tsx
+++ b/packages/cli/src/tui/views/edit/edit-confirm-view.tsx
@@ -1,3 +1,4 @@
+import { ASSET_TYPE_COLORS } from '@agent-facets/brand'
 import { Box, Text } from 'ink'
 import { useEffect } from 'react'
 import { truncateDescription } from '../../components/asset-description.tsx'
@@ -24,7 +25,7 @@ export function EditConfirmView({ onConfirm, onBack }: { onConfirm: () => void; 
   }, [setFocusIds, focus])
 
   return (
-    <Box flexDirection="column" padding={1} gap={1}>
+    <Box flexDirection="column">
       <Text bold color={THEME.brand}>
         Review changes
       </Text>
@@ -59,7 +60,7 @@ export function EditConfirmView({ onConfirm, onBack }: { onConfirm: () => void; 
                 return (
                   <Box key={item} flexDirection="column" marginLeft={2}>
                     <Box gap={1}>
-                      <Text color={THEME.success}>●</Text>
+                      <Text color={ASSET_TYPE_COLORS[type]}>●</Text>
                       <Text>{item}</Text>
                     </Box>
                     <Box marginLeft={3}>

--- a/packages/cli/src/tui/views/edit/edit-view.tsx
+++ b/packages/cli/src/tui/views/edit/edit-view.tsx
@@ -68,7 +68,7 @@ export function EditView({
   }, [focusedId, focus])
 
   return (
-    <Box flexDirection="column" padding={1} gap={1}>
+    <Box flexDirection="column">
       <Text bold color={THEME.brand}>
         Edit facet
       </Text>

--- a/packages/cli/src/tui/views/edit/reconciliation-view.tsx
+++ b/packages/cli/src/tui/views/edit/reconciliation-view.tsx
@@ -130,7 +130,7 @@ export function ReconciliationView({
   }
 
   return (
-    <Box flexDirection="column" padding={1} gap={1}>
+    <Box flexDirection="column">
       <Text bold color={THEME.brand}>
         Reconciliation — {items.length} item{items.length !== 1 ? 's' : ''} to resolve
       </Text>

--- a/packages/cli/src/tui/views/edit/success-view.tsx
+++ b/packages/cli/src/tui/views/edit/success-view.tsx
@@ -1,0 +1,26 @@
+import type { EditOperation } from '@agent-facets/engine'
+import { Box, Text } from 'ink'
+import { THEME } from '../../theme.ts'
+
+export function EditSuccessView({ operations, buildArg }: { operations: EditOperation[]; buildArg: string }) {
+  const scaffolded = operations.filter((op) => op.op === 'scaffold').length
+  const deleted = operations.filter((op) => op.op === 'delete-file').length
+  const parts: string[] = []
+  if (scaffolded > 0) parts.push(`${scaffolded} scaffolded`)
+  if (deleted > 0) parts.push(`${deleted} removed`)
+  parts.push('manifest updated')
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color={THEME.success} bold>
+          Changes applied.
+        </Text>
+      </Text>
+      <Box marginLeft={2}>
+        <Text color={THEME.hint}>{parts.join(' · ')}</Text>
+      </Box>
+      <Text color={THEME.hint}>Run "facet build{buildArg}" to validate your facet.</Text>
+    </Box>
+  )
+}

--- a/packages/cli/src/tui/views/edit/wizard.tsx
+++ b/packages/cli/src/tui/views/edit/wizard.tsx
@@ -1,4 +1,4 @@
-import type { EditContext, EditResult, ReconciliationResolution } from '@agent-facets/engine'
+import type { EditContext, EditOperation, EditResult, ReconciliationResolution } from '@agent-facets/engine'
 import { useApp } from 'ink'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FocusModeProvider, useFocusMode } from '../../context/focus-mode-context.ts'
@@ -11,9 +11,10 @@ import { EditConfirmView } from './edit-confirm-view.tsx'
 import { EditView } from './edit-view.tsx'
 import { manifestToFormState } from './manifest-to-form.ts'
 import { ReconciliationView } from './reconciliation-view.tsx'
+import { EditSuccessView } from './success-view.tsx'
 import { useEditSession } from './use-edit-session.ts'
 
-type EditPhase = 'reconciliation' | 'editing' | 'confirmation'
+type EditPhase = 'reconciliation' | 'editing' | 'confirmation' | 'done'
 
 export interface EditWizardSnapshot {
   phase: EditPhase
@@ -31,11 +32,23 @@ export interface EditWizardProps {
   context: EditContext
   snapshot?: EditWizardSnapshot
   onComplete: (result: EditResult) => void
+  /** Apply edit operations to disk. Called before the success view renders. */
+  onApply?: (result: EditResult & { outcome: 'applied' }) => Promise<void>
+  /** Argument suffix for the "facet build" hint (e.g. " my-dir" or ""). */
+  buildArg?: string
   onSnapshot?: (snapshot: EditWizardSnapshot) => void
   onRequestEditor?: (section: AssetSectionKey, name: string, description: string) => void
 }
 
-function EditWizardInner({ context, snapshot, onComplete, onSnapshot, onRequestEditor }: EditWizardProps) {
+function EditWizardInner({
+  context,
+  snapshot,
+  onComplete,
+  onApply,
+  buildArg = '',
+  onSnapshot,
+  onRequestEditor,
+}: EditWizardProps) {
   const { exit } = useApp()
   const { setMode } = useFocusMode()
   const { form } = useFormState()
@@ -44,12 +57,22 @@ function EditWizardInner({ context, snapshot, onComplete, onSnapshot, onRequestE
 
   const initialPhase = snapshot?.phase ?? (hasReconciliation ? 'reconciliation' : 'editing')
   const [phase, setPhase] = useState<EditPhase>(initialPhase)
+  const [doneOperations, setDoneOperations] = useState<EditOperation[]>([])
   const { resolutions, resolve, buildResult } = useEditSession(context)
 
   // Report snapshot to parent for editor round-trips
   useEffect(() => {
-    onSnapshot?.({ phase, formState: form, focusedId, resolutions })
+    if (phase !== 'done') {
+      onSnapshot?.({ phase, formState: form, focusedId, resolutions })
+    }
   }, [phase, form, focusedId, resolutions, onSnapshot])
+
+  // Defer exit so React paints the success view before Ink unmounts.
+  useEffect(() => {
+    if (phase === 'done') {
+      exit()
+    }
+  }, [phase, exit])
 
   const cancel = useCallback(() => {
     onComplete({ outcome: 'cancelled' })
@@ -67,10 +90,21 @@ function EditWizardInner({ context, snapshot, onComplete, onSnapshot, onRequestE
     [form, onRequestEditor],
   )
 
-  const handleConfirm = useCallback(() => {
-    onComplete(buildResult(form))
-    exit()
-  }, [form, buildResult, onComplete, exit])
+  const handleConfirm = useCallback(async () => {
+    const result = buildResult(form)
+    onComplete(result)
+    if (onApply && result.outcome === 'applied') {
+      await onApply(result)
+      setDoneOperations(result.operations)
+      setPhase('done')
+    } else {
+      exit()
+    }
+  }, [form, buildResult, onComplete, onApply, exit])
+
+  if (phase === 'done') {
+    return <EditSuccessView operations={doneOperations} buildArg={buildArg} />
+  }
 
   if (phase === 'reconciliation') {
     return (


### PR DESCRIPTION
### Why

The CLI's TUI wizards for `create` and `edit` had a few rough edges: success messaging was printed to stdout after the Ink UI unmounted, focused elements used the primary brand color instead of a distinct focus color, and layout padding was inconsistent across views.

### Details

**Focus color**: A new `focus` semantic token (`ACCENTS_DARK.pink`) has been added to the theme and applied consistently across all interactive components — cursors (`▸`), focused field labels, buttons, select rows, and asset items — replacing the previous use of `THEME.primary` for focus states.

**Success views**: Both the create and edit flows now render an Ink-based success view (`CreateSuccessView`, `EditSuccessView`) as the final wizard phase (`'done'`) before Ink exits, rather than printing to stdout after unmount. The scaffold/apply callbacks (`onScaffold`, `onApply`) are passed into the wizard components so the UI can own the full lifecycle including the completion message and the `facet build` hint.

**Wizard API**: `runCreateWizardInk` and `runEditWizardInk` now accept an options object with `onScaffold`/`onApply` callbacks and a `buildArg` string, and return a simple `boolean` (completed vs. cancelled) instead of the result object. The command-layer callers no longer need to handle the result shape or print anything themselves.

**Layout cleanup**: Removed `padding={1}` wrappers from several views and replaced them with explicit `marginLeft={2}` on individual elements for more consistent indentation. The wizard header border was removed in favour of a plain inline layout. Asset items and inline inputs received alignment fixes.

**Asset type colors**: The confirm views for both create and edit now use `ASSET_TYPE_COLORS` from `@agent-facets/brand` for asset bullet dots, matching the color coding used elsewhere.

**`viper-plans` fixture**: The `viper-plans` facet is now pinned to a registry version (`0.1.0`) instead of a git source, and its fixture files (commands, skills, `facet.json`) have been added to the repo.

### Verification

Manual testing of the `facet create` and `facet edit` flows, verifying the success view renders inside the Ink frame before exit and that the `facet build` hint appears correctly with and without a directory argument.