### PR TITLE
Update scoped facet test to use `@scope/name` identity and add `^test`/`^types` Turborepo dependencies

### DIFF
--- a/packages/cli/src/commands/publish/__tests__/publish.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publish.test.ts
@@ -511,15 +511,26 @@ describe('publishCommand — registry interaction (preserved scenarios)', () => 
     expect(stdout).toContain('an admin will review your submission shortly')
   })
 
-  test('namespaced facet: URL-encodes the slash', async () => {
+  test('scoped facet: URL-encodes the scoped identity', async () => {
+    // The facet identity grammar (FacetManifestSchema) accepts an unscoped
+    // slug (`cowsay`) or a scoped `@scope/name` (`@acme/cowsay`); the legacy
+    // bare-slash form (`acme/cowsay`) is no longer a valid manifest name.
+    //
+    // TODO(scoped-routes): the registry has moved to literal-slash scoped
+    // routes (`/v0/facets/@scope/name/...`), but the engine registry client
+    // still hits the single-`{name}` route and lets openapi-fetch percent-
+    // encode the whole identity (`@acme/cowsay` → `%40acme%2Fcowsay`). The
+    // scoped-route migration (publish/resolve/download) is tracked separately;
+    // this assertion documents the *current* client behavior and is expected
+    // to flip to the literal-slash form when that lands.
     await buildFacetFixture(projectRoot, {
-      name: 'acme/cowsay',
+      name: '@acme/cowsay',
       version: '0.1.0',
       commands: { cowsay: '# cowsay\n' },
     })
     const spy = createFetchSpy(
       () =>
-        new Response(JSON.stringify(fixtures.publishResponse({ name: 'acme/cowsay' })), {
+        new Response(JSON.stringify(fixtures.publishResponse({ name: '@acme/cowsay' })), {
           status: 201,
         }),
     )
@@ -530,7 +541,7 @@ describe('publishCommand — registry interaction (preserved scenarios)', () => 
     expect(spy.calls).toHaveLength(1)
     const call = spy.calls[0]
     if (call === undefined) expect.unreachable()
-    expect(call.url).toBe('https://api.test/v0/facets/acme%2Fcowsay/versions')
+    expect(call.url).toBe('https://api.test/v0/facets/%40acme%2Fcowsay/versions')
   })
 
   test('413 (tarball too large): renders the registry error verbatim', async () => {

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "outputs": ["dist/**"]
     },
     "test": {
-      "dependsOn": [],
+      "dependsOn": ["^test"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
       "outputs": ["$TURBO_ROOT$/test-results/**"]
     },
@@ -18,7 +18,7 @@
       "outputs": ["$TURBO_ROOT$/test-results/**"]
     },
     "types": {
-      "dependsOn": []
+      "dependsOn": ["^types"]
     },
     "check": {
       "dependsOn": [


### PR DESCRIPTION
### Why

The test for scoped facet publishing was using the legacy bare-slash form (`acme/cowsay`) as the manifest name, which is no longer a valid identity according to `FacetManifestSchema`. Valid identities are either an unscoped slug (`cowsay`) or a scoped `@scope/name` form (`@acme/cowsay`).

### Details

The test is updated to use `@acme/cowsay` as the facet name, and the expected URL reflects the current client behavior where `openapi-fetch` percent-encodes the entire identity (`@acme/cowsay` → `%40acme%2Fcowsay`) rather than using a literal-slash scoped route (`/v0/facets/@scope/name/...`). A TODO comment documents that the registry has already moved to literal-slash scoped routes, but the engine registry client still uses the single `{name}` route parameter. The assertion is intentionally written to match current behavior and is expected to be updated when the scoped-route migration for publish/resolve/download lands.

Additionally, `turbo.json` is updated so that `test` and `types` tasks depend on their upstream equivalents (`^test` and `^types`), ensuring dependent packages are tested and type-checked before downstream packages.

### Verification

CI.