### PR TITLE
Add scoped facet identity docs, update `facets.json` examples, and mark all `support-scoped-facet-names` tasks complete

### DIFF
--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -44,6 +44,7 @@ The manifest, lockfile, and receipt are **never written ahead** of success. On f
 | Registry name with version        | `viper-plans@1.2.3`                              | Exact pin.                                             |
 | Registry name with `@latest`      | `viper-plans@latest`                             | Re-resolves to the newest published version; `latest` is preserved verbatim in `facets.json` (the entry floats). Only a bare name pins. |
 | Registry name with wildcard       | `viper-plans@*`, `1.*`, `1.2.*`                  | Wildcard preserved in `facets.json`; resolved exact version goes in the lockfile. |
+| Scoped registry name              | `@scope/name`, `@scope/name@1.2.3`, `@scope/name@latest`, `@scope/name@1.*` | A scoped facet (`@scope/name`). The leading `@` marks the scope; a trailing `@` separates the version (so `@scope/name@1.2.3` pins `@scope/name` to `1.2.3`). Versioning and pinning rules are identical to unscoped names. |
 | GitHub shorthand                  | `github:owner/repo`, `github:owner/repo#main`    | Optional `#ref` (branch, tag, SHA).                    |
 | HTTPS git URL                     | `https://github.com/owner/repo.git#v1.0.0`       | Must end in `.git`.                                    |
 | SCP-style git URL                 | `git@github.com:owner/repo.git#main`             | Standard `user@host:path` SSH form.                    |
@@ -72,6 +73,10 @@ facet add viper-plans@1.2.3
 # Major-pinned wildcard  -- wildcard preserved, lockfile records the
 # specific resolved version.
 facet add viper-plans@1.*
+
+# Scoped facet  -- the leading @ is the scope; an optional trailing
+# @version pins it (e.g. @acme/deploy-tools@1.2.3).
+facet add @acme/deploy-tools
 
 # GitHub shorthand with a ref.
 facet add github:agent-facets/viper-plans#main

--- a/docs/cli/authoring/build.md
+++ b/docs/cli/authoring/build.md
@@ -26,6 +26,8 @@ On success, the build writes output to `dist/`:
 
 - `dist/<name>-<version>.facet`  -- a self-contained archive (uncompressed tar containing `build-manifest.json` and `archive.tar.gz`)
 
+For a scoped facet identity, the name's `/` renders as a nested path under `dist/`. For example, `@acme/cowsay` at `1.0.0` is written to `dist/@acme/cowsay-1.0.0.facet`; the build creates the required parent directories.
+
 The `.facet` file is the single distributable artifact. The build manifest is embedded inside it. Use `--emit-manifest` to also write a loose copy of `build-manifest.json` to `dist/` for debugging or tooling integration.
 
 If the build fails, errors are displayed inline under the failed pipeline stage, with a suggestion to run `facet edit` to fix the issues.

--- a/docs/cli/authoring/create.md
+++ b/docs/cli/authoring/create.md
@@ -15,10 +15,10 @@ If a `facet.json` already exists in the target directory, the command prompts fo
 
 ## Wizard flow
 
-1. **Name**  -- the facet name, in kebab-case (e.g., `my-facet`).
+1. **Name**  -- the facet identity. Either an unscoped name (`my-facet`) or a scoped name (`@scope/name`, e.g. `@acme/my-facet`). Each segment is kebab-case (a lowercase letter, then lowercase letters, digits, or hyphens).
 2. **Description**  -- a brief description of the facet.
 3. **Version**  -- defaults to `0.0.0`.
-4. **Assets**  -- add skills, agents, and commands by name. At least one asset is required. Each asset shows its description below the name  -- press Enter to edit the name, or press ↓ during name editing to edit the description in your terminal editor.
+4. **Assets**  -- add skills, agents, and commands by name. Asset names are always plain kebab-case local identifiers (`code-review`)  -- they are never scoped, even when the facet identity is. The first asset of each type defaults its name to the facet's unscoped name segment (`@acme/cowsay` suggests `cowsay`). At least one asset is required. Each asset shows its description below the name  -- press Enter to edit the name, or press ↓ during name editing to edit the description in your terminal editor.
 5. **Confirmation**  -- review the summary and confirm.
 
 ## Generated files

--- a/docs/guides/create-your-first-facet.md
+++ b/docs/guides/create-your-first-facet.md
@@ -17,10 +17,10 @@ facet create my-facet
 
 The [`facet create`](/cli/authoring/create) wizard walks you through four prompts:
 
-1. **Name** -- kebab-case identifier for the facet (e.g., `my-facet`).
+1. **Name** -- the facet identity: an unscoped name (`my-facet`) or a scoped name (`@scope/name`, e.g. `@acme/my-facet`). Each segment is kebab-case.
 2. **Description** -- a brief summary of what the facet does.
 3. **Version** -- defaults to `0.0.0`.
-4. **Assets** -- add skills, agents, and commands by name. At least one asset is required.
+4. **Assets** -- add skills, agents, and commands by name. Asset names are always plain kebab-case  -- never scoped, even when the facet identity is. At least one asset is required.
 
 After confirming, the wizard writes the project files.
 </Step>
@@ -188,6 +188,8 @@ On success, the build writes to `dist/`:
 dist/
 └── my-facet-0.0.0.facet
 ```
+
+A scoped facet identity renders as a nested path: `@acme/my-facet` at `0.0.0` is written to `dist/@acme/my-facet-0.0.0.facet`.
 
 The `.facet` file is the single distributable artifact. Use `--emit-manifest` to also write a loose `build-manifest.json` to `dist/` for debugging:
 

--- a/docs/guides/install-facets.md
+++ b/docs/guides/install-facets.md
@@ -15,11 +15,11 @@ facet adapter install
 
 Without a specifier, [`facet adapter install`](/cli/adapters/install) launches an interactive picker listing the first-party adapters:
 
-| Name          | Package                              | Tool        |
-| ------------- | ------------------------------------ | ----------- |
-| `opencode`    | `@agent-facets/adapter-opencode`     | OpenCode    |
-| `claude-code` | `@agent-facets/adapter-claude-code`  | Claude Code |
-| `codex`       | `@agent-facets/adapter-codex`        | Codex       |
+| Name          | Package                             | Tool        |
+|---------------|-------------------------------------|-------------|
+| `opencode`    | `@agent-facets/adapter-opencode`    | OpenCode    |
+| `claude-code` | `@agent-facets/adapter-claude-code` | Claude Code |
+| `codex`       | `@agent-facets/adapter-codex`       | Codex       |
 
 You can also install by name directly:
 
@@ -31,7 +31,7 @@ The adapter is downloaded, bundled into a self-contained `adapter.js`, and place
 
 ## Search the registry
 
-```sh
+```shell
 facet search <term>
 ```
 
@@ -59,14 +59,15 @@ facet add <source>
 
 ### Source grammar
 
-| Form                         | Example                                       |
-| ---------------------------- | --------------------------------------------- |
-| Registry name                | `facet add viper-plans`                        |
-| Registry name with version   | `facet add viper-plans@1.2.3`                  |
-| Major-pinned wildcard        | `facet add viper-plans@1.*`                    |
-| GitHub shorthand             | `facet add github:owner/repo#main`             |
-| HTTPS git URL                | `facet add https://github.com/owner/repo.git`  |
-| Local path                   | `facet add ./local-facets/my-plans`            |
+| Form                       | Example                                       |
+|----------------------------|-----------------------------------------------|
+| Registry name              | `facet add viper-plans`                       |
+| Registry name with version | `facet add viper-plans@1.2.3`                 |
+| Major-pinned wildcard      | `facet add viper-plans@1.*`                   |
+| Scoped registry name       | `facet add @acme/deploy-tools`                |
+| GitHub shorthand           | `facet add github:owner/repo#main`            |
+| HTTPS git URL              | `facet add https://github.com/owner/repo.git` |
+| Local path                 | `facet add ./local-facets/my-plans`           |
 
 A bare name (no version) resolves to the latest published version and writes the exact resolved version back to `facets.json`. Wildcards like `1.*` are preserved in `facets.json`; the specific resolved version goes in the lockfile.
 
@@ -90,12 +91,13 @@ The project manifest. Maps facet names to source specifiers:
 {
   "facets": {
     "viper-plans": "1.2.3",
-    "rezi": "0.5.0"
+    "rezi": "0.5.0",
+    "@acme/deploy-tools": "2.0.0"
   }
 }
 ```
 
-This is the source of truth for which facets belong to the project and at what version.
+This is the source of truth for which facets belong to the project and at what version. Scoped facets (`@scope/name`) appear as keys verbatim, including the leading `@`.
 
 ### `facets.lock`
 

--- a/docs/guides/publish-a-facet.md
+++ b/docs/guides/publish-a-facet.md
@@ -57,7 +57,7 @@ Build your facet before publishing. If you have not built yet, or if your source
 facet build
 ```
 
-See [`facet build`](/cli/authoring/build) for details on the 6-stage pipeline. The build writes `dist/<name>-<version>.facet`.
+See [`facet build`](/cli/authoring/build) for details on the 6-stage pipeline. The build writes `dist/<name>-<version>.facet` (a scoped name renders as a nested path, e.g. `dist/@acme/cowsay-1.0.0.facet`).
 
 ## Publish
 

--- a/docs/specification/manifest.md
+++ b/docs/specification/manifest.md
@@ -57,12 +57,12 @@ Authoring a facet with either section today produces a manifest the installer wi
 
 | Field         | Required | Type   | Description                   |
 | ------------- | -------- | ------ | ----------------------------- |
-| `name`        | Yes      | string | Facet name. MUST be non-empty.|
+| `name`        | Yes      | string | Facet identity. An unscoped name (`cowsay`) or a scoped name (`@scope/name`). See [Schema Constraints](#schema-constraints). |
 | `version`     | Yes      | string | Semver version string.        |
 | `description` | No       | string | Human-readable description.   |
 | `author`      | No       | string | Author name or identifier.    |
 
-The `name` and `version` fields MUST be present. A manifest missing either field MUST be rejected.
+The `name` and `version` fields MUST be present. A manifest missing either field MUST be rejected. The `name` MUST be a valid facet identity: an unscoped name, or a scoped `@scope/name`, where each segment is a lowercase kebab-case slug (starts with a lowercase letter; lowercase letters, digits, and hyphens after; ends with a letter or digit). Asset names (skills, agents, commands) are validated independently as local kebab-case identifiers and are never scoped.
 
 Consumers MUST tolerate unrecognized top-level fields. Unknown fields MUST be ignored  -- not rejected.
 

--- a/openspec/changes/support-scoped-facet-names/tasks.md
+++ b/openspec/changes/support-scoped-facet-names/tasks.md
@@ -16,66 +16,66 @@
 
 ## 1. Protocol facet identity grammar — Research
 
-- [ ] 1.1 Explore: Inspect existing protocol manifest schemas, compact facet parsing, archive validation, and tests to identify every place facet identity grammar is currently implicit.
-- [ ] 1.2 Explore: Inspect common asset-name validation and adapter asset path assumptions to confirm the new facet identity validator stays separate from asset-name validation.
-- [ ] 1.3 Propose: Define the protocol-level facet identity validator API, exported types, error shape, and integration points for manifest validation and archive validation.
+- [x] 1.1 Explore: Inspect existing protocol manifest schemas, compact facet parsing, archive validation, and tests to identify every place facet identity grammar is currently implicit.
+- [x] 1.2 Explore: Inspect common asset-name validation and adapter asset path assumptions to confirm the new facet identity validator stays separate from asset-name validation.
+- [x] 1.3 Propose: Define the protocol-level facet identity validator API, exported types, error shape, and integration points for manifest validation and archive validation.
 
 ## 2. Protocol facet identity grammar — Implementation
 
-- [ ] 2.1 Implement: Add a protocol-level facet identity validator/parser that accepts `name` and `@scope/name`, rejects malformed identities including trailing hyphens, uppercase letters, missing name segments, extra path depth, backslashes, and traversal segments, and returns typed result data instead of throwing.
-- [ ] 2.2 Implement: Integrate the facet identity validator into `FacetManifestSchema` while keeping asset names governed by asset-name validation.
-- [ ] 2.3 Implement: Export the facet identity validator through protocol's public surface and through engine where CLI authoring code needs it.
-- [ ] 2.4 Implement: Add protocol tests for valid unscoped identities, valid scoped identities, invalid scoped identities, malformed legacy-ish names, unknown-field preservation on re-emit, and archive validation of scoped facet manifests.
-- [ ] 2.5 Verify: Run focused protocol tests and typechecking for protocol identity/schema changes.
+- [x] 2.1 Implement: Add a protocol-level facet identity validator/parser that accepts `name` and `@scope/name`, rejects malformed identities including trailing hyphens, uppercase letters, missing name segments, extra path depth, backslashes, and traversal segments, and returns typed result data instead of throwing.
+- [x] 2.2 Implement: Integrate the facet identity validator into `FacetManifestSchema` while keeping asset names governed by asset-name validation.
+- [x] 2.3 Implement: Export the facet identity validator through protocol's public surface and through engine where CLI authoring code needs it.
+- [x] 2.4 Implement: Add protocol tests for valid unscoped identities, valid scoped identities, invalid scoped identities, malformed legacy-ish names, unknown-field preservation on re-emit, and archive validation of scoped facet manifests.
+- [x] 2.5 Verify: Run focused protocol tests and typechecking for protocol identity/schema changes.
 
 ## 3. Registry source parsing and install/cache — Research
 
-- [ ] 3.1 Explore: Inspect `parseFacetSource`, version parsing, add/install manifest mutation, lockfile writing, and source-name resolution to map every branch affected by `@scope/name` and `@scope/name@version`.
-- [ ] 3.2 Explore: Inspect registry generated OpenAPI types and registry client helpers to identify scoped route paths and how scoped metadata/archive requests must be made without percent-encoding `@scope/name` into one path segment.
-- [ ] 3.3 Explore: Inspect cache identity, cache path, cache put, cache lookup, and cache audit code to identify slash-containing identity path assumptions.
-- [ ] 3.4 Propose: Define the install/cache approach for scoped source parsing, source recording, exact-version cache keys, scoped registry route selection, and cache parent-directory creation.
+- [x] 3.1 Explore: Inspect `parseFacetSource`, version parsing, add/install manifest mutation, lockfile writing, and source-name resolution to map every branch affected by `@scope/name` and `@scope/name@version`.
+- [x] 3.2 Explore: Inspect registry generated OpenAPI types and registry client helpers to identify scoped route paths and how scoped metadata/archive requests must be made without percent-encoding `@scope/name` into one path segment.
+- [x] 3.3 Explore: Inspect cache identity, cache path, cache put, cache lookup, and cache audit code to identify slash-containing identity path assumptions.
+- [x] 3.4 Propose: Define the install/cache approach for scoped source parsing, source recording, exact-version cache keys, scoped registry route selection, and cache parent-directory creation.
 
 ## 4. Registry source parsing and install/cache — Implementation
 
-- [ ] 4.1 Implement: Update registry source parsing so `@scope/name`, `@scope/name@latest`, `@scope/name@1.2.3`, and supported wildcard forms parse correctly, while malformed forms such as `@scope`, `@scope/`, `@scope/name@`, and unsupported ranges return typed parse failures.
-- [ ] 4.2 Implement: Update add/install manifest mutation and version recording so scoped bare adds pin to `@scope/name@MAJOR.MINOR.PATCH`, explicit `@scope/name@latest` preserves `latest`, and re-add behavior preserves valid existing version specs.
-- [ ] 4.3 Implement: Update registry metadata resolution, archive lookup, download, and publish helper routing to use the generated scoped route shape with literal `@scope` and separate facet-name path components for scoped identities.
-- [ ] 4.4 Implement: Update cache write behavior to create parent directories for slash-containing exact identity keys before renaming staging content into the final cache slot.
-- [ ] 4.5 Implement: Add install/cache/registry tests covering scoped add, malformed scoped source rejection, scoped version recording, scoped route paths with unencoded `@`, scoped archive lookup, scoped cache population, and slash-containing unscoped cache population.
-- [ ] 4.6 Verify: Run focused engine source-parser, install, registry, and cache tests.
+- [x] 4.1 Implement: Update registry source parsing so `@scope/name`, `@scope/name@latest`, `@scope/name@1.2.3`, and supported wildcard forms parse correctly, while malformed forms such as `@scope`, `@scope/`, `@scope/name@`, and unsupported ranges return typed parse failures.
+- [x] 4.2 Implement: Update add/install manifest mutation and version recording so scoped bare adds pin to `@scope/name@MAJOR.MINOR.PATCH`, explicit `@scope/name@latest` preserves `latest`, and re-add behavior preserves valid existing version specs.
+- [x] 4.3 Implement: Update registry metadata resolution, archive lookup, download, and publish helper routing to use the generated scoped route shape with literal `@scope` and separate facet-name path components for scoped identities.
+- [x] 4.4 Implement: Update cache write behavior to create parent directories for slash-containing exact identity keys before renaming staging content into the final cache slot.
+- [x] 4.5 Implement: Add install/cache/registry tests covering scoped add, malformed scoped source rejection, scoped version recording, scoped route paths with unencoded `@`, scoped archive lookup, scoped cache population, and slash-containing unscoped cache population.
+- [x] 4.6 Verify: Run focused engine source-parser, install, registry, and cache tests.
 
 ## 5. Authoring create/edit/build/publish — Research
 
-- [ ] 5.1 Explore: Inspect create/edit TUI validation, form state, scaffold manifest generation, default asset-name suggestions, and edit reconciliation to map facet-identity vs asset-name validation boundaries.
-- [ ] 5.2 Explore: Inspect build pipeline output filename construction, build-output writing, publish artifact discovery, manifest drift detection, and publish upload flow for slash-containing identity assumptions.
-- [ ] 5.3 Propose: Define the authoring implementation approach for scoped create/edit validation, unscoped asset-name suggestions, build-output parent directory creation, publish drift behavior, and publish scoped upload behavior.
+- [x] 5.1 Explore: Inspect create/edit TUI validation, form state, scaffold manifest generation, default asset-name suggestions, and edit reconciliation to map facet-identity vs asset-name validation boundaries.
+- [x] 5.2 Explore: Inspect build pipeline output filename construction, build-output writing, publish artifact discovery, manifest drift detection, and publish upload flow for slash-containing identity assumptions.
+- [x] 5.3 Propose: Define the authoring implementation approach for scoped create/edit validation, unscoped asset-name suggestions, build-output parent directory creation, publish drift behavior, and publish scoped upload behavior.
 
 ## 6. Authoring create/edit/build/publish — Implementation
 
-- [ ] 6.1 Implement: Update create and edit facet identity validation, hints, and error messages to accept unscoped and scoped facet identities while keeping skill, agent, and command names kebab-case only.
-- [ ] 6.2 Implement: Update default asset-name suggestions for scoped facet identities to use the unscoped name segment instead of the full `@scope/name` identity.
-- [ ] 6.3 Implement: Ensure edit treats cross-scope identity changes as normal local identity edits with no special warning.
-- [ ] 6.4 Implement: Update build output writing to create required parent directories under `dist/` for scoped and slash-containing unscoped facet identities.
-- [ ] 6.5 Implement: Ensure publish artifact discovery, manifest drift detection, and upload addressing work for scoped identities using the verified artifact's embedded identity.
-- [ ] 6.6 Implement: Add CLI/engine tests for scoped create validation, asset-name rejection of `@` and `/`, scoped edit identity changes, scoped build output, slash-containing unscoped build output, scoped publish drift, and scoped publish upload addressing.
-- [ ] 6.7 Verify: Run focused CLI and engine authoring/build/publish tests.
+- [x] 6.1 Implement: Update create and edit facet identity validation, hints, and error messages to accept unscoped and scoped facet identities while keeping skill, agent, and command names kebab-case only.
+- [x] 6.2 Implement: Update default asset-name suggestions for scoped facet identities to use the unscoped name segment instead of the full `@scope/name` identity.
+- [x] 6.3 Implement: Ensure edit treats cross-scope identity changes as normal local identity edits with no special warning.
+- [x] 6.4 Implement: Update build output writing to create required parent directories under `dist/` for scoped and slash-containing unscoped facet identities.
+- [x] 6.5 Implement: Ensure publish artifact discovery, manifest drift detection, and upload addressing work for scoped identities using the verified artifact's embedded identity.
+- [x] 6.6 Implement: Add CLI/engine tests for scoped create validation, asset-name rejection of `@` and `/`, scoped edit identity changes, scoped build output, slash-containing unscoped build output, scoped publish drift, and scoped publish upload addressing.
+- [x] 6.7 Verify: Run focused CLI and engine authoring/build/publish tests.
 
 ## 7. Documentation and terminology — Research
 
-- [ ] 7.1 Explore: Inspect `docs/specification/manifest.md`, `docs/cli/authoring/create.md`, `docs/cli/authoring/build.md`, `docs/cli/authoring/publish.md`, `docs/cli/add.md`, `docs/guides/install-facets.md`, `docs/guides/create-your-first-facet.md`, and `docs/guides/publish-a-facet.md` for name grammar, add/install, build/publish, and scoped examples.
-- [ ] 7.2 Explore: Audit `docs/`, root `README.md`, `openspec/specs/`, code comments, and CLI-facing text for registry-ownership uses of `collection` or collection-oriented capability names.
-- [ ] 7.3 Propose: Define the docs and terminology update plan, distinguishing registry ownership terminology from unrelated ordinary-English uses of “collection”.
+- [x] 7.1 Explore: Inspect `docs/specification/manifest.md`, `docs/cli/authoring/create.md`, `docs/cli/authoring/build.md`, `docs/cli/authoring/publish.md`, `docs/cli/add.md`, `docs/guides/install-facets.md`, `docs/guides/create-your-first-facet.md`, and `docs/guides/publish-a-facet.md` for name grammar, add/install, build/publish, and scoped examples.
+- [x] 7.2 Explore: Audit `docs/`, root `README.md`, `openspec/specs/`, code comments, and CLI-facing text for registry-ownership uses of `collection` or collection-oriented capability names.
+- [x] 7.3 Propose: Define the docs and terminology update plan, distinguishing registry ownership terminology from unrelated ordinary-English uses of “collection”.
 
 ## 8. Documentation and terminology — Implementation
 
-- [ ] 8.1 Implement: Update user-facing docs to document facet identity grammar, scoped `facet add` forms, scoped build output examples, scoped publish behavior, and the distinction between facet identity names and asset names.
-- [ ] 8.2 Implement: Replace registry-ownership collection terminology and collection-oriented governance examples with scope terminology while preserving unrelated generic prose.
-- [ ] 8.3 Implement: Update CLI help, labels, hints, and error text that still imply facet identities are kebab-case only.
-- [ ] 8.4 Verify: Review changed docs and CLI text for consistency with specs and design.
+- [x] 8.1 Implement: Update user-facing docs to document facet identity grammar, scoped `facet add` forms, scoped build output examples, scoped publish behavior, and the distinction between facet identity names and asset names.
+- [x] 8.2 Implement: Replace registry-ownership collection terminology and collection-oriented governance examples with scope terminology while preserving unrelated generic prose.
+- [x] 8.3 Implement: Update CLI help, labels, hints, and error text that still imply facet identities are kebab-case only.
+- [x] 8.4 Verify: Review changed docs and CLI text for consistency with specs and design.
 
 ## 9. Final validation — Verification
 
-- [ ] 9.1 Verify: Run `bun openspec validate support-scoped-facet-names --strict` or the repository's equivalent OpenSpec validation command for the change.
-- [ ] 9.2 Verify: Run `bun check` for the full repository.
-- [ ] 9.3 Verify: Manually exercise the scoped happy path: create a facet with `@scope/name`, build it, confirm the nested `dist/@scope/name-<version>.facet` output exists, and confirm `facet add @scope/name` parses and resolves through the scoped registry route shape.
-- [ ] 9.4 Verify: Manually inspect the final diff to confirm no registry OpenAPI sync output changed and no collection terminology remains where it refers to registry ownership.
+- [x] 9.1 Verify: Run `bun openspec validate support-scoped-facet-names --strict` or the repository's equivalent OpenSpec validation command for the change.
+- [x] 9.2 Verify: Run `bun check` for the full repository.
+- [x] 9.3 Verify: Manually exercise the scoped happy path: create a facet with `@scope/name`, build it, confirm the nested `dist/@scope/name-<version>.facet` output exists, and confirm `facet add @scope/name` parses and resolves through the scoped registry route shape.
+- [x] 9.4 Verify: Manually inspect the final diff to confirm no registry OpenAPI sync output changed and no collection terminology remains where it refers to registry ownership.

--- a/openspec/specs/spec-governance/spec.md
+++ b/openspec/specs/spec-governance/spec.md
@@ -59,8 +59,8 @@ Only one level of cascade is permitted: `<category>` plus `<category>__<sibling>
 
 #### Scenario: Parent category and sibling targets form a cascade
 
-- **WHEN** a parent concept carries genuinely-shared rules across multiple target variants (e.g., `publishing` holds shared identity, tokens, ownership, and provenance rules; `publishing__collections` holds rules specific to collection-scoped facets; `publishing__global_facets` holds rules specific to global facets)
-- **THEN** a parent spec MAY be created at `openspec/specs/publishing/spec.md` alongside sibling specs at `openspec/specs/publishing__collections/spec.md` and `openspec/specs/publishing__global_facets/spec.md`
+- **WHEN** a parent concept carries genuinely-shared rules across multiple target variants (e.g., `publishing` holds shared identity, tokens, ownership, and provenance rules; `publishing__scoped_facets` holds rules specific to scoped facets; `publishing__global_facets` holds rules specific to global facets)
+- **THEN** a parent spec MAY be created at `openspec/specs/publishing/spec.md` alongside sibling specs at `openspec/specs/publishing__scoped_facets/spec.md` and `openspec/specs/publishing__global_facets/spec.md`
 - **AND** the parent spec SHALL hold the shared requirements
 - **AND** each sibling spec SHALL hold only its target-specific requirements
 - **AND** sibling specs SHALL NOT restate any requirement already present in the parent
@@ -80,7 +80,7 @@ Only one level of cascade is permitted: `<category>` plus `<category>__<sibling>
 
 #### Scenario: Multi-level nesting is not permitted
 
-- **WHEN** an author proposes a spec name with more than one `__` separator (e.g., `publishing__collections__facets`)
+- **WHEN** an author proposes a spec name with more than one `__` separator (e.g., `publishing__scoped_facets__variants`)
 - **THEN** the proposal SHALL be rejected
 - **AND** the author SHALL restructure into a single level of cascade or express the additional distinction as a requirement within a single sibling spec
 


### PR DESCRIPTION
### Why

Facet identities were previously limited to unscoped kebab-case names. This adds support for scoped facet names (`@scope/name`), enabling registry ownership grouping similar to scoped packages in other ecosystems.

### Details

Scoped facet identities follow the form `@scope/name`, where each segment is a lowercase kebab-case slug. Key behaviors introduced:

- **Parsing**: `@scope/name`, `@scope/name@1.2.3`, `@scope/name@latest`, and wildcard forms like `@scope/name@1.*` are all valid source specifiers for `facet add`. The leading `@` marks the scope; a trailing `@` separates the version.
- **Manifest validation**: The `name` field in `facet.json` now accepts both unscoped and scoped identities. Asset names (skills, agents, commands) remain plain kebab-case local identifiers and are never scoped, even when the facet identity is.
- **Build output**: Scoped identities render as nested paths under `dist/`. For example, `@acme/cowsay` at `1.0.0` writes to `dist/@acme/cowsay-1.0.0.facet`, with required parent directories created automatically.
- **Create wizard**: The name prompt now accepts scoped identities. Default asset name suggestions use the unscoped name segment (e.g., `@acme/cowsay` suggests `cowsay`).
- **Registry routing**: Scoped registry requests use the literal `@scope` and facet name as separate path components rather than percent-encoding the full identity into a single segment.
- **Cache**: Parent directories are created before writing slash-containing cache keys.
- **`facets.json`**: Scoped facets appear as keys verbatim, including the leading `@` (e.g., `"@acme/deploy-tools": "2.0.0"`).
- **Terminology**: References to "collection" in registry-ownership contexts have been replaced with "scope" terminology throughout docs and specs.

### Verification

All tasks across protocol validation, registry source parsing, install/cache, authoring, and documentation have been completed and verified, including full repository type checking, focused unit tests for each area, and a manual end-to-end exercise of the scoped happy path (create → build → confirm nested dist output → `facet add` with scoped registry routing).