### PR TITLE
Expand opencode adapter metadata to support `model`, `permission`, `agent`, `mode`, and `subtask` fields

### DIFF
--- a/.changeset/chilly-camels-pick.md
+++ b/.changeset/chilly-camels-pick.md
@@ -1,0 +1,5 @@
+---
+"@agent-facets/adapter-opencode": minor
+---
+
+Expand metadata support to include model, permission, agent, and subtask fields

--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,6 @@
     "viper-plans": "0.2.0",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "2.0.0"
+    "@julian/openspec-adversary": "2.1.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "2.0.0",
-      "integrity": "sha256:a2345cd23eee7b0e07b166bbb8a49d129025587d8e89ca235d4b94a3121532e8",
+      "version": "2.1.0",
+      "integrity": "sha256:e17f53f75b6acd198e893ebfa1b754749f043b34f27b9d53426bb713dff7bfa3",
       "assets": [
         {
           "scope": "project",
@@ -32,7 +32,7 @@
         {
           "scope": "project",
           "type": "command",
-          "name": "review-adversary"
+          "name": "reconcile-adversary-review"
         },
         {
           "scope": "project",

--- a/packages/adapters/opencode/src/__tests__/adapter.test.ts
+++ b/packages/adapters/opencode/src/__tests__/adapter.test.ts
@@ -37,6 +37,39 @@ describe('opencode adapter — buildAssetMetadata', () => {
     const result = adapter.buildAssetMetadata({ model: 123 })
     expect(result.ok).toBe(false)
   })
+
+  test('accepts command frontmatter: agent + subtask', () => {
+    const result = adapter.buildAssetMetadata({ agent: 'opencode-adversary', subtask: true })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toEqual({ agent: 'opencode-adversary', subtask: true })
+    }
+  })
+
+  test('accepts agent frontmatter: mode subagent', () => {
+    const result = adapter.buildAssetMetadata({ mode: 'subagent' })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toEqual({ mode: 'subagent' })
+    }
+  })
+
+  test('accepts scoped permission block (string shorthand + nested glob object)', () => {
+    const result = adapter.buildAssetMetadata({
+      permission: { edit: { '*': 'deny', 'openspec/changes/*/adversarial/**': 'allow' }, bash: 'ask' },
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  test('rejects invalid mode', () => {
+    const result = adapter.buildAssetMetadata({ mode: 'nonsense' })
+    expect(result.ok).toBe(false)
+  })
+
+  test('rejects non-boolean subtask', () => {
+    const result = adapter.buildAssetMetadata({ subtask: 'yes' })
+    expect(result.ok).toBe(false)
+  })
 })
 
 describe('opencode adapter — project-scope I/O round-trip', () => {
@@ -84,6 +117,36 @@ describe('opencode adapter — project-scope I/O round-trip', () => {
     expect(raw).toContain('description: plan things')
     expect(raw).toContain('model: sonnet')
     expect(raw).toContain('# plan')
+  })
+
+  test('agent installs with mode: subagent front-matter and round-trips', async () => {
+    await adapter.installAsset('project', 'agent', 'openspec-adversary/adversary', 'agent body', {
+      name: 'adversary',
+      description: 'adversary subagent',
+      mode: 'subagent',
+    })
+    const path = join(workDir, '.opencode/agents/openspec-adversary/adversary.md')
+    const raw = readFileSync(path, 'utf8')
+    expect(raw).toContain('mode: subagent')
+    expect(raw).toContain('agent body')
+
+    const result = await adapter.readAsset('project', 'agent', 'openspec-adversary/adversary')
+    expect(result.content.trim()).toBe('agent body')
+    expect(result.metadata).toEqual({ name: 'adversary', description: 'adversary subagent', mode: 'subagent' })
+  })
+
+  test('command installs with agent + subtask front-matter', async () => {
+    await adapter.installAsset('project', 'command', 'openspec-adversary/run-adversary', 'command body', {
+      name: 'run-adversary',
+      description: 'authoring half',
+      agent: 'opencode-adversary',
+      subtask: true,
+    })
+    const path = join(workDir, '.opencode/commands/openspec-adversary/run-adversary.md')
+    const raw = readFileSync(path, 'utf8')
+    expect(raw).toContain('agent: opencode-adversary')
+    expect(raw).toContain('subtask: true')
+    expect(raw).toContain('command body')
   })
 
   test('readAsset round-trips body and front-matter metadata', async () => {

--- a/packages/adapters/opencode/src/index.ts
+++ b/packages/adapters/opencode/src/index.ts
@@ -10,11 +10,30 @@ import {
 } from '@agent-facets/adapter'
 import { type } from 'arktype'
 
-/** OpenCode per-asset metadata schema */
+/**
+ * OpenCode per-asset metadata schema.
+ *
+ * A single generic schema serves every asset type because the adapter's
+ * `buildAssetMetadata` hook is not asset-type-aware. Command-only keys
+ * (`agent`, `subtask`) and agent-only keys (`mode`) therefore coexist here;
+ * a facet only sets the keys relevant to the asset it attaches them to.
+ *
+ * `permission` is `Record<string, unknown>` because OpenCode permission
+ * values may be a shorthand action string ("allow" | "ask" | "deny") OR a
+ * nested glob/pattern → action object (e.g. `edit: { "*": "deny", "foo/**":
+ * "allow" }`). Constraining it tighter would reject valid OpenCode config.
+ * The legacy `permissions` key is retained unchanged for back-compat.
+ */
 const OpenCodeMetadataSchema = type({
   'tools?': 'Record<string, boolean>',
   'model?': 'string',
   'permissions?': 'Record<string, "allow" | "deny">',
+  // OpenCode agent frontmatter
+  'mode?': '"primary" | "subagent" | "all"',
+  'permission?': 'Record<string, unknown>',
+  // OpenCode command frontmatter — a command may target an agent and force a subtask
+  'agent?': 'string',
+  'subtask?': 'boolean',
 })
 
 /**


### PR DESCRIPTION
### Why

The OpenCode adapter's metadata schema only supported `tools`, `model`, and `permissions`, which wasn't enough to describe agents and commands that use OpenCode-specific frontmatter fields like `mode`, `permission`, `agent`, and `subtask`.

### Details

`mode` (`"primary" | "subagent" | "all"`) and `permission` are agent-oriented fields; `agent` and `subtask` are command-oriented. Because `buildAssetMetadata` is not asset-type-aware, all fields live in a single shared schema and a facet is expected to only set the keys relevant to its asset type.

`permission` is typed as `Record<string, unknown>` rather than a stricter shape because OpenCode allows permission values to be either a shorthand action string (`"allow" | "ask" | "deny"`) or a nested glob-to-action object (e.g. `edit: { "*": "deny", "foo/**": "allow" }`). A tighter type would reject valid OpenCode config.

The existing `permissions` key is retained as-is for backwards compatibility.

The `@julian/openspec-adversary` facet is bumped to `2.1.0`, which renames the `review-adversary` command to `reconcile-adversary-review`.

### Verification

New tests cover acceptance of valid `agent`/`subtask`, `mode: subagent`, and scoped `permission` blocks, as well as rejection of invalid `mode` values and non-boolean `subtask`. Round-trip install/read tests confirm the new frontmatter fields are written and parsed correctly.