### PR TITLE
Fix `writeBuildOutput` to create parent directories for scoped (`@scope/name`) and slash-containing archive paths, and accept scoped facet names in create/edit views

### DIFF
--- a/.changeset/fast-boats-drop.md
+++ b/.changeset/fast-boats-drop.md
@@ -1,0 +1,6 @@
+---
+"agent-facets": patch
+"@agent-facets/engine": patch
+---
+
+Fix `writeBuildOutput` to create parent directories for scoped (`@scope/name`) and slash-containing archive paths, and accept scoped facet names in create/edit views

--- a/openspec/changes/support-scoped-facet-names/specs/authoring__facets/spec.md
+++ b/openspec/changes/support-scoped-facet-names/specs/authoring__facets/spec.md
@@ -150,7 +150,7 @@ The scaffolded project SHALL be immediately buildable — running the build comm
 
 The system SHALL compile a facet project into a build output directory. The build command SHALL read the manifest, validate it, verify that every declared asset file exists, is non-empty, and contains no YAML front matter, resolve all file-based prompts to their content, run all validation checks, assemble the resolved output into a deterministic compressed archive, compute content hashes, and write the archive and build manifest to a `dist/` directory. The build command SHALL NOT modify the manifest or any content files. The build command SHALL NOT be interactive — it SHALL behave identically in all environments.
 
-The build output SHALL contain a compressed archive (`.facet` file) with the manifest and all text asset files with prompts resolved to their final string content, and a build manifest (`build-manifest.json`) recording content hashes. For a slash-containing facet identity, including a scoped identity, the system SHALL create any required parent directories under `dist/` before writing the built archive.
+The build output SHALL contain a compressed archive (`.facet` file) with the manifest and all text asset files with prompts resolved to their final string content, and a build manifest (`build-manifest.json`) recording content hashes. For a scoped facet identity, whose name renders as a nested path under `dist/`, the system SHALL create any required parent directories under `dist/` before writing the built archive. The build-output write boundary SHALL create parent directories for any slash-containing archive path, so the same fix also repairs the pre-existing failure for any nested archive filename.
 
 The build command SHALL render its progress as a step-by-step display, showing each pipeline stage as it completes — including the archive assembly stage. On success, the system SHALL display the archive contents listing and the archive content hash. On failure, the system SHALL indicate which stage failed and display errors with their field paths, and SHALL suggest running the editing command to fix the issues. After the display exits, the system SHALL print a brief plain-text summary to stdout — including the content hash — so it persists in terminal scroll-back.
 
@@ -170,10 +170,11 @@ The build command SHALL render its progress as a step-by-step display, showing e
 - **AND** the archive SHALL contain `facet.json` at the archive root with `name` set to `@julian/cowsay`
 - **AND** the archive's internal asset paths SHALL continue to be derived from asset names, not from the facet identity
 
-#### Scenario: Successful build of a slash-containing unscoped facet identity
+#### Scenario: Build-output write boundary creates parent directories for a nested archive path
 
-- **WHEN** the author runs the build command for a valid facet whose name is `acme/cowsay`
-- **THEN** the system SHALL write the built archive under `dist/` without failing on the slash in the identity
+- **WHEN** the build-output write boundary writes an archive whose filename renders as a nested path under `dist/` (for example a scoped `@scope/name` identity, or any other slash-containing archive filename)
+- **THEN** the system SHALL create the required parent directories under `dist/` before writing the archive
+- **AND** the write SHALL NOT fail with a missing-directory error
 
 #### Scenario: Build fails on invalid manifest
 

--- a/packages/cli/src/__tests__/create-build.e2e.test.ts
+++ b/packages/cli/src/__tests__/create-build.e2e.test.ts
@@ -150,6 +150,35 @@ describe('writeScaffold', () => {
     expect(manifest.version).toBe('0.0.0')
   })
 
+  test('scaffolds a scoped facet and builds it to a nested dist/ path', async () => {
+    const dir = await createFixtureDir('scaffold-scoped')
+    const files = await writeScaffold(
+      {
+        name: '@julian/cowsay',
+        version: DEFAULT_VERSION,
+        description: 'Cowsay tools',
+        // The default first-asset name suggestion is the unscoped segment
+        // (`cowsay`), so a scoped scaffold uses a plain kebab asset name.
+        skills: ['cowsay'],
+        agents: [],
+        commands: [],
+      },
+      dir,
+    )
+
+    // The manifest carries the scoped identity verbatim; the asset path is
+    // derived from the (unscoped) asset name.
+    expect(files).toContain('skills/cowsay/SKILL.md')
+    const manifest = JSON.parse(await Bun.file(join(dir, 'facet.json')).text())
+    expect(manifest.name).toBe('@julian/cowsay')
+
+    // The scoped project builds, and the archive lands at the nested path.
+    const result = await runCli('build', dir)
+    expect(result.exitCode).toBe(0)
+    const distArchive = await Bun.file(join(dir, `dist/@julian/cowsay-${DEFAULT_VERSION}.facet`)).exists()
+    expect(distArchive).toBe(true)
+  })
+
   test('scaffolded project passes build', async () => {
     const dir = await createFixtureDir('scaffold-buildable')
     await writeScaffold(

--- a/packages/cli/src/commands/publish/__tests__/publish.test.ts
+++ b/packages/cli/src/commands/publish/__tests__/publish.test.ts
@@ -311,6 +311,38 @@ describe('publishCommand — content drift', () => {
     if (call === undefined) expect.unreachable()
     expect(call.body).toEqual(originalBytes)
   })
+
+  test('scoped facet, non-TTY content drift: warns and uploads via the scoped route', async () => {
+    // Exercises the scoped build-output fix (nested dist/ path), name-agnostic
+    // drift detection, and the scoped upload route together.
+    await buildFacetFixture(projectRoot, {
+      name: '@acme/cowsay',
+      version: '0.1.0',
+      description: 'old description',
+      commands: { cowsay: '# cowsay\n' },
+    })
+    const manifest = JSON.parse(readFileSync(join(projectRoot, 'facet.json'), 'utf8')) as { description: string }
+    manifest.description = 'new description'
+    writeFileSync(join(projectRoot, 'facet.json'), JSON.stringify(manifest, null, 2))
+    const spy = createFetchSpy(
+      () => new Response(JSON.stringify(fixtures.publishResponse({ name: '@acme/cowsay' })), { status: 201 }),
+    )
+    globalThis.fetch = spy.fetch
+    const distPath = buildArtifactPath(projectRoot, '@acme/cowsay', '0.1.0')
+    const originalBytes = new Uint8Array(await Bun.file(distPath).bytes())
+
+    const { result, stderr } = await withTTY(false, () => captureStderr(() => publishCommand.run([], {})))
+
+    expect(result).toBe(0)
+    expect(stderr).toContain('out of date')
+    expect(spy.calls).toHaveLength(1)
+    const call = spy.calls[0]
+    if (call === undefined) expect.unreachable()
+    // Drifted-but-existing artifact uploaded unchanged, via the scoped route.
+    expect(call.body).toEqual(originalBytes)
+    expect(call.url).toBe('https://api.test/v0/facets/%40acme/cowsay/versions')
+    expect(call.url).not.toContain('%2F')
+  })
 })
 
 describe('publishCommand — identity drift', () => {

--- a/packages/cli/src/tui/views/create/create-view.tsx
+++ b/packages/cli/src/tui/views/create/create-view.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_VERSION, isValidKebabCase } from '@agent-facets/engine'
+import { parseFacetName, validateFacetName } from '@agent-facets/protocol'
 import { Box, Text } from 'ink'
 import { useCallback, useEffect } from 'react'
 import type { AssetType } from '../../../commands/create/types'
@@ -45,9 +46,12 @@ export function CreateView({
   const { form } = useFormState()
   const { setFocusIds, focus, focusedId } = useFocusOrder()
 
-  const validateKebab = useCallback((v: string) => {
+  // Facet identity: an unscoped slug (`my-facet`) or a scoped `@scope/name`
+  // (`@acme/my-facet`). Asset names (below) stay kebab-case only.
+  const validateName = useCallback((v: string) => {
     if (!v) return undefined
-    if (!isValidKebabCase(v)) return 'Must be kebab-case (e.g., my-facet)'
+    const result = validateFacetName(v)
+    if (!result.ok) return 'Must be a facet name (e.g., my-facet or @scope/name)'
     return undefined
   }, [])
 
@@ -67,6 +71,17 @@ export function CreateView({
 
   const totalAssets = form.assets.skill.items.length + form.assets.command.items.length + form.assets.agent.items.length
   const canCreate = assetsReady && totalAssets > 0
+
+  // The first asset of each type defaults its name to the facet's unscoped
+  // base segment (`@acme/cowsay` → `cowsay`), so the suggestion is always a
+  // valid kebab asset name. Falls back to the raw value while the name is
+  // still being typed / invalid.
+  const defaultAssetName = (() => {
+    const raw = form.fields.name.value
+    if (!raw) return undefined
+    const parsed = parseFacetName(raw)
+    return parsed.ok ? parsed.value.name : raw
+  })()
 
   // Recompute focus order
   useEffect(() => {
@@ -91,8 +106,8 @@ export function CreateView({
         field="name"
         label="Name"
         placeholder="my-facet"
-        hint="kebab-case"
-        validate={validateKebab}
+        hint="name or @scope/name"
+        validate={validateName}
         onConfirm={() => focus('field-description')}
       />
 
@@ -119,7 +134,7 @@ export function CreateView({
           <AssetSection
             section={type}
             label={ASSET_LABELS[type]}
-            defaultName={form.assets[type].items.length === 0 ? form.fields.name.value : undefined}
+            defaultName={form.assets[type].items.length === 0 ? defaultAssetName : undefined}
             dimmed={!assetsReady}
             onEditDescription={onEditDescription}
             validate={(v) => {

--- a/packages/cli/src/tui/views/edit/edit-view.tsx
+++ b/packages/cli/src/tui/views/edit/edit-view.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_VERSION, isValidKebabCase } from '@agent-facets/engine'
+import { validateFacetName } from '@agent-facets/protocol'
 import { Box, Text } from 'ink'
 import { useCallback, useEffect } from 'react'
 import { AssetSection } from '../../components/asset-section.tsx'
@@ -43,9 +44,15 @@ export function EditView({
   const { form } = useFormState()
   const { setFocusIds, focus, focusedId } = useFocusOrder()
 
-  const validateKebab = useCallback((v: string) => {
+  // Facet identity: an unscoped slug or a scoped `@scope/name`. Changing the
+  // name from one scope to another is a normal local edit — there is no
+  // special scope-change warning (cross-scope movement is a registry
+  // authorization concern, surfaced downstream). Asset names (below) stay
+  // kebab-case only.
+  const validateName = useCallback((v: string) => {
     if (!v) return undefined
-    if (!isValidKebabCase(v)) return 'Must be kebab-case (e.g., my-facet)'
+    const result = validateFacetName(v)
+    if (!result.ok) return 'Must be a facet name (e.g., my-facet or @scope/name)'
     return undefined
   }, [])
 
@@ -78,8 +85,8 @@ export function EditView({
           field="name"
           label="Name"
           placeholder="my-facet"
-          hint="kebab-case"
-          validate={validateKebab}
+          hint="name or @scope/name"
+          validate={validateName}
           onConfirm={() => focus('field-description')}
         />
 

--- a/packages/engine/src/__tests__/build-pipeline.test.ts
+++ b/packages/engine/src/__tests__/build-pipeline.test.ts
@@ -753,6 +753,72 @@ describe('writeBuildOutput', () => {
     expect(looseText).toBe(embeddedEntry.text)
   })
 
+  test('writes a scoped facet to a nested dist/ path, creating parent dirs', async () => {
+    const dir = await createFixtureDir('scoped-output')
+    await Bun.write(join(dir, 'skills/cowsay/SKILL.md'), '# Cowsay')
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name: '@julian/cowsay',
+        version: '1.0.0',
+        skills: { cowsay: { description: 'Cowsay tools' } },
+      }),
+    )
+
+    const result = await runBuildPipeline(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    // Without the parent-dir mkdir this rejects with ENOENT.
+    await writeBuildOutput(result, dir)
+
+    // The archive lands at the nested scoped path.
+    const archivePath = join(dir, 'dist/@julian/cowsay-1.0.0.facet')
+    expect(await Bun.file(archivePath).exists()).toBe(true)
+
+    // The archive's embedded facet.json keeps the scoped identity; the inner
+    // asset paths are still derived from asset names, not the facet identity.
+    const outerBytes = await Bun.file(archivePath).arrayBuffer()
+    const outerEntries = parseTar(outerBytes)
+    const innerEntry = outerEntries.find((e) => e.name === 'archive.tar.gz')
+    if (!innerEntry?.data) throw new Error('archive.tar.gz not found in outer tar')
+    const innerFiles = await parseTarGzip(innerEntry.data)
+    const facetJsonEntry = innerFiles.find((f) => f.name === 'facet.json')
+    if (!facetJsonEntry) throw new Error('facet.json not found in inner archive')
+    expect(JSON.parse(facetJsonEntry.text).name).toBe('@julian/cowsay')
+    expect(innerFiles.map((f) => f.name).sort()).toEqual(['facet.json', 'skills/cowsay/SKILL.md'])
+  })
+
+  test('writeBuildOutput creates parent dirs for a slash-containing archive filename', async () => {
+    // The build-output parent-dir fix is the load-bearing repair. A bare
+    // slash-containing manifest name (`acme/cowsay`) no longer passes
+    // FacetManifestSchema, so it can't reach here through runBuildPipeline —
+    // but the write boundary itself must still create parent dirs for ANY
+    // slash-containing archive filename (scoped names, plus defense-in-depth
+    // for the pre-existing nested-path bug). We exercise the boundary
+    // directly with a synthesized BuildResult.
+    const dir = await createFixtureDir('slash-write-boundary')
+    const realResult = await (async () => {
+      await Bun.write(join(dir, 'skills/cowsay/SKILL.md'), '# Cowsay')
+      await Bun.write(
+        join(dir, 'facet.json'),
+        JSON.stringify({
+          name: '@acme/cowsay',
+          version: '1.0.0',
+          skills: { cowsay: { description: 'Cowsay tools' } },
+        }),
+      )
+      const r = await runBuildPipeline(dir)
+      if (!r.ok) expect.unreachable()
+      return r
+    })()
+    // Re-point the archive filename at a bare slash-namespaced path to prove
+    // the write boundary creates parents regardless of how the name renders.
+    const slashResult = { ...realResult, archiveFilename: 'acme/cowsay-1.0.0.facet' }
+    await writeBuildOutput(slashResult, dir)
+
+    expect(await Bun.file(join(dir, 'dist/acme/cowsay-1.0.0.facet')).exists()).toBe(true)
+  })
+
   test('cleans previous dist/ before writing', async () => {
     const dir = await createFixtureDir('clean-dist')
     await Bun.write(join(dir, 'skills/x/SKILL.md'), '# Skill')

--- a/packages/engine/src/__tests__/edit.test.ts
+++ b/packages/engine/src/__tests__/edit.test.ts
@@ -2,11 +2,35 @@ import { describe, expect, test } from 'bun:test'
 import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { isValidKebabCase } from '@agent-facets/engine'
 import type { FacetManifest } from '@agent-facets/protocol'
 import { writeManifest } from '../edit/manifest-writer.ts'
 import { reconcile } from '../edit/reconcile.ts'
 import type { DiscoveredAsset } from '../edit/scanner.ts'
 import { scanAssets } from '../edit/scanner.ts'
+
+// --- Asset-name grammar (diverges from facet identity grammar) ---
+
+describe('isValidKebabCase — asset-name grammar', () => {
+  test.each(['cowsay', 'code-review', 'viper-plans', 'x1', 'a'])('accepts kebab asset name %p', (name) => {
+    expect(isValidKebabCase(name)).toBe(true)
+  })
+
+  // Asset names stay local kebab identifiers and are NOT scoped facet
+  // identities: the scope marker `@` and the scope separator `/` are both
+  // rejected, along with uppercase, underscores, and spaces.
+  test.each([
+    '@scope',
+    '@scope/name',
+    'acme/cowsay',
+    'Cowsay',
+    'cow_say',
+    'cow say',
+    'cow/say',
+  ])('rejects non-kebab asset name %p (e.g. @ and /)', (name) => {
+    expect(isValidKebabCase(name)).toBe(false)
+  })
+})
 
 async function createFixtureDir(name: string): Promise<string> {
   const dir = join(tmpdir(), `facets-edit-test-${name}-${Date.now()}`)

--- a/packages/engine/src/build/write-output.ts
+++ b/packages/engine/src/build/write-output.ts
@@ -1,5 +1,5 @@
 import { mkdir, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { BUILD_OUTPUT_DIR } from '../registry/artifact-path.ts'
 import type { BuildResult } from './pipeline.ts'
 
@@ -28,8 +28,16 @@ export async function writeBuildOutput(
   await rm(distDir, { recursive: true, force: true })
   await mkdir(distDir, { recursive: true })
 
-  // Write the .facet archive (self-contained outer tar)
-  await Bun.write(join(distDir, result.archiveFilename), result.archiveBytes)
+  // Write the .facet archive (self-contained outer tar). For a scoped
+  // (`@scope/name`) or slash-containing unscoped (`acme/name`) facet
+  // identity, `archiveFilename` embeds the slash and renders as a nested
+  // path under dist/ (e.g. `dist/@scope/name-1.0.0.facet`). `Bun.write`
+  // does not create parent directories, so create the archive's parent
+  // first. For a flat name, `dirname` is `distDir` (already created above),
+  // making this a no-op.
+  const archivePath = join(distDir, result.archiveFilename)
+  await mkdir(dirname(archivePath), { recursive: true })
+  await Bun.write(archivePath, result.archiveBytes)
 
   // Optionally write loose build manifest
   if (options.emitManifest) {


### PR DESCRIPTION
### Why

Scoped facet names (e.g. `@acme/cowsay`) embed a slash, which causes the archive filename to render as a nested path under `dist/` (e.g. `dist/@acme/cowsay-1.0.0.facet`). `Bun.write` does not create intermediate directories, so builds of scoped facets were failing with a missing-directory error. The same underlying bug also affected any other slash-containing archive filename.

### Details

The fix is in `writeBuildOutput`: after computing `archivePath`, the code now calls `mkdir(dirname(archivePath), { recursive: true })` before writing the archive. For flat (unscoped) names, `dirname` resolves to `distDir`, which already exists, making the call a no-op.

The create and edit views previously validated the facet name field using `isValidKebabCase`, which rejects the `@` and `/` characters required for scoped names. Both views now use `validateFacetName` from the protocol package instead, with updated hint text (`name or @scope/name`). Asset names within a facet remain kebab-case only — `isValidKebabCase` is still used for those fields.

The first-asset default name suggestion in the create view is now derived from the unscoped base segment of the facet name (`@acme/cowsay` → `cowsay`) via `parseFacetName`, so the suggestion is always a valid kebab asset name even when a scoped identity is entered.

The spec scenario for the slash-containing unscoped identity (`acme/cowsay`) has been reframed: bare slash-containing unscoped names no longer pass `FacetManifestSchema`, so the scenario now documents the write-boundary behavior directly — parent directories are created for any slash-containing archive path.

### Verification

- New unit test in `build-pipeline.test.ts` builds a `@julian/cowsay` facet end-to-end and asserts the archive lands at `dist/@julian/cowsay-1.0.0.facet`, that `facet.json` inside the archive retains the scoped identity, and that inner asset paths are derived from asset names rather than the facet identity.
- A second unit test exercises the write boundary directly with a synthesized slash-containing archive filename to confirm parent directory creation independent of the manifest schema.
- E2E test in `create-build.e2e.test.ts` scaffolds a `@julian/cowsay` project, builds it, and asserts the archive exists at the nested dist path.
- Publish test covers scoped facet content-drift detection and confirms the upload targets the correct scoped route (`%40acme/cowsay/versions`) without double-encoding the slash.