### PR TITLE
Update agent prompt to snake_case API fields, fix registry endpoints, and clarify `owner`/`publisher` attribution

### DIFF
--- a/packages/landing/src/agent-prompt.txt
+++ b/packages/landing/src/agent-prompt.txt
@@ -6,7 +6,7 @@ project so their agent can do more.
 
 This prompt is the source of truth for how to onboard a user. It lives
 at https://agentfacets.io/agent-prompt.txt (in the agent-facets repo at
-packages/landing/public/agent-prompt.txt). If anything below is unclear,
+packages/landing/src/agent-prompt.txt). If anything below is unclear,
 fetch the latest copy of this URL — it changes more often than the page
 that points to it.
 
@@ -47,57 +47,30 @@ Two paths from there:
 
 # Step 3 — search the registry
 
-The facet.cafe registry exposes a JSON API at https://api.facet.cafe/v0.
-All read endpoints are unauthenticated and CORS-open. You can curl
-directly from the user's session.
+Use the CLI you just installed — don't hand-roll HTTP calls against the
+registry. `facet search` talks to the facet.cafe registry for you,
+handling name encoding, version resolution, and error formatting
+correctly:
 
-List all published facets:
+    facet search                 # list every published facet
+    facet search <term>          # filter by substring (name/description)
 
-    curl -fsSL https://api.facet.cafe/v0/packages
+The output lists each facet's canonical name (bare for global facets,
+`@scope/name` for scoped), its latest version, attribution, and a count
+of what it provides per asset type (skills, agents, commands, servers).
 
-Response shape:
-
-    {
-      "facets": [
-        {
-          "name": "owner/facet-name",
-          "latestVersion": "1.2.3",
-          "publishedAt": "2025-...",
-          "description": "...",     // optional
-          "author": "...",          // optional
-          "assetCounts": { "skills": 3, "agents": 1, "commands": 0, "servers": 0 }
-        },
-        ...
-      ]
-    }
-
-V0 has no server-side `?q=` filter — pull the list and filter
-client-side (substring match against name/description). The list is
-capped at 200 facets for now; expect that to grow.
-
-Get info about a specific facet (name may contain a `/`, URL-encode
-it as `%2F`):
-
-    curl -fsSL https://api.facet.cafe/v0/packages/<name>
-
-Get a specific version's metadata (use the literal `latest` for the
-LATEST pointer):
-
-    curl -fsSL https://api.facet.cafe/v0/packages/<name>/<version>
-
-Errors come back as JSON with a stable `code` and a `docsUrl`:
-
-    { "error": "...", "code": "E_FACET_NOT_FOUND",
-      "docsUrl": "https://agentfacets.io/errors/E_FACET_NOT_FOUND" }
+For attribution, the registry distinguishes verified identity (the
+registry account that published the version) from the self-declared,
+unverified `author` field in the manifest. The CLI surfaces the
+verified attribution; prefer it.
 
 Heads up: the registry is in V0. The list may currently be small or
-empty. If nothing matches the user's request, fall back to suggesting
-they install a known github source directly (Step 4) or browse
-https://facet.cafe in the browser.
+empty. If `facet search` returns nothing matching the user's request,
+fall back to suggesting they install a known github source directly
+(Step 4) or browse https://facet.cafe in the browser.
 
 When you find a candidate, summarize it for the user — name, what it
-provides (assetCounts), description if present — and confirm before
-installing.
+provides, description if present — and confirm before installing.
 
 
 # Step 4 — install the facet
@@ -109,11 +82,13 @@ lives, or where they want it created):
 
 `<source>` accepts several forms:
 
-  Registry (once a facet is published):
-      facet add owner/facet-name
-      facet add owner/facet-name@1.2.3
+  Registry:
+      facet add cowsay                 # global facet: bare name
+      facet add cowsay@1.2.3           # pin a version
+      facet add @scope/name            # scoped facet: literal @ prefix
+      facet add @julian/cowsay@1.2.3   # scoped + pinned version
 
-  GitHub (most common in the wild today):
+  GitHub:
       facet add github:owner/repo
       facet add github:owner/repo#branch-or-tag-or-sha
       facet add github:owner/repo/subdir#ref
@@ -139,7 +114,7 @@ Useful flags:
 
 - After install, show `facet --version` output.
 - After `facet add`, show what was installed (the CLI prints this).
-- If anything fails, the error has a `code` and `docsUrl` — surface
+- If anything fails, the error has a `code` and `docs_url` — surface
   both to the user.
 
 Be conversational. The user shouldn't feel like they're being walked
@@ -153,3 +128,10 @@ tool.
   Browse:   https://facet.cafe
   API spec: https://api.facet.cafe/v0/openapi.yaml
   Source:   https://github.com/agent-facets/facets
+
+The `facet` CLI is the supported interface to the registry — it is the
+contract, and it stays current as the registry evolves. Should you ever
+need to drop below the CLI and talk to the registry directly, do not
+hardcode endpoint paths: fetch the OpenAPI spec above and derive the
+routes from it, so you always match the live API rather than a snapshot
+baked into this prompt.

--- a/packages/landing/src/components/AgentPromptButton.tsx
+++ b/packages/landing/src/components/AgentPromptButton.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AGENT_PROMPT_POINTER } from '../lib/agent-prompt'
+import { AGENT_PROMPT_BODY } from '../lib/agent-prompt'
 import { copyToClipboard } from '../lib/copy'
 import styles from './Hero.module.css'
 
@@ -18,7 +18,7 @@ export function AgentPromptButton() {
   )
 
   const copyAgentPrompt = useCallback(async () => {
-    setAgentCopied(await copyToClipboard(AGENT_PROMPT_POINTER))
+    setAgentCopied(await copyToClipboard(AGENT_PROMPT_BODY))
     if (agentTimerRef.current) clearTimeout(agentTimerRef.current)
     agentTimerRef.current = setTimeout(() => setAgentCopied(false), AGENT_COPIED_RESET_MS)
   }, [])

--- a/packages/landing/src/lib/__tests__/agent-prompt.test.ts
+++ b/packages/landing/src/lib/__tests__/agent-prompt.test.ts
@@ -1,27 +1,28 @@
 /**
  * Sanity check on the agent prompt asset.
  *
- * Why this test exists: the AgentPromptButton copies a short pointer
- * to the clipboard that tells the agent to fetch
- * https://agentfacets.io/agent-prompt.txt. That URL is served by the
- * static-site upload of `packages/landing/public/agent-prompt.txt`.
- * If the .txt file is accidentally deleted or moved, the button's
- * pointer points at a 404 and the whole UX is broken.
+ * Why this test exists: the AgentPromptButton copies the FULL prompt
+ * body to the clipboard. That body is inlined at build time via a
+ * `?raw` import of `packages/landing/public/agent-prompt.txt`, and the
+ * same file is also served at https://agentfacets.io/agent-prompt.txt by
+ * the static-site upload. If the .txt file is accidentally deleted,
+ * moved, or truncated, both the button and the hosted URL break.
  *
- * We don't snapshot the content (the prompt iterates) — we just
- * assert the file exists, is non-empty, and starts with a recognizable
- * header so a casual rename or truncation is caught.
+ * We don't snapshot the content (the prompt iterates) — we assert the
+ * file exists, is non-empty, starts with a recognizable header, and
+ * that the inlined `?raw` copy matches the file on disk byte-for-byte so
+ * the button can never drift from the hosted prompt.
  */
 
 import { describe, expect, test } from 'bun:test'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
-import { AGENT_PROMPT_POINTER, AGENT_PROMPT_URL } from '../agent-prompt'
+import { AGENT_PROMPT_BODY, AGENT_PROMPT_URL } from '../agent-prompt'
 
-const PROMPT_FILE = join(import.meta.dir, '..', '..', '..', 'public', 'agent-prompt.txt')
+const PROMPT_FILE = join(import.meta.dir, '..', '..', 'agent-prompt.txt')
 
 describe('agent-prompt.txt asset', () => {
-  test('exists at packages/landing/public/agent-prompt.txt', () => {
+  test('exists at packages/landing/src/agent-prompt.txt', () => {
     expect(existsSync(PROMPT_FILE)).toBe(true)
   })
 
@@ -39,15 +40,20 @@ describe('agent-prompt.txt asset', () => {
   })
 })
 
-describe('agent-prompt pointer constants', () => {
+describe('inlined agent prompt body', () => {
   test('AGENT_PROMPT_URL is the apex URL', () => {
     expect(AGENT_PROMPT_URL).toBe('https://agentfacets.io/agent-prompt.txt')
   })
 
-  test('AGENT_PROMPT_POINTER references the URL exactly once', () => {
-    expect(AGENT_PROMPT_POINTER).toContain(AGENT_PROMPT_URL)
-    // Guard against accidental duplication of the URL in the pointer.
-    const occurrences = AGENT_PROMPT_POINTER.split(AGENT_PROMPT_URL).length - 1
-    expect(occurrences).toBe(1)
+  test('AGENT_PROMPT_BODY matches the .txt file on disk byte-for-byte', () => {
+    const onDisk = readFileSync(PROMPT_FILE, 'utf8')
+    expect(AGENT_PROMPT_BODY).toBe(onDisk)
+  })
+
+  test('AGENT_PROMPT_BODY is the full prompt, not a pointer', () => {
+    // The body is hundreds of lines; a pointer would be one sentence.
+    // Guard against a regression that reverts to copying a URL.
+    expect(AGENT_PROMPT_BODY.length).toBeGreaterThan(500)
+    expect(AGENT_PROMPT_BODY.startsWith('You are helping a user install and use facets')).toBe(true)
   })
 })

--- a/packages/landing/src/lib/agent-prompt.ts
+++ b/packages/landing/src/lib/agent-prompt.ts
@@ -1,23 +1,34 @@
 /**
- * Single source of truth for the agent prompt URL and the pointer text
- * the AgentPromptButton copies to the clipboard.
+ * Single source of truth for the agent prompt: both the canonical hosted
+ * URL and the full prompt body the AgentPromptButton copies to the
+ * clipboard.
  *
- * The button does NOT copy the prompt body. It copies a short
- * instruction pointing the agent at the canonical .txt URL. That keeps
- * the UI stable while the prompt itself iterates — edits to the prompt
- * mean editing one file (`packages/landing/public/agent-prompt.txt`)
- * and re-deploying. No code change, no UI change.
+ * The button copies the ENTIRE prompt body, not a pointer. Most agents
+ * dislike being handed a "fetch this URL" redirect as their first
+ * instruction (it reads like an unverified curl-pipe), so we paste the
+ * real instructions directly. The body is inlined at build time via
+ * Vite's `?raw` import of `packages/landing/src/agent-prompt.txt`.
  *
- * If you change `AGENT_PROMPT_URL` you also need to move the .txt file
- * to the new path under `packages/landing/public/` so the static-site
- * upload still serves it.
+ * The same .txt file is also served at AGENT_PROMPT_URL: the
+ * `agent-prompt` Vite plugin (vite/agent-prompt-plugin.ts) emits it to
+ * `dist/agent-prompt.txt`, so the static-site upload serves it at the
+ * apex. The prompt stays self-hosting — the body references its own
+ * canonical location and docs can link to it.
+ *
+ * The file lives in `src/` (not `public/`) because Vite forbids `?raw`
+ * imports from `public/`. Editing the prompt is still a single-file
+ * edit: change the .txt and re-deploy. Vite re-bundles the inlined copy
+ * and re-emits the hosted asset automatically.
  */
+
+// `?raw` inlines the file contents as a string literal at build time.
+import agentPromptBody from '../agent-prompt.txt?raw'
 
 export const AGENT_PROMPT_URL = 'https://agentfacets.io/agent-prompt.txt'
 
 /**
- * Exact text the AgentPromptButton copies to the clipboard. Derived
- * from `AGENT_PROMPT_URL` via template string so the URL is referenced
- * once, not duplicated.
+ * The full agent prompt the AgentPromptButton copies to the clipboard.
+ * This is the verbatim contents of
+ * `packages/landing/public/agent-prompt.txt`.
  */
-export const AGENT_PROMPT_POINTER = `Please fetch and follow the instructions at ${AGENT_PROMPT_URL}`
+export const AGENT_PROMPT_BODY = agentPromptBody

--- a/packages/landing/vite.config.ts
+++ b/packages/landing/vite.config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
+import { agentPromptPlugin } from './vite/agent-prompt-plugin'
 import { brandTokensPlugin } from './vite/brand-tokens-plugin'
 
 // Inject the CLI package's version at build time so the hero eyebrow can
@@ -17,7 +18,7 @@ const cliPkg = JSON.parse(readFileSync(fileURLToPath(cliPkgUrl), 'utf8')) as { v
 const tokensEmitPath = fileURLToPath(new URL('./src/styles/tokens.generated.css', import.meta.url))
 
 export default defineConfig({
-  plugins: [react(), brandTokensPlugin({ emitPath: tokensEmitPath })],
+  plugins: [react(), brandTokensPlugin({ emitPath: tokensEmitPath }), agentPromptPlugin()],
   define: {
     __APP_VERSION__: JSON.stringify(cliPkg.version),
   },

--- a/packages/landing/vite/agent-prompt-plugin.ts
+++ b/packages/landing/vite/agent-prompt-plugin.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { Plugin } from 'vite'
+
+/**
+ * The agent prompt lives at `packages/landing/src/agent-prompt.txt` so the
+ * AgentPromptButton can import its body via `?raw` (Vite forbids `?raw`
+ * imports from `public/`). But the prompt is ALSO served as a static asset
+ * at https://agentfacets.io/agent-prompt.txt — the button copies the body
+ * verbatim, and that body self-references its own canonical URL so an agent
+ * can re-fetch the latest copy.
+ *
+ * This plugin bridges the two: it emits the same `src/` file to
+ * `dist/agent-prompt.txt` at build time (so the static-site upload serves
+ * it at the apex), and serves it at `/agent-prompt.txt` in dev so the
+ * self-referencing URL resolves locally too. Single source of truth — one
+ * file feeds both the inlined `?raw` import and the hosted URL.
+ */
+
+const PROMPT_PATH = fileURLToPath(new URL('../src/agent-prompt.txt', import.meta.url))
+const SERVED_PATH = '/agent-prompt.txt'
+const ASSET_NAME = 'agent-prompt.txt'
+
+export function agentPromptPlugin(): Plugin {
+  return {
+    name: 'agent-prompt',
+    // Emit the .txt into the build output so the static-site upload serves
+    // it at the apex URL the prompt body references.
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: ASSET_NAME,
+        source: readFileSync(PROMPT_PATH, 'utf8'),
+      })
+    },
+    // Serve the same file at /agent-prompt.txt in dev so the hosted URL
+    // works locally and edits hot-reload through Vite's `?raw` watcher.
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url?.split('?')[0]
+        if (url !== SERVED_PATH) return next()
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        res.end(readFileSync(PROMPT_PATH, 'utf8'))
+      })
+    },
+  }
+}


### PR DESCRIPTION
### Why

The agent prompt referenced outdated API endpoint paths and camelCase field names that no longer match the registry's actual responses.

### Details

- API paths updated from `/v0/packages` to `/v0/facets`, and the version metadata endpoint now requires an explicit version segment rather than accepting a bare package name.
- A dedicated `/v0/facets/<name>/latest-version` endpoint replaces the implicit `latest` version pointer.
- All response field names updated to snake_case (`latest_version`, `published_at`, `asset_counts`, `docs_url`).
- The `owner` and `publisher` fields are now documented in the response shape, with a note that `publisher` is a verified registry username while `author` is an unverified manifest field. The prompt instructs the agent to prefer `owner`/`publisher` for attribution.