### PR TITLE
Add `parseFacetName`, `parseSlug`, and `validateFacetName` to protocol and enforce facet identity grammar in `FacetManifestSchema`

### DIFF
--- a/.changeset/witty-dolls-sink.md
+++ b/.changeset/witty-dolls-sink.md
@@ -1,0 +1,9 @@
+---
+"@agent-facets/protocol": minor
+---
+
+Add a facet identity grammar to the public API and enforce it in `FacetManifestSchema`.
+
+New exports: `parseFacetName`, `parseSlug`, and `validateFacetName`, along with the `FacetName`, `FacetNameResult`, and `SlugResult` types. A facet identity is either an unscoped slug (`cowsay`) or a scoped `@scope/name` (`@julian/cowsay`), where every segment is a lowercase kebab slug. The parsers return discriminated-union results instead of throwing, and `parseSlug` is exported on its own so other facet-spec implementations (e.g. a registry enforcing scope ownership) validate scopes with the exact same grammar.
+
+`FacetManifestSchema` now validates the manifest `name` field against this grammar. This tightens the previous `name: string` behavior: malformed facet identities (uppercase, leading/trailing hyphens, traversal segments, extra path depth, missing slash after `@scope`, etc.) now fail at manifest validation instead of deferring failure to build, publish, or install. Asset names remain governed separately by `validateAssetName` — asset names stay local path-safe identifiers while facet identities may carry a registry scope.

--- a/openspec/changes/support-scoped-facet-names/.openspec.yaml
+++ b/openspec/changes/support-scoped-facet-names/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/support-scoped-facet-names/design.md
+++ b/openspec/changes/support-scoped-facet-names/design.md
@@ -1,0 +1,101 @@
+## Context
+
+The registry now identifies ownership with scoped facet names such as `@julian/cowsay`, replacing the older collections language. The local CLI stack currently has partial support for slash-containing names but not for leading-`@` scoped names: `facet add` rejects them in `parseFacetSource`, `facet create`/`facet edit` validate the facet identity as kebab-case, and build/cache output paths can treat the slash in a facet name as a directory without creating the required parent directories. The storage-path defect predates scoped names for any slash-containing identity such as `acme/cowsay`; scoped support makes that latent bug unavoidable. The registry API accepts scoped facets through route structure with a literal `@scope` path segment followed by the facet name segment, so registry client plumbing must use that generated API shape rather than encoding the whole scoped identity into one path parameter.
+
+The change crosses protocol, engine, CLI, tests, and docs. The registry OpenAPI snapshot and generated types have already been synced and SHALL NOT be regenerated as part of this change.
+
+User-facing documentation that needs alignment: `docs/specification/manifest.md`, `docs/cli/authoring/create.md`, `docs/cli/authoring/build.md`, `docs/cli/authoring/publish.md`, `docs/cli/add.md`, `docs/guides/install-facets.md`, `docs/guides/create-your-first-facet.md`, and `docs/guides/publish-a-facet.md`. Normative spec-governance examples in `openspec/specs/spec-governance/spec.md` also contain collection-oriented capability names and SHOULD be updated by the specs/implementation work.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one authoritative facet identity grammar: unscoped `name` and scoped `@scope/name`, with both `scope` and `name` using the same lowercase kebab segment grammar.
+- Reuse that grammar in protocol manifest validation, engine registry source parsing, and CLI authoring validation.
+- Parse `@scope/name@version` by treating only the final `@` after the slash as the version separator; the leading `@` is part of the scope marker.
+- Ensure build output and cache paths create required parent directories for scoped names.
+- Keep registry operations scope-agnostic: the CLI SHALL send the scoped name and render registry authorization or ownership failures verbatim.
+- Remove or replace user-facing “collection” terminology where it refers to registry ownership.
+
+**Non-Goals:**
+
+- Organization management, scope claiming, membership checks, and authorization policy are registry concerns and SHALL NOT be implemented in the CLI.
+- The CLI SHALL NOT provide a collection compatibility alias.
+- Asset names SHALL remain local kebab-case identifiers; scoped facet identity support SHALL NOT make skill, agent, or command names slash- or at-sign-qualified.
+- Registry OpenAPI sync SHALL NOT be rerun.
+- Cross-scope ownership transfer semantics are out of scope. Editing a facet identity to a different scope MAY be allowed as a local manifest edit, but whether the resulting scoped artifact can be published SHALL remain a registry authorization decision.
+
+## Decisions
+
+### 1. Put facet identity grammar in protocol and re-export for CLI use through engine
+
+Add a protocol-level pure validator/parser for facet identity names, for example `parseFacetName(value): FacetNameResult` or `validateFacetName(value): ValidatedFacetNameResult`, using a discriminated union result rather than thrown errors. The grammar SHALL accept:
+
+- `name`
+- `@scope/name`
+
+where each segment starts with a lowercase letter and then contains lowercase letters, digits, or hyphens. It SHALL reject empty scope/name segments, backslashes, `.`/`..` segments, uppercase letters, spaces, missing slash after `@scope`, and extra path depth. `FacetManifestSchema` SHALL use this validator for the manifest `name` field. Engine SHALL import this grammar for registry source parsing and scaffold/edit validation; CLI SHALL consume it via engine exports alongside the existing asset-name helpers.
+
+Malformed facet manifest names SHALL be hard validation errors, not warning-only diagnostics. This intentionally tightens the previous `name: string` behavior so invalid local identities fail at manifest validation instead of deferring failure until build, publish, or install.
+
+Alternative considered: extend `validateAssetName` to cover facet names. Rejected because asset names and facet identities now intentionally diverge: assets remain local path-safe kebab identifiers, while facet identities may be registry-scoped. Combining them would make illegal states easier to represent and would risk accidentally allowing scoped asset names.
+
+### 2. Parse registry source specifiers with an explicit scoped-name split
+
+Replace the current `REGISTRY_RE`-only parse with a small parser that first recognizes registry-name grammar, then splits an optional version suffix. For unscoped names, `name@version` keeps the existing behavior. For scoped names, the parser SHALL require `@scope/name` first, then MAY split a version at the next `@` after the slash. Examples:
+
+- `cowsay` → name `cowsay`, version `latest`
+- `cowsay@1.2.3` → name `cowsay`, version `1.2.3`
+- `@julian/cowsay` → name `@julian/cowsay`, version `latest`
+- `@julian/cowsay@latest` → name `@julian/cowsay`, version `latest`
+
+Invalid forms such as `@julian`, `@julian/`, `@julian/cowsay@`, and `@julian/cowsay@^1.0.0` SHALL return typed parse failures. The parser SHALL preserve existing priority for paths, GitHub shorthand, SCP-style git, and URL sources before registry parsing.
+
+Alternative considered: one larger regex. Rejected because the scope marker and version separator both use `@`; explicit split logic is easier to test and makes the ambiguity visible.
+
+### 3. Treat slash-containing facet identities as nested storage paths only at storage boundaries
+
+The canonical facet name remains the exact manifest/registry identity string (`@scope/name`). Storage helpers that derive paths from names SHALL create parent directories before writing or renaming. At minimum:
+
+- `writeBuildOutput` SHALL create `dirname(join(distDir, archiveFilename))` before writing the `.facet` archive.
+- Cache put logic SHALL create `dirname(cachePath(identity))` before renaming a staging directory into a slot for a slash-containing registry/git/local identity.
+- Existing recursive publish discovery under `dist/` SHALL remain because it already finds nested `.facet` archives and supports identity drift detection.
+
+Alternative considered: percent-encode or otherwise flatten names on disk. Rejected for this change because the existing `buildArtifactFilename` contract and publish discovery already document namespaced paths; creating parents is the smallest compatible fix. A future storage-layout change can be proposed separately if flat paths become preferable.
+
+Tests SHALL cover both scoped names (`@scope/name`) and slash-containing unscoped names (`scope/name`) for the build and cache write boundaries so this fix is verified as both scoped-name enablement and repair of the pre-existing nested-path bug.
+
+### 4. Use the registry's scoped route shape without percent-encoding the scope marker
+
+Registry metadata, archive lookup, and publish code SHALL use the scoped route shape exposed by the generated OpenAPI types. Scoped names SHALL be split into the API's scope and facet-name path components where the API requires that shape, preserving the literal `@` scope marker as its own path segment. The client SHALL NOT percent-encode a scoped identity into a single `{name}` path parameter such as `%40scope%2Fname`.
+
+Implementation SHALL add or update tests for `@scope/name` metadata resolution, archive URL lookup, and publish path construction. Those tests SHALL assert that scoped registry requests use the direct scoped path form the registry accepts, with an unencoded `@` marker and separate scope/name path segments.
+
+Alternative considered: manually call `encodeFacetName` or rely on generated-client path-parameter encoding for the entire scoped identity. Rejected because the registry API models scope and facet name as path structure, not as one encoded path parameter.
+
+### 5. Documentation and terminology updates are part of the implementation
+
+Docs that describe facet-name constraints SHALL show both unscoped and scoped examples. Create/edit docs SHALL distinguish facet identity names from asset names. Build/publish docs SHALL show scoped output paths where relevant. Install/add docs SHALL document `@scope/name` and `@scope/name@version` source specifiers. Collection terminology SHALL be removed where it names the old registry ownership model, while ordinary English uses of “collection” unrelated to registry ownership MAY remain.
+
+`facet edit` SHALL NOT warn specially when an author changes an existing facet identity from one scope to another. Cross-scope movement is a normal local manifest edit; source/artifact identity drift and registry authorization are the appropriate downstream checks.
+
+Alternative considered: leave docs to a later release. Rejected because current docs explicitly say `facet create` uses kebab-case names and would contradict the shipped behavior.
+
+## Risks / Trade-offs
+
+- **Risk: scope `@` is misparsed as a version separator.** → Mitigation: implement scoped parsing with slash-aware split logic and table-driven tests for bare, latest, exact, wildcard, and invalid scoped inputs.
+- **Risk: filesystem path traversal through scoped names.** → Mitigation: constrain the facet-name grammar to two safe kebab segments, reject `.`/`..` and backslashes, and only derive paths through existing `join` helpers after validation.
+- **Risk: manifest schema tightening rejects previously loadable local manifests.** → Mitigation: make the accepted grammar explicit in specs/docs, add clear validation errors, and treat this as an intentional registry-alignment tightening rather than a warning-only lint. The implementation SHOULD include tests for invalid legacy-ish names that used to pass because `name` was only typed as `string`.
+- **Risk: cache layout changes for slash-containing names expose existing ENOENT bugs.** → Mitigation: create parent directories at cache/build write boundaries and add tests for scoped registry cache slots and scoped build output.
+- **Risk: registry client code encodes scoped names into the wrong route shape.** → Mitigation: use the generated OpenAPI route shape for scoped facets, preserve the literal `@scope` path segment, and add tests that assert scoped metadata, archive, and publish requests use separate scope/name path segments rather than `%40scope%2Fname`.
+- **Risk: collection terminology audit removes unrelated prose.** → Mitigation: replace only registry ownership terminology and governance examples; leave generic “collection” prose when it describes an ordinary group of things.
+
+## Migration Plan
+
+No data migration is required. Existing unscoped manifests, caches, lockfiles, and built artifacts remain valid. The implementation can ship as a normal CLI/protocol change with backward-compatible grammar expansion.
+
+Rollback is straightforward: reverting the CLI/protocol changes restores previous validation and parsing. Scoped artifacts or manifests created while the change is live would stop validating in rolled-back clients, so release notes SHOULD frame scoped names as requiring the new CLI version.
+
+## Open Questions
+
+None.

--- a/openspec/changes/support-scoped-facet-names/proposal.md
+++ b/openspec/changes/support-scoped-facet-names/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The registry now models ownership with scoped facet names (`@scope/name`) instead of collections, but the CLI authoring and publishing path still needs a full audit so authors can create, build, and publish those names without client-side rejection or stale collection terminology. This change aligns the local facet workflow with the registry API so a user or future organization scope can own published facets without the CLI needing to understand organization semantics.
+
+## What Changes
+
+- Allow facet identity names to use either unscoped kebab-case form (`name`) or scoped form (`@scope/name`) consistently wherever facet manifests are created, validated, built, installed by source specifier, discovered in `dist/`, drift-checked, and uploaded.
+- Update `facet create` and `facet edit` identity validation and guidance so authors MAY enter scoped names while asset names remain kebab-case and path-safe.
+- Ensure `facet add` and source-specifier parsing accept registry sources like `@scope/name`, `@scope/name@1.2.3`, and `@scope/name@latest`, disambiguating the leading scope marker from the trailing version separator.
+- Ensure build output naming, publish artifact discovery, source/artifact identity drift detection, and registry upload addressing handle scoped names without confusing the scope separator (`/`) with a filesystem path. In particular, build output writing MUST create any needed parent directories for names that render as nested paths under `dist/`; this fixes the scoped-name break and the pre-existing failure for any slash-containing identity.
+- Audit code, tests, CLI text, docs, and existing specs for the removed “collection” concept and replace customer-facing terminology with “scope” where it refers to registry ownership, including governance examples that still use collection-oriented capability names.
+- Keep the CLI scope-agnostic: it SHALL pass scoped names through to the registry and surface registry decisions verbatim rather than deciding whether a scope is a user, organization, or otherwise authorized owner.
+- Documentation informed this proposal: `docs/specification/manifest.md` already documents scoped names in composed facet references; `docs/cli/authoring/create.md`, `docs/cli/authoring/build.md`, `docs/cli/authoring/publish.md`, and `docs/guides/publish-a-facet.md` document the affected authoring/build/publish flow and will need alignment where examples or constraints still imply unscoped kebab-case-only names.
+
+## Non-goals
+
+- This change SHALL NOT add organization management, organization membership, or scope-claiming flows to the CLI.
+- This change SHALL NOT re-run registry OpenAPI synchronization; the local generated registry types and checked-in OpenAPI snapshot are the inputs for implementation.
+- This change SHALL NOT reintroduce collections as a compatibility alias in user-facing CLI behavior.
+- This change SHALL NOT change asset naming rules; skills, agents, and commands SHALL remain independently validated as kebab-case local asset identifiers.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `protocol__schemas`: facet manifest identity validation is changing to specify the accepted scoped facet name grammar in the normative schema.
+- `authoring__facets`: authoring requirements are changing so scaffold, edit, build, and validation workflows accept scoped facet identities while preserving kebab-case asset names.
+- `installation`: registry source specifier parsing and add/install requirements are changing so scoped registry facet names are accepted and version suffixes are parsed unambiguously.
+- `publishing`: publish requirements are changing so verified scoped artifact identities are used correctly for artifact lookup, drift handling, and registry upload addressing.
+- `spec-governance`: governance examples are changing to remove collection-oriented capability names from normative examples.
+
+## Impact
+
+- Affected packages likely include `packages/common` name validation helpers, `packages/protocol` facet/build manifest schemas and validators, `packages/engine` source parsing, scaffold/build/publish paths, and `packages/cli` add/create/edit/publish presentation and tests. Registry client URL encoding should be verified against the generated local types and existing tests before changing it.
+- Registry-facing implementation will rely on the already-synced local OpenAPI snapshot and generated types under the engine registry code; the sync process SHALL NOT be run again for this change.
+- Docs and examples in `docs/specification/manifest.md`, `docs/cli/authoring/create.md`, `docs/cli/authoring/build.md`, `docs/cli/authoring/publish.md`, and `docs/guides/publish-a-facet.md` may need updates so constraints and output examples reflect scoped facet names and no longer mention collections.

--- a/openspec/changes/support-scoped-facet-names/specs/authoring__facets/spec.md
+++ b/openspec/changes/support-scoped-facet-names/specs/authoring__facets/spec.md
@@ -1,0 +1,261 @@
+## MODIFIED Requirements
+
+### Requirement: Valid facet manifests are accepted
+
+The system SHALL accept a facet manifest that conforms to the manifest schema. A valid manifest has a name, a version, and at least one text asset (skills, agents, commands, or composed facets). The name SHALL be either an unscoped kebab-case facet identity (`name`) or a scoped facet identity (`@scope/name`). All three text asset types — skills, agents, and commands — use the same descriptor model: a map of asset name to a descriptor with a required description and optional platform metadata. Descriptors SHALL NOT contain prompt references — prompt content is inferred from the file-path convention. Skills use the Agent Skills directory convention `skills/<name>/SKILL.md`. Agents and commands use the flat file convention `agents/<name>.md` and `commands/<name>.md` respectively. All three descriptor types SHALL require a `description` field. Asset names SHALL remain local kebab-case identifiers and SHALL NOT be scoped facet identities.
+
+#### Scenario: Minimal valid manifest with a skill
+
+- **WHEN** an author provides a manifest with a name, version, and a single skill descriptor that includes a description
+- **THEN** the system SHALL accept the manifest
+
+#### Scenario: Valid manifest with a scoped facet identity
+
+- **WHEN** an author provides a manifest whose `name` is `@julian/cowsay`, with a version and a single skill descriptor that includes a description
+- **THEN** the system SHALL accept the manifest
+
+#### Scenario: Manifest with all sections
+
+- **WHEN** an author provides a manifest with identity fields, skill descriptors with descriptions, agent descriptors with descriptions, command descriptors with descriptions, composed facets, and server references
+- **THEN** the system SHALL accept the manifest
+
+#### Scenario: Manifest with only composed facets is valid
+
+- **WHEN** an author provides a manifest with `name`, `version`, and a `facets` section but no local skills, agents, or commands
+- **THEN** the system SHALL accept the manifest
+
+### Requirement: Authors can scaffold a new facet project interactively
+
+The system SHALL provide an interactive wizard that guides the author through creating a new facet project. The wizard SHALL collect the following required information:
+
+- **Name**: A valid facet identity name. The name SHALL be either an unscoped kebab-case name (`name`) or a scoped name (`@scope/name`). The system SHALL validate the name in real-time and reject invalid input.
+- **Description**: A non-empty description. The system SHALL NOT allow the author to complete the wizard without providing a description.
+
+The wizard SHALL also collect optional information:
+
+- **Version**: A valid SemVer version (N.N.N format). The system SHALL default to `0.0.0`. The author MAY accept the default or change it.
+
+The wizard SHALL also allow the author to manage assets (skills, commands, and agents):
+
+- The author SHALL be able to add multiple named assets of any type
+- The author SHALL be able to edit the name of an existing asset
+- The author SHALL be able to remove an existing asset
+- All asset names SHALL be validated as kebab-case in real-time
+- Asset names SHALL be unique within their type — the system SHALL reject duplicates within the same asset type
+- Assets of different types MAY share the same name
+- The first asset added to each type SHOULD default its name to the unscoped name segment of the facet identity as a suggestion
+
+The wizard SHALL require the author to add at least one **asset** before completing. Name, description, and at least one **asset** are all required.
+
+All fields SHALL remain editable throughout the wizard — the author SHALL be able to go back and change any previously entered value.
+
+Before completing, the wizard SHALL display a confirmation summary showing only the asset types that have entries and a preview of the files to be created. The author SHALL be able to confirm or go back.
+
+The wizard SHALL provide an exit confirmation mechanism that prevents accidental loss of unsaved work.
+
+Upon confirmation, the system SHALL create a project directory containing a valid manifest and named starter files for each asset the author specified, with each starter file containing template content that guides authors on what belongs in each section. Skill starter files SHALL be created at `skills/<name>/SKILL.md`. Agent and command starter files SHALL be created at `agents/<name>.md` and `commands/<name>.md` respectively. All starter files SHALL contain no YAML front matter.
+
+The scaffolded project SHALL be immediately buildable — running the build command on a freshly scaffolded project SHALL succeed with no errors.
+
+#### Scenario: Author scaffolds a scoped project with named skills
+
+- **WHEN** the author runs the create wizard, provides a name `@julian/cowsay` and description `Cowsay tools`, and adds a skill named `cowsay`
+- **THEN** the system SHALL create a project directory containing a manifest whose `name` is `@julian/cowsay`
+- **AND** a starter file SHALL be created at `skills/cowsay/SKILL.md`
+- **AND** the manifest SHALL reference all starter files correctly
+
+#### Scenario: Author scaffolds a project with named skills
+
+- **WHEN** the author runs the create wizard, provides a name "viper-plans" and description "VIPER planning tools", and adds two skills named "viper-planning" and "viper-execution-rules"
+- **THEN** the system SHALL create a project directory containing a manifest with the provided identity fields and skill descriptors
+- **AND** starter files SHALL be created at `skills/viper-planning/SKILL.md` and `skills/viper-execution-rules/SKILL.md`
+- **AND** the manifest SHALL reference all starter files correctly
+
+#### Scenario: Author scaffolds a minimal project accepting the default skill name
+
+- **WHEN** the author runs the create wizard, provides a name "code-review" and a description, then adds a skill accepting the default name suggestion
+- **THEN** the system SHALL create a project with a skill named "code-review" (matching the facet name)
+- **AND** the starter file SHALL be at `skills/code-review/SKILL.md`
+
+#### Scenario: Author cannot complete without a description
+
+- **WHEN** the author attempts to complete the wizard without providing a description
+- **THEN** the system SHALL NOT allow completion
+- **AND** the system SHALL indicate that a description is required
+
+#### Scenario: Scoped facet identity is accepted
+
+- **WHEN** the author enters `@acme/deploy-tools` as the facet name
+- **THEN** the system SHALL accept the name as a valid facet identity
+
+#### Scenario: Invalid facet identity is rejected
+
+- **WHEN** the author enters `@acme/Deploy_Tools` as the facet name
+- **THEN** the system SHALL indicate the name is invalid
+- **AND** the system SHALL NOT accept the invalid name
+
+#### Scenario: Asset names are validated as kebab-case
+
+- **WHEN** the author enters an asset name containing uppercase letters, spaces, underscores, slashes, or an at sign
+- **THEN** the system SHALL indicate the name is invalid
+- **AND** the system SHALL NOT accept the invalid name
+
+#### Scenario: Duplicate asset names within a type are rejected
+
+- **WHEN** the author attempts to add a skill with the same name as an existing skill
+- **THEN** the system SHALL reject the duplicate name
+
+#### Scenario: Same name across different asset types is allowed
+
+- **WHEN** the author adds a skill named "viper-plans" and an agent named "viper-plans"
+- **THEN** the system SHALL accept both assets without error
+
+#### Scenario: Author edits an existing asset name
+
+- **WHEN** the author selects an existing asset and changes its name to a valid, unique kebab-case name
+- **THEN** the system SHALL update the asset name
+
+#### Scenario: Author removes an asset
+
+- **WHEN** the author removes a previously added asset
+- **THEN** the asset SHALL no longer appear in the wizard or the confirmation summary
+
+#### Scenario: Author exits the wizard with unsaved work
+
+- **WHEN** the author triggers an exit action during the wizard
+- **THEN** the system SHALL confirm the author's intent to exit
+- **AND** if the author confirms exit, the system SHALL not create any files or directories
+
+#### Scenario: Version field accepts valid SemVer input
+
+- **WHEN** the author sets the version to a valid SemVer value (e.g., "1.0.0" or "100.2.1")
+- **THEN** the system SHALL accept the version
+
+#### Scenario: Version field rejects invalid input
+
+- **WHEN** the author enters a version that does not match the N.N.N pattern
+- **THEN** the system SHALL indicate the version is invalid
+
+#### Scenario: Version defaults to 0.0.0
+
+- **WHEN** the author does not change the version field
+- **THEN** the manifest SHALL contain version `0.0.0`
+
+#### Scenario: Target directory already contains a manifest
+
+- **WHEN** the author runs the create wizard and a manifest already exists in the target directory
+- **THEN** the system SHALL warn the author and ask for confirmation before overwriting
+
+### Requirement: Authors can build a facet locally for validation and inspection
+
+The system SHALL compile a facet project into a build output directory. The build command SHALL read the manifest, validate it, verify that every declared asset file exists, is non-empty, and contains no YAML front matter, resolve all file-based prompts to their content, run all validation checks, assemble the resolved output into a deterministic compressed archive, compute content hashes, and write the archive and build manifest to a `dist/` directory. The build command SHALL NOT modify the manifest or any content files. The build command SHALL NOT be interactive — it SHALL behave identically in all environments.
+
+The build output SHALL contain a compressed archive (`.facet` file) with the manifest and all text asset files with prompts resolved to their final string content, and a build manifest (`build-manifest.json`) recording content hashes. For a slash-containing facet identity, including a scoped identity, the system SHALL create any required parent directories under `dist/` before writing the built archive.
+
+The build command SHALL render its progress as a step-by-step display, showing each pipeline stage as it completes — including the archive assembly stage. On success, the system SHALL display the archive contents listing and the archive content hash. On failure, the system SHALL indicate which stage failed and display errors with their field paths, and SHALL suggest running the editing command to fix the issues. After the display exits, the system SHALL print a brief plain-text summary to stdout — including the content hash — so it persists in terminal scroll-back.
+
+#### Scenario: Successful build of a valid facet
+
+- **WHEN** the author runs the build command in a directory with a valid manifest, all referenced files exist, and no files contain front matter
+- **THEN** the system SHALL write a compressed archive and build manifest to `dist/`
+- **AND** the archive SHALL contain the facet manifest and all text asset files with prompts resolved to their string content
+- **AND** the build manifest SHALL contain the archive content hash and per-asset content hashes
+- **AND** the system SHALL display the archive contents and content hash
+- **AND** the system SHALL print a brief success summary to stdout including the content hash
+
+#### Scenario: Successful build of a scoped facet identity
+
+- **WHEN** the author runs the build command for a valid facet whose name is `@julian/cowsay`
+- **THEN** the system SHALL write the built archive under `dist/` without failing on the scoped name separator
+- **AND** the archive SHALL contain `facet.json` at the archive root with `name` set to `@julian/cowsay`
+- **AND** the archive's internal asset paths SHALL continue to be derived from asset names, not from the facet identity
+
+#### Scenario: Successful build of a slash-containing unscoped facet identity
+
+- **WHEN** the author runs the build command for a valid facet whose name is `acme/cowsay`
+- **THEN** the system SHALL write the built archive under `dist/` without failing on the slash in the identity
+
+#### Scenario: Build fails on invalid manifest
+
+- **WHEN** the author runs the build command and the manifest fails schema validation
+- **THEN** the system SHALL report the validation errors with field paths
+- **AND** the system SHALL suggest running the editing command to fix the issues
+- **AND** the system SHALL NOT write any output to `dist/`
+
+#### Scenario: Build fails on missing asset file
+
+- **WHEN** the author runs the build command and any asset references a file that does not exist
+- **THEN** the system SHALL report which file is missing and which asset references it
+- **AND** the system SHALL suggest running the editing command to fix the issues
+- **AND** the system SHALL NOT write any output to `dist/`
+
+#### Scenario: Build fails on file containing front matter
+
+- **WHEN** the author runs the build command and a content file contains YAML front matter
+- **THEN** the system SHALL report which file contains front matter
+- **AND** the system SHALL suggest running the editing command to strip it
+- **AND** the system SHALL NOT write any output to `dist/`
+
+#### Scenario: Build fails on empty content file
+
+- **WHEN** the author runs the build command and a content file referenced by the manifest is empty (zero bytes or only whitespace)
+- **THEN** the system SHALL report which file is empty and which asset references it
+- **AND** the system SHALL suggest running the editing command to add content
+- **AND** the system SHALL NOT write any output to `dist/`
+
+#### Scenario: Build with no manifest
+
+- **WHEN** the author runs the build command in a directory with no manifest
+- **THEN** the system SHALL report that no manifest was found
+
+#### Scenario: Build cleans previous output
+
+- **WHEN** the author runs the build command and a `dist/` directory already exists from a previous build
+- **THEN** the system SHALL remove the previous `dist/` directory before writing new output
+
+### Requirement: Authors can edit a facet project interactively
+
+The system SHALL provide an interactive editing command that serves as the full authoring workbench for facet manifests. The editing command SHALL combine all capabilities of the scaffolding wizard (identity editing, asset creation, asset removal) with automatic reconciliation of disk contents against the manifest. The editing command SHALL scan conventional **asset** directories to detect discrepancies between disk contents and the manifest. If the manifest is invalid, the editing command SHALL display errors and exit. If drift is detected, the editing command SHALL present a reconciliation phase before proceeding to editing.
+
+#### Scenario: Author edits facet identity fields
+
+- **WHEN** the author runs the edit command on a facet project
+- **THEN** the system SHALL display the current name, description, and version
+- **AND** the author SHALL be able to change any of them
+- **AND** if version is absent, the system SHALL default it to `0.0.0`
+
+#### Scenario: Author changes a facet identity to a different scope
+
+- **WHEN** the author changes a facet's name from `@julian/cowsay` to `@acme/cowsay` during edit
+- **THEN** the system SHALL treat the change as a normal local identity edit
+- **AND** the system SHALL NOT warn specially about changing scopes
+
+#### Scenario: Author creates a new skill from scratch
+
+- **WHEN** the author uses the edit command to add a new skill named "code-review"
+- **THEN** the system SHALL create `skills/code-review/SKILL.md` with a starter template
+- **AND** the system SHALL add a skill descriptor to the manifest with the author-provided description
+
+#### Scenario: Author creates a new agent from scratch
+
+- **WHEN** the author uses the edit command to add a new agent named "reviewer"
+- **THEN** the system SHALL create `agents/reviewer.md` with a starter template
+- **AND** the system SHALL add an agent descriptor to the manifest with the author-provided description
+
+#### Scenario: Author creates a new command from scratch
+
+- **WHEN** the author uses the edit command to add a new command named "run-review"
+- **THEN** the system SHALL create `commands/run-review.md` with a starter template
+- **AND** the system SHALL add a command descriptor to the manifest with the author-provided description
+
+#### Scenario: Author deletes an existing asset
+
+- **WHEN** the author selects an existing asset for deletion during an edit session
+- **THEN** the system SHALL remove the asset's entry from the manifest
+- **AND** the system SHALL remove the asset's file (or directory, for skills) from disk
+
+#### Scenario: Asset names are validated during edit
+
+- **WHEN** the author enters an asset name during the edit session
+- **THEN** the system SHALL validate the name as kebab-case
+- **AND** the system SHALL reject names that are not unique within their asset type

--- a/openspec/changes/support-scoped-facet-names/specs/installation/spec.md
+++ b/openspec/changes/support-scoped-facet-names/specs/installation/spec.md
@@ -1,0 +1,228 @@
+## MODIFIED Requirements
+
+### Requirement: Adding a facet installs it
+
+When a user adds a facet to a project, the system SHALL fetch its content, verify its integrity, materialize its assets into every selected adapter, and update the lockfile in a single operation. A user SHALL NOT need to run a separate install step after adding. Registry-sourced facets SHALL support unscoped names and scoped names.
+
+#### Scenario: Adding a registry facet installs it
+
+- **WHEN** a user adds a registry facet to a project that has at least one selected adapter
+- **THEN** the system SHALL update the project manifest to reference the facet
+- **AND** the system SHALL fetch the facet's content
+- **AND** the system SHALL verify the facet's integrity before any assets are written
+- **AND** the system SHALL materialize the facet's assets into every selected adapter
+- **AND** the system SHALL update the lockfile to record the resolved version, integrity hash, and asset list
+- **AND** the operation SHALL complete in a single command invocation
+
+#### Scenario: Adding a scoped registry facet installs it
+
+- **WHEN** a user adds `@julian/cowsay` to a project that has at least one selected adapter
+- **THEN** the system SHALL treat `@julian/cowsay` as a registry facet source
+- **AND** the system SHALL fetch, verify, materialize, and lock the scoped facet in a single command invocation
+
+#### Scenario: Adding a git facet installs it
+
+- **WHEN** a user adds a git-source facet to a project that has at least one selected adapter
+- **THEN** the system SHALL resolve the symbolic ref to a commit
+- **AND** the system SHALL fetch the facet's content
+- **AND** the system SHALL build the facet locally
+- **AND** the system SHALL verify the facet's integrity before any assets are written
+- **AND** the system SHALL materialize the facet's assets into every selected adapter
+- **AND** the system SHALL update the lockfile to record the resolved commit, integrity hash, and asset list
+
+#### Scenario: Adding a local facet installs it
+
+- **WHEN** a user adds a local-path facet to a project that has at least one selected adapter
+- **THEN** the system SHALL build the facet from the local path
+- **AND** the system SHALL materialize the facet's assets into every selected adapter
+- **AND** the system SHALL update the lockfile to record the version, integrity hash, and asset list
+
+#### Scenario: Re-adding a facet at a different version
+
+- **WHEN** a user adds a facet that is already declared in the project manifest
+- **AND** the new specifier resolves to a different version than the current one
+- **THEN** the system SHALL update the manifest entry to the new specifier
+- **AND** the system SHALL replace the previous version in the lockfile and materialized assets
+- **AND** the user-visible summary SHALL indicate that the facet was updated from the previous version to the new one
+
+#### Scenario: Re-adding the same facet at the same version
+
+- **WHEN** a user adds a facet that is already declared at the same resolved version
+- **THEN** the system SHALL leave the manifest unchanged
+- **AND** the system SHALL re-verify integrity and re-materialize assets to repair any drift
+- **AND** the operation SHALL succeed without error
+
+### Requirement: Adding a facet without a version stores the resolved version pinned
+
+When a user adds a registry facet without specifying a version, the system SHALL resolve the latest published version and SHALL record a version specifier in the project manifest. The system SHALL NOT record the facet name in the version position. A bare name and the literal tag `@latest` SHALL be equivalent and SHALL produce identical results. The user SHALL NOT need to specify a version explicitly to get reproducible builds.
+
+When no manifest entry for the facet exists, or the existing entry's value is not a valid version specifier, the system SHALL record the resolved exact version (`name@MAJOR.MINOR.PATCH` for unscoped names, `@scope/name@MAJOR.MINOR.PATCH` for scoped names) in the project manifest. When a manifest entry already exists and its value is a valid version specifier, the system SHALL preserve that value unchanged, so that a re-add without a version does not overwrite a version the user previously chose.
+
+#### Scenario: Bare facet name is recorded as exact version
+
+- **WHEN** a user adds a registry facet using only its name (no version)
+- **AND** no entry for that facet exists in the project manifest
+- **THEN** the system SHALL resolve the latest published version
+- **AND** the system SHALL record `name@MAJOR.MINOR.PATCH` in the project manifest
+- **AND** the system SHALL NOT record the facet name as the version value
+
+#### Scenario: Scoped bare facet name is recorded as exact version
+
+- **WHEN** a user adds `@julian/cowsay` with no version
+- **AND** no entry for that facet exists in the project manifest
+- **THEN** the system SHALL resolve the latest published version
+- **AND** the system SHALL record `@julian/cowsay@MAJOR.MINOR.PATCH` in the project manifest
+
+#### Scenario: Explicit @latest tag records "latest" in the manifest
+
+- **WHEN** a user adds a registry facet using the literal `name@latest` form
+- **THEN** the system SHALL resolve the latest published version
+- **AND** the system SHALL record `latest` as the version specifier in the project manifest (preserving the user's explicit intent to float)
+- **AND** the system SHALL record the resolved exact version in the lockfile
+
+#### Scenario: Explicit @latest tag on a scoped name records "latest" in the manifest
+
+- **WHEN** a user adds a registry facet using the literal `@scope/name@latest` form
+- **THEN** the system SHALL resolve the latest published version for `@scope/name`
+- **AND** the system SHALL record `latest` as the version specifier in the project manifest
+- **AND** the system SHALL record the resolved exact version in the lockfile
+
+#### Scenario: Wildcard-resolved version is recorded as exact version
+
+- **WHEN** a user adds a registry facet using a wildcard form (e.g., `name@1.*`)
+- **THEN** the system SHALL record the wildcard as written in the project manifest
+- **AND** the system SHALL record the resolved exact version in the lockfile
+
+#### Scenario: Re-adding without a version preserves an existing valid version
+
+- **WHEN** the project manifest already records a facet with a valid version specifier (e.g., `1.*`, `1.2.*`, `1.2.3`, `*`, or `latest`)
+- **AND** a user re-adds that facet without specifying a version
+- **THEN** the system SHALL preserve the existing version specifier in the project manifest unchanged
+- **AND** the system SHALL NOT overwrite it with the resolved exact version
+
+#### Scenario: Re-adding without a version heals an invalid recorded value
+
+- **WHEN** the project manifest records a facet whose value is not a valid version specifier (e.g., the facet name appears in the version position)
+- **AND** a user re-adds that facet without specifying a version
+- **THEN** the system SHALL resolve the latest published version
+- **AND** the system SHALL replace the invalid value with the resolved exact version (`name@MAJOR.MINOR.PATCH` or `@scope/name@MAJOR.MINOR.PATCH`) in the project manifest
+
+#### Scenario: Adding a git or local facet records the full source specifier
+
+- **WHEN** a user adds a facet from a git source or a local path
+- **THEN** the system SHALL record the full source specifier (the git URL with any ref, or the local path) as the manifest value
+- **AND** the system SHALL NOT replace it with a version specifier
+
+### Requirement: Source specifier syntax matches established package-manager conventions
+
+When a user specifies a facet source, the system SHALL accept the same set of forms users expect from established package managers, and SHALL reject obsolete or deprecated prefixes with a clear migration message. Registry sources SHALL accept unscoped names (`name` and `name@version`) and scoped names (`@scope/name` and `@scope/name@version`). In a scoped registry source, the leading `@` SHALL identify the scope and the version separator SHALL be the `@` after the name segment.
+
+#### Scenario: Registry name is accepted
+
+- **WHEN** a user specifies a source of the form `name` or `name@version`
+- **THEN** the system SHALL treat it as a registry source
+
+#### Scenario: Scoped registry name is accepted
+
+- **WHEN** a user specifies a source of the form `@scope/name` or `@scope/name@version`
+- **THEN** the system SHALL treat it as a registry source
+- **AND** the system SHALL parse the name as `@scope/name`
+
+#### Scenario: Scoped registry name with latest is accepted
+
+- **WHEN** a user specifies `@scope/name@latest`
+- **THEN** the system SHALL treat it as a registry source for `@scope/name`
+- **AND** the system SHALL parse the version specifier as `latest`
+
+#### Scenario: Malformed scoped registry name is rejected
+
+- **WHEN** a user specifies `@scope`, `@scope/`, `@scope/name@`, or `@scope/name@^1.0.0`
+- **THEN** the system SHALL reject the source specifier with an actionable error
+
+#### Scenario: GitHub shorthand is accepted
+
+- **WHEN** a user specifies a source of the form `github:owner/repo` (optionally with `#ref`)
+- **THEN** the system SHALL treat it as a git source on GitHub
+
+#### Scenario: SCP-style git URL is accepted
+
+- **WHEN** a user specifies a source of the form `git@host:owner/repo` (optionally with `#ref`)
+- **THEN** the system SHALL treat it as a git source
+
+#### Scenario: HTTPS URL ending in .git is accepted
+
+- **WHEN** a user specifies a source whose scheme is `https` and whose path ends in `.git`
+- **THEN** the system SHALL treat it as a git source
+
+#### Scenario: Local path is accepted
+
+- **WHEN** a user specifies a source that begins with `.`, `~/`, `/`, `\`, or a Windows drive letter
+- **THEN** the system SHALL treat it as a local source
+
+#### Scenario: Deprecated git+ prefix is rejected
+
+- **WHEN** a user specifies a source beginning with `git+`
+- **THEN** the system SHALL reject the source with an error
+- **AND** the error SHALL show the user the equivalent unprefixed form (e.g., suggesting `https://...` or `git@...:...`)
+
+#### Scenario: Redundant file: prefix is tolerated
+
+- **WHEN** a user specifies a source beginning with `file:`
+- **THEN** the system SHALL strip the prefix and treat the remaining path as a local source
+
+### Requirement: Resolved facet content is cached locally
+
+When the system fetches and verifies a facet's content for the first time, the system SHALL retain that content in a local cache so that future installs of the same exact version SHALL NOT require a content download.
+
+Cached content SHALL NOT be installed on trust: before each use, the system SHALL verify that the cached content still matches the integrity recorded for it when it was cached. Cached content that fails this verification SHALL be discarded and treated as absent (re-downloaded and re-verified), and SHALL NOT be installed or recorded in the lockfile.
+
+The cache SHALL be addressed by the **fully-qualified exact version** of a facet, never by the presence or absence of a lockfile entry. Whenever the system holds an exact `name@version` or `@scope/name@version` to install — regardless of how that version was determined (an exact specifier, a satisfying lockfile entry, or a freshly resolved wildcard or `latest`) — the system SHALL consult the cache for that version before downloading, and SHALL use the cached content on a hit. For slash-containing facet identities, the system SHALL create any required cache parent directories before writing the cache entry.
+
+#### Scenario: First fetch populates the cache
+
+- **WHEN** the system installs a facet whose exact version is not present in the cache
+- **THEN** the system SHALL fetch the facet's content
+- **AND** the system SHALL verify the content's integrity
+- **AND** the system SHALL store the verified content in the cache keyed by the exact version
+
+#### Scenario: First fetch of a scoped facet populates the cache
+
+- **WHEN** the system installs `@julian/cowsay@1.0.0` and that exact version is not present in the cache
+- **THEN** the system SHALL fetch and verify the facet's content
+- **AND** the system SHALL store the verified content in the cache keyed by `@julian/cowsay@1.0.0`
+- **AND** the cache write SHALL NOT fail because the facet identity contains a slash
+
+#### Scenario: Subsequent install of the same version hits the cache
+
+- **WHEN** the system installs a facet whose exact version is already present in the cache
+- **THEN** the system SHALL verify the cached content against the integrity recorded for it when it was cached
+- **AND** the system SHALL use the cached content
+- **AND** the system SHALL NOT download that facet's content
+
+#### Scenario: Tampered cached content is discarded and re-fetched
+
+- **WHEN** the system installs a facet whose exact version is present in the cache
+- **AND** the cached content has been modified so it no longer matches the integrity recorded for it when it was cached
+- **THEN** the system SHALL discard the tampered cache entry
+- **AND** the system SHALL download the content again and verify it before use
+- **AND** the system SHALL NOT install the tampered content
+- **AND** the system SHALL NOT record the tampered content's integrity in the lockfile
+
+#### Scenario: Cache hit does not depend on a lockfile entry
+
+- **WHEN** the system holds an exact version to install whose content is cached
+- **AND** the project has no lockfile entry for that facet
+- **THEN** the system SHALL still use the cached content without downloading
+
+#### Scenario: Freshly resolved version still checks the cache before downloading
+
+- **WHEN** the system resolves a wildcard or `latest` to an exact version
+- **AND** that exact version is already present in the cache
+- **THEN** the system SHALL use the cached content
+- **AND** the system SHALL NOT download that version again
+
+#### Scenario: Cache location can be overridden
+
+- **WHEN** an environment variable is set to a custom cache directory path
+- **THEN** the system SHALL use the specified directory as the cache root
+- **AND** all cache reads and writes SHALL occur under that directory

--- a/openspec/changes/support-scoped-facet-names/specs/protocol__schemas/spec.md
+++ b/openspec/changes/support-scoped-facet-names/specs/protocol__schemas/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: A facet manifest schema is published as part of the protocol
+
+The shape of a facet manifest (`facet.json`) SHALL be published as a normative schema. Any system that produces a facet manifest SHALL produce one conforming to the published schema. Any system that consumes a facet manifest SHALL validate it against the published schema before treating any value as trusted. The schema SHALL define the required fields, the permitted shapes for skills/agents/commands, the optional `facets` and `servers` sections, the accepted facet identity grammar, and the rules for unrecognized fields.
+
+A facet identity name SHALL be either an unscoped kebab-case name (`name`) or a scoped name (`@scope/name`). In a scoped name, both `scope` and `name` SHALL use lowercase kebab-case segments that start with a lowercase letter, contain only lowercase letters, digits, and hyphens after the first character, and end with a lowercase letter or digit. A facet manifest whose `name` is malformed SHALL be rejected as invalid. Asset names SHALL remain independently validated as local asset identifiers and SHALL NOT become scoped names.
+
+#### Scenario: A producer emits a manifest conforming to the published schema
+
+- **WHEN** a system produces a `facet.json` for distribution
+- **THEN** the produced manifest SHALL satisfy every requirement of the published schema
+- **AND** another facet-compatible system SHALL accept the manifest after validating it
+
+#### Scenario: A consumer accepts a scoped facet identity
+
+- **WHEN** a system receives a `facet.json` whose `name` is `@julian/cowsay`
+- **THEN** the system SHALL accept the facet identity as valid
+- **AND** the scoped identity SHALL remain the facet's canonical name
+
+#### Scenario: A consumer rejects a malformed facet identity
+
+- **WHEN** a system receives a `facet.json` whose `name` is `@julian`, `@/cowsay`, `@julian/`, `@julian/cow/say`, `@julian/cow_say`, `Cowsay`, or `../cowsay`
+- **THEN** the system SHALL reject the manifest as invalid
+- **AND** the system SHALL surface a structured error indicating that the facet identity is malformed
+
+#### Scenario: A consumer rejects a manifest that violates the published schema
+
+- **WHEN** a system receives a `facet.json` that omits a required field or contains a field with the wrong type
+- **THEN** the system SHALL reject the manifest as invalid
+- **AND** the system SHALL surface a structured error indicating which constraint was violated
+
+#### Scenario: A consumer tolerates unrecognized fields
+
+- **WHEN** a system receives a `facet.json` containing a field not defined in the schema
+- **THEN** the system SHALL accept the manifest as valid
+- **AND** the system SHALL preserve the unknown field if it later re-emits the manifest

--- a/openspec/changes/support-scoped-facet-names/specs/publishing/spec.md
+++ b/openspec/changes/support-scoped-facet-names/specs/publishing/spec.md
@@ -1,0 +1,127 @@
+## MODIFIED Requirements
+
+### Requirement: Publish ships an already-built, verified facet artifact
+
+Building and publishing are distinct steps. Building is the only operation that constructs a facet archive from source and persists it to the project's build-output location. Publishing reads that already-built artifact, verifies it against the facet artifact specification, and uploads it. The system SHALL NOT construct a facet archive from source as part of publishing on the normal path, and SHALL NOT upload an artifact that has not been verified against the integrity and content rules a facet-compatible system applies to a `.facet`.
+
+When the expected built artifact for the source's declared name and version is absent, the system SHALL NOT contact the registry. In an interactive terminal, the system SHALL offer the user the option to build the current source before publishing; on acceptance, the system SHALL build, verify, and upload; on decline, the system SHALL report that there is nothing to publish and exit with a non-zero code. In a non-interactive context the system SHALL NOT prompt and SHALL fail with a clear "no built artifact; build first" message.
+
+The system SHALL verify the built artifact before uploading it. Verification SHALL apply the same checks a facet-compatible system applies to a `.facet` archive: the recomputed inner-archive content hash equals the integrity value recorded in the artifact's build manifest, every per-asset hash recorded in the build manifest matches the actual hash of the corresponding file, the embedded facet manifest is schema-valid, and the inner content satisfies the artifact content rules (no empty declared assets, no naming collisions within an asset type). A verification failure SHALL fail the publish before the registry is contacted, with an error that identifies the built artifact as the invalid party and suggests rebuilding.
+
+When the built artifact disagrees with the current source manifest — the artifact was built from an older or different manifest and not rebuilt — the system SHALL surface the disagreement to the user as source drift. The system SHALL distinguish two kinds of drift: **content drift**, where the artifact and the source share the same name and version but the manifest content differs; and **identity drift**, where the artifact and the source disagree on name or version.
+
+In an interactive terminal, **content drift** SHALL surface as a two-option choice: rebuild the current source and publish the freshly built artifact, or publish the existing artifact unchanged. **Identity drift** SHALL surface as a three-option choice: build the current source and publish that freshly built artifact, publish the existing (differently-identified) artifact unchanged under its own embedded identity, or cancel without publishing.
+
+In a non-interactive context the system SHALL NOT prompt for either drift kind; it SHALL emit a drift warning to standard error and upload the existing artifact unchanged.
+
+When the system uploads a freshly built artifact through a build offer, it SHALL write the build output to the build-output location, verify the freshly built artifact, and upload that. When the system uploads an existing artifact through a "publish existing" choice, it SHALL upload that artifact unchanged and use its embedded identity for the upload address; if the registry rejects the upload because that identity is already published (immutability), the rejection SHALL be surfaced verbatim to the user as the indication that the source needs a version bump.
+
+The name and version used to address the upload SHALL be read from the verified artifact's embedded build manifest and facet manifest, not from a separate parse of the source-tree facet manifest. When that name is scoped, the upload SHALL address the registry using the registry's scoped route shape, with the literal scope marker and facet name as separate path components accepted by the registry API.
+
+#### Scenario: Missing artifact in an interactive terminal — user accepts the build offer
+
+- **WHEN** a user publishes from a source directory whose declared name and version have no corresponding built artifact in the build-output location
+- **AND** the publish is run in an interactive terminal
+- **AND** the user accepts the offer to build the current source
+- **THEN** the system SHALL build the current source, verify the built artifact, and upload it
+- **AND** the system SHALL NOT contact the registry before verification succeeds
+
+#### Scenario: Missing artifact in an interactive terminal — user declines the build offer
+
+- **WHEN** a user publishes from a source directory with no corresponding built artifact
+- **AND** the publish is run in an interactive terminal
+- **AND** the user declines the offer to build the current source
+- **THEN** the system SHALL report that there is nothing to publish
+- **AND** the system SHALL NOT contact the registry
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Missing artifact in a non-interactive context
+
+- **WHEN** a user publishes from a source directory with no corresponding built artifact
+- **AND** the publish is run in a non-interactive context
+- **THEN** the system SHALL NOT prompt
+- **AND** the system SHALL fail with a message stating that no built artifact exists and that the user must build first
+- **AND** the system SHALL NOT contact the registry
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Built artifact is self-inconsistent
+
+- **WHEN** a user publishes and the built artifact's recomputed inner-archive content hash, any per-asset hash, embedded manifest schema validity, or content rules do not match what its build manifest claims
+- **THEN** the system SHALL fail with a verification error identifying the built artifact as the invalid party
+- **AND** the error SHALL suggest rebuilding the artifact
+- **AND** the system SHALL NOT contact the registry
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Content drift in an interactive terminal — user accepts the rebuild offer
+
+- **WHEN** a user publishes and the built artifact's embedded facet manifest has the same name and version as the source manifest but the manifest content differs (content drift)
+- **AND** the publish is run in an interactive terminal
+- **AND** the user accepts the offer to rebuild the current source
+- **THEN** the system SHALL build the current source, write the freshly built artifact to the build-output location, verify it, and upload it
+- **AND** the uploaded artifact SHALL match the current source
+
+#### Scenario: Content drift in an interactive terminal — user declines the rebuild offer
+
+- **WHEN** a user publishes and the built artifact has the same name and version as the source manifest but the manifest content differs
+- **AND** the publish is run in an interactive terminal
+- **AND** the user declines the offer to rebuild
+- **THEN** the system SHALL upload the existing, drifted artifact unchanged
+- **AND** the system SHALL record that the user explicitly accepted shipping an artifact that does not match the current source
+
+#### Scenario: Identity drift in an interactive terminal — user chooses to build the current source
+
+- **WHEN** a user publishes and the built artifact's embedded facet manifest disagrees with the source manifest on name or version (identity drift)
+- **AND** the publish is run in an interactive terminal
+- **AND** the user chooses to build the current source and publish the freshly built artifact
+- **THEN** the system SHALL build the current source, write the freshly built artifact to the build-output location, verify it, and upload it under the freshly built artifact's embedded identity
+- **AND** the uploaded artifact SHALL match the current source
+
+#### Scenario: Identity drift in an interactive terminal — user chooses to publish the existing artifact
+
+- **WHEN** a user publishes and the built artifact disagrees with the source manifest on name or version
+- **AND** the publish is run in an interactive terminal
+- **AND** the user chooses to publish the existing artifact as-is
+- **THEN** the system SHALL upload the existing artifact unchanged
+- **AND** the upload address SHALL use the existing artifact's embedded identity, not the source manifest's name or version
+
+#### Scenario: Identity drift in an interactive terminal — user cancels
+
+- **WHEN** a user publishes and the built artifact disagrees with the source manifest on name or version
+- **AND** the publish is run in an interactive terminal
+- **AND** the user cancels rather than choosing to build or publish the existing artifact
+- **THEN** the system SHALL NOT contact the registry
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Source drift in a non-interactive context
+
+- **WHEN** a user publishes and the built artifact disagrees with the current source manifest in any way (content or identity)
+- **AND** the publish is run in a non-interactive context
+- **THEN** the system SHALL NOT prompt
+- **AND** the system SHALL emit a drift warning to standard error
+- **AND** the system SHALL upload the existing, drifted artifact unchanged
+
+#### Scenario: Happy path — built artifact matches source
+
+- **WHEN** a user publishes and the built artifact exists and matches the current source manifest
+- **THEN** the system SHALL verify the built artifact
+- **AND** on successful verification, the system SHALL upload the built artifact unchanged
+- **AND** the name and version on the upload SHALL be read from the artifact's embedded manifests
+
+#### Scenario: Upload address uses the artifact's embedded identity
+
+- **WHEN** a user publishes any built artifact
+- **THEN** the name and version used to address the upload SHALL come from the artifact's embedded build manifest and facet manifest
+- **AND** the system SHALL NOT separately parse the source-tree facet manifest to determine the upload address
+
+#### Scenario: Scoped upload uses scoped registry address
+
+- **WHEN** a user publishes a verified artifact whose embedded facet name is `@julian/cowsay`
+- **THEN** the system SHALL upload the artifact under the `@julian` scope and `cowsay` name accepted by the registry API
+- **AND** the system SHALL NOT collapse the scoped identity into a single percent-encoded name segment
+
+#### Scenario: Registry rejects scoped upload authorization
+
+- **WHEN** a user publishes a verified artifact whose embedded facet name is `@acme/cowsay`
+- **AND** the registry rejects the upload because the authenticated user is not authorized to publish under `@acme`
+- **THEN** the system SHALL surface the registry's rejection verbatim
+- **AND** the system SHALL NOT replace the registry's scope ownership explanation with CLI-authored text

--- a/openspec/changes/support-scoped-facet-names/specs/spec-governance/spec.md
+++ b/openspec/changes/support-scoped-facet-names/specs/spec-governance/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Category-domain naming for sibling domains
+
+When multiple independent domains share a parent concept, they MAY use `__` (double underscore) to encode the category: `category__domain`. Each `category__domain` SHALL be a fully independent spec with its own `spec.md`.
+
+A `<category>` parent spec at `openspec/specs/<category>/spec.md` MAY also exist alongside its `__`-suffixed siblings, forming a **cascade**: the parent holds requirements common to all siblings, and each sibling holds requirements specific to its target. When a parent spec is present, its requirements SHALL apply to every `<category>__<sibling>` spec as if inlined, AND sibling specs SHALL NOT restate parent requirements. The parent spec is OPTIONAL — sibling-only layouts (no parent) remain valid.
+
+The cascade SHALL be expressed by naming convention and reading order alone (parent first, then siblings). Spec files SHALL NOT use in-file inheritance, import, or extension syntax to link sibling specs to their parent.
+
+The `__` separator SHALL NOT be used to encode a *feature* of a single domain (a capability inside one domain that does not stand alone as an independently-testable target). The discriminator SHALL be whether the right-hand side is an independently-testable target variant with its own consumers and rules (allowed) or a capability inside one domain (forbidden).
+
+Only one level of cascade is permitted: `<category>` plus `<category>__<sibling>`. Multi-segment names such as `<category>__<sub>__<leaf>` SHALL NOT be used.
+
+#### Scenario: Sibling domains share a category
+
+- **WHEN** two or more domains are independent systems under a shared concept (e.g., facet authoring and server authoring are both authoring systems)
+- **THEN** they MAY use `category__domain` naming (e.g., `authoring__facets`, `authoring__servers`)
+- **AND** each SHALL have its own independent spec at `openspec/specs/category__domain/spec.md`
+- **AND** a parent `authoring/spec.md` is OPTIONAL — the sibling-only layout is valid
+
+#### Scenario: Parent category and sibling targets form a cascade
+
+- **WHEN** a parent concept carries genuinely-shared rules across multiple target variants (e.g., `authoring` holds shared identity and asset naming rules; `authoring__facets` holds rules specific to facet projects; `authoring__servers` holds rules specific to server projects)
+- **THEN** a parent spec MAY be created at `openspec/specs/authoring/spec.md` alongside sibling specs at `openspec/specs/authoring__facets/spec.md` and `openspec/specs/authoring__servers/spec.md`
+- **AND** the parent spec SHALL hold the shared requirements
+- **AND** each sibling spec SHALL hold only its target-specific requirements
+- **AND** sibling specs SHALL NOT restate any requirement already present in the parent
+- **AND** the cascade SHALL be conveyed by naming and reading order only — sibling specs SHALL NOT contain `extends:`, `imports:`, or any other inheritance directive
+
+#### Scenario: Feature within a domain does not use category separator
+
+- **WHEN** a capability is a *feature* of a single domain — a capability inside that domain that does not stand alone as an independently-testable target with its own consumers and rules (e.g., login within auth, prompt resolution within facet authoring)
+- **THEN** it SHALL NOT use `__` to create a separate spec (e.g., `auth__login` is forbidden)
+- **AND** it SHALL be expressed as a requirement within the parent domain's spec
+- **AND** the cascade pattern (parent + `__`-siblings for independently-testable target variants) SHALL NOT be used to dress up a feature-of-a-domain split
+
+#### Scenario: Standalone domain does not require a category
+
+- **WHEN** a domain has no sibling domains under a shared concept (e.g., `installation`, `spec-governance`)
+- **THEN** it SHALL use a plain kebab-case name without a `__` separator
+
+#### Scenario: Multi-level nesting is not permitted
+
+- **WHEN** an author proposes a spec name with more than one `__` separator (e.g., `authoring__facets__scaffold`)
+- **THEN** the proposal SHALL be rejected
+- **AND** the author SHALL restructure into a single level of cascade or express the additional distinction as a requirement within a single sibling spec

--- a/openspec/changes/support-scoped-facet-names/tasks.md
+++ b/openspec/changes/support-scoped-facet-names/tasks.md
@@ -1,0 +1,81 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. Protocol facet identity grammar — Research
+
+- [ ] 1.1 Explore: Inspect existing protocol manifest schemas, compact facet parsing, archive validation, and tests to identify every place facet identity grammar is currently implicit.
+- [ ] 1.2 Explore: Inspect common asset-name validation and adapter asset path assumptions to confirm the new facet identity validator stays separate from asset-name validation.
+- [ ] 1.3 Propose: Define the protocol-level facet identity validator API, exported types, error shape, and integration points for manifest validation and archive validation.
+
+## 2. Protocol facet identity grammar — Implementation
+
+- [ ] 2.1 Implement: Add a protocol-level facet identity validator/parser that accepts `name` and `@scope/name`, rejects malformed identities including trailing hyphens, uppercase letters, missing name segments, extra path depth, backslashes, and traversal segments, and returns typed result data instead of throwing.
+- [ ] 2.2 Implement: Integrate the facet identity validator into `FacetManifestSchema` while keeping asset names governed by asset-name validation.
+- [ ] 2.3 Implement: Export the facet identity validator through protocol's public surface and through engine where CLI authoring code needs it.
+- [ ] 2.4 Implement: Add protocol tests for valid unscoped identities, valid scoped identities, invalid scoped identities, malformed legacy-ish names, unknown-field preservation on re-emit, and archive validation of scoped facet manifests.
+- [ ] 2.5 Verify: Run focused protocol tests and typechecking for protocol identity/schema changes.
+
+## 3. Registry source parsing and install/cache — Research
+
+- [ ] 3.1 Explore: Inspect `parseFacetSource`, version parsing, add/install manifest mutation, lockfile writing, and source-name resolution to map every branch affected by `@scope/name` and `@scope/name@version`.
+- [ ] 3.2 Explore: Inspect registry generated OpenAPI types and registry client helpers to identify scoped route paths and how scoped metadata/archive requests must be made without percent-encoding `@scope/name` into one path segment.
+- [ ] 3.3 Explore: Inspect cache identity, cache path, cache put, cache lookup, and cache audit code to identify slash-containing identity path assumptions.
+- [ ] 3.4 Propose: Define the install/cache approach for scoped source parsing, source recording, exact-version cache keys, scoped registry route selection, and cache parent-directory creation.
+
+## 4. Registry source parsing and install/cache — Implementation
+
+- [ ] 4.1 Implement: Update registry source parsing so `@scope/name`, `@scope/name@latest`, `@scope/name@1.2.3`, and supported wildcard forms parse correctly, while malformed forms such as `@scope`, `@scope/`, `@scope/name@`, and unsupported ranges return typed parse failures.
+- [ ] 4.2 Implement: Update add/install manifest mutation and version recording so scoped bare adds pin to `@scope/name@MAJOR.MINOR.PATCH`, explicit `@scope/name@latest` preserves `latest`, and re-add behavior preserves valid existing version specs.
+- [ ] 4.3 Implement: Update registry metadata resolution, archive lookup, download, and publish helper routing to use the generated scoped route shape with literal `@scope` and separate facet-name path components for scoped identities.
+- [ ] 4.4 Implement: Update cache write behavior to create parent directories for slash-containing exact identity keys before renaming staging content into the final cache slot.
+- [ ] 4.5 Implement: Add install/cache/registry tests covering scoped add, malformed scoped source rejection, scoped version recording, scoped route paths with unencoded `@`, scoped archive lookup, scoped cache population, and slash-containing unscoped cache population.
+- [ ] 4.6 Verify: Run focused engine source-parser, install, registry, and cache tests.
+
+## 5. Authoring create/edit/build/publish — Research
+
+- [ ] 5.1 Explore: Inspect create/edit TUI validation, form state, scaffold manifest generation, default asset-name suggestions, and edit reconciliation to map facet-identity vs asset-name validation boundaries.
+- [ ] 5.2 Explore: Inspect build pipeline output filename construction, build-output writing, publish artifact discovery, manifest drift detection, and publish upload flow for slash-containing identity assumptions.
+- [ ] 5.3 Propose: Define the authoring implementation approach for scoped create/edit validation, unscoped asset-name suggestions, build-output parent directory creation, publish drift behavior, and publish scoped upload behavior.
+
+## 6. Authoring create/edit/build/publish — Implementation
+
+- [ ] 6.1 Implement: Update create and edit facet identity validation, hints, and error messages to accept unscoped and scoped facet identities while keeping skill, agent, and command names kebab-case only.
+- [ ] 6.2 Implement: Update default asset-name suggestions for scoped facet identities to use the unscoped name segment instead of the full `@scope/name` identity.
+- [ ] 6.3 Implement: Ensure edit treats cross-scope identity changes as normal local identity edits with no special warning.
+- [ ] 6.4 Implement: Update build output writing to create required parent directories under `dist/` for scoped and slash-containing unscoped facet identities.
+- [ ] 6.5 Implement: Ensure publish artifact discovery, manifest drift detection, and upload addressing work for scoped identities using the verified artifact's embedded identity.
+- [ ] 6.6 Implement: Add CLI/engine tests for scoped create validation, asset-name rejection of `@` and `/`, scoped edit identity changes, scoped build output, slash-containing unscoped build output, scoped publish drift, and scoped publish upload addressing.
+- [ ] 6.7 Verify: Run focused CLI and engine authoring/build/publish tests.
+
+## 7. Documentation and terminology — Research
+
+- [ ] 7.1 Explore: Inspect `docs/specification/manifest.md`, `docs/cli/authoring/create.md`, `docs/cli/authoring/build.md`, `docs/cli/authoring/publish.md`, `docs/cli/add.md`, `docs/guides/install-facets.md`, `docs/guides/create-your-first-facet.md`, and `docs/guides/publish-a-facet.md` for name grammar, add/install, build/publish, and scoped examples.
+- [ ] 7.2 Explore: Audit `docs/`, root `README.md`, `openspec/specs/`, code comments, and CLI-facing text for registry-ownership uses of `collection` or collection-oriented capability names.
+- [ ] 7.3 Propose: Define the docs and terminology update plan, distinguishing registry ownership terminology from unrelated ordinary-English uses of “collection”.
+
+## 8. Documentation and terminology — Implementation
+
+- [ ] 8.1 Implement: Update user-facing docs to document facet identity grammar, scoped `facet add` forms, scoped build output examples, scoped publish behavior, and the distinction between facet identity names and asset names.
+- [ ] 8.2 Implement: Replace registry-ownership collection terminology and collection-oriented governance examples with scope terminology while preserving unrelated generic prose.
+- [ ] 8.3 Implement: Update CLI help, labels, hints, and error text that still imply facet identities are kebab-case only.
+- [ ] 8.4 Verify: Review changed docs and CLI text for consistency with specs and design.
+
+## 9. Final validation — Verification
+
+- [ ] 9.1 Verify: Run `bun openspec validate support-scoped-facet-names --strict` or the repository's equivalent OpenSpec validation command for the change.
+- [ ] 9.2 Verify: Run `bun check` for the full repository.
+- [ ] 9.3 Verify: Manually exercise the scoped happy path: create a facet with `@scope/name`, build it, confirm the nested `dist/@scope/name-<version>.facet` output exists, and confirm `facet add @scope/name` parses and resolves through the scoped registry route shape.
+- [ ] 9.4 Verify: Manually inspect the final diff to confirm no registry OpenAPI sync output changed and no collection terminology remains where it refers to registry ownership.

--- a/packages/protocol/src/__tests__/facet-manifest.test.ts
+++ b/packages/protocol/src/__tests__/facet-manifest.test.ts
@@ -89,6 +89,18 @@ describe('FacetManifestSchema — valid manifests', () => {
     const result = FacetManifestSchema(input)
     expect(result).not.toBeInstanceOf(type.errors)
   })
+
+  test('manifest with a scoped facet identity is valid', () => {
+    const input = {
+      name: '@julian/cowsay',
+      version: '1.0.0',
+      skills: { cowsay: { description: 'Cowsay tools' } },
+    }
+    const result = FacetManifestSchema(input)
+    expect(result).not.toBeInstanceOf(type.errors)
+    const data = result as FacetManifest
+    expect(data.name).toBe('@julian/cowsay')
+  })
 })
 
 // --- Invalid manifests ---
@@ -104,6 +116,28 @@ describe('FacetManifestSchema — invalid manifests', () => {
     const input = { name: 'my-facet', skills: { x: { description: 'A skill' } } }
     const result = FacetManifestSchema(input)
     expect(result).toBeInstanceOf(type.errors)
+  })
+
+  // Facet identity grammar (protocol__schemas/spec.md). The manifest `name`
+  // must be a valid facet name — an unscoped slug or a scoped `@scope/name`.
+  // This intentionally tightens the previous `name: string` behavior so
+  // malformed legacy-ish identities (which used to pass) now fail.
+  test.each([
+    '@julian', // missing slash
+    '@/cowsay', // empty scope
+    '@julian/', // empty name
+    '@julian/cow/say', // extra path depth
+    '@julian/cow_say', // underscore
+    'Cowsay', // uppercase
+    '../cowsay', // traversal
+    'cow_say', // underscore (unscoped)
+    'cow say', // space
+  ])('malformed facet identity %p is rejected', (name) => {
+    const input = { name, version: '1.0.0', skills: { x: { description: 'A skill' } } }
+    const result = FacetManifestSchema(input)
+    expect(result).toBeInstanceOf(type.errors)
+    const errors = result as InstanceType<typeof type.errors>
+    expect(errors.some((e) => e.message.includes('valid facet name'))).toBe(true)
   })
 
   test('agent missing description', () => {

--- a/packages/protocol/src/__tests__/facet-name.test.ts
+++ b/packages/protocol/src/__tests__/facet-name.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+import { parseFacetName, parseSlug, validateFacetName } from '@agent-facets/protocol'
+
+// --- parseSlug: the atomic identity grammar ---
+
+describe('parseSlug — valid slugs', () => {
+  test.each(['a', 'cowsay', 'viper-plans', 'code-review', 'x1', 'a-b-c', 'web3', 'foo--bar'])('accepts %p', (value) => {
+    const result = parseSlug(value)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.value).toBe(value)
+  })
+})
+
+describe('parseSlug — invalid slugs', () => {
+  test.each([
+    '', // empty
+    'Cowsay', // uppercase
+    'COWSAY',
+    'cow_say', // underscore
+    '1cow', // leading digit
+    '-cow', // leading hyphen
+    'cow-', // trailing hyphen
+    'cow say', // space
+    '@cow', // at-sign
+    'cow/say', // slash
+    'cow.say', // dot
+    '..',
+    'café', // non-ascii
+  ])('rejects %p', (value) => {
+    const result = parseSlug(value)
+    expect(result.ok).toBe(false)
+  })
+})
+
+// --- parseFacetName: unscoped + scoped composition ---
+
+describe('parseFacetName — valid unscoped identities', () => {
+  test.each(['cowsay', 'viper-plans', 'a', 'code-review'])('accepts %p as unscoped', (value) => {
+    const result = parseFacetName(value)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.value.kind).toBe('unscoped')
+    expect(result.canonical).toBe(value)
+    if (result.value.kind !== 'unscoped') expect.unreachable()
+    expect(result.value.name).toBe(value)
+  })
+})
+
+describe('parseFacetName — valid scoped identities', () => {
+  test.each([
+    ['@julian/cowsay', 'julian', 'cowsay'],
+    ['@acme/deploy-tools', 'acme', 'deploy-tools'],
+    ['@a/b', 'a', 'b'],
+  ])('accepts %p', (value, scope, name) => {
+    const result = parseFacetName(value)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    if (result.value.kind !== 'scoped') expect.unreachable()
+    expect(result.value.scope).toBe(scope)
+    expect(result.value.name).toBe(name)
+    expect(result.canonical).toBe(value)
+  })
+})
+
+describe('parseFacetName — invalid scoped identities', () => {
+  // Cases drawn from protocol__schemas/spec.md scenario "rejects a malformed
+  // facet identity" plus the design.md risk list.
+  test.each([
+    '@julian', // missing slash
+    '@julian/', // empty name
+    '@/cowsay', // empty scope
+    '@julian/cow/say', // extra path depth
+    '@julian/cow_say', // underscore in name
+    '@Julian/cowsay', // uppercase scope
+    '@julian/Cowsay', // uppercase name
+    '@julian/cow-', // trailing hyphen in name
+    '@julian/cowsay@', // trailing at-sign (not a valid name segment)
+  ])('rejects %p', (value) => {
+    const result = parseFacetName(value)
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('parseFacetName — invalid unscoped / legacy-ish identities', () => {
+  test.each([
+    '', // empty
+    'Cowsay', // uppercase
+    'cow_say', // underscore
+    '../cowsay', // traversal
+    'cow/say', // bare slash (not scoped)
+    'cow say', // space
+    'cow-', // trailing hyphen
+    '-cow', // leading hyphen
+  ])('rejects %p', (value) => {
+    const result = parseFacetName(value)
+    expect(result.ok).toBe(false)
+  })
+})
+
+// --- validateFacetName: thin boolean wrapper ---
+
+describe('validateFacetName', () => {
+  test('accepts a valid unscoped name', () => {
+    expect(validateFacetName('cowsay')).toEqual({ ok: true })
+  })
+
+  test('accepts a valid scoped name', () => {
+    expect(validateFacetName('@julian/cowsay')).toEqual({ ok: true })
+  })
+
+  test('rejects a malformed name with a reason', () => {
+    const result = validateFacetName('@julian')
+    expect(result.ok).toBe(false)
+    if (result.ok) expect.unreachable()
+    expect(result.reason.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/protocol/src/__tests__/validate-archive.test.ts
+++ b/packages/protocol/src/__tests__/validate-archive.test.ts
@@ -301,6 +301,23 @@ describe('validateFacetArchive', () => {
   })
 
   describe('embedded facet manifest failures (Step 6)', () => {
+    test('a scoped embedded facet manifest is accepted', async () => {
+      // Archive validation inherits the facet-name grammar via
+      // validateFacetManifest. A scoped identity (`@scope/name`) must verify
+      // exactly like an unscoped one.
+      const scopedResolved: ResolvedFacetManifest = {
+        ...validResolved,
+        name: '@julian/cowsay',
+      }
+      const { outerBytes } = buildFixtureArchive(scopedResolved)
+
+      const result = await validateFacetArchive(outerBytes, { gunzip: okGunzip })
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) expect.unreachable()
+      expect(result.data.facetManifest.name).toBe('@julian/cowsay')
+    })
+
     test('an invalid embedded facet manifest is rejected', async () => {
       // Pack a facet.json that is malformed JSON. The outer build manifest
       // and per-asset hashes will still be self-consistent — the failure

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -59,6 +59,11 @@ export type { BuildManifest } from './schemas/build-manifest.ts'
 export { BuildManifestSchema } from './schemas/build-manifest.ts'
 export type { FacetManifest } from './schemas/facet-manifest.ts'
 export { FacetManifestSchema } from './schemas/facet-manifest.ts'
+// facet identity grammar (slugs + scoped/unscoped facet names) — exported so
+// other facet-spec implementations (e.g. the registry enforcing scope
+// ownership) validate scopes with the same grammar.
+export type { FacetName, FacetNameResult, SlugResult } from './schemas/facet-name.ts'
+export { parseFacetName, parseSlug, validateFacetName } from './schemas/facet-name.ts'
 export type { Lockfile, LockfileAssetEntry, LockfileFacet, LockfileSource } from './schemas/lockfile.ts'
 export { LOCKFILE_VERSION, LockfileSchema } from './schemas/lockfile.ts'
 export type { FacetsJson } from './schemas/project-manifest.ts'

--- a/packages/protocol/src/schemas/facet-manifest.ts
+++ b/packages/protocol/src/schemas/facet-manifest.ts
@@ -1,5 +1,6 @@
 import { validateAssetName } from '@agent-facets/common'
 import { type } from 'arktype'
+import { validateFacetName } from './facet-name.ts'
 
 // --- Sub-schemas ---
 
@@ -51,6 +52,11 @@ const ServerReference = type('string').or({ image: 'string' })
  * Structural validation covers field types and shapes. Narrow constraints enforce:
  * 1. At least one text asset (skills, agents, commands, or facets) must be present
  * 2. Selective facets entries must include at least one asset type selection
+ * 3. Asset names must be filesystem-safe (validateAssetName)
+ * 4. The facet identity `name` must be a valid facet name — an unscoped slug
+ *    or a scoped `@scope/name` (validateFacetName). Asset names and facet
+ *    identities intentionally diverge: asset names stay local kebab-ish path
+ *    identifiers; facet identities may carry a registry scope.
  */
 export const FacetManifestSchema = type({
   name: 'string',
@@ -63,6 +69,17 @@ export const FacetManifestSchema = type({
   'facets?': FacetsEntry.array(),
   'servers?': type.Record('string', ServerReference),
 }).narrow((data, ctx) => {
+  // Constraint 0: the facet identity name must be a valid facet name. Either
+  // an unscoped slug (`cowsay`) or a scoped `@scope/name` (`@julian/cowsay`).
+  // This intentionally tightens the previous `name: string` behavior so
+  // malformed local identities fail at manifest validation instead of
+  // deferring failure to build/publish/install. Asset names are governed
+  // separately by validateAssetName (Constraint 3).
+  const facetName = validateFacetName(data.name)
+  if (!facetName.ok) {
+    ctx.mustBe(`a valid facet name: ${facetName.reason}`)
+  }
+
   // Constraint 1: at least one text asset
   const hasSkills = data.skills && Object.keys(data.skills).length > 0
   const hasAgents = data.agents && Object.keys(data.agents).length > 0

--- a/packages/protocol/src/schemas/facet-name.ts
+++ b/packages/protocol/src/schemas/facet-name.ts
@@ -1,0 +1,127 @@
+/**
+ * Facet identity grammar — the canonical rules for what a facet is called.
+ *
+ * The grammar is layered around one atomic unit, the **slug**:
+ *
+ *  - A slug is a single lowercase-kebab segment: it starts with a lowercase
+ *    letter, contains only lowercase letters, digits, and hyphens after the
+ *    first character, and ends with a lowercase letter or digit.
+ *  - A username is a slug. A scope is a slug. A global (unscoped) facet name
+ *    is a slug. The base name of a scoped facet is a slug. They are all the
+ *    same constraint — `parseSlug` is the single source of truth.
+ *
+ * A **facet name** is built from slugs. It is either:
+ *
+ *  - **unscoped**: a single slug (`cowsay`), or
+ *  - **scoped**: `@<scope>/<name>` where both `scope` and `name` are slugs
+ *    (`@julian/cowsay`).
+ *
+ * `parseSlug` is exported on its own so other facet-spec implementations
+ * (notably the registry, which enforces scope ownership) validate scopes with
+ * the exact same grammar instead of duplicating it.
+ *
+ * Both parsers return discriminated-union results rather than throwing, so
+ * callers handle malformed identities as data.
+ */
+
+/**
+ * A single kebab-case identity segment: lowercase letter start, lowercase /
+ * digit / hyphen interior, alphanumeric end. No uppercase, no underscores, no
+ * leading/trailing hyphen, no slashes, no `@`, no `.`/`..` traversal, no
+ * whitespace. Single-character names (`a`) are permitted.
+ */
+const SLUG_RE = /^[a-z]([a-z0-9-]*[a-z0-9])?$/
+
+const SLUG_RULE =
+  'a lowercase kebab-case slug (lowercase letter start; lowercase letters, digits, and hyphens after; alphanumeric end)'
+
+/** Result of validating a single slug. Errors are data, not exceptions. */
+export type SlugResult = { ok: true; value: string } | { ok: false; reason: string }
+
+/**
+ * Validate a single slug — the atomic facet-identity grammar shared by
+ * usernames, scopes, global facet names, bare facet names, and the base name
+ * of a scoped facet.
+ */
+export function parseSlug(value: string): SlugResult {
+  if (value === '') {
+    return { ok: false, reason: 'must not be empty' }
+  }
+  if (!SLUG_RE.test(value)) {
+    return { ok: false, reason: `must be ${SLUG_RULE}` }
+  }
+  return { ok: true, value }
+}
+
+/**
+ * A parsed facet identity.
+ *
+ * `unscoped` carries the bare slug; `scoped` carries the scope slug and the
+ * base name slug separately. The canonical string form is recovered from
+ * `FacetNameResult.canonical` so callers never re-assemble `@scope/name` by
+ * hand.
+ */
+export type FacetName = { kind: 'unscoped'; name: string } | { kind: 'scoped'; scope: string; name: string }
+
+/** Result of parsing a full facet identity. Errors are data, not exceptions. */
+export type FacetNameResult = { ok: true; value: FacetName; canonical: string } | { ok: false; reason: string }
+
+/**
+ * Parse a full facet identity: an unscoped slug (`cowsay`) or a scoped name
+ * (`@scope/name`). Both forms are validated slug-by-slug via `parseSlug`.
+ *
+ * The leading `@` marks a scoped name; for a scoped name there SHALL be
+ * exactly one `/` separating the scope slug from the base name slug. Extra
+ * path depth (`@scope/name/extra`), a missing slash (`@scope`), and empty
+ * segments (`@scope/`, `@/name`) are all rejected.
+ */
+export function parseFacetName(value: string): FacetNameResult {
+  if (value === '') {
+    return { ok: false, reason: 'facet name must not be empty' }
+  }
+
+  if (value.startsWith('@')) {
+    const rest = value.slice(1)
+    const slashIndex = rest.indexOf('/')
+    if (slashIndex === -1) {
+      return { ok: false, reason: 'scoped facet name must be of the form "@scope/name"' }
+    }
+    if (rest.indexOf('/', slashIndex + 1) !== -1) {
+      return { ok: false, reason: 'scoped facet name must contain exactly one "/" separating scope and name' }
+    }
+    const scopePart = rest.slice(0, slashIndex)
+    const namePart = rest.slice(slashIndex + 1)
+
+    const scope = parseSlug(scopePart)
+    if (!scope.ok) {
+      return { ok: false, reason: `scope "${scopePart}" ${scope.reason}` }
+    }
+    const name = parseSlug(namePart)
+    if (!name.ok) {
+      return { ok: false, reason: `facet name "${namePart}" ${name.reason}` }
+    }
+
+    return {
+      ok: true,
+      value: { kind: 'scoped', scope: scope.value, name: name.value },
+      canonical: `@${scope.value}/${name.value}`,
+    }
+  }
+
+  const name = parseSlug(value)
+  if (!name.ok) {
+    return { ok: false, reason: `facet name "${value}" ${name.reason}` }
+  }
+  return { ok: true, value: { kind: 'unscoped', name: name.value }, canonical: name.value }
+}
+
+/**
+ * Thin boolean-style wrapper over `parseFacetName` for schema `.narrow()`
+ * call sites that only need pass/fail + a reason. Mirrors the shape of
+ * `validateAssetName` from `@agent-facets/common` so the two compose
+ * identically into `ctx.mustBe(...)`.
+ */
+export function validateFacetName(value: string): { ok: true } | { ok: false; reason: string } {
+  const result = parseFacetName(value)
+  return result.ok ? { ok: true } : { ok: false, reason: result.reason }
+}


### PR DESCRIPTION
### Why

The registry identifies ownership with scoped facet names such as `@julian/cowsay`, but the protocol had no authoritative grammar for what a facet identity is allowed to look like. The manifest `name` field was typed as a plain `string`, meaning malformed identities (uppercase letters, trailing hyphens, traversal segments, missing slash after `@scope`, extra path depth) passed manifest validation and only failed later at build, publish, or install time.

### Details

A new `facet-name.ts` module in `@agent-facets/protocol` defines the canonical facet identity grammar around a single atomic unit, the **slug**: a lowercase-letter-start, lowercase/digit/hyphen interior, alphanumeric-end segment. A facet name is either an unscoped slug (`cowsay`) or a scoped `@scope/name` (`@julian/cowsay`) where both `scope` and `name` are slugs.

Three exports are added to the protocol public surface:

- `parseSlug` — validates a single slug segment. Exported independently so other implementations (e.g. a registry enforcing scope ownership) reuse the exact same grammar rather than duplicating it.
- `parseFacetName` — parses a full facet identity into a discriminated-union `FacetName` (`unscoped` or `scoped`) and returns a `FacetNameResult` rather than throwing. The `canonical` field on a successful result means callers never re-assemble `@scope/name` by hand.
- `validateFacetName` — a thin boolean-style wrapper over `parseFacetName` shaped to compose into ArkType's `ctx.mustBe(...)`, mirroring `validateAssetName` from `@agent-facets/common`.

`FacetManifestSchema` now calls `validateFacetName` in its `.narrow()` block before the existing asset-count and asset-name constraints. Asset names remain governed separately by `validateAssetName` — asset names stay local path-safe kebab identifiers while facet identities may carry a registry scope. Combining the two validators was explicitly rejected to avoid making illegal states easier to represent.

The tightening is intentional and breaking for previously-loadable manifests with malformed names. Invalid identities that used to pass because `name` was typed as `string` now fail at manifest validation.

### Verification

New unit tests cover:

- `parseSlug` valid and invalid cases including empty, uppercase, underscore, leading/trailing hyphen, dot, slash, and non-ASCII inputs.
- `parseFacetName` valid unscoped and scoped identities, all malformed scoped forms from the spec (`@julian`, `@/cowsay`, `@julian/`, `@julian/cow/say`, `@julian/cow_say`, uppercase variants, trailing hyphens), and malformed unscoped forms including traversal segments and bare slashes.
- `validateFacetName` pass/fail/reason shape.
- `FacetManifestSchema` acceptance of `@julian/cowsay` and rejection of each malformed identity listed in the spec scenario, asserting the error message includes `"valid facet name"`.
- `validateFacetArchive` acceptance of a scoped embedded facet manifest (`@julian/cowsay`).