### PR TITLE
Bump `bun` to 1.3.14

### DIFF
--- a/.changeset/big-numbers-boil.md
+++ b/.changeset/big-numbers-boil.md
@@ -1,0 +1,11 @@
+---
+"@agent-facets/adapter": patch
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+"@agent-facets/protocol": patch
+---
+
+Upgraded bun from 1.3.13 to 1.3.14

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@fission-ai/openspec": "1.3.1",
         "@octokit/auth-app": "8.2.0",
         "@types/aws-lambda": "8.10.161",
-        "@types/bun": "1.3.13",
+        "@types/bun": "1.3.14",
         "@types/node": "24.12.4",
         "dedent": "1.7.2",
         "mint": "4.2.588",
@@ -787,7 +787,7 @@
 
     "@types/aws-lambda": ["@types/aws-lambda@8.10.161", "", {}, "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
@@ -971,7 +971,7 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 TURBO_TEAM = "facets"
 
 [tools]
-bun = "1.3.13"
+bun = "1.3.14"
 node = "24.14.1"
 lefthook = "2.1.4"
 gh = "2.89.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@changesets/release-utils": "0.2.7",
     "@fission-ai/openspec": "1.3.1",
     "@octokit/auth-app": "8.2.0",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "@types/node": "24.12.4",
     "dedent": "1.7.2",
     "mint": "4.2.588",


### PR DESCRIPTION
### Why

Bumps Bun from `1.3.13` to `1.3.14` to stay current with the latest release.

### Verification

CI