### PR TITLE
Exclude internal packages from changeset versioning and remove `@agent-facets/engine` from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [["agent-facets", "@agent-facets/adapter", "@agent-facets/protocol"]],
-  "ignore": [],
+  "ignore": ["@agent-facets/engine", "@agent-facets/common", "@agent-facets/landing", "@agent-facets/functions"],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/floppy-maps-chew.md
+++ b/.changeset/floppy-maps-chew.md
@@ -1,6 +1,5 @@
 ---
 "agent-facets": patch
-"@agent-facets/engine": patch
 ---
 
 Make `OnLog` accept a lazy builder thunk, remove `foo` facet, and drop skipped TTY adapter-picker tests

--- a/.changeset/quiet-sloths-jam.md
+++ b/.changeset/quiet-sloths-jam.md
@@ -1,5 +1,5 @@
 ---
-"@agent-facets/engine": patch
+"agent-facets": patch
 ---
 
 Sort lockfile facet keys alphabetically on write for deterministic diffs


### PR DESCRIPTION
### Why

Internal packages (`@agent-facets/engine`, `@agent-facets/common`, `@agent-facets/landing`, `@agent-facets/functions`) should not be published to npm, so they need to be excluded from changesets versioning. Additionally, two existing changesets were incorrectly attributed to `@agent-facets/engine` rather than the root `agent-facets` package.

### Details

- Added the internal packages to the `ignore` list in the changeset config so they are never versioned or published.
- Moved the changeset entries for "Make `OnLog` accept a lazy builder thunk..." and "Sort lockfile facet keys alphabetically..." from `@agent-facets/engine` to `agent-facets`, correcting the package attribution.