### PR TITLE
Make `OnLog` accept a lazy builder thunk, remove `foo` facet, and drop skipped TTY adapter-picker tests

### DIFF
--- a/.changeset/floppy-maps-chew.md
+++ b/.changeset/floppy-maps-chew.md
@@ -1,0 +1,6 @@
+---
+"agent-facets": patch
+"@agent-facets/engine": patch
+---
+
+Make `OnLog` accept a lazy builder thunk, remove `foo` facet, and drop skipped TTY adapter-picker tests

--- a/facets.json
+++ b/facets.json
@@ -1,7 +1,6 @@
 {
   "facets": {
     "viper-plans": "0.2.0",
-    "cowsay": "0.2.0",
-    "foo": "0.0.0"
+    "cowsay": "0.2.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -31,21 +31,6 @@
         }
       ]
     },
-    "foo": {
-      "source": {
-        "kind": "registry",
-        "registry": "https://api.facet.cafe"
-      },
-      "version": "0.0.0",
-      "integrity": "sha256:20771b24e69769d83758b275d8b1807b8f6675cae7fa5034ee40a17a5fca8089",
-      "assets": [
-        {
-          "scope": "project",
-          "type": "skill",
-          "name": "foo"
-        }
-      ]
-    },
     "viper-plans": {
       "source": {
         "kind": "registry",

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -39,7 +39,7 @@ function findContentFrame(frames: ReadonlyArray<string | undefined>): string {
 function makeFakeRun(
   events: ReadonlyArray<StageEvent>,
   result: RunInstallResult,
-): (onStage: (e: StageEvent) => void, onLog?: (line: string) => void) => Promise<RunInstallResult> {
+): (onStage: (e: StageEvent) => void, onLog?: (build: () => string) => void) => Promise<RunInstallResult> {
   return async (onStage, _onLog) => {
     for (const event of events) {
       onStage(event)

--- a/packages/cli/src/commands/adapter/index.ts
+++ b/packages/cli/src/commands/adapter/index.ts
@@ -71,7 +71,7 @@ async function handleInstall(args: string[]): Promise<number> {
           break
       }
     },
-    onLog: (line) => console.log(line),
+    onLog: (build) => console.log(build()),
   })
   if (!result.ok) {
     writeCliError(describeAdapterInstallFailure(result.failure))

--- a/packages/cli/src/commands/adapter/pick-and-install.ts
+++ b/packages/cli/src/commands/adapter/pick-and-install.ts
@@ -83,7 +83,7 @@ export async function pickAndInstallAdapters(): Promise<PickAndInstallResult> {
         else if (stage === 'downloading') console.log(`Downloading ${detail}...`)
         else if (stage === 'placing') console.log(`Installing adapter "${detail}"...`)
       },
-      onLog: (line) => console.log(line),
+      onLog: (build) => console.log(build()),
     })
     if (!result.ok) {
       writeCliError(describeAdapterInstallFailure(result.failure))

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -195,27 +195,6 @@ describe('facet add — error paths', () => {
     expect(code).toBe(1)
     expect(stderr).toContain('no adapters installed')
   })
-
-  // Skipped: in TTY mode with zero adapters, `addCommand` mounts the
-  // adapter picker and waits for input. Driving the picker from inside
-  // an in-process unit test would require either spying on
-  // `pickAndInstallAdapters` (the cleanest contract — assert the
-  // handoff happens) or simulating keypresses against a live Ink
-  // mount. The picker itself is covered in isolation by
-  // `install-picker.test.tsx`, so the marginal coverage here is "did
-  // we route to the picker". Capturing that properly requires module
-  // mocking infrastructure we don't currently have wired up — left as
-  // a deliberate skip with a follow-up note.
-  test.skip('no adapters + TTY → hands off to pickAndInstallAdapters', async () => {
-    const fixture = buildLocalFixture('viper-plans')
-    const rel = `./${fixture.split('/').pop()}`
-    await withTTY(true, async () => {
-      // TODO: spy on pickAndInstallAdapters and assert it was called.
-      // Until then, this test is intentionally skipped — running it
-      // unmodified would mount the picker and hang the suite.
-      await addCommand.run([rel], {})
-    })
-  })
 })
 
 describe('facet add — manifest snapshot rollback', () => {

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -137,17 +137,6 @@ describe('facet install — CLI error paths', () => {
     expect(stderr).toContain('facet adapter install <name>')
   })
 
-  // Skipped: in TTY mode with zero adapters, `installCommand` now mounts
-  // the adapter picker (via ensureAdapters) and waits for input. Driving
-  // the picker from inside an in-process unit test would require either
-  // spying on `pickAndInstallAdapters` or simulating keypresses against a
-  // live Ink mount. The picker itself is covered in isolation by
-  // `install-picker.test.tsx`; see add.test.ts for the identical skip.
-  test.skip('no adapters + TTY → hands off to pickAndInstallAdapters', () => {
-    // Placeholder — running this unmodified would mount the picker and
-    // hang the suite.
-  })
-
   test('exits 1 with usage error on positional argument', async () => {
     installFakeAdapter(adaptersDir, 'test-adapter')
     writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: {} }))

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -30,7 +30,7 @@ export interface InstallViewProps {
    * `onLog` into the engine call; the view routes it through Ink's
    * stderr writer so it doesn't race the progress bar repaint.
    */
-  run: (onStage: (event: StageEvent) => void, onLog?: (line: string) => void) => Promise<InstallViewResult>
+  run: (onStage: (event: StageEvent) => void, onLog?: (build: () => string) => void) => Promise<InstallViewResult>
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
    * renders "Installing facets..."; `'remove'` renders "Removing
@@ -174,8 +174,8 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
    * above the live region, on the stderr stream.
    */
   const onLog = useCallback(
-    (line: string) => {
-      writeToStderr(`${line}\n`)
+    (build: () => string) => {
+      writeToStderr(`${build()}\n`)
     },
     [writeToStderr],
   )

--- a/packages/engine/src/adapters/install-service.ts
+++ b/packages/engine/src/adapters/install-service.ts
@@ -192,13 +192,14 @@ export async function locateAndVerifyAdapter(
   const resolved = await resolveEntryPoint(sourceDir)
 
   if (resolved.kind === 'prebuilt') {
-    opts.onLog?.(`[verbose]   using prebuilt bundle for ${basename(sourceDir)}`)
+    opts.onLog?.(() => `[verbose]   using prebuilt bundle for ${basename(sourceDir)}`)
     const verifyResult = await verifyPrebuiltInIsolation(resolved.path)
     if (verifyResult.ok) {
       return { bundlePath: resolved.path, adapter: verifyResult.adapter, cleanup: noopCleanup }
     }
     opts.onLog?.(
-      `[verbose]   prebuilt bundle for ${basename(sourceDir)} did not load cleanly (${verifyResult.message}); rebundling from source`,
+      () =>
+        `[verbose]   prebuilt bundle for ${basename(sourceDir)} did not load cleanly (${verifyResult.message}); rebundling from source`,
     )
     const sourceEntry = await resolveSourceEntry(sourceDir, resolved.path)
     const built = await rebundleAdapter(sourceDir, sourceEntry)

--- a/packages/engine/src/install/__tests__/journal.test.ts
+++ b/packages/engine/src/install/__tests__/journal.test.ts
@@ -158,7 +158,7 @@ describe('InstallJournal — onLog observability', () => {
     journal.record({ label: 'install foo', undo: async () => {} })
     journal.record({ label: 'install bar', undo: async () => {} })
 
-    await journal.rollback({ onLog: (line) => lines.push(line) })
+    await journal.rollback({ onLog: (build) => lines.push(build()) })
 
     // LIFO so `bar` first, `foo` second.
     expect(lines).toEqual(['[verbose] undo install bar', '[verbose] undo install foo'])
@@ -174,7 +174,7 @@ describe('InstallJournal — onLog observability', () => {
       },
     })
 
-    await journal.rollback({ onLog: (line) => lines.push(line) })
+    await journal.rollback({ onLog: (build) => lines.push(build()) })
 
     expect(lines).toHaveLength(1)
     expect(lines[0]).toContain('undo FAILED install foo')

--- a/packages/engine/src/install/add/resolve-name.ts
+++ b/packages/engine/src/install/add/resolve-name.ts
@@ -83,7 +83,7 @@ export async function resolveFacetName(source: Source, specifier: string, onLog?
     if (manifest.data.facets && manifest.data.facets.length > 0) {
       return { ok: false, failure: { reason: 'composition-rejected', specifier } }
     }
-    onLog?.(`[verbose]   resolved name "${manifest.data.name}" from ${specifier}`)
+    onLog?.(() => `[verbose]   resolved name "${manifest.data.name}" from ${specifier}`)
     return { ok: true, name: manifest.data.name }
   } finally {
     if (cleanup) await cleanup()

--- a/packages/engine/src/install/commit/git-cache.ts
+++ b/packages/engine/src/install/commit/git-cache.ts
@@ -34,14 +34,14 @@ export function auditedGitCacheLookup(facetName: string, effectiveLocked: Lockfi
     // Missing/invalid sidecar — the slot cannot be audited, so it
     // cannot be used. Evict and re-clone (soft miss).
     evictCacheSlot(lookup.path)
-    onLog(`[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; evicted, recloning`)
+    onLog(() => `[verbose]   cache slot ${lookup.path} has no valid integrity sidecar; evicted, recloning`)
     return { kind: 'miss' }
   }
 
   const audit = auditCacheSlot(lookup.path, sidecar)
   if (!audit.ok) {
     evictCacheSlot(lookup.path)
-    onLog(`[verbose]   cache slot ${lookup.path} failed its self-audit; evicted, recloning`)
+    onLog(() => `[verbose]   cache slot ${lookup.path} failed its self-audit; evicted, recloning`)
     return { kind: 'miss' }
   }
 
@@ -61,6 +61,6 @@ export function auditedGitCacheLookup(facetName: string, effectiveLocked: Lockfi
     }
   }
 
-  onLog(`[verbose]   cache hit ${lookup.path} (audited)`)
+  onLog(() => `[verbose]   cache hit ${lookup.path} (audited)`)
   return { kind: 'hit', slotPath: lookup.path }
 }

--- a/packages/engine/src/install/commit/registry-support.ts
+++ b/packages/engine/src/install/commit/registry-support.ts
@@ -15,7 +15,7 @@ export async function fetchMeta(
   onStage: (event: StageEvent) => void,
   onLog: OnLog,
 ): Promise<{ ok: true; value: RegistryMetadata } | { ok: false; error: RegistryError }> {
-  onLog(`[verbose]   fetching registry metadata for ${name}`)
+  onLog(() => `[verbose]   fetching registry metadata for ${name}`)
   onStage({ kind: 'facet-stage', facet: name, stage: 'fetch' })
   const metaResult = await resolveRegistryMetadataBatch([{ name, version }])
   if (!metaResult.ok) return metaResult

--- a/packages/engine/src/install/commit/resolve-git.ts
+++ b/packages/engine/src/install/commit/resolve-git.ts
@@ -87,7 +87,7 @@ export async function resolveGitFacet(args: ResolveGitFacetArgs): Promise<Resolv
       await rm(cloned.dir, { recursive: true, force: true }).catch(() => {})
     }
     clonedCommit = cloned.commit
-    onLog(`[verbose]   cloned ${source.url} → ${sourceDir} (sha: ${cloned.commit})`)
+    onLog(() => `[verbose]   cloned ${source.url} → ${sourceDir} (sha: ${cloned.commit})`)
   }
 
   try {
@@ -151,7 +151,7 @@ export async function resolveGitFacet(args: ResolveGitFacetArgs): Promise<Resolv
       }
       sourceDir = putResult.path
       cleanup = undefined
-      onLog(`[verbose]   cached ${facetName}@${buildResult.data.version} from clone`)
+      onLog(() => `[verbose]   cached ${facetName}@${buildResult.data.version} from clone`)
 
       if (effectiveLocked !== undefined) {
         // The build just reproduced the locked integrity; the lockfile

--- a/packages/engine/src/install/commit/resolve-registry.ts
+++ b/packages/engine/src/install/commit/resolve-registry.ts
@@ -82,7 +82,7 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
     }
     meta = metaResult.value
     exactVersion = meta.version
-    onLog(`[verbose]   resolved ${facetName} ${describeVersionSpec(source.version)} → ${exactVersion}`)
+    onLog(() => `[verbose]   resolved ${facetName} ${describeVersionSpec(source.version)} → ${exactVersion}`)
   }
 
   // Lazily fetch (at most once) the metadata for the exact version —
@@ -156,16 +156,16 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
 
   // Log cache hit/miss for verbose diagnostics.
   if (lookup.hit) {
-    onLog(`[verbose]   cache hit ${facetName}@${exactVersion}`)
+    onLog(() => `[verbose]   cache hit ${facetName}@${exactVersion}`)
   } else {
-    onLog(`[verbose]   cache miss ${facetName}@${exactVersion}; downloading`)
+    onLog(() => `[verbose]   cache miss ${facetName}@${exactVersion}; downloading`)
   }
 
   // 4. Run the chain; retry once as a miss after a tampered-slot evict.
   onStage({ kind: 'facet-stage', facet: facetName, stage: 'verify' })
   let result = await materializeVersion(input)
   if (!result.ok && result.code === 'cache-tampered') {
-    onLog(`[verbose]   cache slot for ${facetName}@${exactVersion} failed its self-audit; evicted, refetching`)
+    onLog(() => `[verbose]   cache slot for ${facetName}@${exactVersion} failed its self-audit; evicted, refetching`)
     const m = await ensureMeta()
     if (!m.ok) {
       return { ok: false, failure: { code: 'REGISTRY_ERROR', facet: facetName, error: m.error } }
@@ -175,9 +175,9 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
   if (!result.ok) {
     return { ok: false, failure: chainFailureToRunInstall(facetName, result) }
   }
-  onLog(`[verbose]   materialized ${facetName}@${exactVersion} from ${result.slotPath}`)
+  onLog(() => `[verbose]   materialized ${facetName}@${exactVersion} from ${result.slotPath}`)
   if (!lookup.hit) {
-    onLog(`[verbose]   downloaded + cached ${facetName}@${exactVersion}`)
+    onLog(() => `[verbose]   downloaded + cached ${facetName}@${exactVersion}`)
   }
 
   // Finalize from the verified slot.

--- a/packages/engine/src/install/commit/tri-write.ts
+++ b/packages/engine/src/install/commit/tri-write.ts
@@ -61,7 +61,7 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
   if (frozenLockfile) {
     try {
       writeReceipt(projectRoot, newReceipt)
-      args.onLog?.(`[verbose]   wrote receipt (${receiptPath(projectRoot)}) [frozen]`)
+      args.onLog?.(() => `[verbose]   wrote receipt (${receiptPath(projectRoot)}) [frozen]`)
     } catch {
       // Non-fatal by design (see doc comment).
     }
@@ -104,7 +104,7 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
   for (const write of writes) {
     try {
       write.fn()
-      args.onLog?.(`[verbose]   wrote ${write.file} (${write.path})`)
+      args.onLog?.(() => `[verbose]   wrote ${write.file} (${write.path})`)
     } catch (error) {
       for (const image of preImages) {
         restorePreImage(image)

--- a/packages/engine/src/install/journal.ts
+++ b/packages/engine/src/install/journal.ts
@@ -66,10 +66,10 @@ export class InstallJournal {
       try {
         await entry.undo()
         entriesUndone++
-        opts.onLog?.(`[verbose] undo ${entry.label}`)
+        opts.onLog?.(() => `[verbose] undo ${entry.label}`)
       } catch (err) {
         failures++
-        opts.onLog?.(`[verbose] undo FAILED ${entry.label}: ${err instanceof Error ? err.message : String(err)}`)
+        opts.onLog?.(() => `[verbose] undo FAILED ${entry.label}: ${err instanceof Error ? err.message : String(err)}`)
       }
     }
     return { ok: failures === 0, failures, entriesUndone }

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -140,7 +140,7 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
       return { ok: false, failure: { kind: 'unsupported-adapter', adapter: adapter.name } }
     }
 
-    opts.onLog?.(`[verbose]   installing ${opts.facetName}@${opts.manifest.version} → ${adapter.name}`)
+    opts.onLog?.(() => `[verbose]   installing ${opts.facetName}@${opts.manifest.version} → ${adapter.name}`)
 
     for (const asset of opts.newAssets) {
       const content = contentFor(opts.manifest, asset)
@@ -199,7 +199,7 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
         previous.content === candidateSplit.content &&
         JSON.stringify(previous.metadata ?? {}) === JSON.stringify(mergedCandidateMetadata)
       ) {
-        opts.onLog?.(`[verbose]     =${asset.type}:${asset.name} (skipped)`)
+        opts.onLog?.(() => `[verbose]     =${asset.type}:${asset.name} (skipped)`)
         skipped++
         continue
       }
@@ -220,7 +220,7 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
           },
         }
       }
-      opts.onLog?.(`[verbose]     ${sigil}${asset.type}:${asset.name}${writtenPath ? ` → ${writtenPath}` : ''}`)
+      opts.onLog?.(() => `[verbose]     ${sigil}${asset.type}:${asset.name}${writtenPath ? ` → ${writtenPath}` : ''}`)
       written++
 
       opts.journal.record({
@@ -269,7 +269,7 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
           },
         }
       }
-      opts.onLog?.(`[verbose]     -${asset.type}:${asset.name}${deletedPath ? ` → ${deletedPath}` : ''}`)
+      opts.onLog?.(() => `[verbose]     -${asset.type}:${asset.name}${deletedPath ? ` → ${deletedPath}` : ''}`)
       deleted++
 
       if (previous) {

--- a/packages/engine/src/install/remove/index.ts
+++ b/packages/engine/src/install/remove/index.ts
@@ -55,7 +55,7 @@ export async function runRemove(opts: RunRemoveOptions): Promise<RunRemoveResult
   const filteredNames = prep.names
 
   for (const name of filteredNames) {
-    onLog?.(`[verbose]   removing "${name}"`)
+    onLog?.(() => `[verbose]   removing "${name}"`)
   }
 
   const removals: Removal[] = filteredNames.map((name) => ({ facetName: name }))

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -85,7 +85,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     const receipt: Receipt = receiptResult.ok ? receiptResult.receipt : bootstrapReceipt(projectRoot, previousLockfile)
     if (receiptResult.ok) {
       for (const invalid of receiptResult.invalidEntries) {
-        onLog(`[warn] receipt asset entry rejected for ${invalid.facet}: "${invalid.asset}" (${invalid.reason})`)
+        onLog(() => `[warn] receipt asset entry rejected for ${invalid.facet}: "${invalid.asset}" (${invalid.reason})`)
         onStage({ kind: 'receipt-invalid-asset', ...invalid })
       }
     }
@@ -196,7 +196,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
   }
 
   function noopStage(_event: StageEvent): void {}
-  function noopLog(_line: string): void {}
+  function noopLog(_build: () => string): void {}
 
   /**
    * Failure path that runs before the install lock has been released

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -48,9 +48,12 @@ export interface InstallSummary {
 export type FacetStage = 'parse' | 'resolve' | 'fetch' | 'verify' | 'load' | 'build' | 'materialize'
 
 /**
- * Verbose-log sink. Receives a single, fully-formatted line (the caller
- * owns formatting — prefix, indentation, sigils). The CLI routes these to
- * stderr under `--verbose`. Convention:
+ * Verbose-log sink. Accepts a lazy builder (thunk) that produces a single,
+ * fully-formatted line. The thunk is only invoked when the sink is active,
+ * so template interpolation and conditional concatenation are skipped
+ * entirely when `--verbose` is off and `onLog` is undefined.
+ *
+ * The builder should return a line following these conventions:
  *
  *   - prefix `[verbose] ` (diagnostics) or `[warn] ` (non-fatal)
  *   - top-level operations: one space after prefix (`[verbose] …`)
@@ -58,7 +61,7 @@ export type FacetStage = 'parse' | 'resolve' | 'fetch' | 'verify' | 'load' | 'bu
  *   - asset sigils: `+` new / `~` repaired/updated / `-` deleted / `=` unchanged
  *   - `→` (U+2192) separates source → destination
  */
-export type OnLog = (line: string) => void
+export type OnLog = (build: () => string) => void
 
 /**
  * Structured progress event. View layers subscribe via the `onStage`


### PR DESCRIPTION
### Why

Verbose log messages were being eagerly interpolated even when `--verbose` is off and `onLog` is `undefined`. For installs with many facets, this means string formatting work was happening unconditionally on every log call, even when the output would never be used.

### Details

`OnLog` has been changed from `(line: string) => void` to `(build: () => string) => void`. All call sites now pass a thunk (arrow function returning the formatted string) instead of a pre-built string. The thunk is only invoked inside the sink, so template literal interpolation and string concatenation are skipped entirely when the caller has not provided an `onLog` handler.

The `foo` facet has also been removed from `facets.json` and `facets.lock`.

Skipped placeholder tests that had no meaningful assertions and would have hung the test suite by mounting the interactive adapter picker were removed.

### Verification

CI — existing tests have been updated to call `build()` inside their captured `onLog` callbacks, preserving the same observable behavior.