### PR TITLE
Add `viper-continue` command, bump `viper-plans` to 0.2.0, and make tool calls optional with file-tool fallbacks

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "0.1.0",
+    "viper-plans": "0.2.0",
     "cowsay": "0.2.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -36,8 +36,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.1.0",
-      "integrity": "sha256:4033523b90d098adadf23ecc725b9c71ec4e334f04a6cb8ab7851ba247321526",
+      "version": "0.2.0",
+      "integrity": "sha256:343ff1fba77c66b934d89a5f544ecac2bcac9e15e57fa46885544a33c49bdcac",
       "assets": [
         {
           "scope": "project",
@@ -48,6 +48,11 @@
           "scope": "project",
           "type": "skill",
           "name": "viper-planning"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "viper-continue"
         },
         {
           "scope": "project",

--- a/fixtures/viper-plans/commands/viper-continue.md
+++ b/fixtures/viper-plans/commands/viper-continue.md
@@ -1,0 +1,69 @@
+Load the `viper-execution-rules` skill for guidance on the VIPER execution protocol.
+
+Plan name (if provided): $ARGUMENTS
+
+## Plan Detection
+
+Identify the plan to execute using these rules, in order:
+
+1. **Explicit argument**: If a plan name was provided as `$ARGUMENTS`, use it directly.
+
+2. **History detection** (express path): Look back through the conversation for an **unambiguous** signal that a plan was persisted **this session**. Accept either:
+   - A `viper-write-plan` **tool call** in the conversation history (it carries the exact plan name), OR
+   - An **assistant message** stating a plan was just persisted, naming it (e.g. a closing handoff message like "Plan saved as **<name>**").
+
+   Resolution:
+   - **Exactly one plan name found** → take the **express path** (continue to Express Execution below).
+   - **Multiple distinct plan names found**, OR a "persisted" message with **no resolvable plan name** (e.g. compaction dropped the tool call and the message is ambiguous) → **fail out**. Tell the user: "Multiple plans detected in this session — it's ambiguous which one to run. Please use `/viper-run` to select a plan, or pass a plan name: `/viper-continue <name>`." **Stop here.**
+
+3. **No signal at all** (fresh agent, no persisted plan in history) → fall through to the **Full Selection Fallback** below.
+
+## Express Execution
+
+The user just approved this plan — don't make them re-read it. Keep the gate minimal.
+
+1. **Load the plan**: Read `.opencode/plans/<name>/plan.md` fresh. If the `viper-read-plan` tool is available, use it. Otherwise, read the file directly with your file tools.
+
+2. **Count the steps**: Count the `### Step` headings in the plan content.
+
+3. **Single gate**: Tell the user which plan you found and how many steps it has, in one line. Then use the `question` tool with a short prompt:
+   - **Run it** — Begin execution
+   - **Show the full plan first** — Display the plan, then ask again
+   - **Cancel** — Do not execute
+
+4. **Execute**: On "Run it", follow the `viper-execution-rules` skill protocol:
+   - Create one TODO per step heading
+   - Execute steps in order following the VIPER protocol
+   - Gate Propose and Review steps on user approval/feedback
+   - Stop on Verify failures
+   - Enforce hard rules (Explore→Propose before Implement, Verify after Implement)
+
+## Full Selection Fallback
+
+No plan was detected in conversation history. Fall back to the full selection flow:
+
+1. **Discover plans**: If the `viper-list-plans` tool is available, use it. Otherwise, enumerate the subdirectories of `.opencode/plans/` with your file tools.
+
+2. **Select a plan**:
+   - If only one plan exists, auto-select it but confirm with the user using the `question` tool: "Found one plan: **<name>**. Review it?"
+   - If multiple plans exist, use the `question` tool to let the user select which plan to review and execute:
+      - Show the list of plan names for selection
+      - Allow only one selection
+   - If no plans exist, tell the user and suggest using `/viper-plan` to create one
+
+3. **Load the plan**: Read `.opencode/plans/<name>/plan.md` fully. If the `viper-read-plan` tool is available, use it. Otherwise, read the file directly.
+
+4. **Display the plan to the user**: Show the VIPER plan steps to the user
+
+5. **Confirm execution**:
+   - Use the `question` tool to ask the user to choose between: execute the plan, view the plan in full, or reject it
+   - If they choose to view the plan, show the full content and ask again
+   - If they reject the plan, stop execution and ask if they want to delete the plan file
+
+6. **Execute**: Follow the viper-execution-rules skill protocol (same as Express Execution step 4).
+
+## Cleanup
+
+Once complete, ask the user if they want to delete the plan with the `question` tool using a simple yes/no binary.
+
+If they answer yes: if the `viper-delete-plan` tool is available, use it. Otherwise, delete the `.opencode/plans/<name>/` directory directly with your file tools.

--- a/fixtures/viper-plans/commands/viper-plan.md
+++ b/fixtures/viper-plans/commands/viper-plan.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 3. Compose VIPER steps that match the shape of the change (not every change needs all 5 types)
 4. Display the plan to the user in full for review
 5. Use the `question` tool to ask the user to approve the plan before implementation. If they request changes, update the plan and ask again until approved.
-6. Once approved, persist the plan using the `viper-write-plan` tool
+6. Once approved, persist the plan: if the `viper-write-plan` tool is available, use it. Otherwise, create the directory `.opencode/plans/<name>/` and write the plan to `.opencode/plans/<name>/plan.md` directly with your file tools.
 7. Do not try to implement — planning and execution are separate concerns
 
-Tell the user they may use the `/viper-run` command to execute the newly created plan.
+Tell the user they may use `/viper-run` to select and execute any plan, or `/viper-continue` to immediately run the plan just created.

--- a/fixtures/viper-plans/commands/viper-run.md
+++ b/fixtures/viper-plans/commands/viper-run.md
@@ -4,7 +4,7 @@ Plan name (if provided): $ARGUMENTS
 
 ## Workflow
 
-1. **Discover plans**: Use the `viper-list-plans` tool to discover available plans
+1. **Discover plans**: If the `viper-list-plans` tool is available, use it. Otherwise, enumerate the subdirectories of `.opencode/plans/` with your file tools.
 
 2. **Select a plan**:
    - If a plan name was provided as an argument, use it (look for a plan directory with that name)
@@ -14,7 +14,7 @@ Plan name (if provided): $ARGUMENTS
       - Allow only one selection
    - If no plans exist, tell the user and suggest using `/viper-plan` to create one
 
-3. **Load the plan**: Read `.opencode/plans/<name>/plan.md` fully
+3. **Load the plan**: Read `.opencode/plans/<name>/plan.md` fully. If the `viper-read-plan` tool is available, use it. Otherwise, read the file directly with your file tools.
 
 4. **Display the plan to the user**: Show the VIPER plan steps to the user
 
@@ -35,4 +35,4 @@ Plan name (if provided): $ARGUMENTS
 
 Once complete, ask the user if they want to delete the plan with the `question` tool using a simple yes/no binary.
 
-If they answer yes, use the `viper-delete-plan` tool to remove the plan.
+If they answer yes: if the `viper-delete-plan` tool is available, use it. Otherwise, delete the `.opencode/plans/<name>/` directory directly with your file tools.

--- a/fixtures/viper-plans/facet.json
+++ b/fixtures/viper-plans/facet.json
@@ -1,6 +1,6 @@
 {
   "name": "viper-plans",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "VIPER planning and execution",
   "skills": {
     "viper-planning": {
@@ -16,6 +16,9 @@
     },
     "viper-run": {
       "description": "Execute a VIPER plan from .opencode/plans/"
+    },
+    "viper-continue": {
+      "description": "Continue execution of the most recently persisted VIPER plan"
     }
   }
 }

--- a/fixtures/viper-plans/skills/viper-execution-rules/SKILL.md
+++ b/fixtures/viper-plans/skills/viper-execution-rules/SKILL.md
@@ -48,12 +48,16 @@ Before executing ANY step, check its type prefix and follow the corresponding ru
 ### Propose Steps (READ-ONLY + USER GATE)
 
 1. Read the relevant files mentioned in the step
-2. Show the user the current code and your intended changes
-3. Use `mcp_question` to ask for explicit approval
-4. **DO NOT write, edit, or create ANY files during a Propose step**
-5. **DO NOT proceed to the next step until the user approves**
+2. **Present the full proposal as regular assistant output text** — include current code, intended changes, rationale, and any other details the user needs to make a decision. All of this goes in your message text, NOT in the `question` MCP tool.
+3. **After** presenting the proposal, use the `question` MCP tool with a short approval prompt. The question must be concise (e.g., "Do you approve this change?") with three options:
+   - **Approve** — Proceed with the proposed changes
+   - **Reject** — Do not make this change
+   - **Request changes** — The user will describe what to adjust (custom input)
+4. **NEVER put detailed explanations, code snippets, or rationale inside the `question` MCP tool options or descriptions.** The question tool is only for the approval gate — all substance goes in the assistant message above it.
+5. **DO NOT write, edit, or create ANY files during a Propose step**
+6. **DO NOT proceed to the next step until the user approves**
 
-If the user rejects or requests changes, revise the proposal and ask again.
+If the user requests changes, revise the proposal and present + ask again.
 
 ### Implement Steps (WRITE)
 
@@ -64,10 +68,13 @@ If the user rejects or requests changes, revise the proposal and ask again.
 ### Review Steps (READ-ONLY + USER GATE)
 
 1. Analyze what was done or found — read code, examine changes, assess quality
-2. Present your findings and analysis to the user
-3. Use `mcp_question` to ask for feedback before proceeding
-4. **DO NOT write, edit, or create ANY files during a Review step**
-5. **DO NOT proceed to the next step until the user responds**
+2. **Present your full findings and analysis as regular assistant output text.** Include all relevant details, code references, and observations in your message — NOT in the `question` MCP tool.
+3. **After** presenting your analysis, use the `question` MCP tool with a short feedback prompt. The question must be concise (e.g., "How would you like to proceed?") with options like:
+   - **Looks good, continue** — Proceed to the next step
+   - **I have concerns** — The user will describe their concerns (custom input)
+4. **NEVER put detailed findings, code snippets, or analysis inside the `question` MCP tool options or descriptions.** The question tool is only for the gate — all substance goes in the assistant message above it.
+5. **DO NOT write, edit, or create ANY files during a Review step**
+6. **DO NOT proceed to the next step until the user responds**
 
 If the user has concerns, address them before moving on.
 

--- a/fixtures/viper-plans/skills/viper-planning/SKILL.md
+++ b/fixtures/viper-plans/skills/viper-planning/SKILL.md
@@ -12,12 +12,14 @@ Every plan MUST include a Step Types legend at the top so the executor can refer
 - **Verify** → CHECK. Run automated checks (tests, lint, type checks).
   If all checks pass, proceed. If anything fails, STOP and notify the user.
 - **Implement** → WRITE. Make code changes — create, edit, or delete files.
-- **Propose** → READ-ONLY + USER GATE. Show the user intended changes and ask for approval
-  using the `question` tool. Do not write anything. Do not proceed until the user approves.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
 - **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
   No writes allowed. Use this to understand the problem space before acting.
-- **Review** → READ-ONLY + USER GATE. Analyze what was done or found, present findings
-  to the user, and wait for feedback before proceeding.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
 ```
 
 ## Hard Rules


### PR DESCRIPTION
### Why

The `viper-continue` command provides a fast path for immediately running a plan that was just created in the same session, without requiring the user to go through the full plan selection flow of `viper-run`.

### Details

**New `viper-continue` command** detects which plan to run using a priority order:
1. An explicit plan name passed as an argument
2. History detection — looks for a `viper-write-plan` tool call or an assistant message naming a persisted plan from the current session (express path)
3. Falls back to the full selection flow if no plan is detected in history

The express path skips re-displaying the full plan and instead presents a minimal single gate (plan name + step count), then proceeds directly to execution. Ambiguous history (multiple distinct plan names found) causes a hard stop with a clear error directing the user to `/viper-run` or to pass a name explicitly.

**Tool availability guards** were added across `viper-plan`, `viper-run`, and `viper-continue` so that commands fall back to direct file operations when MCP tools (`viper-write-plan`, `viper-read-plan`, `viper-list-plans`, `viper-delete-plan`) are not available. This makes the facet functional in environments without those tools registered.

**Propose and Review step instructions** in `viper-execution-rules` and `viper-planning` were clarified to enforce that all substantive content (code, rationale, findings) goes in the assistant message text, with the `question` tool used only as a concise approval/feedback gate. The allowed options for Propose steps are now explicitly `Approve / Reject / Request changes`.