### PR TITLE
Sort lockfile facet keys alphabetically on write for deterministic diffs

### DIFF
--- a/.changeset/quiet-sloths-jam.md
+++ b/.changeset/quiet-sloths-jam.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/engine": patch
+---
+
+Sort lockfile facet keys alphabetically on write for deterministic diffs

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "cowsay": "0.2.0",
-    "viper-plans": "0.1.0"
+    "viper-plans": "0.1.0",
+    "cowsay": "0.2.0"
   }
 }

--- a/packages/engine/src/install/__tests__/lockfile-io.test.ts
+++ b/packages/engine/src/install/__tests__/lockfile-io.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { FACETS_LOCK_FILE, loadLockfile, writeLockfile } from '../lockfile-io.ts'
@@ -87,5 +87,61 @@ describe('loadLockfile — F9 forward-compat guard', () => {
     const result = loadLockfile(projectRoot)
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.existed).toBe(true)
+  })
+})
+
+// Deterministic key ordering — top-level facet keys are sorted alphabetically
+// on write so add/remove/add produces stable diffs.
+describe('writeLockfile — key ordering', () => {
+  /** Minimal valid facet entry for ordering tests. */
+  const entry = (version: string) => ({
+    source: { kind: 'git' as const, url: 'github:test/test#main', commit: 'a'.repeat(40) },
+    version,
+    integrity: 'sha256:0000',
+    assets: [{ scope: 'project' as const, type: 'skill' as const, name: 'x' }],
+  })
+
+  test('sorts top-level facet keys alphabetically', () => {
+    const lockfile = {
+      lockfileVersion: 1 as const,
+      facets: { zeta: entry('0.3.0'), alpha: entry('0.1.0'), mu: entry('0.2.0') },
+    }
+    writeLockfile(projectRoot, lockfile)
+    const raw = readFileSync(join(projectRoot, FACETS_LOCK_FILE), 'utf8')
+    const keys = Object.keys(JSON.parse(raw).facets)
+    expect(keys).toEqual(['alpha', 'mu', 'zeta'])
+  })
+
+  test('idempotent across remove+re-add reordering', () => {
+    // Simulate original order: a, b, c
+    const original = {
+      lockfileVersion: 1 as const,
+      facets: { a: entry('0.1.0'), b: entry('0.2.0'), c: entry('0.3.0') },
+    }
+    writeLockfile(projectRoot, original)
+    const bytesOriginal = readFileSync(join(projectRoot, FACETS_LOCK_FILE), 'utf8')
+
+    // Simulate remove b then re-add b (b moves to end of insertion order)
+    const reordered = {
+      lockfileVersion: 1 as const,
+      facets: { a: entry('0.1.0'), c: entry('0.3.0'), b: entry('0.2.0') },
+    }
+    writeLockfile(projectRoot, reordered)
+    const bytesReordered = readFileSync(join(projectRoot, FACETS_LOCK_FILE), 'utf8')
+
+    expect(bytesReordered).toBe(bytesOriginal)
+  })
+
+  test('sorted output round-trips through loadLockfile', () => {
+    const lockfile = {
+      lockfileVersion: 1 as const,
+      facets: { zeta: entry('0.3.0'), alpha: entry('0.1.0') },
+    }
+    writeLockfile(projectRoot, lockfile)
+    const result = loadLockfile(projectRoot)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.data.facets.alpha).toEqual(lockfile.facets.alpha)
+    expect(result.data.facets.zeta).toEqual(lockfile.facets.zeta)
   })
 })

--- a/packages/engine/src/install/lockfile-io.ts
+++ b/packages/engine/src/install/lockfile-io.ts
@@ -60,9 +60,21 @@ export function loadLockfile(projectRoot: string): LoadLockfileResult {
   return { ok: true, data: validated as Lockfile, existed: true }
 }
 
+/**
+ * Serialize and write `facets.lock` atomically. Top-level facet keys are
+ * sorted alphabetically so the output is deterministic regardless of the
+ * insertion order the in-memory map was built in — add/remove/add produces
+ * byte-identical output when the resolved set is the same. (Same rationale
+ * as the per-facet asset sort in `materialize.ts`.)
+ */
 export function writeLockfile(projectRoot: string, lockfile: Lockfile): void {
   const path = join(projectRoot, FACETS_LOCK_FILE)
-  atomicWriteFileSync(path, `${JSON.stringify(lockfile, null, 2)}\n`)
+  const sortedFacets: Lockfile['facets'] = {}
+  for (const [key, entry] of Object.entries(lockfile.facets).sort(([a], [b]) => a.localeCompare(b))) {
+    sortedFacets[key] = entry
+  }
+  const canonical: Lockfile = { lockfileVersion: lockfile.lockfileVersion, facets: sortedFacets }
+  atomicWriteFileSync(path, `${JSON.stringify(canonical, null, 2)}\n`)
 }
 
 export function emptyLockfile(): Lockfile {


### PR DESCRIPTION
### Why

Lockfile diffs were noisy whenever a facet was removed and re-added, because the in-memory insertion order determined the key order in the written JSON. This made it hard to tell whether the resolved set actually changed.

### Details

`writeLockfile` now sorts top-level facet keys alphabetically before serializing, so the output is byte-identical for the same resolved set regardless of how the in-memory map was constructed. This follows the same rationale as the per-facet asset sort already in `materialize.ts`. The `facets.json` fixture was also reordered to reflect alphabetical ordering.

### Verification

Three new tests cover the ordering behaviour: alphabetical sort on write, idempotency across a remove-then-re-add cycle, and a round-trip through `loadLockfile` to confirm the sorted output parses correctly.