### PR TITLE
Add registry URL to `facet whoami` output

### DIFF
--- a/.changeset/few-waves-notice.md
+++ b/.changeset/few-waves-notice.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": patch
+---
+
+Add in registry URL to `facet whoami`

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,7 @@
 {
   "facets": {
     "viper-plans": "0.2.0",
-    "cowsay": "0.2.0"
+    "cowsay": "0.2.0",
+    "@julian/review-openspec-design": "1.0.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -1,6 +1,21 @@
 {
   "lockfileVersion": 1,
   "facets": {
+    "@julian/review-openspec-design": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.facet.cafe"
+      },
+      "version": "1.0.0",
+      "integrity": "sha256:85593c37edc4e1afa60670c55c5d9727669e14aca2fc4388a4a502492ab2ca2b",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "review-openspec-design"
+        }
+      ]
+    },
     "cowsay": {
       "source": {
         "kind": "registry",

--- a/packages/cli/src/commands/whoami/__tests__/whoami.test.ts
+++ b/packages/cli/src/commands/whoami/__tests__/whoami.test.ts
@@ -54,7 +54,16 @@ describe('whoamiCommand', () => {
     expect(stdout).toContain('ada')
     expect(stdout).toContain('ada@example.com')
     expect(stdout).toContain('pro')
+    expect(stdout).toContain('registry: https://api.test')
     expect(stdout).toContain('FACET_TOKEN')
+  })
+
+  test('falls back to the default registry URL when FACET_REGISTRY_URL is unset', async () => {
+    delete process.env.FACET_REGISTRY_URL
+    stubProfile()
+    const { result, stdout } = await captureStdout(() => whoamiCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('registry: https://api.facet.cafe')
   })
 
   test('does not name the env source when the credential comes from the file', async () => {

--- a/packages/cli/src/commands/whoami/index.ts
+++ b/packages/cli/src/commands/whoami/index.ts
@@ -1,4 +1,4 @@
-import { fetchAuthMe, resolveCredential } from '@agent-facets/engine'
+import { fetchAuthMe, getRegistryBaseUrl, resolveCredential } from '@agent-facets/engine'
 import type { Command } from '../../commands.ts'
 import { writeCliError } from '../../util/errors.ts'
 import { translateEngineRegistryError } from '../../util/registry-errors.ts'
@@ -44,6 +44,7 @@ export const whoamiCommand: Command = {
     if (suspended) {
       process.stdout.write('  status: suspended\n')
     }
+    process.stdout.write(`  registry: ${getRegistryBaseUrl()}\n`)
     if (cred.source === 'env') {
       process.stdout.write('  credential: FACET_TOKEN (environment)\n')
     }


### PR DESCRIPTION
### Why

Users running `facet whoami` had no way to see which registry URL their CLI was pointed at, making it harder to debug configuration issues or confirm they're talking to the right environment.

### Details

The `registry` line is printed using `getRegistryBaseUrl()`, which falls back to `https://api.facet.cafe` when `FACET_REGISTRY_URL` is not set. A new test covers this fallback behavior explicitly.

### Verification

New tests added for both the case where `FACET_REGISTRY_URL` is set and where it falls back to the default. CI covers it.