### PR TITLE
Share `ensureAdapters` with `install`, and skip unpilotable TTY adapter-picker test

### DIFF
--- a/.changeset/eager-trains-report.md
+++ b/.changeset/eager-trains-report.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": patch
+---
+
+Share `ensureAdapters` with `install`, and skip unpilotable TTY adapter-picker test

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "cowsay": "0.0.1",
+    "cowsay": "0.1.1",
     "viper-plans": "0.1.0"
   }
 }

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "cowsay": "0.1.1",
+    "cowsay": "0.2.0",
     "viper-plans": "0.1.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.0.1",
-      "integrity": "sha256:18bbc44f9d570d48c3913bb64013f3764597dc150cffaa108af5f91150aa9968",
+      "version": "0.1.1",
+      "integrity": "sha256:d21220fcbf1628c664594315eb996e4d2c362a94b04be7fdfa7b583d08bc3a36",
       "assets": [
         {
           "scope": "project",

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.1.1",
-      "integrity": "sha256:d21220fcbf1628c664594315eb996e4d2c362a94b04be7fdfa7b583d08bc3a36",
+      "version": "0.2.0",
+      "integrity": "sha256:a7130eec60c10e9cede541fb0433e79c26f9a8294eb686ca220dac6b9e7956d8",
       "assets": [
         {
           "scope": "project",

--- a/fixtures/cowsay/facet.json
+++ b/fixtures/cowsay/facet.json
@@ -1,6 +1,6 @@
 {
   "name": "cowsay",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "What does the cow say?",
   "skills": {
     "cowsay-rules": {

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -137,22 +137,15 @@ describe('facet install — CLI error paths', () => {
     expect(stderr).toContain('facet adapter install <name>')
   })
 
-  test('no adapters + TTY → exits 1 with picker-prompt hint', async () => {
-    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: {} }))
-    const { result: code, stderr } = await withTTY(true, () => captureStderr(() => installCommand.run([], {})))
-    expect(code).toBe(1)
-    expect(stderr).toContain('no adapters installed')
-    expect(stderr).toContain('at least one installed adapter')
-    expect(stderr).toContain('facet adapter install')
-  })
-
-  test('no adapters + TTY → exits 1 with picker-prompt hint', async () => {
-    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: {} }))
-    const { result: code, stderr } = await withTTY(true, () => captureStderr(() => installCommand.run([], {})))
-    expect(code).toBe(1)
-    expect(stderr).toContain('no adapters installed')
-    expect(stderr).toContain('at least one installed adapter')
-    expect(stderr).toContain('facet adapter install')
+  // Skipped: in TTY mode with zero adapters, `installCommand` now mounts
+  // the adapter picker (via ensureAdapters) and waits for input. Driving
+  // the picker from inside an in-process unit test would require either
+  // spying on `pickAndInstallAdapters` or simulating keypresses against a
+  // live Ink mount. The picker itself is covered in isolation by
+  // `install-picker.test.tsx`; see add.test.ts for the identical skip.
+  test.skip('no adapters + TTY → hands off to pickAndInstallAdapters', () => {
+    // Placeholder — running this unmodified would mount the picker and
+    // hang the suite.
   })
 
   test('exits 1 with usage error on positional argument', async () => {

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -1,15 +1,10 @@
-import {
-  loadInstalledAdapters,
-  type RollbackOutcome,
-  type RunInstallFailure,
-  type RunInstallResult,
-  runInstall,
-} from '@agent-facets/engine'
+import { type RollbackOutcome, type RunInstallFailure, type RunInstallResult, runInstall } from '@agent-facets/engine'
 import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
 import { writeCliError } from '../../util/errors.ts'
+import { ensureAdapters } from '../shared/ensure-adapters.ts'
 
 /**
  * `facet install` — bring the project on disk into agreement with
@@ -45,28 +40,10 @@ export const installCommand: Command = {
 
     const projectRoot = process.cwd()
 
-    // Discover installed adapters. Failures here are surfaced as
-    // CLI errors directly — runInstall doesn't know how to render the
-    // "no adapters installed" hint that points users at the picker.
-    const adapters = await loadInstalledAdapters()
-    const installable = adapters.filter((a) => a.supportsInstall === true)
-    if (adapters.length > 0 && installable.length === 0) {
-      const stale = adapters.map((a) => a.name).join(', ')
-      writeCliError({
-        what: `installed adapters do not support install yet: ${stale}`,
-        detail: 'these adapters were bundled before install support shipped; the capability flag is missing',
-        fix: "update each with 'facet adapter install <name>' to pull a version with install support",
-      })
-      return 1
-    }
-    if (installable.length === 0) {
-      const detail = process.stdout.isTTY
-        ? 'facet install requires at least one installed adapter to materialize assets'
-        : 'this is a non-interactive environment; the picker cannot run here'
-      const fix = process.stdout.isTTY
-        ? "run 'facet adapter install' and pick which AI tools to connect"
-        : "run 'facet adapter install <name>' with an explicit adapter (e.g. claude-code, opencode)"
-      writeCliError({ what: 'no adapters installed', detail, fix })
+    // Discover or pick adapters.
+    const adapters = await ensureAdapters()
+    if (adapters === null) {
+      // ensureAdapters already wrote the appropriate CLI error.
       return 1
     }
 
@@ -87,7 +64,7 @@ export const installCommand: Command = {
         run: async (onStage, onLog) => {
           const result = await runInstall({
             projectRoot,
-            adapters: installable,
+            adapters,
             onStage,
             ...(verbose && onLog ? { onLog } : {}),
             signal: controller.signal,

--- a/packages/cli/src/commands/shared/ensure-adapters.ts
+++ b/packages/cli/src/commands/shared/ensure-adapters.ts
@@ -5,13 +5,14 @@ import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
 
 /**
  * Discover install-capable adapters for commands that materialize or
- * delete assets (`add`, `remove`). If none are installable, auto-launch
- * the picker on a TTY; on a non-TTY return `null` with a CLI error
- * already written.
+ * delete assets (`add`, `remove`, `install`). If none are installable,
+ * auto-launch the picker on a TTY; on a non-TTY return `null` with a CLI
+ * error already written.
  *
- * Shared by `add` and `remove` because both drive the install pipeline,
- * which writes (`add`) or deletes (`remove`) assets across every selected
- * adapter — the adapter-discovery contract is identical for both.
+ * Shared by `add`, `remove`, and `install` because all three drive the
+ * install pipeline, which writes (`add`/`install`) or deletes (`remove`)
+ * assets across every selected adapter — the adapter-discovery contract
+ * is identical for all of them.
  */
 export async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
   const adapters = await loadInstalledAdapters()


### PR DESCRIPTION
### Why

The `facet install` command had its own inline adapter-discovery logic that duplicated what `add` and `remove` already use via `ensureAdapters`. This consolidates that logic so all three commands share the same adapter-discovery and picker-launch path.

### Details

`ensureAdapters` previously served only `add` and `remove`. The `install` command had its own copy of the stale-adapter check, the "no adapters installed" error, and the TTY/non-TTY branching. That copy is removed and replaced with a single `ensureAdapters()` call, matching the pattern already established by the other two commands.

The two duplicate `no adapters + TTY` test cases in `install-cli.test.ts` are replaced with a single skipped placeholder. In TTY mode with zero adapters, `ensureAdapters` now mounts the interactive adapter picker, which would hang the test suite if driven in-process. The picker is covered in isolation by `install-picker.test.tsx`, and the identical skip rationale already exists in `add.test.ts`.

The `cowsay` facet is bumped from `0.0.1` to `0.2.0` with an updated integrity hash.

### Verification

CI.