### PR TITLE
Bump `@julian/openspec-adversary` to `2.2.1` and add `add-facet-visibility-to-manifest` openspec change

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,6 @@
     "viper-plans": "0.2.0",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "2.1.0"
+    "@julian/openspec-adversary": "2.2.1"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "2.1.0",
-      "integrity": "sha256:e17f53f75b6acd198e893ebfa1b754749f043b34f27b9d53426bb713dff7bfa3",
+      "version": "2.2.1",
+      "integrity": "sha256:c89f3a38e0deade748ab63c6e8d74ae65eee717fa2ccd8cc69ebca96c0caf189",
       "assets": [
         {
           "scope": "project",
@@ -23,6 +23,11 @@
           "scope": "project",
           "type": "skill",
           "name": "review-openspec-adversary"
+        },
+        {
+          "scope": "project",
+          "type": "agent",
+          "name": "opencode-adversary"
         },
         {
           "scope": "project",

--- a/openspec/changes/add-facet-visibility-to-manifest/.openspec.yaml
+++ b/openspec/changes/add-facet-visibility-to-manifest/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/add-facet-visibility-to-manifest/adversarial/artifacts/design.md
+++ b/openspec/changes/add-facet-visibility-to-manifest/adversarial/artifacts/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The facet manifest (`facet.json`) is the source of truth for a facet's identity and assets. It is validated by the published `FacetManifestSchema`, embedded verbatim inside the built `.facet` archive, and — on `facet publish` — uploaded to the registry as part of that archive, with `name`/`version` read from the embedded copy rather than re-parsed from source. The registry is gaining support for private facets, but an author has no manifest-level way to state that intent today.
+
+The reconciled proposal scopes this to a single optional top-level `private` boolean: `true` marks the facet private, `false` or omission keeps it public. Registry-side authorization, billing, search filtering, org semantics, and richer visibility states are explicitly out of scope.
+
+Three properties of the existing system constrain the design and are easy to get wrong:
+
+1. **The manifest is immutable to tooling.** No command (`build`, `edit`, `create`, `publish`) rewrites `facet.json`. A field that "defaults to public" MUST therefore default *semantically* at read time — the schema MUST NOT inject `private: false` into a manifest that omitted it, because that would either rewrite the author's file or create a built-vs-source mismatch.
+2. **Unrecognized fields are tolerated and preserved.** `private` is loadable by older tooling today as an unknown field. This is what makes the change non-breaking; it also means "recognized" is the only new guarantee we add.
+3. **The embedded manifest is inside the content-integrity hash.** The canonical fingerprint (`content_integrity`) is SHA-256 over the inner tar, which contains `facet.json`. `private` is part of that file, so its presence or value is inherently part of the artifact fingerprint — no separate plumbing carries it, and changing it changes the hash.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add an OPTIONAL top-level `private: boolean` to the published facet manifest schema, with non-boolean values rejected and omission treated as public at the point of interpretation.
+- Keep the change non-breaking: manifests that omit `private` validate exactly as before; older tooling still loads manifests that carry it.
+- Ensure the author's declared `private` value travels verbatim, with zero new transport plumbing, through build → embedded archive → publish upload, exactly as `name`/`version` already do.
+- Update `docs/specification/manifest.md`, `docs/specification/publish.md`, and `docs/guides/publish-a-facet.md` so documentation does not drift from the schema (Article III).
+
+**Non-Goals:**
+
+- Registry interpretation, authorization, or enforcement of `private`. The CLI carries intent; the registry decides.
+- Any CLI flag (`--private`) or interactive wizard prompt to set visibility. The manifest is the single source of truth; the author edits the file.
+- A richer `visibility` enumeration or any third audience state (unlisted, org-scoped, invite-only).
+- Mutating, normalizing, or injecting `private` into the on-disk manifest by any command.
+
+## Decisions
+
+### Decision 1: Boolean `private`, not a `visibility` string enum
+
+**Choice:** Represent visibility as `'private?': 'boolean'` on `FacetManifestSchema`.
+
+**Rationale:** The near-term registry model is exactly two-valued. A boolean is the minimal faithful encoding. The cost of being wrong is bounded and recoverable: because unrecognized fields are tolerated, a future `visibility: "unlisted"` field can be *added* alongside `private` without breaking older tooling, and a precedence rule resolved then.
+
+**Alternatives considered:**
+- *`visibility: "public" | "private"` string enum now.* More future-proof against a third state, but it pays migration cost today for a state the proposal explicitly rules out of scope, and it makes the common case (public) require an explicit value or a defaulting rule. Rejected as premature — but see Open Questions, because this is the one decision a reviewer should actively confirm.
+- *Top-level `private` vs. nesting under a `registry`/`publish` object.* A nested object anticipates more publish-time metadata, but there is none today; a flat top-level field matches `name`/`version`/`author` and the manifest's existing shape. Chosen: flat.
+
+### Decision 2: Omission means public via read-time interpretation, never via schema injection
+
+**Choice:** Treat absent `private` as public wherever visibility is interpreted. The schema MUST NOT add a default value; `build`, `edit`, `create`, and `publish` MUST NOT write `private` into a manifest the author did not author it into.
+
+**Rationale:** Preserves the manifest-is-immutable invariant and avoids a built-vs-source mismatch. If the schema injected `private: false`, a manifest that omitted it would validate-to a different shape than it was written in, and any consumer re-emitting the manifest (or comparing source against the embedded copy) would see spurious drift.
+
+**Alternatives considered:**
+- *Schema-level default (`'private': 'boolean = false'`).* Rejected: arktype defaulting would materialize the field on the validated object, diverging the in-memory shape from the on-disk bytes and risking drift false-positives in publish's source-vs-embedded comparison.
+
+### Decision 3: `private` is recognized, not merely tolerated — and a non-boolean is an error
+
+**Choice:** Add `private` to the schema's known keys with type `boolean`. A `private` whose value is a string, number, or object MUST fail validation with a field-pathed error (`private must be boolean`). Omission and either boolean remain valid.
+
+**Rationale:** "Tolerated unknown field" gives no feedback if an author writes `private: "true"` (a string). Making it recognized turns that mistake into an actionable build/validate-time error rather than a silent value the registry later rejects opaquely. This is the concrete authoring value the proposal promises ("authors receive clear feedback before build or publish").
+
+**Alternatives considered:**
+- *Leave it as an unknown tolerated field.* Rejected: no validation, no feedback, and the registry would be the first place a typo surfaces — exactly the out-of-band problem this change exists to remove.
+
+### Decision 4: No new drift class — editing `private` post-build is ordinary content drift
+
+**Choice:** Do not add visibility-specific drift handling. Changing `private` in source after building yields the existing **content drift** condition (same name+version, differing embedded-vs-source manifest content), handled by the existing publish prompts.
+
+**Rationale:** `private` is manifest content; the publish flow already detects and surfaces content drift for any manifest edit. A visibility-specific path would duplicate machinery and create an inconsistent author experience. The only required work is ensuring the drift comparison treats `private` as a content-bearing field (it will, since it compares manifest content), and that docs mention visibility edits as a content-drift example.
+
+### Decision 5: No changes to lockfile, project manifest, build-manifest, or server-manifest schemas
+
+**Choice:** Confine the schema change to `FacetManifestSchema`. The build manifest's `integrity` already fingerprints the embedded `facet.json` (which now may carry `private`); no field is added to `build-manifest.json`, the lockfile, or `facets.json`.
+
+**Rationale:** Visibility is a publish-time author intent, not an install-time resolution input. A consumer installing a facet does not branch on `private`; the registry gates access. Recording it in install-side artifacts would imply install-time semantics that do not exist.
+
+## Risks / Trade-offs
+
+- **A future third visibility state forces an additive migration.** → Mitigation: unrecognized-field tolerance means `visibility` can be added later without breaking older tooling; the precedence between `private` and a future `visibility` is deferred but tractable. Confirm in Open Questions before freezing specs.
+- **`private` silently becomes part of the content fingerprint.** Toggling `private` changes `content_integrity`, so the "same" facet at the same version with flipped visibility is a different artifact and collides with registry immutability if re-published at the same version. → Mitigation: this is correct and consistent with every other manifest edit; document it as content drift requiring a version bump, exactly like editing a description.
+- **Author writes `private` in source but ships a stale `dist/` built before they added it.** → Mitigation: handled by existing content-drift prompts; no new behavior. Documented as an example.
+- **Older CLIs ignore `private` entirely.** An author on an old CLI who sets `private: true` gets a public publish with no warning. → Mitigation: acceptable and unavoidable for a forward-compatible field; the registry is the ultimate gate, and the field reaches it once any current CLI builds the artifact.
+
+## Migration Plan
+
+No data migration. Roll-out is additive and ordered so no intermediate state is broken:
+
+1. Add `'private?': 'boolean'` to `FacetManifestSchema`; the inferred `FacetManifest` gains `private?: boolean`. Existing manifests (no `private`) validate unchanged.
+2. Update the three doc surfaces (`manifest.md` field table + a short "Visibility" subsection; `publish.md` note that visibility travels in the embedded manifest and a content-drift example; `publish-a-facet.md` drift-detection note).
+3. No rollback complexity: removing the field later would re-demote `private` to a tolerated unknown field, still loadable. Forward and backward compatible at every step.
+
+## Open Questions
+
+1. **Boolean vs. `visibility` string — final confirmation.** Is any third audience state (unlisted, org-scoped, invite-only) anticipated within the near-term registry roadmap? If yes, model `visibility: "public" | "private"` from the start to avoid an additive-but-awkward `private`+`visibility` coexistence later. If no, the boolean stands. This is the one decision that gates the `protocol__schemas` delta and SHOULD be answered before specs are frozen.
+2. **Should `private: false` be explicitly accepted, or only `true` + omission?** Recommendation: accept both booleans explicitly (an author writing `false` is stating intent and SHOULD not be punished), with omission == `false` semantically. Confirm.
+3. **Does the registry want visibility echoed anywhere outside the embedded manifest** (e.g., a publish request field) for its own convenience? Out of scope per the proposal, but worth a one-line confirmation that the registry will read the embedded manifest rather than expecting a separate parameter.

--- a/openspec/changes/add-facet-visibility-to-manifest/adversarial/artifacts/proposal.md
+++ b/openspec/changes/add-facet-visibility-to-manifest/adversarial/artifacts/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The registry is gaining support for private facets, but a facet author has no way to declare, at authoring time, that a facet is intended to be private. Today the only signal the registry receives about a facet's intended audience is its name and version. An author who wants a facet kept private must rely on out-of-band registry configuration that the facet's own source tree knows nothing about — so the source-of-truth `facet.json` and the published artifact disagree about a property the author cares deeply about. We need the manifest itself to carry the author's stated intent so it travels with the built `.facet` artifact and reaches the registry verbatim on publish.
+
+## What Changes
+
+- The facet manifest schema gains an OPTIONAL top-level `private` boolean field. Its absence is equivalent to `private: false` (public). The field's only legal values are `true` and `false`; any non-boolean value MUST be rejected.
+- Manifest validation accepts manifests with `private` present (either value) and continues to accept manifests that omit it. A manifest carrying `private` is otherwise unconstrained by this field — a private facet has the same identity, asset, and content requirements as a public one.
+- The built `.facet` archive carries the author's declared `private` value verbatim in its embedded manifest. The publish flow uploads it unchanged, exactly as it already uploads `name` and `version` from the embedded manifest — so the registry reads the author's stated visibility from the artifact, not from a separate channel. This change does **not** define how the registry interprets, enforces, or authorizes private status; it defines only that the author's declared intent is carried.
+- The authoring surfaces (manifest reference documentation) describe `private` as an OPTIONAL identity-adjacent field with a documented default of public.
+
+This is intentionally the smallest viable shape: a single boolean. A boolean is sufficient **only because** the registry's audience model today is exactly two-valued (public vs. private). Whether a richer visibility model (e.g. `unlisted`, org-scoped, invite-only) is anticipated is the central open question for the design phase; if it is, a boolean would force a later breaking migration and a string-valued `visibility` discriminator would age better. The proposal commits to the boolean for now and flags the tradeoff for design.
+
+No field is removed. No existing requirement is loosened. There are **no BREAKING changes**: because the manifest schema already tolerates and preserves unrecognized fields, older tooling that predates this change continues to load manifests that carry `private`, treating it as an unknown-but-preserved field.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ Facet visibility is a property of an existing artifact (the facet manifest) carried through existing flows (authoring and publishing); it does not introduce a new product domain.
+
+### Modified Capabilities
+
+- `protocol__schemas`: The published facet manifest schema gains the OPTIONAL `private` boolean field, with its default-when-absent semantics and value constraints stated normatively.
+- `authoring__facets`: Manifest acceptance requirements acknowledge `private` as a recognized OPTIONAL field (accepted whether present or absent), so it is no longer merely tolerated as an unknown field but a defined part of the contract.
+- `publishing`: The publish flow's "upload the embedded manifest verbatim" requirement is clarified to explicitly include the author's declared `private` value, so visibility intent reaches the registry unaltered.
+
+## Impact
+
+- **Protocol schema** (`packages/protocol/src/schemas/facet-manifest.ts`): add an optional `private: boolean` to `FacetManifestSchema`; the inferred `FacetManifest` type gains `private?: boolean`.
+- **Documentation**: `docs/specification/manifest.md` (the canonical manifest reference) gains a `private` row and a short subsection documenting the public default; `docs/specification/publish.md` notes that visibility travels in the embedded manifest. Per Article III, these updates are scoped work, not drift.
+- **Out of scope for code impact**: the registry's interpretation/enforcement of `private`, any CLI flag to set `private` at publish time, and any wizard prompt for visibility. The manifest is the single source of truth; tooling reads what the author wrote.
+- **Dependencies / APIs**: no new dependencies. No change to the lockfile, project manifest, build-manifest, or server-manifest schemas — visibility is a publish-time author intent, not an install-time resolution property.
+
+### Documentation reviewed
+
+`docs/specification/manifest.md` (manifest field reference and the source-of-truth/immutability rules) and `docs/specification/publish.md` (which establishes that the upload address and embedded values come from the built artifact's embedded manifest, not a re-parse of source) directly informed this proposal.

--- a/openspec/changes/add-facet-visibility-to-manifest/adversarial/reviews/design-review.md
+++ b/openspec/changes/add-facet-visibility-to-manifest/adversarial/reviews/design-review.md
@@ -1,0 +1,80 @@
+# Adversarial Comparison Review — `design`
+
+**Sources compared**
+- **Main**: `openspec/changes/add-facet-visibility-to-manifest/design.md`
+- **Adversary**: `openspec/changes/add-facet-visibility-to-manifest/adversarial/artifacts/design.md` (authored blind by `/run-adversary`, against the reconciled `proposal`)
+
+The adversary never saw Main while authoring. Both built on the reconciled proposal and the permanent schema/integrity/publish specs and docs. This review reads both for the first time and verifies the load-bearing engineering claims against the actual code.
+
+## Grading bar
+
+Design-scoped rubric:
+1. **Decision quality** — each key choice has a rationale and alternatives considered (the `design.md` instruction's core demand).
+2. **Technical correctness** — claims about the codebase are *true*; the design would actually work if implemented.
+3. **Risk/trade-off coverage** — the dangerous interactions are surfaced, not just the happy path.
+4. **Doc-impact discipline** (Article III + design rules) — names the doc files that need updating.
+5. **Migration/rollback realism**.
+6. **Open Questions** — surfaces what genuinely must be settled before specs freeze.
+
+## Code verification (the part that decides this review)
+
+I checked the two designs' contested factual claims against source:
+
+- **`packages/protocol/src/loaders/facet.ts:13–44`** — `ResolvedFacetManifest` enumerates only `name, version, description, author, skills, agents, commands, facets, servers`. No `private`.
+- **`facet.ts:151–161`** — `resolvePromptsFromMap` rebuilds the resolved object field-by-field with conditional spreads. **Any field not explicitly listed is silently dropped.** A new `private` on `FacetManifest` would NOT survive into `ResolvedFacetManifest` without an added line here.
+- **`packages/protocol/src/build/content-hash.ts:30–31`** — `collectArchiveEntries` embeds `facet.json` from the **original `manifestContent` string**, not from the resolved object. So the **archive bytes** keep `private` regardless of the resolved-object gap.
+- **`packages/protocol/src/integrity/validate-archive.ts:323–329`** — archive verification **reconstructs** a `ResolvedFacetManifest` via `resolvePromptsFromMap` and runs build validators on it. This is a second consumer of the resolved representation, beyond build/materialize/tests.
+
+**Verdict on the contested claims:**
+- Main's **"Preserve `private` in `ResolvedFacetManifest`"** decision is **correct and necessary**. Without the added field + the added copy line in `resolvePromptsFromMap`, the resolved representation drops `private`. The adversary **missed this entirely** — its "zero new transport plumbing" framing is true for the *archive bytes* but false for the *resolved in-memory representation* that engine, archive-verification, and tests consume.
+- The adversary's **`content_integrity` fingerprint** observation (toggling `private` changes the canonical hash → re-publishing flipped visibility at the same version collides with registry immutability) is **correct and Main does not mention `content_integrity` at all**. Main covers the *content-drift* consequence (same conclusion at the publish-prompt layer) but never connects it to the integrity fingerprint or the immutability collision.
+
+Both designs caught a real thing the other missed. Neither is strictly dominant.
+
+## Coverage comparison
+
+| Dimension | Main | Adversary |
+| --- | --- | --- |
+| Boolean over `visibility` enum, with alternatives | ✅ | ✅ (also rejects nested `registry`/`publish` object — extra alternative) |
+| Omission == public | ✅ (states it) | ✅ + **explicitly forbids schema-injected default**, with arktype `= false` rejected and the drift-false-positive reason |
+| `private` recognized, non-boolean rejected | ✅ | ✅ (adds the field-pathed error + the `private: "true"` typo motivation) |
+| **`ResolvedFacetManifest` must carry `private`** | ✅ **caught — correct & load-bearing** | ❌ **missed** |
+| **`content_integrity` fingerprint / immutability collision** | ❌ not mentioned | ✅ **caught — correct** |
+| No new drift class (content drift reuse) | ✅ (names `detectManifestDrift`, `reason: 'content'`) | ✅ (same conclusion, no internal names) |
+| No lockfile/project/build-manifest/server changes | ➖ implicit | ✅ **explicit decision with rationale** |
+| Concrete code path / file map | ✅ **names exact files + functions** (`facet-manifest.ts`, `loaders/facet.ts`, `build/pipeline.ts`, `publish/index.ts`, `detectManifestDrift`) | ➖ names schema file + behavior, fewer internal anchors |
+| Doc surfaces (Article III) | ✅ all three + per-file what-changes in migration | ✅ all three + per-file what-changes |
+| Open Questions | ⚠️ **"None."** | ✅ three (visibility confirm; accept `false` explicitly; registry echo) |
+| Risks | 4, solid | 4, incl. the fingerprint/immutability one and the stale-`dist/` example |
+| RFC 2119 usage | ✅ SHALL/SHOULD throughout | ⚠️ MUST in places, more prose elsewhere (acceptable for design, not a spec) |
+
+## Material divergences — which is stronger and why
+
+1. **`ResolvedFacetManifest` preservation (Main wins, decisively, verified).** This is the single most important finding in the review. Main identified that a recognized manifest field silently dies in `resolvePromptsFromMap` unless explicitly copied, and that the resolved representation is consumed independently of the archive bytes. The adversary's design is **incomplete without this** — implementing only the adversary's plan would ship a `private` that's in the archive but absent from the resolved object that archive-verification and materialize see. **Fold Main's decision in as-is.**
+
+2. **`content_integrity` fingerprint + immutability collision (Adversary wins, verified).** The adversary connected `private` to the canonical hash and spelled out the immutability consequence (flip visibility → new fingerprint → same-version re-publish is a 409). Main reaches the adjacent content-drift conclusion but never names the fingerprint or the version-bump requirement. **Fold the adversary's risk bullet into Main's Risks**, and carry the "visibility change needs a version bump, like any content edit" note into the publish docs.
+
+3. **Open Questions (Adversary wins).** Main declares **"None."** — but the proposal reconciliation explicitly seeded the boolean-vs-`visibility` question as the gate before specs freeze, and the adversary preserved it plus two more (accept `false` explicitly; does the registry expect a separate publish parameter vs. reading the embedded manifest). Main closing this to "None" is the one place Main is **weaker than the reconciled proposal already established**. **Restore at least the visibility-confirmation Open Question**; it is load-bearing for the `protocol__schemas` delta.
+
+4. **Concrete code anchoring (Main wins).** Main names exact files and the `detectManifestDrift` function, which makes the `tasks` artifact easier to derive. The adversary stayed one level more abstract. Minor, but real for the next phase.
+
+5. **"No changes to adjacent schemas" explicitness (Adversary marginally wins).** The adversary made it a numbered decision with rationale (visibility is publish-time intent, not install-time resolution); Main leaves it implicit. Cheap to adopt.
+
+## Merge recommendation (per decision)
+
+- **Decision: model as `private?: boolean`** — Keep Main. Optionally add the adversary's rejected "nested object" alternative for completeness. Low priority.
+- **Decision: omission == public** — **Strengthen Main with the adversary's framing**: state explicitly that the schema MUST NOT inject a default and no command may write `private` into the on-disk manifest, citing the drift-false-positive reason and the rejected arktype `= false` alternative. This is a genuine hardening.
+- **Decision: recognized + non-boolean rejected** — Keep Main; adopt the adversary's concrete `private: "true"` typo motivation as the rationale.
+- **Decision: preserve in `ResolvedFacetManifest`** — **Keep Main verbatim. Verified necessary.** Ensure the resulting `tasks` artifact includes the one-line edit to `resolvePromptsFromMap` (facet.ts:151–161) and an update to the `ResolvedFacetManifest` interface.
+- **Decision: reuse content drift** — Keep Main (it names the function). Append the adversary's fingerprint/immutability consequence as the rationale for *why* a visibility change is real content drift.
+- **NEW decision to add (from adversary):** "No changes to lockfile/project/build-manifest/server-manifest schemas," with the publish-time-intent rationale.
+- **Risks** — Add the adversary's `content_integrity`/immutability risk and the stale-`dist/` example.
+- **Open Questions** — **Replace "None." with at least the boolean-vs-`visibility` confirmation** (proposal reconciliation already flagged this as the spec-freeze gate), plus the "accept `false` explicitly" confirmation.
+
+## Blocking cross-cutting items (settle before archiving the change)
+
+1. ⛔ **`ResolvedFacetManifest` + `resolvePromptsFromMap` must be updated.** Verified against `loaders/facet.ts`. If the `specs`/`tasks` phase does not capture this, the implementation will silently drop `private` from the resolved representation consumed by archive-verification (`validate-archive.ts:329`) and materialize. This must be reflected in the `tasks` artifact.
+2. ⛔ **Reinstate the boolean-vs-`visibility` Open Question.** Main's "None." regresses a decision the reconciled proposal deliberately left open as the gate for the `protocol__schemas` delta. Resolve it (or keep it explicitly open) before specs freeze — if a third audience state is anticipated near-term, the spec MUST model `visibility` from the start.
+3. ✅ Doc-impact: both designs agree on the three surfaces; no conflict. Ensure the publish docs gain the "visibility change is content drift; bump the version" note (from divergence #2).
+
+**Net:** Main is the stronger, more implementable design — it caught the one verified must-fix engineering gap (`ResolvedFacetManifest`) the adversary missed, and it anchors to concrete files the `tasks` phase needs. But Main has two real regressions against the reconciled proposal that the adversary got right: it omits the `content_integrity`/immutability consequence, and it closes the visibility Open Question to "None." Reconcile by keeping Main's structure and folding in the adversary's fingerprint risk, the explicit "no schema-injected default" hardening, the "no adjacent-schema changes" decision, and the restored Open Question.

--- a/openspec/changes/add-facet-visibility-to-manifest/adversarial/reviews/proposal-review.md
+++ b/openspec/changes/add-facet-visibility-to-manifest/adversarial/reviews/proposal-review.md
@@ -1,0 +1,60 @@
+# Adversarial Comparison Review — `proposal`
+
+**Sources compared**
+- **Main**: `openspec/changes/add-facet-visibility-to-manifest/proposal.md` (the main agent's version)
+- **Adversary**: `openspec/changes/add-facet-visibility-to-manifest/adversarial/artifacts/proposal.md` (authored blind by `/run-adversary`)
+
+Both were authored from the same inputs (proposal instructions, constitution, the `protocol__schemas` / `authoring__facets` / `publishing` specs, and the manifest/publish docs). The adversary never saw Main while authoring; this review reads both for the first time.
+
+## Grading bar
+
+Proposal-scoped rubric:
+1. **Value-centric** — frames the customer/author problem, not the implementation.
+2. **Smallest valuable slice** — distilled scope, tradeoffs surfaced.
+3. **Correct artifact mechanics** — required sections present (Why / What Changes / **Non-goals** / Capabilities / Impact), word budget (300–1000 target, <1500 hard), domain-named capabilities.
+4. **Capabilities contract** — the proposal→specs handshake: every modified domain named correctly, no invented domains.
+5. **Documentation citation** (Article III) — cites the docs that informed it.
+6. **Coverage** — does it surface the real downstream consequences a specs/design author will need?
+
+## Coverage comparison
+
+| Dimension | Main | Adversary |
+| --- | --- | --- |
+| `private` boolean, public-by-default, omission == public | ✅ | ✅ |
+| Backward-compat / no BREAKING | ✅ (states it) | ✅ (explains *why* — schema already tolerates+preserves unknown fields) |
+| Non-goals section | ✅ **present, strong** | ❌ **MISSING — rule violation** |
+| Carried verbatim in embedded manifest to registry | ✅ | ✅ (slightly sharper: ties to existing `name`/`version` upload contract) |
+| Capabilities: 3 modified domains, no new | ✅ | ✅ (identical set + rationale) |
+| **Build/publish drift consequence of editing `private`** | ✅ **calls it out as content drift** | ❌ **absent** (and implicitly contradicted by "out of scope" framing) |
+| Richer-visibility tradeoff (boolean vs `visibility` string) flagged for design | ⚠️ one line ("Do not introduce a new visibility state unless…") | ✅ **explicit, framed as the central design open question** |
+| Value-type discipline (RFC2119 in modified-cap bullets) | ✅ uses SHALL | ➖ descriptive (acceptable for a proposal; specs phase owns normative language) |
+| Docs cited | ✅ manifest.md, publish.md, **+ guides/publish-a-facet.md** | ✅ manifest.md, publish.md |
+| Word budget | ✅ ~330 words, comfortably in band | ✅ ~480 words, in band |
+
+## Material divergences — which is stronger and why
+
+1. **Non-goals (BLOCKING, Main wins).** The proposal rules explicitly require a "Non-goals" section. **Main has one and it is excellent** — it pre-empts the four most dangerous scope-creep vectors (registry authz/billing/grants/search, org-membership semantics, auth-model changes, retroactive migration of published records). **The adversary omits the section entirely** — a hard rule violation. This is the clearest case in the review where Main is decisively stronger, and it is not close.
+
+2. **Drift consequence (Main wins, and it's correct).** Main's Impact section observes that "changing `private` after build is content drift and must be surfaced consistently with other manifest edits." I verified this against the `publishing` spec: content drift is defined as same name+version but differing manifest content. `private` is manifest content, so editing it post-build is content drift by the existing definition. Main surfaces a real, correct downstream consequence that the specs/design author must honor; **the adversary misses it** and its "out of scope: tooling reads what the author wrote" framing slightly undersells that the drift machinery already in `publishing` will interact with this field. Fold Main's point in — it is load-bearing for the `publishing` delta spec.
+
+3. **Visibility-model tradeoff (Adversary wins, but it's a design concern).** The adversary frames boolean-vs-`visibility`-string as *the* central open question and explains the migration cost of guessing wrong. Main mentions it in a single deferral bullet. The adversary's framing is more useful **as input to the design phase**, but note: a proposal should not over-index on a design decision. The right resolution is a one-line pointer in the proposal plus a real Open Question in `design.md` — not expanding the proposal.
+
+4. **"Why" quality (Adversary marginally stronger).** The adversary's Why articulates the concrete pain — source-of-truth `facet.json` and the registry disagreeing via out-of-band config — which is a sharper value statement than Main's "encode that intent in the artifact of record." Minor; Main's is adequate.
+
+5. **Docs citation breadth (Main marginally stronger).** Main also cites `docs/guides/publish-a-facet.md`, a third surface that will need updating. The adversary cites only the two specification pages. Pull the guide reference into the reconciled Impact so the docs-update scope is complete (Article III).
+
+## Merge recommendation (per section)
+
+- **Why** — Keep Main's structure; optionally graft the adversary's sharper framing ("`facet.json` and the published artifact disagree about a property the author cares about via out-of-band config"). Low priority.
+- **What Changes** — Keep Main. Optionally adopt the adversary's explicit "only legal values are `true`/`false`; non-boolean MUST be rejected" clause — it tightens the specs handshake. Keep Main's "do not introduce a new visibility state unless design shows otherwise" bullet.
+- **Non-goals** — **Keep Main's section verbatim.** This is the section the adversary lacks; nothing to merge, everything to preserve.
+- **Capabilities** — Identical across both (`protocol__schemas`, `authoring__facets`, `publishing`; no new). No change.
+- **Impact** — Keep Main, including the **content-drift observation** (it is correct and important). Ensure all three doc surfaces are listed (`manifest.md`, `publish.md`, `guides/publish-a-facet.md`).
+- **Visibility-model tradeoff** — Do **not** expand the proposal. Carry it forward as an explicit Open Question in `design.md`: "boolean `private` vs. string `visibility` discriminator — is any third audience state (unlisted / org / invite-only) anticipated near-term?" The adversary's reasoning is the raw material for that Open Question.
+
+## Blocking cross-cutting items (settle before archiving the change)
+
+1. **Main is missing nothing structurally; the adversary's omission of Non-goals is the only hard rule violation — and Main already satisfies it.** No blocking edit to Main is required on that axis. ✅
+2. **Carry the boolean-vs-`visibility` decision into `design.md` as an Open Question** before specs are frozen. If design concludes a richer model is plausible near-term, the specs MUST model `visibility` from the start to avoid a breaking migration — this decision gates the `protocol__schemas` delta. ⛔ until resolved in design.
+
+**Net:** Main is the stronger proposal and is ready to proceed largely as-is. The reconciliation work is small: (a) optionally tighten the `private` value constraint using the adversary's wording, (b) ensure the content-drift point and the third doc surface survive into the final Impact, and (c) seed the design phase with the visibility-model Open Question the adversary articulated.

--- a/openspec/changes/add-facet-visibility-to-manifest/adversarial/state.json
+++ b/openspec/changes/add-facet-visibility-to-manifest/adversarial/state.json
@@ -1,0 +1,30 @@
+{
+  "change": "add-facet-visibility-to-manifest",
+  "schema": "spec-driven",
+  "entries": {
+    "proposal": {
+      "artifactId": "proposal",
+      "mainPaths": ["proposal.md"],
+      "adversarialPaths": ["adversarial/artifacts/proposal.md"],
+      "reviewPath": "adversarial/reviews/proposal-review.md",
+      "dependencies": [],
+      "status": "reconciled",
+      "authoredAt": "2026-06-16T18:47:51Z",
+      "comparedAt": "2026-06-16T18:48:56Z",
+      "reconciledAt": "2026-06-16T18:55:00Z",
+      "notes": "Adopted adversary's sharper out-of-band-config framing and explicit optional private boolean constraints. Preserved main proposal's Non-goals, content-drift impact, docs scope, and chose boolean over a broader visibility discriminator."
+    },
+    "design": {
+      "artifactId": "design",
+      "mainPaths": ["design.md"],
+      "adversarialPaths": ["adversarial/artifacts/design.md"],
+      "reviewPath": "adversarial/reviews/design-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-06-16T19:38:09Z",
+      "comparedAt": "2026-06-16T19:59:34Z",
+      "reconciledAt": "2026-06-16T20:06:04Z",
+      "notes": "Adopted adversary's content-integrity and immutability consequence, no schema-injected default hardening, explicit adjacent-schema non-work, and stale-dist risk. Preserved main design's ResolvedFacetManifest requirement and settled private boolean decision."
+    }
+  }
+}

--- a/openspec/changes/add-facet-visibility-to-manifest/design.md
+++ b/openspec/changes/add-facet-visibility-to-manifest/design.md
@@ -1,0 +1,121 @@
+## Context
+
+Facet privacy intent belongs in `facet.json` because the manifest is the author-facing source of truth and is embedded in the built `.facet` artifact that publish verifies and uploads. Today the published facet manifest schema recognizes identity, description, author, text assets, composed facets, and server references, while tolerating unknown fields for forward compatibility. That tolerance is not enough for private facets: `private` must become a recognized schema field so authors get validation, generated types expose the value, build embeds it as manifest content, and publish can carry it to the registry without a side channel.
+
+The relevant code path is intentionally layered:
+
+- `packages/protocol/src/schemas/facet-manifest.ts` defines the normative `FacetManifestSchema` and inferred `FacetManifest` type.
+- `packages/protocol/src/loaders/facet.ts` validates raw manifest bytes and resolves prompt content into `ResolvedFacetManifest`.
+- `packages/engine/src/build/pipeline.ts` loads the source manifest, validates build content, and embeds the original `facet.json` text in the archive.
+- `packages/cli/src/commands/publish/index.ts` verifies the built archive, reads the embedded manifest, detects source-vs-artifact drift via `detectManifestDrift`, and uploads the artifact unchanged.
+
+Because the embedded `facet.json` is part of the inner archive, `private` participates in the artifact's canonical content fingerprint. Changing `private` is therefore a real content change, not publish-only metadata.
+
+Documentation currently describes manifest fields and publish behavior in `docs/specification/manifest.md`, `docs/specification/publish.md`, and `docs/guides/publish-a-facet.md`; all three need updates so docs remain aligned with the schema.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a recognized optional top-level `private` boolean in the facet manifest schema.
+- Preserve public-by-default compatibility: omitted `private` and `private: false` both mean public.
+- Reject non-boolean `private` values during manifest validation.
+- Preserve `private` through validation, prompt resolution, build archive embedding, archive verification, and publish drift detection.
+- Document that `private` is author intent carried to the registry; registry-side enforcement remains the registry's responsibility.
+
+**Non-Goals:**
+
+- No registry authorization, access-control, search-filtering, billing, or download-enforcement implementation.
+- No CLI publish flag, wizard prompt, or interactive editor control for setting privacy in this change.
+- No `visibility` string discriminator or additional states such as `unlisted`, organization-scoped, or invite-only visibility.
+- No migration of existing registry records.
+
+## Decisions
+
+### Decision: Model privacy as `private?: boolean`
+
+The manifest SHALL use an optional top-level `private` boolean. `true` means the author intends to publish privately; `false` and omission both mean public.
+
+**Rationale:** The near-term registry model is two-state: public or private. A boolean is the smallest representation that matches that product model, is easy to explain in author-facing JSON, and keeps the manifest contract stable for existing public facets. This design intentionally does not reserve a broader visibility model for hypothetical future audience states.
+
+**Alternatives considered:**
+
+- `visibility: "public" | "private"`: more extensible, but it pre-optimizes for audience states that are explicitly out of scope. It also creates a wider protocol concept before registry semantics exist.
+- Required `private: false` for public facets: explicit, but it would create unnecessary churn for every existing manifest and make public-by-default compatibility harder to communicate.
+- A nested `registry` or `publish` object: more expandable, but there is no other publish-time manifest metadata today. A flat top-level field matches the current manifest shape.
+
+### Decision: Omission means public without schema-injected defaults
+
+The schema SHALL accept omitted `private`, `private: false`, and `private: true`, but SHALL NOT inject `private: false` into validated manifest values when the field is omitted. Public-by-default behavior is semantic interpretation, not manifest mutation.
+
+**Rationale:** Tooling treats `facet.json` as the source of truth and publish compares source and embedded manifests structurally. A schema-level default that materializes `private: false` would make the validated object differ from the author's on-disk manifest, risking false content-drift detection or accidental re-emission of a field the author did not write.
+
+**Alternatives considered:**
+
+- Arktype/default-level `private = false`: rejected because it turns an omitted field into present manifest data.
+
+### Decision: Recognize `private` in protocol, not engine or CLI
+
+`FacetManifestSchema` SHALL own the field definition and type validation. Engine and CLI should receive the value through `FacetManifest` rather than maintaining their own parsing or validation rules.
+
+**Rationale:** Manifest shape is part of the published facet artifact specification. Protocol is the single source of truth for schemas and bytes validators, and registry implementations can consume the same protocol package when validating uploads. Recognition also turns author typos such as `private: "true"` into local, field-pathed validation errors instead of silently tolerated unknown data that only fails at the registry.
+
+**Alternatives considered:**
+
+- CLI-only handling during `facet publish`: rejected because it would create an out-of-band publish setting instead of embedding author intent in the artifact.
+- Registry-only handling of unknown manifest fields: rejected because authors would not get local validation and TypeScript consumers would not see `private` in the manifest type.
+
+### Decision: Preserve `private` in `ResolvedFacetManifest`
+
+`ResolvedFacetManifest` SHOULD gain `private?: boolean`, and `resolvePromptsFromMap` SHOULD copy the field from the validated manifest when it is present.
+
+**Rationale:** The built archive embeds the original `facet.json` text, so archive bytes would carry `private` even without this change. However, `ResolvedFacetManifest` is returned by build and consumed by downstream tooling/tests as the resolved representation of the manifest. Omitting a recognized top-level manifest field there would create a subtle second representation that loses visibility intent.
+
+**Alternatives considered:**
+
+- Only update `FacetManifest`: smaller, but violates the single-source-of-truth expectation for resolved manifest data.
+
+### Decision: Let existing drift detection classify privacy edits as content drift
+
+No new drift branch is needed. `detectManifestDrift` already compares validated manifests structurally after checking `name` and `version`; changing `private` after build will be classified as `reason: 'content'`.
+
+**Rationale:** Privacy intent is manifest content. Reusing the existing content-drift behavior keeps publish prompts and non-interactive warnings consistent with edits to description or asset descriptors. Because `facet.json` participates in the artifact content fingerprint, flipping `private` also produces a different artifact; publishing that changed artifact under an already-published version should collide with registry immutability just like any other manifest edit. Authors must bump the version when publishing a visibility change to an already-published facet.
+
+**Alternatives considered:**
+
+- Add a privacy-specific drift reason: rejected for this change because it expands CLI surface area without changing the user's available choices. The user still chooses whether to rebuild or publish the existing artifact unchanged.
+
+### Decision: Do not change adjacent artifact schemas
+
+The lockfile, project manifest, build manifest, and server manifest schemas SHALL NOT gain visibility fields as part of this change.
+
+**Rationale:** Facet privacy is publish-time author intent carried inside the facet manifest. Install-time artifacts do not decide whether a caller is authorized to see or download a private facet; the registry gates access before an installer receives metadata or bytes. The existing build manifest already fingerprints the embedded `facet.json`, so no separate build-manifest field is needed.
+
+### Decision: Document registry responsibility without duplicating registry policy
+
+Docs SHALL explain that `private` travels in the embedded manifest and is submitted during publish, while registry-side authorization and visibility enforcement are outside this repo's CLI/protocol change.
+
+**Rationale:** The CLI publishes verified artifact bytes; it does not enforce registry audience policy. Documentation should prevent authors from assuming local tooling alone makes a facet private.
+
+## Risks / Trade-offs
+
+- **Risk: Authors assume `private: true` alone enforces access control locally.** → Mitigation: docs and publish wording will state that the field expresses author intent and that the registry accepts, rejects, or enforces private visibility.
+- **Risk: Future audience states appear after choosing a boolean.** → Mitigation: the change intentionally scopes to the current two-state registry model. Future richer visibility semantics can be introduced as a separate protocol change if the product model changes.
+- **Risk: Existing tooling preserves unknown fields but does not understand `private`.** → Mitigation: omission remains public, and older tooling already tolerates unknown fields; newer tooling recognizes and validates the field.
+- **Risk: Resolved manifest and embedded manifest diverge.** → Mitigation: update `ResolvedFacetManifest` alongside `FacetManifest` so recognized manifest-level metadata is not dropped from the resolved representation.
+- **Risk: Authors try to flip visibility for an already-published version.** → Mitigation: document that `private` changes artifact content and therefore requires the same version-bump discipline as other manifest edits.
+- **Risk: Authors edit `private` in source but publish a stale `dist/` artifact.** → Mitigation: existing content-drift prompts and non-interactive warnings already cover source-vs-embedded manifest mismatch; add `private` to docs as an example of content drift.
+
+## Migration Plan
+
+1. Update protocol schema/types and tests to accept omitted `private`, `private: false`, and `private: true`, and reject non-boolean values without injecting a default.
+2. Update manifest resolution tests so `ResolvedFacetManifest` preserves `private` when present.
+3. Update publish/drift tests to cover changing `private` after build as content drift.
+4. Leave lockfile, project manifest, build manifest, and server manifest schemas unchanged.
+5. Update documentation in `docs/specification/manifest.md`, `docs/specification/publish.md`, and `docs/guides/publish-a-facet.md`, including a note that changing `private` after publish requires a new version.
+
+Rollback is straightforward: remove the recognized schema field and docs updates. Existing manifests containing `private` would return to being tolerated as unknown fields by older-compatible schema behavior, but newer tests and docs would need reverting.
+
+## Open Questions
+
+None. The design chooses `private?: boolean`, explicitly accepts `private: false`, and relies on the registry reading visibility intent from the embedded manifest rather than a separate publish parameter.

--- a/openspec/changes/add-facet-visibility-to-manifest/proposal.md
+++ b/openspec/changes/add-facet-visibility-to-manifest/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The registry API is preparing to support private facets, but facet authors currently have no manifest-level way to declare that a publish attempt is intended to create a private facet. Without a manifest field, private publishing depends on out-of-band registry configuration that the source-of-truth `facet.json` and built `.facet` artifact cannot express, so authors cannot carry privacy intent through build and publish consistently.
+
+## What Changes
+
+- Add an optional top-level `private` boolean for facet authors, where `private: true` marks the facet as private and `false` or omission keeps the facet public.
+- Define `private` as a recognized manifest field rather than an unknown extension; non-boolean values MUST be rejected.
+- Treat `private` as part of the validated facet manifest, embedded built artifact, and publish payload, so local tooling and the registry interpret the same source of truth.
+- Update manifest and publish documentation to describe public-by-default behavior and how an author opts into private publishing.
+- Preserve backwards compatibility for existing manifests that omit the field; they remain public and continue to validate.
+- Choose a boolean rather than a broader `visibility` discriminator because the near-term registry model is public vs private only; additional audience states are out of scope for this change.
+
+## Non-goals
+
+- This change does not implement registry-side authorization, billing, access grants, search filtering, or private artifact download enforcement.
+- This change does not define organization/team membership semantics or future visibility states such as unlisted, team-only, or invite-only.
+- This change does not change the current publish authentication model beyond carrying the manifest-declared privacy intent in the artifact being uploaded.
+- This change does not migrate existing published registry records; existing facets remain public unless a future registry migration explicitly changes them.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ This change extends existing manifest and publish behavior rather than introducing a new product domain.
+
+### Modified Capabilities
+
+- `protocol__schemas`: The facet manifest schema SHALL define the optional `private` boolean, reject non-boolean values, and preserve public-by-default compatibility behavior.
+- `authoring__facets`: Facet authoring validation and loading SHALL accept and preserve the privacy declaration so authors receive clear feedback before build or publish.
+- `publishing`: Publishing SHALL upload the already-built artifact with the embedded `private` value unchanged and SHALL rely on the registry to accept, reject, or enforce private visibility.
+
+## Impact
+
+- Affected protocol code includes the facet manifest schema, validated manifest type, manifest loader validation, archive verification, and any tests that assert valid or invalid manifest shapes.
+- Affected engine/CLI code includes build and publish paths that compare source and embedded manifests for drift, because changing `private` after build is content drift and must be surfaced consistently with other manifest edits.
+- The design artifact SHOULD document why `private?: boolean` is the chosen representation and why richer audience states such as unlisted, organization-scoped, or invite-only visibility are out of scope.
+- Affected documentation includes `docs/specification/manifest.md`, `docs/specification/publish.md`, and `docs/guides/publish-a-facet.md`, which informed this proposal and will need updates to avoid drift from the schema.
+- No new runtime dependency is expected.


### PR DESCRIPTION
### Why

The registry is gaining support for private facets, but authors currently have no manifest-level way to declare that intent. Without a manifest field, private publishing depends on out-of-band registry configuration that `facet.json` and the built `.facet` artifact cannot express, meaning privacy intent cannot travel consistently through build and publish.

### Details

Bumps `@julian/openspec-adversary` to `2.2.1`, which introduces the `opencode-adversary` agent asset used to run blind adversarial authoring against the main agent's artifacts.

This version bump was made to support the `add-facet-visibility-to-manifest` change, which went through a full adversarial spec cycle (proposal → design, each with a blind adversary artifact and a comparison review). The reconciled outputs are included here.

The core design adds an optional top-level `private?: boolean` to `FacetManifestSchema`. Key decisions from the reconciled design:

- Omission and `false` both mean public. The schema must not inject a default value, as materializing `private: false` on validated objects would diverge from on-disk bytes and trigger false content-drift detection during publish.
- Non-boolean values (e.g. `private: "true"`) are rejected with a field-pathed validation error rather than silently tolerated as an unknown field.
- `ResolvedFacetManifest` must also gain `private?: boolean` and `resolvePromptsFromMap` must copy it explicitly — archive bytes carry the field via the embedded `facet.json` string, but the resolved in-memory representation used by archive verification and downstream tooling would silently drop it otherwise.
- No new drift classification is needed. Changing `private` after build is ordinary content drift. Because `facet.json` participates in the artifact content fingerprint, flipping visibility also changes `content_integrity`, meaning a visibility change at an already-published version collides with registry immutability and requires a version bump.
- Lockfile, project manifest, build manifest, and server manifest schemas are unchanged. Visibility is publish-time author intent, not an install-time resolution input.