### PR TITLE
Add `foo` facet, return written paths from `installAsset`/`deleteAsset`, introduce `OnLog` type, and emit verbose diagnostics throughout install pipeline

### DIFF
--- a/.changeset/eight-socks-hug.md
+++ b/.changeset/eight-socks-hug.md
@@ -1,0 +1,8 @@
+---
+"@agent-facets/adapter-claude-code": minor
+"@agent-facets/adapter-opencode": minor
+"@agent-facets/adapter": minor
+"agent-facets": minor
+---
+
+Added verbose logging and updated adapters to return asset install paths (for logging purposes)

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,7 @@
 {
   "facets": {
     "viper-plans": "0.2.0",
-    "cowsay": "0.2.0"
+    "cowsay": "0.2.0",
+    "foo": "0.0.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -31,6 +31,21 @@
         }
       ]
     },
+    "foo": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.facet.cafe"
+      },
+      "version": "0.0.0",
+      "integrity": "sha256:20771b24e69769d83758b275d8b1807b8f6675cae7fa5034ee40a17a5fca8089",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "foo"
+        }
+      ]
+    },
     "viper-plans": {
       "source": {
         "kind": "registry",

--- a/packages/adapter/src/__tests__/asset-fs.test.ts
+++ b/packages/adapter/src/__tests__/asset-fs.test.ts
@@ -117,7 +117,8 @@ describe('deleteAssetFile', () => {
   })
 
   test('is a no-op when the asset is absent', async () => {
-    await expect(deleteAssetFile({ file: join(workDir, 'missing.md') })).resolves.toBeUndefined()
+    const missingPath = join(workDir, 'missing.md')
+    await expect(deleteAssetFile({ file: missingPath })).resolves.toBe(missingPath)
   })
 })
 

--- a/packages/adapter/src/__tests__/index.test.ts
+++ b/packages/adapter/src/__tests__/index.test.ts
@@ -10,11 +10,15 @@ function validDefinition(): Adapter {
   return {
     name: 'test-adapter',
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
-    async installAsset() {},
+    async installAsset() {
+      return undefined
+    },
     async readAsset() {
       return { content: 'test' }
     },
-    async deleteAsset() {},
+    async deleteAsset() {
+      return undefined
+    },
   }
 }
 
@@ -79,11 +83,15 @@ describe('defineAdapter — returned adapter shape', () => {
           data: { defaulted: this.defaultValue },
         }
       },
-      async installAsset() {},
+      async installAsset() {
+        return undefined
+      },
       async readAsset() {
         return { content: 'test' }
       },
-      async deleteAsset() {},
+      async deleteAsset() {
+        return undefined
+      },
     }
     const adapter = defineAdapter(definition)
 
@@ -141,6 +149,7 @@ describe('defineAdapter — stub fallbacks for missing asset methods', () => {
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset() {
         installCalled = true
+        return undefined
       },
       async readAsset() {
         readCalled = true
@@ -148,6 +157,7 @@ describe('defineAdapter — stub fallbacks for missing asset methods', () => {
       },
       async deleteAsset() {
         deleteCalled = true
+        return undefined
       },
     })
 

--- a/packages/adapter/src/asset-fs.ts
+++ b/packages/adapter/src/asset-fs.ts
@@ -57,10 +57,11 @@ export async function installAssetFile(
   path: AssetPath,
   body: string,
   metadata?: Record<string, unknown>,
-): Promise<void> {
+): Promise<string> {
   await mkdir(dirname(path.file), { recursive: true })
   const combined = assembleAssetContent(body, metadata)
   await writeFile(path.file, combined, 'utf8')
+  return path.file
 }
 
 /**
@@ -78,9 +79,10 @@ export async function readAssetFile(path: AssetPath): Promise<{ content: string;
  * contract — see Adjustment B). Also removes any legacy `.meta.json`
  * sidecar left behind by earlier versions so upgrades reconverge cleanly.
  */
-export async function deleteAssetFile(path: AssetPath): Promise<void> {
+export async function deleteAssetFile(path: AssetPath): Promise<string> {
   await rm(path.file, { force: true })
   await rm(`${path.file}.meta.json`, { force: true })
+  return path.file
 }
 
 // --- front-matter helpers (exported for adapter-level customization) ---

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -33,14 +33,29 @@ export interface Adapter {
    */
   buildAssetMetadata(data: unknown): Validated<AdapterMetadata>
 
-  /** Install an asset at the given scope */
-  installAsset(scope: Scope, assetType: AssetType, name: string, content: string, metadata: unknown): Promise<void>
+  /**
+   * Install an asset at the given scope. Returns the absolute path the
+   * asset was written to, if available — used for verbose diagnostic
+   * logging. Returning `void` is backward-compatible (older adapters
+   * that don't return a path still satisfy the contract).
+   */
+  installAsset(
+    scope: Scope,
+    assetType: AssetType,
+    name: string,
+    content: string,
+    metadata: unknown,
+  ): Promise<string | undefined>
 
   /** Read an asset's content from the given scope */
   readAsset(scope: Scope, assetType: AssetType, name: string): Promise<{ content: string; metadata?: AdapterMetadata }>
 
-  /** Delete an asset from the given scope */
-  deleteAsset(scope: Scope, assetType: AssetType, name: string): Promise<void>
+  /**
+   * Delete an asset from the given scope. Returns the absolute path of
+   * the deleted asset, if available — used for verbose diagnostic
+   * logging. Returning `void` is backward-compatible.
+   */
+  deleteAsset(scope: Scope, assetType: AssetType, name: string): Promise<string | undefined>
 }
 
 // Re-export common types for convenience — SDK consumers don't need to install common

--- a/packages/adapters/claude-code/src/__tests__/adapter.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/adapter.test.ts
@@ -118,7 +118,7 @@ describe('claude-code adapter — project-scope I/O round-trip', () => {
   })
 
   test('deleteAsset is a no-op when asset is absent', async () => {
-    await expect(adapter.deleteAsset('project', 'skill', 'never-installed')).resolves.toBeUndefined()
+    await expect(adapter.deleteAsset('project', 'skill', 'never-installed')).resolves.toBeString()
   })
 
   test('installAsset overwrites unconditionally (idempotent by contract)', async () => {

--- a/packages/adapters/claude-code/src/index.ts
+++ b/packages/adapters/claude-code/src/index.ts
@@ -43,7 +43,7 @@ export default defineAdapter({
   },
 
   async installAsset(scope, assetType, name, content, metadata) {
-    await installAssetFile({ file: resolvePath(scope, assetType, name) }, content, metadata as Record<string, unknown>)
+    return installAssetFile({ file: resolvePath(scope, assetType, name) }, content, metadata as Record<string, unknown>)
   },
 
   async readAsset(scope, assetType, name) {
@@ -51,7 +51,7 @@ export default defineAdapter({
   },
 
   async deleteAsset(scope, assetType, name) {
-    await deleteAssetFile({ file: resolvePath(scope, assetType, name) })
+    return deleteAssetFile({ file: resolvePath(scope, assetType, name) })
   },
 })
 

--- a/packages/adapters/opencode/src/__tests__/adapter.test.ts
+++ b/packages/adapters/opencode/src/__tests__/adapter.test.ts
@@ -112,7 +112,7 @@ describe('opencode adapter — project-scope I/O round-trip', () => {
   })
 
   test('deleteAsset is a no-op when asset is absent', async () => {
-    await expect(adapter.deleteAsset('project', 'skill', 'never-installed')).resolves.toBeUndefined()
+    await expect(adapter.deleteAsset('project', 'skill', 'never-installed')).resolves.toBeString()
   })
 
   test('installAsset overwrites unconditionally (idempotent by contract)', async () => {

--- a/packages/adapters/opencode/src/index.ts
+++ b/packages/adapters/opencode/src/index.ts
@@ -42,7 +42,7 @@ export default defineAdapter({
   },
 
   async installAsset(scope, assetType, name, content, metadata) {
-    await installAssetFile({ file: resolvePath(scope, assetType, name) }, content, metadata as Record<string, unknown>)
+    return installAssetFile({ file: resolvePath(scope, assetType, name) }, content, metadata as Record<string, unknown>)
   },
 
   async readAsset(scope, assetType, name) {
@@ -50,7 +50,7 @@ export default defineAdapter({
   },
 
   async deleteAsset(scope, assetType, name) {
-    await deleteAssetFile({ file: resolvePath(scope, assetType, name) })
+    return deleteAssetFile({ file: resolvePath(scope, assetType, name) })
   },
 })
 

--- a/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
@@ -266,7 +266,7 @@ describe('facet adapter install — fast path from extracted npm tarball', () =>
       const result = await runCli(['adapter', 'install', extractedDir], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(0)
-      expect(result.stdout).toContain('Using prebuilt bundle...')
+      expect(result.stdout).toContain('using prebuilt bundle for')
       expect(result.stdout).toContain('Adapter "opencode" installed successfully.')
 
       // Adapter should be placed at <facetDir>/adapters/opencode/adapter.js
@@ -351,17 +351,17 @@ describe('facet adapter install — slow-path fallback after broken prebuilt', (
 
       expect(result.exitCode).toBe(0)
       // Fast path is attempted then rejected — both logs should appear
-      expect(result.stdout).toContain('Using prebuilt bundle...')
-      expect(result.stdout).toContain('Prebuilt bundle did not load cleanly')
-      expect(result.stdout).toContain('Rebundling from source')
+      expect(result.stdout).toContain('using prebuilt bundle for')
+      expect(result.stdout).toContain('did not load cleanly')
+      expect(result.stdout).toContain('rebundling from source')
       expect(result.stdout).toContain('Adapter "my-fallback-adapter" installed successfully.')
 
-      // No double resolution: `Using prebuilt bundle...` must appear exactly
-      // once. If the slow-path dispatch erroneously called bundleAdapter()
-      // (which re-runs resolveEntryPoint), a stale prebuilt could be picked
-      // again and we'd see the log twice. Guards against the regression
-      // described in the Cursor review for PR #142.
-      const prebuiltLogCount = (result.stdout.match(/Using prebuilt bundle\.\.\./g) ?? []).length
+      // No double resolution: the prebuilt log must appear exactly once. If
+      // the slow-path dispatch erroneously called bundleAdapter() (which
+      // re-runs resolveEntryPoint), a stale prebuilt could be picked again
+      // and we'd see the log twice. Guards against the regression described
+      // in the Cursor review for PR #142.
+      const prebuiltLogCount = (result.stdout.match(/using prebuilt bundle for/g) ?? []).length
       expect(prebuiltLogCount).toBe(1)
 
       const installedBundle = join(adaptersIn(facetDir), 'my-fallback-adapter', 'adapter.js')
@@ -396,9 +396,9 @@ describe('facet adapter install — externalized prebuilt (PR #142 P1 regression
       // The fast path is tried (the bundle looks OK from package.json's
       // POV) but isolated verification fails because `fixture-runtime-dep`
       // can't be resolved away from the source tree.
-      expect(result.stdout).toContain('Using prebuilt bundle...')
-      expect(result.stdout).toContain('Prebuilt bundle did not load cleanly')
-      expect(result.stdout).toContain('Rebundling from source')
+      expect(result.stdout).toContain('using prebuilt bundle for')
+      expect(result.stdout).toContain('did not load cleanly')
+      expect(result.stdout).toContain('rebundling from source')
       expect(result.stdout).toContain('Adapter "my-externalized-adapter" installed successfully.')
 
       // The placed bundle should be the rebundled (self-contained) output,

--- a/packages/engine/src/__tests__/build-pipeline.test.ts
+++ b/packages/engine/src/__tests__/build-pipeline.test.ts
@@ -139,11 +139,15 @@ describe('detectNamingCollisions', () => {
 const mockAdapter = defineAdapter({
   name: 'mock-adapter',
   buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
-  async installAsset() {},
+  async installAsset() {
+    return undefined
+  },
   async readAsset() {
     return { content: 'Your asset sir...' }
   },
-  async deleteAsset() {},
+  async deleteAsset() {
+    return undefined
+  },
 })
 
 /** A mock adapter that rejects all metadata */
@@ -153,11 +157,15 @@ const rejectingAdapter = defineAdapter({
     ok: false,
     errors: [{ path: 'tools', message: 'Invalid tools config', expected: 'Record<string, boolean>', actual: 'string' }],
   }),
-  async installAsset() {},
+  async installAsset() {
+    return undefined
+  },
   async readAsset() {
     return { content: 'Your asset sir...' }
   },
-  async deleteAsset() {},
+  async deleteAsset() {
+    return undefined
+  },
 })
 
 describe('validateAdapterMetadata', () => {
@@ -515,11 +523,15 @@ describe('runBuildPipeline', () => {
         enrichedData = { model: input.model ?? 'auto' }
         return { ok: true, data: enrichedData }
       },
-      async installAsset() {},
+      async installAsset() {
+        return undefined
+      },
       async readAsset() {
         return { content: 'Your asset sir...' }
       },
-      async deleteAsset() {},
+      async deleteAsset() {
+        return undefined
+      },
     })
 
     const result = await runBuildPipeline(dir, [defaultingAdapter])

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -107,7 +107,9 @@ function buildBadReadAdapter(name: string): Adapter {
       err.code = 'EACCES'
       throw err
     },
-    async deleteAsset() {},
+    async deleteAsset() {
+      return undefined
+    },
   } as Adapter
 }
 

--- a/packages/engine/src/adapters/install-service.ts
+++ b/packages/engine/src/adapters/install-service.ts
@@ -2,6 +2,7 @@ import { cp, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
+import type { OnLog } from '../install/types.ts'
 import { type CloneAdapterGitResult, cloneAdapterGitRepository } from '../sources/adapter/git.ts'
 import { type ResolveLocalAdapterResult, resolveLocalAdapterPath } from '../sources/adapter/local.ts'
 import { type DownloadNpmResult, downloadNpmPackage } from '../sources/adapter/npm.ts'
@@ -30,7 +31,7 @@ export interface AdapterInstallOptions {
    * reasons). Terminal mode prints these; the Ink picker can route them
    * into a `detail` slot under the running stage.
    */
-  onLog?: (line: string) => void
+  onLog?: OnLog
 }
 
 /**
@@ -186,17 +187,19 @@ const noopCleanup = async (): Promise<void> => {}
  */
 export async function locateAndVerifyAdapter(
   sourceDir: string,
-  opts: { onLog?: (line: string) => void } = {},
+  opts: { onLog?: OnLog } = {},
 ): Promise<{ bundlePath: string; adapter: Adapter; cleanup: () => Promise<void> }> {
   const resolved = await resolveEntryPoint(sourceDir)
 
   if (resolved.kind === 'prebuilt') {
-    opts.onLog?.('Using prebuilt bundle...')
+    opts.onLog?.(`[verbose]   using prebuilt bundle for ${basename(sourceDir)}`)
     const verifyResult = await verifyPrebuiltInIsolation(resolved.path)
     if (verifyResult.ok) {
       return { bundlePath: resolved.path, adapter: verifyResult.adapter, cleanup: noopCleanup }
     }
-    opts.onLog?.(`Prebuilt bundle did not load cleanly (${verifyResult.message}). Rebundling from source...`)
+    opts.onLog?.(
+      `[verbose]   prebuilt bundle for ${basename(sourceDir)} did not load cleanly (${verifyResult.message}); rebundling from source`,
+    )
     const sourceEntry = await resolveSourceEntry(sourceDir, resolved.path)
     const built = await rebundleAdapter(sourceDir, sourceEntry)
     const adapter = await verifyAdapter(built.bundlePath)

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -109,6 +109,7 @@ export type {
   InstallDelta,
   InstallSummary,
   LockfileDriftEntry,
+  OnLog,
   Removal,
   RollbackOutcome,
   RunInstallFailure,

--- a/packages/engine/src/install/add/index.ts
+++ b/packages/engine/src/install/add/index.ts
@@ -1,6 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import { runInstall } from '../run-install.ts'
-import type { RunInstallResult, StageEvent } from '../types.ts'
+import type { OnLog, RunInstallResult, StageEvent } from '../types.ts'
 import { type AddPrepareFailure, type AddSource, type PrepareAddResult, prepareAdd } from './prepare.ts'
 
 export type { AddPrepareFailure, AddSource, PrepareAddResult }
@@ -14,7 +14,7 @@ export interface RunAddOptions {
    *  name resolution and manifest loading (the expensive part). */
   prepared?: Extract<PrepareAddResult, { ok: true }>
   onStage?: (event: StageEvent) => void
-  onLog?: (line: string) => void
+  onLog?: OnLog
   signal?: AbortSignal
 }
 

--- a/packages/engine/src/install/add/prepare.ts
+++ b/packages/engine/src/install/add/prepare.ts
@@ -1,7 +1,7 @@
 import type { FacetsJson } from '@agent-facets/protocol'
 import { loadFacetsJson } from '../../manifest/project-files.ts'
 import type { Source } from '../../sources/facet/types.ts'
-import type { Addition } from '../types.ts'
+import type { Addition, OnLog } from '../types.ts'
 import { type ResolveNameFailure, resolveFacetName } from './resolve-name.ts'
 
 /**
@@ -39,7 +39,7 @@ export type PrepareAddResult =
 export async function prepareAdd(
   projectRoot: string,
   sources: ReadonlyArray<AddSource>,
-  onLog?: (line: string) => void,
+  onLog?: OnLog,
 ): Promise<PrepareAddResult> {
   // 1. Load the manifest (or note it doesn't exist yet).
   const loaded = loadFacetsJson(projectRoot)

--- a/packages/engine/src/install/add/resolve-name.ts
+++ b/packages/engine/src/install/add/resolve-name.ts
@@ -3,6 +3,7 @@ import { loadManifest } from '../../loaders/facet.ts'
 import { cloneFacetGitSource } from '../../sources/facet/resolve-git.ts'
 import { resolveLocalFacetSource } from '../../sources/facet/resolve-local.ts'
 import type { Source } from '../../sources/facet/types.ts'
+import type { OnLog } from '../types.ts'
 
 /**
  * Structured failure for facet name resolution. Tagged on `reason` so
@@ -31,11 +32,7 @@ export type ResolveNameResult = { ok: true; name: string } | { ok: false; failur
  * Composition (a facet that declares other facets) is rejected.
  * Never throws.
  */
-export async function resolveFacetName(
-  source: Source,
-  specifier: string,
-  onLog?: (line: string) => void,
-): Promise<ResolveNameResult> {
+export async function resolveFacetName(source: Source, specifier: string, onLog?: OnLog): Promise<ResolveNameResult> {
   if (source.kind === 'registry') {
     return { ok: true, name: source.name }
   }

--- a/packages/engine/src/install/commit/drift-removal.ts
+++ b/packages/engine/src/install/commit/drift-removal.ts
@@ -5,7 +5,7 @@ import { materialize } from '../materialize.ts'
 import { materializeFailureToRunInstall } from '../materialize-failure.ts'
 import type { Receipt } from '../receipt.ts'
 import { removalManifest } from '../removal-manifest.ts'
-import type { FacetOutcome, RunInstallFailure, StageEvent } from '../types.ts'
+import type { FacetOutcome, OnLog, RunInstallFailure, StageEvent } from '../types.ts'
 
 export interface DriftRemovalSuccess {
   /** One `removed` outcome per cleaned-up facet. */
@@ -23,7 +23,7 @@ export interface DriftRemovalArgs {
   journal: InstallJournal
   signal?: AbortSignal
   onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
+  onLog: OnLog
 }
 
 /**

--- a/packages/engine/src/install/commit/git-cache.ts
+++ b/packages/engine/src/install/commit/git-cache.ts
@@ -1,6 +1,6 @@
 import type { LockfileFacet } from '@agent-facets/protocol'
 import { auditCacheSlot, type CacheIdentity, cacheGet, evictCacheSlot, readCachedIntegrity } from '../../cache/index.ts'
-import type { RunInstallFailure } from '../types.ts'
+import type { OnLog, RunInstallFailure } from '../types.ts'
 
 /**
  * Outcome of an audited git cache lookup.
@@ -24,11 +24,7 @@ export type GitCacheLookup =
  * audit (tampered bytes, missing/invalid sidecar) evicts the slot and
  * degrades to a miss (re-clone).
  */
-export function auditedGitCacheLookup(
-  facetName: string,
-  effectiveLocked: LockfileFacet,
-  onLog: (line: string) => void,
-): GitCacheLookup {
+export function auditedGitCacheLookup(facetName: string, effectiveLocked: LockfileFacet, onLog: OnLog): GitCacheLookup {
   const cacheId: CacheIdentity = { kind: 'git', name: facetName, version: effectiveLocked.version }
   const lookup = cacheGet(cacheId)
   if (!lookup.hit) return { kind: 'miss' }

--- a/packages/engine/src/install/commit/install-loop.ts
+++ b/packages/engine/src/install/commit/install-loop.ts
@@ -4,7 +4,7 @@ import { classifyOutcome } from '../classify-outcome.ts'
 import type { InstallJournal } from '../journal.ts'
 import { materialize } from '../materialize.ts'
 import { materializeFailureToRunInstall } from '../materialize-failure.ts'
-import type { FacetOutcome, RunInstallFailure, StageEvent } from '../types.ts'
+import type { FacetOutcome, OnLog, RunInstallFailure, StageEvent } from '../types.ts'
 import { resolveFacet } from './resolve-facet.ts'
 
 export interface InstallLoopSuccess {
@@ -28,7 +28,7 @@ export interface InstallLoopArgs {
   journal: InstallJournal
   signal?: AbortSignal
   onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
+  onLog: OnLog
 }
 
 /**

--- a/packages/engine/src/install/commit/registry-support.ts
+++ b/packages/engine/src/install/commit/registry-support.ts
@@ -2,7 +2,7 @@ import type { VersionSpec } from '@agent-facets/protocol'
 import { resolveRegistryMetadataBatch } from '../../registry/index.ts'
 import type { RegistryError, RegistryMetadata } from '../../registry/types.ts'
 import type { MaterializeVersionResult } from '../materialize-version/index.ts'
-import type { RunInstallFailure, StageEvent } from '../types.ts'
+import type { OnLog, RunInstallFailure, StageEvent } from '../types.ts'
 
 /**
  * Fetch metadata for a single spec, normalizing the batch surface to a
@@ -13,7 +13,9 @@ export async function fetchMeta(
   name: string,
   version: VersionSpec,
   onStage: (event: StageEvent) => void,
+  onLog: OnLog,
 ): Promise<{ ok: true; value: RegistryMetadata } | { ok: false; error: RegistryError }> {
+  onLog(`[verbose]   fetching registry metadata for ${name}`)
   onStage({ kind: 'facet-stage', facet: name, stage: 'fetch' })
   const metaResult = await resolveRegistryMetadataBatch([{ name, version }])
   if (!metaResult.ok) return metaResult

--- a/packages/engine/src/install/commit/resolve-facet.ts
+++ b/packages/engine/src/install/commit/resolve-facet.ts
@@ -2,7 +2,7 @@ import type { Adapter } from '@agent-facets/adapter'
 import type { Lockfile } from '@agent-facets/protocol'
 import { parseFacetSource } from '../../sources/facet/parse-source.ts'
 import { parseVersionSpec } from '../../sources/facet/parse-version.ts'
-import type { StageEvent } from '../types.ts'
+import type { OnLog, StageEvent } from '../types.ts'
 import { resolveEffectiveLocked } from './effective-locked.ts'
 import { resolveGitFacet } from './resolve-git.ts'
 import { resolveLocalFacet } from './resolve-local.ts'
@@ -18,7 +18,7 @@ export interface ResolveFacetArgs {
   isExplicitAddition: boolean
   frozenLockfile: boolean
   onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
+  onLog: OnLog
 }
 
 /**

--- a/packages/engine/src/install/commit/resolve-git.ts
+++ b/packages/engine/src/install/commit/resolve-git.ts
@@ -9,7 +9,7 @@ import type { Source } from '../../sources/facet/types.ts'
 import { cloneFailureToRunInstall } from '../clone-failure.ts'
 import { computeAssetList } from '../materialize.ts'
 import { resolveCloneRef } from '../resolve-clone-ref.ts'
-import type { StageEvent } from '../types.ts'
+import type { OnLog, StageEvent } from '../types.ts'
 import { buildLockfileSource, loadFacetContent } from './finalize-facet.ts'
 import { auditedGitCacheLookup } from './git-cache.ts'
 import type { ResolveFacetResult } from './types.ts'
@@ -21,7 +21,7 @@ export interface ResolveGitFacetArgs {
   /** See `ResolveRegistryFacetArgs.effectiveLocked`. */
   effectiveLocked: LockfileFacet | undefined
   onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
+  onLog: OnLog
 }
 
 /**
@@ -151,6 +151,7 @@ export async function resolveGitFacet(args: ResolveGitFacetArgs): Promise<Resolv
       }
       sourceDir = putResult.path
       cleanup = undefined
+      onLog(`[verbose]   cached ${facetName}@${buildResult.data.version} from clone`)
 
       if (effectiveLocked !== undefined) {
         // The build just reproduced the locked integrity; the lockfile

--- a/packages/engine/src/install/commit/resolve-local.ts
+++ b/packages/engine/src/install/commit/resolve-local.ts
@@ -5,7 +5,7 @@ import { runBuildPipeline } from '../../build/pipeline.ts'
 import { resolveLocalFacetSource } from '../../sources/facet/resolve-local.ts'
 import type { Source } from '../../sources/facet/types.ts'
 import { computeAssetList } from '../materialize.ts'
-import type { StageEvent } from '../types.ts'
+import type { OnLog, StageEvent } from '../types.ts'
 import { buildLockfileSource, loadFacetContent } from './finalize-facet.ts'
 import type { ResolveFacetResult } from './types.ts'
 
@@ -26,7 +26,7 @@ export interface ResolveLocalFacetArgs {
    */
   frozenLockfile: boolean
   onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
+  onLog: OnLog
 }
 
 /**

--- a/packages/engine/src/install/commit/resolve-registry.ts
+++ b/packages/engine/src/install/commit/resolve-registry.ts
@@ -8,7 +8,7 @@ import { computeAssetList } from '../materialize.ts'
 import type { ConfirmingMiss, LockedMiss, MaterializeVersionInput } from '../materialize-version/index.ts'
 import { materializeVersion } from '../materialize-version/index.ts'
 import { parseLockedVersion } from '../parse-locked-version.ts'
-import type { StageEvent } from '../types.ts'
+import type { OnLog, StageEvent } from '../types.ts'
 import { loadFacetContent } from './finalize-facet.ts'
 import { chainFailureToRunInstall, fetchMeta } from './registry-support.ts'
 import type { ResolveFacetResult } from './types.ts'
@@ -26,7 +26,7 @@ export interface ResolveRegistryFacetArgs {
    */
   effectiveLocked: LockfileFacet | undefined
   onStage: (event: StageEvent) => void
-  onLog: (line: string) => void
+  onLog: OnLog
 }
 
 /**
@@ -76,19 +76,20 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
     // arrives here with `effectiveLocked === undefined` by the
     // structural discriminator): resolve fresh. Confirmation rides this
     // same response.
-    const metaResult = await fetchMeta(facetName, source.version, onStage)
+    const metaResult = await fetchMeta(facetName, source.version, onStage, onLog)
     if (!metaResult.ok) {
       return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: metaResult.error } }
     }
     meta = metaResult.value
     exactVersion = meta.version
+    onLog(`[verbose]   resolved ${facetName} ${describeVersionSpec(source.version)} → ${exactVersion}`)
   }
 
   // Lazily fetch (at most once) the metadata for the exact version —
   // needed for confirming-hit confirmation and for any download.
   const ensureMeta = async (): ReturnType<typeof fetchMeta> => {
     if (meta !== undefined) return { ok: true, value: meta }
-    const result = await fetchMeta(facetName, parseLockedVersion(exactVersion), onStage)
+    const result = await fetchMeta(facetName, parseLockedVersion(exactVersion), onStage, onLog)
     if (result.ok) meta = result.value
     return result
   }
@@ -153,6 +154,13 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
     input = missInput(m.value)
   }
 
+  // Log cache hit/miss for verbose diagnostics.
+  if (lookup.hit) {
+    onLog(`[verbose]   cache hit ${facetName}@${exactVersion}`)
+  } else {
+    onLog(`[verbose]   cache miss ${facetName}@${exactVersion}; downloading`)
+  }
+
   // 4. Run the chain; retry once as a miss after a tampered-slot evict.
   onStage({ kind: 'facet-stage', facet: facetName, stage: 'verify' })
   let result = await materializeVersion(input)
@@ -168,6 +176,9 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
     return { ok: false, failure: chainFailureToRunInstall(facetName, result) }
   }
   onLog(`[verbose]   materialized ${facetName}@${exactVersion} from ${result.slotPath}`)
+  if (!lookup.hit) {
+    onLog(`[verbose]   downloaded + cached ${facetName}@${exactVersion}`)
+  }
 
   // Finalize from the verified slot.
   const content = await loadFacetContent(facetName, result.slotPath, onStage)

--- a/packages/engine/src/install/commit/tri-write.ts
+++ b/packages/engine/src/install/commit/tri-write.ts
@@ -4,7 +4,7 @@ import type { FacetsJson, Lockfile, LockfileFacet } from '@agent-facets/protocol
 import { writeFacetsJson } from '../../manifest/project-files.ts'
 import { FACETS_LOCK_FILE, writeLockfile } from '../lockfile-io.ts'
 import { type Receipt, type ReceiptFacetEntry, receiptPath, writeReceipt } from '../receipt.ts'
-import type { RunInstallFailure } from '../types.ts'
+import type { OnLog, RunInstallFailure } from '../types.ts'
 
 /**
  * Derive the new receipt from the entries this run resolved. The
@@ -34,6 +34,7 @@ export interface TriWriteArgs {
   newLockfile: Lockfile
   newReceipt: Receipt
   frozenLockfile: boolean
+  onLog?: OnLog
 }
 
 /**
@@ -60,6 +61,7 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
   if (frozenLockfile) {
     try {
       writeReceipt(projectRoot, newReceipt)
+      args.onLog?.(`[verbose]   wrote receipt (${receiptPath(projectRoot)}) [frozen]`)
     } catch {
       // Non-fatal by design (see doc comment).
     }
@@ -102,6 +104,7 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
   for (const write of writes) {
     try {
       write.fn()
+      args.onLog?.(`[verbose]   wrote ${write.file} (${write.path})`)
     } catch (error) {
       for (const image of preImages) {
         restorePreImage(image)

--- a/packages/engine/src/install/journal.ts
+++ b/packages/engine/src/install/journal.ts
@@ -19,6 +19,8 @@
  * per Adjustment B).
  */
 
+import type { OnLog } from './types.ts'
+
 export interface JournalEntry {
   /** Human-readable label, surfaced through --verbose. */
   label: string
@@ -27,7 +29,7 @@ export interface JournalEntry {
 }
 
 export interface JournalRollbackOptions {
-  onLog?: (line: string) => void
+  onLog?: OnLog
 }
 
 export interface JournalRollbackResult {

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -2,7 +2,7 @@ import type { Adapter } from '@agent-facets/adapter'
 import { splitFrontMatter } from '@agent-facets/common'
 import type { LockfileAssetEntry, ResolvedFacetManifest } from '@agent-facets/protocol'
 import type { InstallJournal } from './journal.ts'
-import type { StageEvent } from './types.ts'
+import type { OnLog, StageEvent } from './types.ts'
 
 /**
  * Compute the NEW asset set a facet contributes at this version. Derived
@@ -59,7 +59,7 @@ export interface MaterializeOptions {
   oldAssets: readonly LockfileAssetEntry[]
   newAssets: readonly LockfileAssetEntry[]
   journal: InstallJournal
-  onLog?: (line: string) => void
+  onLog?: OnLog
   /** Structured progress events for view layers. */
   onStage?: (event: StageEvent) => void
 }
@@ -140,6 +140,8 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
       return { ok: false, failure: { kind: 'unsupported-adapter', adapter: adapter.name } }
     }
 
+    opts.onLog?.(`[verbose]   installing ${opts.facetName}@${opts.manifest.version} → ${adapter.name}`)
+
     for (const asset of opts.newAssets) {
       const content = contentFor(opts.manifest, asset)
       const metadata = buildAssetMetadata(opts.manifest, asset, adapter.name)
@@ -197,14 +199,16 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
         previous.content === candidateSplit.content &&
         JSON.stringify(previous.metadata ?? {}) === JSON.stringify(mergedCandidateMetadata)
       ) {
-        opts.onLog?.(`[verbose]   =${asset.type}:${asset.name} → ${adapter.name} (skipped)`)
+        opts.onLog?.(`[verbose]     =${asset.type}:${asset.name} (skipped)`)
         skipped++
         continue
       }
 
-      opts.onLog?.(`[verbose]   +${asset.type}:${asset.name} → ${adapter.name}`)
+      // Sigil: `+` new asset (didn't exist before), `~` repaired/updated (existed but changed)
+      const sigil = previous === null ? '+' : '~'
+      let writtenPath: string | undefined
       try {
-        await adapter.installAsset(asset.scope, asset.type, asset.name, content, metadata)
+        writtenPath = await adapter.installAsset(asset.scope, asset.type, asset.name, content, metadata)
       } catch (err) {
         return {
           ok: false,
@@ -216,6 +220,7 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
           },
         }
       }
+      opts.onLog?.(`[verbose]     ${sigil}${asset.type}:${asset.name}${writtenPath ? ` → ${writtenPath}` : ''}`)
       written++
 
       opts.journal.record({
@@ -250,9 +255,9 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
         previous = null
       }
 
-      opts.onLog?.(`[verbose]   -${asset.type}:${asset.name} → ${adapter.name}`)
+      let deletedPath: string | undefined
       try {
-        await adapter.deleteAsset(asset.scope, asset.type, asset.name)
+        deletedPath = await adapter.deleteAsset(asset.scope, asset.type, asset.name)
       } catch (err) {
         return {
           ok: false,
@@ -264,6 +269,7 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
           },
         }
       }
+      opts.onLog?.(`[verbose]     -${asset.type}:${asset.name}${deletedPath ? ` → ${deletedPath}` : ''}`)
       deleted++
 
       if (previous) {

--- a/packages/engine/src/install/remove/index.ts
+++ b/packages/engine/src/install/remove/index.ts
@@ -1,6 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import { runInstall } from '../run-install.ts'
-import type { Removal, RunInstallResult, StageEvent } from '../types.ts'
+import type { OnLog, Removal, RunInstallResult, StageEvent } from '../types.ts'
 import { prepareRemove, type RemovePrepareFailure, type RemovePrepareResult } from './prepare.ts'
 
 export type { RemovePrepareFailure, RemovePrepareResult }
@@ -14,7 +14,7 @@ export interface RunRemoveOptions {
   /** Pre-validated state from {@link prepareRemove}. */
   prepared?: Extract<RemovePrepareResult, { ok: true }>
   onStage?: (event: StageEvent) => void
-  onLog?: (line: string) => void
+  onLog?: OnLog
   signal?: AbortSignal
 }
 

--- a/packages/engine/src/install/run-install-support.ts
+++ b/packages/engine/src/install/run-install-support.ts
@@ -1,5 +1,5 @@
 import type { InstallJournal } from './journal.ts'
-import type { FacetOutcome, InstallSummary, RunInstallFailure, RunInstallResult } from './types.ts'
+import type { FacetOutcome, InstallSummary, OnLog, RunInstallFailure, RunInstallResult } from './types.ts'
 
 /** Aggregate per-facet outcomes into the post-install summary counts. */
 export function summarize(
@@ -26,7 +26,7 @@ export function summarize(
 export async function rollbackAndFail(
   journal: InstallJournal,
   failure: RunInstallFailure,
-  onLog: (line: string) => void,
+  onLog: OnLog,
 ): Promise<RunInstallResult> {
   const rollback = await journal.rollback({ onLog })
   return {

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -173,6 +173,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       newLockfile,
       newReceipt,
       frozenLockfile,
+      onLog,
     })
     if (!written.ok) {
       return await rollbackAndFail(journal, written.failure, onLog)

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -48,6 +48,19 @@ export interface InstallSummary {
 export type FacetStage = 'parse' | 'resolve' | 'fetch' | 'verify' | 'load' | 'build' | 'materialize'
 
 /**
+ * Verbose-log sink. Receives a single, fully-formatted line (the caller
+ * owns formatting — prefix, indentation, sigils). The CLI routes these to
+ * stderr under `--verbose`. Convention:
+ *
+ *   - prefix `[verbose] ` (diagnostics) or `[warn] ` (non-fatal)
+ *   - top-level operations: one space after prefix (`[verbose] …`)
+ *   - per-facet / per-asset detail: three spaces (`[verbose]   …`)
+ *   - asset sigils: `+` new / `~` repaired/updated / `-` deleted / `=` unchanged
+ *   - `→` (U+2192) separates source → destination
+ */
+export type OnLog = (line: string) => void
+
+/**
  * Structured progress event. View layers subscribe via the `onStage`
  * callback and render whatever subset they care about.
  */
@@ -338,7 +351,7 @@ export interface RunInstallOptions {
    *  `{ additions: [], removals: [] }` for a plain `facet install`. */
   delta?: InstallDelta
   onStage?: (event: StageEvent) => void
-  onLog?: (line: string) => void
+  onLog?: OnLog
   signal?: AbortSignal
   frozenLockfile?: boolean
 }


### PR DESCRIPTION
### Why

Verbose diagnostic logging during `facet install` was sparse and inconsistent, making it hard to trace exactly what the engine was doing — which registry requests were made, whether a cache was hit or missed, which files were written and where, and what happened during adapter installation.

### Details

`installAsset` and `deleteAsset` on the `Adapter` interface now return `Promise<string | undefined>` instead of `Promise<void>`. The returned string is the absolute path the asset was written to or deleted from, used to enrich verbose log lines. Returning `void` remains backward-compatible — older adapters that don't return a path still satisfy the contract. The `installAssetFile` and `deleteAssetFile` helpers in `asset-fs` now return the file path to support this.

A named `OnLog` type is introduced in `install/types.ts` and propagated throughout the engine in place of the inline `(line: string) => void` signature. The type carries a doc comment that establishes formatting conventions: `[verbose]` vs `[warn]` prefixes, indentation levels for top-level vs per-facet/per-asset detail, and asset sigils (`+` new, `~` repaired/updated, `-` deleted, `=` unchanged).

New log lines are emitted at key points in the install pipeline:
- Registry metadata fetches and version resolution
- Cache hits and misses, downloads, and post-clone caching
- Per-asset install and delete operations, including the written/deleted path when available
- Manifest file writes (lockfile, `facets.json`, receipt) including the frozen-lockfile path
- Adapter prebuilt bundle detection, verification failures, and rebundling

Log message casing and phrasing for adapter install messages is normalized to lowercase to match the new conventions, and tests are updated to match.

A `foo` facet fixture at `0.0.0` is added to `facets.json` and `facets.lock` for use in tests.

### Verification

CI — existing unit and e2e tests are updated to reflect the new return values and log message strings.