### PR TITLE
Remove `@agent-facets/engine` from two changesets

### DIFF
--- a/.changeset/fair-toys-juggle.md
+++ b/.changeset/fair-toys-juggle.md
@@ -1,6 +1,5 @@
 ---
 "agent-facets": patch
-"@agent-facets/engine": patch
 ---
 
 Route scoped facet publish, resolve, and download through two-segment `{scope}/{name}` registry paths to avoid `%2F`-encoding rejection

--- a/.changeset/fast-boats-drop.md
+++ b/.changeset/fast-boats-drop.md
@@ -1,6 +1,5 @@
 ---
 "agent-facets": patch
-"@agent-facets/engine": patch
 ---
 
 Fix `writeBuildOutput` to create parent directories for scoped (`@scope/name`) and slash-containing archive paths, and accept scoped facet names in create/edit views


### PR DESCRIPTION
### Why

The `@agent-facets/engine` package was incorrectly included in two changesets that only apply to `agent-facets`.

### Details

Removes `@agent-facets/engine` from the `fair-toys-juggle` and `fast-boats-drop` changesets, which cover:
- Routing scoped facet publish, resolve, and download through two-segment `{scope}/{name}` registry paths to avoid `%2F`-encoding rejection
- Fixing `writeBuildOutput` to create parent directories for scoped (`@scope/name`) and slash-containing archive paths, and accepting scoped facet names in create/edit views

These changes are scoped to `agent-facets` only and should not trigger a release for `@agent-facets/engine`.