### PR TITLE
Tighten `parseSlug` to 2-64 chars, reject consecutive hyphens, and refresh manifest spec docs to document canonical facet-name grammar

### DIFF
--- a/.changeset/early-garlics-dance.md
+++ b/.changeset/early-garlics-dance.md
@@ -1,0 +1,6 @@
+---
+"@agent-facets/protocol": minor
+"agent-facets": minor
+---
+
+Tighten `parseSlug` to 2-64 chars, reject consecutive hyphens, and refresh manifest spec docs to document canonical facet-name grammar

--- a/docs/cli/authoring/create.md
+++ b/docs/cli/authoring/create.md
@@ -15,7 +15,7 @@ If a `facet.json` already exists in the target directory, the command prompts fo
 
 ## Wizard flow
 
-1. **Name**  -- the facet identity. Either an unscoped name (`my-facet`) or a scoped name (`@scope/name`, e.g. `@acme/my-facet`). Each segment is kebab-case (a lowercase letter, then lowercase letters, digits, or hyphens).
+1. **Name**  -- the facet identity. Either an unscoped name (`my-facet`) or a scoped name (`@scope/name`, e.g. `@acme/my-facet`). See the [Manifest Schema](/specification/manifest#facet-name-grammar) for the full name grammar.
 2. **Description**  -- a brief description of the facet.
 3. **Version**  -- defaults to `0.0.0`.
 4. **Assets**  -- add skills, agents, and commands by name. Asset names are always plain kebab-case local identifiers (`code-review`)  -- they are never scoped, even when the facet identity is. The first asset of each type defaults its name to the facet's unscoped name segment (`@acme/cowsay` suggests `cowsay`). At least one asset is required. Each asset shows its description below the name  -- press Enter to edit the name, or press ↓ during name editing to edit the description in your terminal editor.

--- a/docs/specification/manifest.md
+++ b/docs/specification/manifest.md
@@ -3,8 +3,7 @@ title: "Manifest Schema"
 description: "The facet manifest format  -- fields, types, and constraints."
 ---
 
-The facet manifest (`facet.json`) is the source of truth for what a facet contains, what other facets it composes text
-from, and which MCP servers it references. This page defines every field in the manifest schema.
+The facet manifest (`facet.json`) is the source of truth for a facet's identity and the text assets it contains. This page defines every field in the manifest schema and is the canonical reference for the facet name grammar.
 
 ## Example
 
@@ -28,30 +27,7 @@ commands:
   review:
     description: "Run a code review"
     prompt: { file: commands/review.md }
-
-facets:
-  - "code-review-base@1.0.0"
-  - name: typescript-patterns
-    version: "2.1.0"
-    skills: [ts-conventions, any-usage]
-
-servers:
-  jira: "1.0.0"
-  github: "2.3.0"
-  "@acme/deploy": "0.5.0"
-  slack:
-    image: "ghcr.io/acme/slack-bot:v2"
 ```
-
-<Note>
-**Closed-alpha note.** The `facets:` and `servers:` sections are spec'd here for the open-beta target, but the current installer treats them differently:
-
-- A non-empty `facets:` (composition) is **hard-rejected** during install. Composition support is open-beta scope.
-- A `servers:` declaration is **warned** during install  -- the server names are surfaced to the user but not materialized. Server materialization is also open-beta scope.
-
-Authoring a facet with either section today produces a manifest the installer will refuse (composition) or partially handle (servers). Plan accordingly.
-</Note>
-
 
 ## Identity
 
@@ -62,9 +38,37 @@ Authoring a facet with either section today produces a manifest the installer wi
 | `description` | No       | string | Human-readable description.   |
 | `author`      | No       | string | Author name or identifier.    |
 
-The `name` and `version` fields MUST be present. A manifest missing either field MUST be rejected. The `name` MUST be a valid facet identity: an unscoped name, or a scoped `@scope/name`, where each segment is a lowercase kebab-case slug (starts with a lowercase letter; lowercase letters, digits, and hyphens after; ends with a letter or digit). Asset names (skills, agents, commands) are validated independently as local kebab-case identifiers and are never scoped.
+The `name` and `version` fields MUST be present. A manifest missing either field MUST be rejected. The `name` MUST be a valid facet identity: an unscoped name (`<slug>`) or a scoped name (`@<scope>/<slug>`). Asset names (skills, agents, commands) are validated independently as local kebab-case identifiers and are never scoped.
 
 Consumers MUST tolerate unrecognized top-level fields. Unknown fields MUST be ignored  -- not rejected.
+
+### Facet Name Grammar
+
+A facet identity is one of exactly two forms:
+
+- **Unscoped:** a single slug, e.g. `cowsay`.
+- **Scoped:** `@<scope>/<slug>`, where both the scope and the base name are slugs, e.g. `@julian/cowsay`.
+
+Every slug component (the unscoped name, a scope, and a scoped base name) MUST satisfy the same grammar:
+
+- It MUST be at least 2 and at most 64 characters long.
+- It MUST start with a lowercase ASCII letter (`a`-`z`).
+- It MUST end with a lowercase ASCII letter or ASCII digit.
+- It MUST contain only lowercase ASCII letters, ASCII digits, and hyphens (`-`).
+- It MUST NOT contain consecutive hyphens.
+
+Names are validated, never normalized. Uppercase letters, non-ASCII characters, underscores, dots, spaces, and other characters outside the grammar are rejected rather than rewritten.
+
+| Valid          | Invalid             | Why invalid                          |
+| -------------- | ------------------- | ------------------------------------ |
+| `ab`           | `a`                 | shorter than 2 characters            |
+| `cowsay`       | `Cowsay`            | uppercase letters                    |
+| `admin-tester` | `1abc`              | does not start with a letter         |
+| `apple-b34r`   | `abc-`              | ends with a hyphen                   |
+| `@julian/cowsay` | `abc--def`        | consecutive hyphens                  |
+| `@acme/deploy-tools` | `abc_def`       | underscore is not allowed            |
+
+The following scoped shapes are rejected: a bare scope (`@scope`), a missing scope (`@/name`), a missing name (`@scope/`), extra path depth (`@scope/name/extra`), and the legacy un-prefixed form (`scope/name`).
 
 ## Text Assets
 
@@ -76,7 +80,7 @@ Text assets are the locally authored content included in the facet.
 | `agents`   | No       | map of string → agent descriptor  | Agent name → agent descriptor (description, prompt, adapter config).         |
 | `commands` | No       | map of string → command descriptor| Command name → command descriptor (description, prompt).                     |
 
-A facet MUST have at least one text asset  -- either locally authored or composed from other facets via the `facets` section. A manifest with no text assets MUST be rejected.
+A facet MUST have at least one locally authored text asset. A manifest with no text assets MUST be rejected.
 
 ### Agent Descriptor
 
@@ -101,99 +105,10 @@ The `adapters` section is OPTIONAL. It contains adapter-specific configuration (
 
 The `prompt` field follows the same rules as the agent descriptor's `prompt`.
 
-## Composed Facets
-
-The `facets` section declares text composed from other published facets. Each entry is either a compact string or a selective object.
-
-### Compact Form
-
-Takes all text assets from the referenced facet:
-
-```yaml
-facets:
-  - "code-review-base@1.0.0"
-```
-
-Format: `"name@version"`. For scoped names: `"@scope/name@version"`.
-
-### Selective Form
-
-Cherry-picks specific assets from the referenced facet:
-
-```yaml
-facets:
-  - name: typescript-patterns
-    version: "2.1.0"
-    skills: [ts-conventions, any-usage]
-    agents: [baseline-reviewer]
-    commands: [lint-check]
-```
-
-| Field      | Required | Type             | Description                          |
-| ---------- | -------- | ---------------- | ------------------------------------ |
-| `name`     | Yes      | string           | Source facet name.                    |
-| `version`  | Yes      | string           | Exact version to compose from.       |
-| `skills`   | No       | array of strings | Skill names to include.              |
-| `agents`   | No       | array of strings | Agent names to include.              |
-| `commands` | No       | array of strings | Command names to include.            |
-
-A selective entry MUST include at least one asset type (`skills`, `agents`, or `commands`). A selective entry with none MUST be rejected.
-
-### Composition Semantics
-
-Text composition is resolved before the facet archive reaches the registry. The `facets` section serves dual purpose:
-
-1. **Composition directive**  -- instructs the build/publish process which text assets to include from other facets.
-2. **Attribution record**  -- documents exactly where composed content came from.
-
-The manifest itself is never modified by composition. The build process reads it, resolves composition sources, and packages the composed files alongside local files into the facet archive.
-
-Composed text uses **exact version pins** (e.g., `"name@1.0.0"`). The composed text is frozen at that version in the archive.
-
-### Naming Constraints
-
-Composed asset names MUST NOT collide with locally authored asset names. If a composed facet includes a skill named `code-review` and the local facet also declares a skill named `code-review`, this is a naming collision. Collisions MUST be detected at build time and MUST be an error.
-
-## Server References
-
-The `servers` section declares MCP server references. MCP servers are a separate artifact type from facets (see [MCP Server Assets](/specification/servers)). The `servers` section declares which servers this facet needs. There are two forms depending on the server's execution mode.
-
-### Source-Mode
-
-A string value declares a floor version constraint:
-
-```yaml
-servers:
-  jira: "1.0.0"
-  "@acme/deploy": "0.5.0"
-```
-
-The floor version is the minimum acceptable version. At install time, the CLI resolves the reference to the latest version at or above the floor (see [Install & Resolve](/specification/install)).
-
-### Ref-Mode
-
-An object value with an `image` field declares an OCI image reference:
-
-```yaml
-servers:
-  slack:
-    image: "ghcr.io/acme/slack-bot:v2"
-```
-
-The image reference follows standard OCI conventions: `:` for tags, `@` for digests. At install time, the CLI resolves tags to digests and pins the digest in the lockfile.
-
-### Server Reference Summary
-
-| Key         | Value type | Mode        | Description                                                                |
-| ----------- | ---------- | ----------- | -------------------------------------------------------------------------- |
-| server name | string     | Source-mode | Floor version  -- minimum acceptable version (e.g., `"1.0.0"`).             |
-| server name | object     | Ref-mode    | Object with `image` field containing an OCI image reference.               |
-
 ## Schema Constraints
 
-1. A facet MUST have at least one text asset (locally authored or composed).
-2. Selective `facets` entries MUST include at least one asset type.
-3. Composed asset names MUST NOT collide with locally authored asset names.
-4. The `@` character is used for both scoping (`@scope/name`) and version pinning (`name@version`). Scoped and versioned: `@scope/name@version`.
-5. Consumers MUST tolerate unrecognized fields. Unknown fields MUST be ignored.
-6. The manifest MUST NOT be modified by any tooling  -- it is immutable.
+1. The `name` MUST be a valid facet identity (see [Facet Name Grammar](#facet-name-grammar)), and the `version` MUST be a semver string.
+2. A facet MUST have at least one locally authored text asset.
+3. The `@` character marks a scope (`@scope/name`) and also separates a name from a version when a facet is referenced elsewhere (`name@version`, `@scope/name@version`).
+4. Consumers MUST tolerate unrecognized fields. Unknown fields MUST be ignored.
+5. The manifest MUST NOT be modified by any tooling  -- it is immutable.

--- a/openspec/changes/tighten-protocol-slug-facet-name-validation/.openspec.yaml
+++ b/openspec/changes/tighten-protocol-slug-facet-name-validation/.openspec.yaml
@@ -1,2 +1,0 @@
-schema: spec-driven
-created: 2026-06-15

--- a/openspec/specs/protocol__schemas/spec.md
+++ b/openspec/specs/protocol__schemas/spec.md
@@ -6,9 +6,11 @@ Defines the published, normative schemas for the artifacts a facet-compatible sy
 
 ### Requirement: A facet manifest schema is published as part of the protocol
 
-The shape of a facet manifest (`facet.json`) SHALL be published as a normative schema. Any system that produces a facet manifest SHALL produce one conforming to the published schema. Any system that consumes a facet manifest SHALL validate it against the published schema before treating any value as trusted. The schema SHALL define the required fields, the permitted shapes for skills/agents/commands, the optional `facets` and `servers` sections, the accepted facet identity grammar, and the rules for unrecognized fields.
+The shape of a facet manifest (`facet.json`) SHALL be published as a normative schema. Any system that produces a facet manifest SHALL produce one conforming to the published schema. Any system that consumes a facet manifest SHALL validate it against the published schema before treating any value as trusted. The schema SHALL define the required fields, the permitted shapes for skills/agents/commands, the accepted facet identity grammar, and the rules for unrecognized fields.
 
-A facet identity name SHALL be either an unscoped kebab-case name (`name`) or a scoped name (`@scope/name`). In a scoped name, both `scope` and `name` SHALL use lowercase kebab-case segments that start with a lowercase letter, contain only lowercase letters, digits, and hyphens after the first character, and end with a lowercase letter or digit. A facet manifest whose `name` is malformed SHALL be rejected as invalid. Asset names SHALL remain independently validated as local asset identifiers and SHALL NOT become scoped names.
+A facet identity name SHALL be either an unscoped name (`<slug>`) or a scoped name (`@<scope>/<slug>`). Each `slug` and `scope` component SHALL satisfy the same component grammar: it MUST be at least 2 characters and at most 64 characters, MUST start with a lowercase ASCII letter, MUST end with a lowercase ASCII letter or ASCII digit, MUST contain only lowercase ASCII letters, ASCII digits, and hyphens, and MUST NOT contain consecutive hyphens. Uppercase letters, non-ASCII characters, underscores, dots, spaces, plus signs, tildes, emoji, and any other character outside the component grammar SHALL be rejected rather than normalized. A facet manifest whose `name` is malformed SHALL be rejected as invalid. Asset names SHALL remain independently validated as local asset identifiers and SHALL NOT become scoped names.
+
+The facet manifest schema SHALL NOT document unsupported composition or server-reference fields as part of the current user-facing manifest contract. Current user-facing manifest documentation SHALL describe only supported manifest behavior and SHALL use the manifest specification page as the canonical place for facet-name grammar.
 
 #### Scenario: A producer emits a manifest conforming to the published schema
 
@@ -16,15 +18,28 @@ A facet identity name SHALL be either an unscoped kebab-case name (`name`) or a 
 - **THEN** the produced manifest SHALL satisfy every requirement of the published schema
 - **AND** another facet-compatible system SHALL accept the manifest after validating it
 
-#### Scenario: A consumer accepts a scoped facet identity
+#### Scenario: A consumer accepts valid unscoped facet identities
+
+- **WHEN** a system receives a `facet.json` whose `name` is `ab`, `cowsay`, `julian`, `admin-tester`, `apple-b34r`, or `f-o-s-s-o`
+- **THEN** the system SHALL accept the facet identity as valid
+- **AND** the accepted identity SHALL remain the facet's canonical name without normalization
+
+#### Scenario: A consumer accepts a valid scoped facet identity
 
 - **WHEN** a system receives a `facet.json` whose `name` is `@julian/cowsay`
 - **THEN** the system SHALL accept the facet identity as valid
+- **AND** both scoped identity components SHALL satisfy the same component grammar as unscoped facet names
 - **AND** the scoped identity SHALL remain the facet's canonical name
 
-#### Scenario: A consumer rejects a malformed facet identity
+#### Scenario: A consumer rejects invalid slug components
 
-- **WHEN** a system receives a `facet.json` whose `name` is `@julian`, `@/cowsay`, `@julian/`, `@julian/cow/say`, `@julian/cow_say`, `Cowsay`, or `../cowsay`
+- **WHEN** a system receives a `facet.json` whose `name` is empty, `a`, `z`, `A`, `Cowsay`, `1abc`, `-abc`, `abc-`, `abc--def`, `abc_def`, `abc.def`, `abc def`, `éclair`, `gооgle` with Cyrillic homoglyphs, or any component longer than 64 characters
+- **THEN** the system SHALL reject the manifest as invalid
+- **AND** the system SHALL surface a structured error indicating that the facet identity is malformed
+
+#### Scenario: A consumer rejects malformed scoped facet identities
+
+- **WHEN** a system receives a `facet.json` whose `name` is `@scope`, `@/name`, `@scope/`, `@scope/name/extra`, or `scope/name`
 - **THEN** the system SHALL reject the manifest as invalid
 - **AND** the system SHALL surface a structured error indicating that the facet identity is malformed
 

--- a/packages/protocol/src/__tests__/facet-manifest.test.ts
+++ b/packages/protocol/src/__tests__/facet-manifest.test.ts
@@ -132,6 +132,11 @@ describe('FacetManifestSchema — invalid manifests', () => {
     '../cowsay', // traversal
     'cow_say', // underscore (unscoped)
     'cow say', // space
+    'a', // single character
+    'abc--def', // consecutive hyphens
+    'scope/name', // legacy scoped syntax without at-prefix
+    'gооgle', // Cyrillic homoglyphs
+    'a'.repeat(65), // exceeds maximum length
   ])('malformed facet identity %p is rejected', (name) => {
     const input = { name, version: '1.0.0', skills: { x: { description: 'A skill' } } }
     const result = FacetManifestSchema(input)

--- a/packages/protocol/src/__tests__/facet-name.test.ts
+++ b/packages/protocol/src/__tests__/facet-name.test.ts
@@ -4,7 +4,20 @@ import { parseFacetName, parseSlug, validateFacetName } from '@agent-facets/prot
 // --- parseSlug: the atomic identity grammar ---
 
 describe('parseSlug — valid slugs', () => {
-  test.each(['a', 'cowsay', 'viper-plans', 'code-review', 'x1', 'a-b-c', 'web3', 'foo--bar'])('accepts %p', (value) => {
+  test.each([
+    'ab',
+    'cowsay',
+    'julian',
+    'admin-tester',
+    'apple-b34r',
+    'f-o-s-s-o',
+    'viper-plans',
+    'code-review',
+    'x1',
+    'a-b-c',
+    'web3',
+    'a'.repeat(64), // maximum length
+  ])('accepts %p', (value) => {
     const result = parseSlug(value)
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
@@ -15,18 +28,35 @@ describe('parseSlug — valid slugs', () => {
 describe('parseSlug — invalid slugs', () => {
   test.each([
     '', // empty
+    'a', // single character
+    'z', // single character
+    'A', // single uppercase character
     'Cowsay', // uppercase
     'COWSAY',
     'cow_say', // underscore
+    'abc_def', // underscore
+    '1abc', // leading digit
     '1cow', // leading digit
+    '-abc', // leading hyphen
     '-cow', // leading hyphen
+    'abc-', // trailing hyphen
     'cow-', // trailing hyphen
+    'abc--def', // consecutive hyphens
+    'foo--bar', // consecutive hyphens
+    'abc def', // space
     'cow say', // space
     '@cow', // at-sign
     'cow/say', // slash
+    'abc.def', // dot
     'cow.say', // dot
+    'a+b', // plus sign
+    'a~b', // tilde
+    'a😀b', // emoji
     '..',
     'café', // non-ascii
+    'éclair', // non-ascii
+    'gооgle', // Cyrillic homoglyphs
+    'a'.repeat(65), // exceeds maximum length
   ])('rejects %p', (value) => {
     const result = parseSlug(value)
     expect(result.ok).toBe(false)
@@ -36,7 +66,7 @@ describe('parseSlug — invalid slugs', () => {
 // --- parseFacetName: unscoped + scoped composition ---
 
 describe('parseFacetName — valid unscoped identities', () => {
-  test.each(['cowsay', 'viper-plans', 'a', 'code-review'])('accepts %p as unscoped', (value) => {
+  test.each(['cowsay', 'viper-plans', 'ab', 'code-review'])('accepts %p as unscoped', (value) => {
     const result = parseFacetName(value)
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
@@ -51,7 +81,7 @@ describe('parseFacetName — valid scoped identities', () => {
   test.each([
     ['@julian/cowsay', 'julian', 'cowsay'],
     ['@acme/deploy-tools', 'acme', 'deploy-tools'],
-    ['@a/b', 'a', 'b'],
+    ['@ab/cd', 'ab', 'cd'],
   ])('accepts %p', (value, scope, name) => {
     const result = parseFacetName(value)
     expect(result.ok).toBe(true)
@@ -67,14 +97,21 @@ describe('parseFacetName — invalid scoped identities', () => {
   // Cases drawn from protocol__schemas/spec.md scenario "rejects a malformed
   // facet identity" plus the design.md risk list.
   test.each([
+    '@scope', // missing slash
     '@julian', // missing slash
-    '@julian/', // empty name
+    '@/name', // empty scope
     '@/cowsay', // empty scope
+    '@scope/', // empty name
+    '@julian/', // empty name
+    '@scope/name/extra', // extra path depth
     '@julian/cow/say', // extra path depth
     '@julian/cow_say', // underscore in name
     '@Julian/cowsay', // uppercase scope
     '@julian/Cowsay', // uppercase name
     '@julian/cow-', // trailing hyphen in name
+    '@julian/co--w', // consecutive hyphens in name
+    '@a/cowsay', // single-character scope
+    '@julian/a', // single-character name
     '@julian/cowsay@', // trailing at-sign (not a valid name segment)
   ])('rejects %p', (value) => {
     const result = parseFacetName(value)
@@ -85,9 +122,12 @@ describe('parseFacetName — invalid scoped identities', () => {
 describe('parseFacetName — invalid unscoped / legacy-ish identities', () => {
   test.each([
     '', // empty
+    'a', // single character
     'Cowsay', // uppercase
     'cow_say', // underscore
+    'co--wsay', // consecutive hyphens
     '../cowsay', // traversal
+    'scope/name', // legacy scoped syntax without at-prefix
     'cow/say', // bare slash (not scoped)
     'cow say', // space
     'cow-', // trailing hyphen

--- a/packages/protocol/src/schemas/facet-name.ts
+++ b/packages/protocol/src/schemas/facet-name.ts
@@ -3,12 +3,15 @@
  *
  * The grammar is layered around one atomic unit, the **slug**:
  *
- *  - A slug is a single lowercase-kebab segment: it starts with a lowercase
- *    letter, contains only lowercase letters, digits, and hyphens after the
- *    first character, and ends with a lowercase letter or digit.
+ *  - A slug is a single lowercase-kebab segment that is 2-64 characters long.
+ *    It starts with a lowercase ASCII letter, ends with a lowercase ASCII
+ *    letter or digit, contains only lowercase ASCII letters, ASCII digits,
+ *    and hyphens in between, and never contains consecutive hyphens.
  *  - A username is a slug. A scope is a slug. A global (unscoped) facet name
  *    is a slug. The base name of a scoped facet is a slug. They are all the
- *    same constraint — `parseSlug` is the single source of truth.
+ *    same constraint — `parseSlug` is the single source of truth, and it
+ *    encodes the registry's canonical naming grammar so callers never need a
+ *    separate stricter validator.
  *
  * A **facet name** is built from slugs. It is either:
  *
@@ -20,20 +23,26 @@
  * (notably the registry, which enforces scope ownership) validate scopes with
  * the exact same grammar instead of duplicating it.
  *
- * Both parsers return discriminated-union results rather than throwing, so
- * callers handle malformed identities as data.
+ * Input is validated, never normalized: uppercase letters and non-ASCII
+ * characters are rejected rather than down-cased or transliterated. Both
+ * parsers return discriminated-union results rather than throwing, so callers
+ * handle malformed identities as data.
  */
+
+/** Minimum length of a slug component (inclusive). */
+const SLUG_MIN_LENGTH = 2
+/** Maximum length of a slug component (inclusive). */
+const SLUG_MAX_LENGTH = 64
 
 /**
- * A single kebab-case identity segment: lowercase letter start, lowercase /
- * digit / hyphen interior, alphanumeric end. No uppercase, no underscores, no
- * leading/trailing hyphen, no slashes, no `@`, no `.`/`..` traversal, no
- * whitespace. Single-character names (`a`) are permitted.
+ * The canonical slug grammar: starts with a lowercase ASCII letter, ends with
+ * a lowercase ASCII letter or digit, contains only lowercase ASCII letters,
+ * digits, and hyphens in between, and rejects consecutive hyphens via the
+ * `-(?!-+)` negative lookahead. The grammar alone requires at least 2
+ * characters (a first and a final position); explicit length checks in
+ * `parseSlug` still run first so callers get clearer error messages.
  */
-const SLUG_RE = /^[a-z]([a-z0-9-]*[a-z0-9])?$/
-
-const SLUG_RULE =
-  'a lowercase kebab-case slug (lowercase letter start; lowercase letters, digits, and hyphens after; alphanumeric end)'
+const SLUG_RE = /^[a-z]([a-z0-9]|-(?!-+))*[a-z0-9]$/
 
 /** Result of validating a single slug. Errors are data, not exceptions. */
 export type SlugResult = { ok: true; value: string } | { ok: false; reason: string }
@@ -41,14 +50,33 @@ export type SlugResult = { ok: true; value: string } | { ok: false; reason: stri
 /**
  * Validate a single slug — the atomic facet-identity grammar shared by
  * usernames, scopes, global facet names, bare facet names, and the base name
- * of a scoped facet.
+ * of a scoped facet. This is the single source of truth for the canonical
+ * naming grammar; it is intentionally case-sensitive and ASCII-only.
+ *
+ * The checks run from most specific to most general so the returned reason is
+ * actionable for registry and CLI callers.
  */
 export function parseSlug(value: string): SlugResult {
   if (value === '') {
     return { ok: false, reason: 'must not be empty' }
   }
+  if (value.length < SLUG_MIN_LENGTH) {
+    return { ok: false, reason: `must be at least ${SLUG_MIN_LENGTH} characters` }
+  }
+  if (value.length > SLUG_MAX_LENGTH) {
+    return { ok: false, reason: `must be at most ${SLUG_MAX_LENGTH} characters` }
+  }
+  if (!/^[a-z]/.test(value)) {
+    return { ok: false, reason: 'must start with a lowercase ASCII letter' }
+  }
+  if (!/[a-z0-9]$/.test(value)) {
+    return { ok: false, reason: 'must end with a lowercase ASCII letter or digit' }
+  }
+  if (value.includes('--')) {
+    return { ok: false, reason: 'must not contain consecutive hyphens' }
+  }
   if (!SLUG_RE.test(value)) {
-    return { ok: false, reason: `must be ${SLUG_RULE}` }
+    return { ok: false, reason: 'must contain only lowercase ASCII letters, digits, and hyphens' }
   }
   return { ok: true, value }
 }
@@ -68,12 +96,16 @@ export type FacetNameResult = { ok: true; value: FacetName; canonical: string } 
 
 /**
  * Parse a full facet identity: an unscoped slug (`cowsay`) or a scoped name
- * (`@scope/name`). Both forms are validated slug-by-slug via `parseSlug`.
+ * (`@scope/name`). Both forms are validated slug-by-slug via `parseSlug`, so
+ * every component obeys the same canonical grammar — there is no second,
+ * looser grammar for facet names.
  *
  * The leading `@` marks a scoped name; for a scoped name there SHALL be
  * exactly one `/` separating the scope slug from the base name slug. Extra
  * path depth (`@scope/name/extra`), a missing slash (`@scope`), and empty
- * segments (`@scope/`, `@/name`) are all rejected.
+ * segments (`@scope/`, `@/name`) are all rejected. Legacy `scope/name`
+ * (without the leading `@`) is not a scoped form: it is treated as an
+ * unscoped slug and rejected because a slug may not contain `/`.
  */
 export function parseFacetName(value: string): FacetNameResult {
   if (value === '') {


### PR DESCRIPTION
### Why

The protocol's `parseSlug` helper was more permissive than the registry's established naming contract, accepting single-character slugs and consecutive hyphens (`foo--bar`) that the registry rejects. Since `parseSlug` is intended to become the single source of truth for usernames, organization names, scopes, and facet name components across the registry and CLI, it must enforce the canonical grammar before callers depend on divergent rules.

### Details

**Protocol changes (`packages/protocol/src/schemas/facet-name.ts`):**

- `parseSlug` now enforces a 2–64 character length, lowercase ASCII start, lowercase ASCII/digit end, lowercase ASCII/digit/hyphen-only content, and no consecutive hyphens. Validation is ordered from most specific to most general so error reasons are actionable (e.g. "must not contain consecutive hyphens" rather than a generic regex failure).
- `parseFacetName` continues to delegate all component validation to `parseSlug`, accepting exactly `<slug>` and `@<scope>/<slug>`. Bare scopes (`@scope`), missing segments (`@/name`, `@scope/`), extra path depth (`@scope/name/extra`), and legacy `scope/name` (without `@`) are all rejected.
- Input is validated, never normalized — uppercase and non-ASCII characters are rejected rather than folded or transliterated.

**Documentation changes:**

- `docs/specification/manifest.md` is now the canonical reference for the facet name grammar. It documents the two accepted identity forms, the shared slug component rules, a valid/invalid example table, and the rejected scoped-name shapes. The speculative "Composed Facets" and "Server References" sections have been removed because neither is a supported user-facing manifest feature.
- `docs/cli/authoring/create.md` no longer duplicates the grammar inline; it links to the manifest specification instead.

This is a **breaking change**: previously accepted names such as `a`, `z`, and `foo--bar` are now rejected.

### Verification

Expanded protocol test coverage in `facet-name.test.ts` and `facet-manifest.test.ts` covers every valid and invalid example from the spec, including uppercase, non-ASCII, Cyrillic homoglyphs, consecutive hyphens, length boundaries, malformed scoped names, and legacy `scope/name` syntax.