### PR TITLE
Bump `@julian/openspec-adversary` to `2.3.2` and add `expose-facet-privacy-toggle` openspec change

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,6 @@
     "viper-plans": "0.2.0",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "2.3.0"
+    "@julian/openspec-adversary": "2.3.2"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "2.3.0",
-      "integrity": "sha256:12f91506d77467081816cd89412828df91a25d2de2ab897803a7dbc468dc1c1b",
+      "version": "2.3.2",
+      "integrity": "sha256:abedfa1f9247a3808007acdc75b5721969de97089aa31aee139cf7c4d8bb7ac8",
       "assets": [
         {
           "scope": "project",

--- a/openspec/changes/expose-facet-privacy-toggle/.openspec.yaml
+++ b/openspec/changes/expose-facet-privacy-toggle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/design.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/design.md
@@ -1,0 +1,136 @@
+## Context
+
+The facet manifest schema already recognizes an optional top-level `private` boolean. `private: true` declares private publish intent; `false` or omission is public-by-default. Validation does not synthesize a default — omission stays omission in validated data — so tooling sees exactly what the author wrote (`packages/protocol/src/schemas/facet-manifest.ts`; `docs/specification/manifest.md` Privacy section). Everything downstream of the manifest already honors this field: build embeds it verbatim into the `.facet` artifact, publish carries it to the registry as ordinary manifest content, publish-time drift detection treats a flipped `private` as content drift, and immutability forces a version bump to change visibility on an already-published version (`docs/specification/publish.md`, `docs/guides/publish-a-facet.md`).
+
+The gap is entirely at the front of the authoring workflow. The interactive `facet create` wizard and `facet edit` workbench collect and display the facet's identity fields (name, description, version) and asset sets, but never surface `private`. The only documented way to set or flip visibility is to hand-edit `facet.json` (`docs/guides/publish-a-facet.md` "Making a published facet private (or public)"). This is hidden functionality: authors do not discover the field, cannot observe a facet's current visibility while editing, and risk typos the manifest validator only catches later.
+
+Current implementation state relevant to this design:
+
+- **Shared form state** (`packages/cli/src/tui/context/form-state-context.ts`) models identity fields as `FieldState` (a `{ value: string; status }` shape) and three asset sections. There is no boolean-backed field and no boolean input primitive anywhere in `packages/cli/src/tui`. The closest focusable patterns are `components/button.tsx` (Enter-to-act) and `components/editable-field.tsx` (string-field lifecycle, hard-typed to `RequiredFieldKey`).
+- **Focus order** (`context/focus-order-context.ts`) is an ordered array of string IDs, computed per-view by a duplicated `computeFocusIds(form)` in `views/create/create-view.tsx` and `views/edit/edit-view.tsx`.
+- **Confirmation pages** (`views/create/confirm-view.tsx`, `views/edit/edit-confirm-view.tsx`) render Name/Description/Version rows before applying.
+- **Scaffold generation** (`packages/engine/src/scaffold/index.ts`) builds the manifest object via conditional key assignment — `name`/`version` always written, `description`/asset sections written only when non-empty — then `JSON.stringify(manifest, null, 2)`. There is no `private` and no `author` in `ScaffoldOptions`.
+- **Edit result construction** (`packages/cli/src/tui/views/edit/use-edit-session.ts` `buildManifest`) rebuilds the manifest by spreading `...original` then overwriting identity fields and rebuilding asset sections (empty sections are `delete`d). Because of `...original`, any existing `private` already survives an edit untouched even though no UI references it. The write goes through engine's `edit/manifest-writer.ts` (`Bun.write(path, JSON.stringify(manifest, null, 2))`).
+- **Edit seeding** (`views/edit/manifest-to-form.ts`) maps `name`/`description`/`version` and assets into form state; it does not read `private`.
+
+Constraints:
+
+- The change MUST NOT alter the schema, build embedding, publish behavior, or registry semantics. It is an authoring affordance only.
+- Public-by-default MUST remain omission, not `private: false` — including when an author moves a previously private facet back to public. This is the proposal's settled rule and matches the schema's "omission is not synthesized" guarantee, so an in-tool toggle round-trips to a manifest byte-identical to what a careful author would hand-write.
+- Constitution Article III: this change alters documented CLI behavior, so the affected docs MUST be identified and updated as scoped work.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make publish visibility a first-class, observable choice in both interactive authoring tools, so authors can set it on create and inspect/change it on edit without leaving the TUI or hand-editing JSON.
+- Preserve the manifest's existing serialization contract exactly: `private: true` is written only when selected; every public selection omits the key, never emitting `private: false`.
+- Surface, at the point of toggling, the consequence that visibility is manifest content — it requires a rebuild to take effect and a version bump if the current version is already published — so authors meet the existing publish-time rules at decision time rather than at failure time.
+- Keep documentation aligned: update create/edit docs to mention the new step, and rewrite the publish guide's hand-edit instruction to lead with the in-tool toggle while preserving rebuild/version-bump discipline.
+
+**Non-Goals:**
+
+- No schema change, no change to `private` validation, build embedding, or how it travels to the registry.
+- No registry-side visibility enforcement or access control.
+- No standalone non-interactive command (`facet private` / `facet public`).
+- No automatic rebuild or republish on toggle; build and publish remain separate explicit steps.
+- No privacy controls for composed dependencies or installed facets.
+- No new option for non-interactive create/edit (e.g., a `--private` flag). Scope is the interactive flows only; a flag is a possible future addition.
+
+## Decisions
+
+### Decision 1: Model visibility as a dedicated boolean field, not a `FieldState`
+
+`FormState.fields` holds `FieldState` values whose `value` is a `string`. Visibility is a two-state boolean (private vs. public-by-default), so reusing the string `FieldState` shape would force an illegal-state-prone encoding (what string means "public"? is `""` public or unset?).
+
+**Decision:** Add a dedicated boolean-backed entry to `FormState` — `private: boolean` (default `false`) — separate from the string `fields` map, and add a `setPrivate(value: boolean)` mutator to the form-state context. Both `facet create` and `facet edit` share this single field because they share `FormStateProvider`.
+
+**Why over alternatives:**
+
+- *Reuse `FieldState` with `value: 'public' | 'private'`* — overloads a string field to carry an enum, reintroduces the "what is empty?" question, and would require special-casing every `FieldState` consumer. Rejected: it makes an illegal state (`value: ""` on a non-optional toggle) representable.
+- *Store visibility only as the raw `private` value (`boolean | undefined`)* — mirrors the manifest's `boolean | undefined`, but the UI never needs three states: the toggle is binary, and "omitted" and "false" are the same user-facing choice (public). Carrying `undefined` into the form would push manifest-serialization concerns up into the UI. Rejected: the form should model the *user's* binary choice; the omit-vs-write distinction belongs at serialization (Decision 3).
+
+The toggle defaults to public (`private: false`) on create, so a scaffolded manifest with the author taking no action is byte-identical to today's output.
+
+### Decision 2: A new reusable focusable toggle component
+
+No boolean input primitive exists in the TUI. The toggle must participate in the existing focus-order array (Enter/Space to flip, arrow/Tab to move on) and render its current state plus the public-by-default explanation.
+
+**Decision:** Add one reusable toggle component under `packages/cli/src/tui/components/` modeled on `button.tsx`: it reads `focusedId` from `useFocusOrder()` to compute `isFocused`, binds `useInput` while focused to flip the bound boolean on Enter (and Space), and renders a focus prefix consistent with the other focusable rows. It reads/writes the form-state `private` field via the context mutator from Decision 1. The component is shared by both create and edit views.
+
+**Why over alternatives:**
+
+- *A select/radio prompt (two options: Public / Private)* — heavier, visually inconsistent with the single-line identity rows, and `select-prompt.tsx` is documented as single-select "without selection toggle." Rejected: a binary toggle is simpler and matches the row-based form.
+- *Inline the toggle logic in both views* — duplicates focus/keybinding logic across create and edit. Rejected: violates single-source-of-truth; a shared component is the established pattern (`button.tsx`, `editable-field.tsx`).
+
+### Decision 3: Omission-preserving serialization at the manifest-construction boundary
+
+This is the load-bearing decision. The settled rule is: write `private: true` only when private is selected; otherwise omit the key entirely, including when an author returns a previously private facet to public. The two write paths (scaffold and edit) have different starting points and so need different mechanics to reach the same guarantee.
+
+**Scaffold (`generateScaffoldManifest`):** the manifest is built from scratch by conditional assignment. Add `private?: boolean` to `ScaffoldOptions` and a conditional block matching the existing `description` precedent:
+
+```
+if (opts.private) {
+  manifest.private = true
+}
+```
+
+A truthy check means `false`/`undefined` never assigns the key, so `JSON.stringify` omits it. Placed after `version` to match schema field order. `toCreateOptions` and the form defaults in `form-state-context.ts` thread the new field through.
+
+**Edit (`buildManifest`):** the manifest is rebuilt via `...original`, which *reintroduces* any pre-existing `private`. A truthy-only set is therefore insufficient for the public case — moving private→public would leave the spread-in `private: true` in place. The construction MUST explicitly delete the key when public:
+
+```
+if (form.private) {
+  manifest.private = true
+} else {
+  delete manifest.private
+}
+```
+
+This mirrors the asset-section set/`delete` pattern already in `buildManifest` (not the `description` pattern, which has a known stale-value quirk when a field is cleared). The result: private→public writes a manifest with no `private` key at all (omission, not `private: false`), satisfying the settled rule.
+
+**Why over alternatives:**
+
+- *Write `private: false` for public* — simpler and schema-valid, but contradicts the proposal's settled rule and the schema's "omission is not synthesized" guarantee, and would make an in-tool public selection produce a different on-disk manifest than a hand-written one. Rejected by the proposal.
+- *Centralize a single shared manifest writer that strips falsey `private`* — attractive (scaffold and edit currently duplicate `JSON.stringify(x, null, 2)`), but consolidating the two writers is out of scope and the divergent starting points (build-from-scratch vs. spread-original) still need different upstream handling. Noted as a follow-up, not done here.
+
+### Decision 4: Seed edit visibility from the loaded manifest, treating `false` and omission identically
+
+`manifestToFormState` currently ignores `private`. To let the workbench display current visibility, it MUST read it.
+
+**Decision:** In `manifestToFormState`, set the form's `private` field to `manifest.private === true`. Both `private: false` and an omitted field map to `false` (public), because they are the same user-facing state. This is a deliberate normalization at the read boundary: the workbench shows two states, and a manifest that happened to carry an explicit `private: false` is displayed as public. Note the round-trip consequence: opening such a manifest and applying any edit will, per Decision 3's edit `delete`, rewrite it to omit `private` — converging the on-disk form to the canonical omission representation. This is acceptable and arguably desirable (it removes a redundant `private: false`), and MUST be called out in the spec scenarios so it is intended behavior, not a surprise.
+
+### Decision 5: Visibility consequence messaging lives at the toggle, statically
+
+The author must learn that toggling is a content change requiring rebuild (and a version bump if already published). The tools cannot know whether the current version is already published without a registry round-trip, which is out of scope.
+
+**Decision:** Render a short static note adjacent to the toggle (in both create and edit) stating that changing visibility is a manifest content change that takes effect only after a rebuild, and requires a version bump if the current version has already been published. The note is informational and unconditional; it does not query the registry and does not gate the toggle.
+
+**Why over alternatives:**
+
+- *Detect whether the version is published and warn conditionally* — requires a network call and credentials inside the authoring flow, expanding scope into publish/registry concerns the proposal excludes. Rejected.
+- *Surface the warning only at publish time* — that path already exists (drift detection), but the goal is to inform the author at the decision point, not at the failure point. The static note complements, not replaces, the publish-time messaging.
+
+### Decision 6: Confirmation summary shows visibility as a labeled row
+
+Both confirmation pages list identity fields before applying. Visibility is now part of that identity decision.
+
+**Decision:** Add a "Visibility" row to both `confirm-view.tsx` and `edit-confirm-view.tsx`, rendering "Private" when selected and "Public (default)" otherwise. This keeps the summary a faithful preview of what will be written. Because the create confirmation already previews files via `previewScaffoldFiles(opts)`, the threaded `private` option is reflected there automatically once `toCreateOptions` carries it.
+
+## Risks / Trade-offs
+
+- **[Spread reintroduces `private` on edit → private→public would silently stay private]** → Decision 3 mandates an explicit `delete manifest.private` in the public branch of `buildManifest`, mirroring the existing asset-section delete pattern. Spec scenarios MUST cover the private→public round-trip asserting the key is absent (not `false`).
+- **[A manifest with explicit `private: false` is normalized to omission on the next edit-apply]** → This is intended (Decision 4). The risk is an author perceiving an unexpected diff. Mitigation: a spec scenario documents this normalization as expected behavior; the on-disk meaning (public) is unchanged.
+- **[Two divergent write paths drift apart]** → Scaffold and edit already serialize independently with identical formatting. This change adds parallel `private` logic to both, increasing the surface that must stay in sync. Mitigation: identical guarantee expressed as spec scenarios that apply to both flows; a future consolidation of the two writers is noted but explicitly out of scope.
+- **[Boolean field breaks `FieldState`-shaped consumers]** → A new boolean field on `FormState` outside the string `fields` map could be missed by code that iterates `fields`. Mitigation: keep the boolean as a sibling of `fields`, not a member, and add it to defaults, `toCreateOptions`, and `manifestToFormState` in one change so all construction sites are covered.
+- **[Focus-order duplication]** → The new toggle's focus ID must be inserted into the duplicated `computeFocusIds` in both create and edit views, and its `onConfirm`/focus chaining wired in both. Missing one yields a non-reachable or mis-ordered control. Mitigation: add to both views in the same change; cover focus reachability where practical in tests.
+- **[Documentation drift]** (Article III) → `docs/cli/authoring/create.md` and `docs/cli/authoring/edit.md` describe the wizard fields and do not mention visibility; they MUST gain the new step. `docs/guides/publish-a-facet.md` "Making a published facet private (or public)" leads with hand-editing `facet.json`; it MUST be rewritten to lead with the in-tool toggle while preserving the rebuild + version-bump steps. `docs/specification/manifest.md` Privacy section SHOULD note the field is now author-settable through the tools. No behavior change is expected in `docs/specification/publish.md` (publish-time handling is unchanged), but its drift-detection text already correctly describes a flipped `private` as content drift and need not change.
+
+## Migration Plan
+
+No data migration. This is additive UI plus serialization wiring with no schema or on-disk format change. Existing manifests are unaffected until an author opens one in `facet edit` and applies a change, at which point a redundant `private: false` (if any) normalizes to omission (Decision 4) — a no-op in meaning. No rollback concern beyond reverting the code; reverted tools simply stop showing the toggle, and any `private: true` previously written remains valid and honored by build/publish.
+
+## Open Questions
+
+- Should the toggle expose a third explicit "public (`private: false`)" state for authors who want the field written explicitly? The proposal's settled rule (always omit for public) argues no, and a third state reintroduces the illegal-state surface Decision 1 avoids. Treated as resolved against a third state unless a concrete need surfaces.
+- Should a non-interactive `--private` flag for `facet create` be added so CI/scripted scaffolds can declare visibility without the wizard? Out of scope here (Non-Goals), but the threaded `ScaffoldOptions.private` from Decision 3 makes it a small future addition.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/proposal.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+A facet author can already declare publish visibility through the manifest's `private` boolean, and the entire downstream chain — schema validation, build embedding, publish drift detection, and the version-bump-to-change-visibility discipline — already honors it. The one missing link is at the very front of the workflow: the interactive authoring tools (the create wizard and the edit workbench) surface a facet's identity fields but never surface `private`. The only way to set or flip privacy today is to hand-edit `facet.json` by hand, which the documentation itself instructs (`docs/guides/publish-a-facet.md`: "edit facet.json: set 'private': true"). That is a discoverability and safety gap: authors do not learn the field exists, cannot see their facet's current visibility while editing, and risk typos that the manifest validator only catches later. Exposing the toggle in the authoring tools closes the loop so visibility intent is a first-class, observable choice rather than tribal knowledge about a JSON field.
+
+## What Changes
+
+- The interactive **edit** workbench SHALL display the facet's current publish visibility (private vs. public, including the public-by-default state when `private` is omitted) alongside the identity fields, and SHALL let the author change it.
+- The interactive **create** wizard SHALL let an author declare publish visibility while scaffolding a new facet, defaulting to public-by-default so the scaffolded manifest matches today's omit-the-field behavior unless the author opts into private.
+- When an author leaves visibility at public-by-default, the tools SHALL preserve omission of `private` in the manifest rather than writing `private: false`, keeping the on-disk manifest identical to what an author would hand-write and consistent with the existing "omission is not synthesized" rule.
+- When an author explicitly selects public after a facet was private, the tools SHALL write the manifest in a way that records the public choice; the exact on-disk representation (omit `private` vs. write `private: false`) is a design decision deferred to design.md, but both representations are already valid public declarations.
+- The author SHALL be shown, at the point of toggling, that changing visibility is a manifest content change that requires a rebuild before it takes effect and a version bump if the current version is already published — reinforcing the existing publish-time drift and immutability rules rather than letting the author discover them only when publish fails.
+
+## Non-goals
+
+- No change to the `private` schema field, its boolean validation, build embedding, or how it travels to the registry at publish time. Those behaviors already exist and are correct; this change only adds an authoring affordance for setting the value.
+- No registry-side visibility enforcement, access control, or "who can download a private facet" behavior. That is the registry's responsibility and is explicitly outside the CLI/protocol surface.
+- No new top-level command (e.g., a standalone `facet private`/`facet public`). The toggle lives inside the existing authoring tools; a dedicated non-interactive command is a possible future addition, not part of this change.
+- No automatic rebuild or republish triggered by toggling visibility. The toggle edits source manifest intent only; the existing build and publish steps remain separate and unchanged.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. This change adds an authoring affordance for an already-specified field; it introduces no new product domain. -->
+
+### Modified Capabilities
+
+- `authoring__facets`: The interactive create wizard and edit workbench requirements gain the ability to view and set the facet's publish visibility. The edit workbench's "edit facet identity fields" behavior and the create wizard's identity-collection behavior are extended to include visibility, and the "omission is not synthesized" guarantee is preserved when the author leaves visibility public-by-default.
+
+## Impact
+
+- **Specs**: `openspec/specs/authoring__facets/spec.md` — the create-wizard and edit-workbench requirements are extended with visibility-toggle scenarios.
+- **Code**: the CLI authoring/edit views (`packages/cli/src/tui/`) and the engine's edit/scaffold manifest mutations (`packages/engine/src/edit/`, `packages/engine/src/scaffold/`, `packages/engine/src/manifest/`) — to render the visibility control and write the chosen value through the existing pure manifest-mutation path.
+- **Documentation**: `docs/guides/publish-a-facet.md` currently tells authors to hand-edit `facet.json` to change visibility (the "Making a published facet private (or public)" section). That guidance MUST be updated to describe the new in-tool toggle while still explaining the rebuild + version-bump discipline. `docs/specification/manifest.md`'s Privacy section SHOULD note that the field is now author-settable through the tools, not only by hand-editing. No change to `docs/specification/publish.md` behavior is expected, since publish-time handling is unchanged.
+- **Dependencies / APIs**: none. No new packages, no registry API changes, no schema changes.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/specs/authoring__facets/spec.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/specs/authoring__facets/spec.md
@@ -1,0 +1,270 @@
+## MODIFIED Requirements
+
+### Requirement: Authors can scaffold a new facet project interactively
+
+The system SHALL provide an interactive wizard that guides the author through creating a new facet project. The wizard SHALL collect the following required information:
+
+- **Name**: A valid facet identity name. The name SHALL be either an unscoped kebab-case name (`name`) or a scoped name (`@scope/name`). The system SHALL validate the name in real-time and reject invalid input.
+- **Description**: A non-empty description. The system SHALL NOT allow the author to complete the wizard without providing a description.
+
+The wizard SHALL also collect optional information:
+
+- **Version**: A valid SemVer version (N.N.N format). The system SHALL default to `0.0.0`. The author MAY accept the default or change it.
+- **Privacy**: A choice of whether the new facet declares private publish intent. The system SHALL default to public-by-default. The author MAY choose private publish intent or accept the public-by-default default. The system SHALL present this choice in plain terms the author can act on without consulting external documentation — public-by-default means the facet is publicly listable when published, and private publish intent means the author signals the registry to keep the facet unlisted.
+
+The wizard SHALL also allow the author to manage assets (skills, commands, and agents):
+
+- The author SHALL be able to add multiple named assets of any type
+- The author SHALL be able to edit the name of an existing asset
+- The author SHALL be able to remove an existing asset
+- All asset names SHALL be validated as kebab-case in real-time
+- Asset names SHALL be unique within their type — the system SHALL reject duplicates within the same asset type
+- Assets of different types MAY share the same name
+- The first asset added to each type SHOULD default its name to the unscoped name segment of the facet identity as a suggestion
+
+The wizard SHALL require the author to add at least one **asset** before completing. Name, description, and at least one **asset** are all required.
+
+All fields SHALL remain editable throughout the wizard — the author SHALL be able to go back and change any previously entered value, including the privacy choice.
+
+Before completing, the wizard SHALL display a confirmation summary showing only the asset types that have entries and a preview of the files to be created. The summary SHALL communicate the selected privacy intent. The author SHALL be able to confirm or go back.
+
+The wizard SHALL provide an exit confirmation mechanism that prevents accidental loss of unsaved work.
+
+Upon confirmation, the system SHALL create a project directory containing a valid manifest and named starter files for each asset the author specified, with each starter file containing template content that guides authors on what belongs in each section. Skill starter files SHALL be created at `skills/<name>/SKILL.md`. Agent and command starter files SHALL be created at `agents/<name>.md` and `commands/<name>.md` respectively. All starter files SHALL contain no YAML front matter.
+
+When the author selects private publish intent, the generated manifest SHALL declare `private: true`. When the author accepts public-by-default, the generated manifest SHALL omit the `private` field entirely rather than writing `private: false`.
+
+The scaffolded project SHALL be immediately buildable — running the build command on a freshly scaffolded project SHALL succeed with no errors.
+
+#### Scenario: Author scaffolds a scoped project with named skills
+
+- **WHEN** the author runs the create wizard, provides a name `@julian/cowsay` and description `Cowsay tools`, and adds a skill named `cowsay`
+- **THEN** the system SHALL create a project directory containing a manifest whose `name` is `@julian/cowsay`
+- **AND** a starter file SHALL be created at `skills/cowsay/SKILL.md`
+- **AND** the manifest SHALL reference all starter files correctly
+
+#### Scenario: Author scaffolds a project with named skills
+
+- **WHEN** the author runs the create wizard, provides a name "viper-plans" and description "VIPER planning tools", and adds two skills named "viper-planning" and "viper-execution-rules"
+- **THEN** the system SHALL create a project directory containing a manifest with the provided identity fields and skill descriptors
+- **AND** starter files SHALL be created at `skills/viper-planning/SKILL.md` and `skills/viper-execution-rules/SKILL.md`
+- **AND** the manifest SHALL reference all starter files correctly
+
+#### Scenario: Author scaffolds a minimal project accepting the default skill name
+
+- **WHEN** the author runs the create wizard, provides a name "code-review" and a description, then adds a skill accepting the default name suggestion
+- **THEN** the system SHALL create a project with a skill named "code-review" (matching the facet name)
+- **AND** the starter file SHALL be at `skills/code-review/SKILL.md`
+
+#### Scenario: Author cannot complete without a description
+
+- **WHEN** the author attempts to complete the wizard without providing a description
+- **THEN** the system SHALL NOT allow completion
+- **AND** the system SHALL indicate that a description is required
+
+#### Scenario: Scoped facet identity is accepted
+
+- **WHEN** the author enters `@acme/deploy-tools` as the facet name
+- **THEN** the system SHALL accept the name as a valid facet identity
+
+#### Scenario: Invalid facet identity is rejected
+
+- **WHEN** the author enters `@acme/Deploy_Tools` as the facet name
+- **THEN** the system SHALL indicate the name is invalid
+- **AND** the system SHALL NOT accept the invalid name
+
+#### Scenario: Asset names are validated as kebab-case
+
+- **WHEN** the author enters an asset name containing uppercase letters, spaces, underscores, slashes, or an at sign
+- **THEN** the system SHALL indicate the name is invalid
+- **AND** the system SHALL NOT accept the invalid name
+
+#### Scenario: Duplicate asset names within a type are rejected
+
+- **WHEN** the author attempts to add a skill with the same name as an existing skill
+- **THEN** the system SHALL reject the duplicate name
+
+#### Scenario: Same name across different asset types is allowed
+
+- **WHEN** the author adds a skill named "viper-plans" and an agent named "viper-plans"
+- **THEN** the system SHALL accept both assets without error
+
+#### Scenario: Author edits an existing asset name
+
+- **WHEN** the author selects an existing asset and changes its name to a valid, unique kebab-case name
+- **THEN** the system SHALL update the asset name
+
+#### Scenario: Author removes an asset
+
+- **WHEN** the author removes a previously added asset
+- **THEN** the asset SHALL no longer appear in the wizard or the confirmation summary
+
+#### Scenario: Author exits the wizard with unsaved work
+
+- **WHEN** the author triggers an exit action during the wizard
+- **THEN** the system SHALL confirm the author's intent to exit
+- **AND** if the author confirms exit, the system SHALL not create any files or directories
+
+#### Scenario: Version field accepts valid SemVer input
+
+- **WHEN** the author sets the version to a valid SemVer value (e.g., "1.0.0" or "100.2.1")
+- **THEN** the system SHALL accept the version
+
+#### Scenario: Version field rejects invalid input
+
+- **WHEN** the author enters a version that does not match the N.N.N pattern
+- **THEN** the system SHALL indicate the version is invalid
+
+#### Scenario: Version defaults to 0.0.0
+
+- **WHEN** the author does not change the version field
+- **THEN** the manifest SHALL contain version `0.0.0`
+
+#### Scenario: Privacy defaults to public-by-default with the field omitted
+
+- **WHEN** the author completes the create wizard without changing the privacy choice
+- **THEN** the generated manifest SHALL NOT contain a `private` field
+- **AND** the system SHALL NOT write `private: false`
+
+#### Scenario: Author selects private publish intent during create
+
+- **WHEN** the author selects private publish intent in the create wizard and completes it
+- **THEN** the generated manifest SHALL contain `private: true`
+
+#### Scenario: Author selects private then reverts to public before completing
+
+- **WHEN** the author selects private publish intent, then changes the privacy choice back to public-by-default before completing the wizard
+- **THEN** the generated manifest SHALL NOT contain a `private` field
+
+#### Scenario: Confirmation summary reflects the selected privacy intent
+
+- **WHEN** the author reaches the confirmation summary after selecting private publish intent
+- **THEN** the summary SHALL indicate that the facet declares private publish intent
+
+#### Scenario: Target directory already contains a manifest
+
+- **WHEN** the author runs the create wizard and a manifest already exists in the target directory
+- **THEN** the system SHALL warn the author and ask for confirmation before overwriting
+
+### Requirement: Authors can edit a facet project interactively
+
+The system SHALL provide an interactive editing command that serves as the full authoring workbench for facet manifests. The editing command SHALL combine all capabilities of the scaffolding wizard (identity editing, privacy editing, asset creation, asset removal) with automatic reconciliation of disk contents against the manifest. The editing command SHALL scan conventional **asset** directories to detect discrepancies between disk contents and the manifest. If the manifest is invalid, the editing command SHALL display errors and exit. If drift is detected, the editing command SHALL present a reconciliation phase before proceeding to editing.
+
+The editing command SHALL display the facet's current privacy intent so the author can inspect it without opening the manifest file, and SHALL allow the author to change between public-by-default and private publish intent. When the author sets or leaves the facet as private, the written manifest SHALL contain `private: true`. When the author sets or leaves the facet as public-by-default, the written manifest SHALL omit the `private` field; if the manifest previously contained `private: true` or `private: false`, that field SHALL be removed rather than rewritten as `private: false`.
+
+#### Scenario: Author edits facet identity fields
+
+- **WHEN** the author runs the edit command on a facet project
+- **THEN** the system SHALL display the current name, description, and version
+- **AND** the author SHALL be able to change any of them
+- **AND** if version is absent, the system SHALL default it to `0.0.0`
+
+#### Scenario: Author inspects current privacy intent
+
+- **WHEN** the author runs the edit command on a facet whose manifest declares `private: true`
+- **THEN** the system SHALL display that the facet currently declares private publish intent
+
+#### Scenario: Author inspects privacy intent on a public facet
+
+- **WHEN** the author runs the edit command on a facet whose manifest omits `private` or declares `private: false`
+- **THEN** the system SHALL display that the facet is currently public-by-default
+
+#### Scenario: Author changes a public facet to private
+
+- **WHEN** the author runs the edit command on a facet whose manifest omits `private`, sets it to private publish intent, and confirms
+- **THEN** the written manifest SHALL contain `private: true`
+
+#### Scenario: Author changes a private facet to public, omitting the field
+
+- **WHEN** the author runs the edit command on a facet whose manifest declares `private: true`, sets it to public-by-default, and confirms
+- **THEN** the written manifest SHALL NOT contain a `private` field
+- **AND** the system SHALL NOT write `private: false`
+
+#### Scenario: Editing an explicit private:false manifest to public removes the field
+
+- **WHEN** the author runs the edit command on a facet whose manifest declares `private: false`, leaves it public-by-default, and confirms
+- **THEN** the written manifest SHALL NOT contain a `private` field
+
+#### Scenario: Author changes a facet identity to a different scope
+
+- **WHEN** the author changes a facet's name from `@julian/cowsay` to `@acme/cowsay` during edit
+- **THEN** the system SHALL treat the change as a normal local identity edit
+- **AND** the system SHALL NOT warn specially about changing scopes
+
+#### Scenario: Author creates a new skill from scratch
+
+- **WHEN** the author uses the edit command to add a new skill named "code-review"
+- **THEN** the system SHALL create `skills/code-review/SKILL.md` with a starter template
+- **AND** the system SHALL add a skill descriptor to the manifest with the author-provided description
+
+#### Scenario: Author creates a new agent from scratch
+
+- **WHEN** the author uses the edit command to add a new agent named "reviewer"
+- **THEN** the system SHALL create `agents/reviewer.md` with a starter template
+- **AND** the system SHALL add an agent descriptor to the manifest with the author-provided description
+
+#### Scenario: Author creates a new command from scratch
+
+- **WHEN** the author uses the edit command to add a new command named "run-review"
+- **THEN** the system SHALL create `commands/run-review.md` with a starter template
+- **AND** the system SHALL add a command descriptor to the manifest with the author-provided description
+
+#### Scenario: Author deletes an existing asset
+
+- **WHEN** the author selects an existing asset for deletion during an edit session
+- **THEN** the system SHALL remove the asset's entry from the manifest
+- **AND** the system SHALL remove the asset's file (or directory, for skills) from disk
+
+#### Scenario: Asset names are validated during edit
+
+- **WHEN** the author enters an asset name during the edit session
+- **THEN** the system SHALL validate the name as kebab-case
+- **AND** the system SHALL reject names that are not unique within their asset type
+
+### Requirement: Edit is transactional with confirmation
+
+All changes during an edit session SHALL be queued — nothing SHALL be written to disk or manifest until the author explicitly confirms. Before confirmation, the system SHALL display a manifest preview showing identity fields (name, description, version), the privacy intent, and **asset** sections (name and truncated description per **asset**). The author SHALL be able to confirm ("Apply") or go back to editing. The author SHALL be able to exit at any point before confirmation with no changes applied.
+
+#### Scenario: Author confirms changes
+
+- **WHEN** the author reviews the confirmation summary and confirms
+- **THEN** all queued changes SHALL be applied atomically to disk and manifest
+
+#### Scenario: Author exits before confirmation
+
+- **WHEN** the author exits the edit session before confirming
+- **THEN** no files SHALL be created, modified, or deleted
+- **AND** the manifest SHALL remain unchanged
+
+#### Scenario: Confirmation summary shows the privacy intent
+
+- **WHEN** the author reaches the edit confirmation summary
+- **THEN** the summary SHALL show the facet's privacy intent alongside the identity fields
+
+#### Scenario: Confirmation summary shows all deltas
+
+- **WHEN** an edit session includes identity changes, a privacy change, two additions, one deletion, and one front matter strip
+- **THEN** the confirmation summary SHALL list all changes with their details
+
+## ADDED Requirements
+
+### Requirement: Authoring workflows make a privacy change's rebuild and republish consequence visible
+
+Because privacy intent is manifest content embedded in the built artifact, changing it in the create or edit workflows SHALL NOT, on its own, alter any already-built artifact or any already-published version. The authoring workflows SHALL make clear to the author that a privacy change takes effect only after a rebuild, and that propagating the change to a version that has already been published requires a version bump and a republish. The authoring workflows SHALL NOT automatically rebuild, republish, or contact the registry as a result of a privacy change.
+
+#### Scenario: Editing privacy does not rebuild the artifact
+
+- **WHEN** the author changes a facet's privacy intent in the edit workflow and confirms
+- **THEN** the system SHALL update the manifest only
+- **AND** the system SHALL NOT rebuild the facet
+- **AND** the system SHALL NOT contact the registry
+
+#### Scenario: Author is informed that a privacy change needs a rebuild
+
+- **WHEN** the author changes a facet's privacy intent in the create or edit workflow
+- **THEN** the system SHALL make clear that the change affects the built artifact only after the facet is rebuilt
+
+#### Scenario: Author is informed that a published version needs a version bump
+
+- **WHEN** the author changes the privacy intent of a facet whose current version may already be published
+- **THEN** the system SHALL make clear that propagating the change to the registry requires a version bump and a republish, because a published version is immutable

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/tasks.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/tasks.md
@@ -1,0 +1,70 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. Shared form privacy state and scaffold generation — Research
+
+- [ ] 1.1 Explore: Read `packages/cli/src/tui/context/form-state-context.ts` and catalog every construction site of `FormState` and every place that maps form to output: `defaultForm`, the `FormStateContext` default context value, `toCreateOptions()`, and the `FormStateProvider` initial-state path. Note the exact shape of `FormState` (the `fields` map of `FieldState` whose `value` is a `string`, sibling `assets`) so privacy is added as a sibling boolean, not as a `fields` member or an asset.
+- [ ] 1.2 Explore: Read `packages/engine/src/scaffold/index.ts` (`ScaffoldOptions`, `generateScaffoldManifest`, `previewScaffoldFiles`, `writeScaffold`) and the existing conditional-assignment style for optional fields (`description`, `skills`, `agents`, `commands`). Confirm manifest field ordering (`name`, `version`, `description`, then asset sections) so a `private` key can be placed after `version`/`description` and before asset sections. Confirm engine never imports CLI display code (engine `AGENTS.md` boundary).
+- [ ] 1.3 Explore: Read `packages/cli/src/tui/views/edit/manifest-to-form.ts` and `packages/cli/src/tui/views/edit/use-edit-session.ts` (`buildManifest`, which spreads `...original`). Determine exactly how a top-level `private` field is currently preserved/erased through `...original` and how asset sections use explicit set-or-`delete` (the correct local precedent for a removable-after-spread field), in contrast to `description`'s truthy-only assignment.
+- [ ] 1.4 Propose: Define the engine + shared-state approach for the whole implementation block: the `ScaffoldOptions` privacy field shape (`private?: true`, true-only), the `generateScaffoldManifest` conditional that writes `manifest.private = true` only when the option is present and in the correct field position, the `FormState` sibling `private: boolean` (default `false`), the updates to all four form construction sites, `toCreateOptions()` emitting `private: true` only when `form.private` is true, `manifestToFormState()` hydrating `private: manifest.private === true`, and the `buildManifest()` privacy rules (true → set `private: true`; false + `original.private === false` → preserve `false`; false + `original.private !== false` → `delete manifest.private`). Cite the spec scenarios each rule satisfies.
+
+## 2. Shared form privacy state and scaffold generation — Implementation
+
+- [ ] 2.1 Implement: In `packages/engine/src/scaffold/index.ts`, add `private?: true` to `ScaffoldOptions` (documenting the true-only contract at the interface), and update `generateScaffoldManifest()` to assign `manifest.private = true` only when `opts.private` is present, positioned after `version`/`description` and before asset sections.
+- [ ] 2.2 Implement: In `packages/cli/src/tui/context/form-state-context.ts`, add a required sibling `private: boolean` to `FormState`, default it to `false` in `defaultForm` and the context default value, update `toCreateOptions()` to include `private: true` only when `form.private` is true, and add a `setPrivate(value: boolean)` (or equivalent toggle setter) to the context value and provider.
+- [ ] 2.3 Implement: In `packages/cli/src/tui/views/edit/manifest-to-form.ts`, hydrate the new boolean as `private: manifest.private === true` so omission and explicit `private: false` both map to the public UI state.
+- [ ] 2.4 Implement: In `packages/cli/src/tui/views/edit/use-edit-session.ts`, change `buildManifest()` so privacy is handled explicitly after `...original`: set `private: true` when `form.private` is true; preserve `private: false` when `form.private` is false and `original.private === false`; otherwise `delete manifest.private`. Mirror the asset-section set/delete pattern, not the `description` truthy-only pattern.
+- [ ] 2.5 Verify: Run `bun check --filter @agent-facets/engine --filter agent-facets` (or repo-root `bun check`) and confirm types compile across all form construction sites and the engine scaffold change.
+
+## 3. Focusable privacy toggle component and view wiring — Research
+
+- [ ] 3.1 Explore: Read `packages/cli/src/tui/components/button.tsx`, `editable-field.tsx`, and `asset-section.tsx` to learn the focus-order/`useFocusOrder()`/`useInput({ isActive })` conventions, the `▸`-prefix focus affordance, `THEME`/gradient usage, and the `id`/`label`/`onConfirm` prop shape, so a new toggle matches the existing visual and keyboard language.
+- [ ] 3.2 Explore: Read `packages/cli/src/tui/views/create/create-view.tsx` and `packages/cli/src/tui/views/edit/edit-view.tsx`. Record both duplicated `computeFocusIds(form)` implementations, the current focus chain (`field-name` → `field-description` → `field-version` → `add-<firstAssetType>` → … → submit), the `onConfirm` transition wiring on the version field, and the layout position where the toggle must be inserted (after Version, before asset sections).
+- [ ] 3.3 Explore: Read `packages/cli/src/tui/views/create/confirm-view.tsx` and `packages/cli/src/tui/views/edit/edit-confirm-view.tsx` to find where identity rows (`Name:`, `Description:`, `Version:`) are rendered so a `Privacy:` row and a one-line rebuild/version-bump guidance hint can be added consistently in both.
+- [ ] 3.4 Propose: Define the toggle component API (`id`, `label`, `value`, `onToggle`, optional `hint`/`dimmed`), its keyboard activation (Enter, and Space only if consistent with existing input handling), and the exact updated focus chains for both create and edit (`… field-version` → `field-private` → `add-<firstAssetType>` …), including version `onConfirm` → `field-private` and toggle activation → first asset add control. Specify the `Privacy:` confirmation rows and the exact guidance string (e.g. `Privacy is embedded at build time; rebuild after changing it. Published versions require a version bump.`). Emphasize both `computeFocusIds` lists must change in the same step so no wizard ships an unreachable toggle.
+
+## 4. Focusable privacy toggle component and view wiring — Implementation
+
+- [ ] 4.1 Implement: Add a reusable focusable toggle component (e.g. `packages/cli/src/tui/components/boolean-toggle.tsx`) accepting `id`, `label`, `value`, `onToggle`, optional `hint`/`dimmed`, rendering Public/Private clearly using the existing focus affordance and `THEME`.
+- [ ] 4.2 Implement: Wire the toggle into `create-view.tsx`: render it after Version and before asset sections, bind it to `form.private`/`setPrivate`, update `computeFocusIds` to insert `field-private` after `field-version`, set the version field's `onConfirm` to `focus('field-private')`, and route toggle activation to the first asset add control.
+- [ ] 4.3 Implement: Wire the toggle into `edit-view.tsx` with the same placement, binding, `computeFocusIds` update, and focus transitions, so the duplicated focus list is updated in lockstep with create.
+- [ ] 4.4 Implement: Add a `Privacy:` row (`Public`/`Private`) to `confirm-view.tsx` and `edit-confirm-view.tsx`, plus the concise dimmed one-line rebuild/version-bump guidance near the privacy row or summary, without altering build/publish behavior.
+- [ ] 4.5 Verify: Run `bun check` and manually exercise `facet create` and `facet edit` keyboard navigation to confirm the toggle is reachable in both wizards, the confirmation summaries show privacy, and no focus id is orphaned.
+
+## 5. Tests — Research
+
+- [ ] 5.1 Explore: Review existing engine scaffold/edit test patterns (`packages/engine/src/__tests__/edit.test.ts`, `manifest-mutations.test.ts`, and any scaffold coverage) and the CLI integration tests (`packages/cli/src/__tests__/edit-integration.test.ts`, `create-build.e2e.test.ts`) to determine where scaffold-output, form-hydration, and edit-output assertions belong and what is practically testable for Ink components (vs. requiring e2e).
+- [ ] 5.2 Propose: Map each required spec scenario to a concrete test and location, covering: public-default omission, private-true generation, create select-private-then-revert omission, edit omitted-public preservation, edit explicit `private: false` preservation, edit private-to-public deletion, edit public-to-private write, and confirmation summaries showing privacy. Decide which behaviors are unit-testable at the scaffold/`buildManifest`/`manifestToFormState` boundary and which require component or e2e coverage.
+
+## 6. Tests — Implementation
+
+- [ ] 6.1 Implement: Add engine tests for `generateScaffoldManifest()` covering absent (`private` omitted) and `private: true` paths, including field ordering.
+- [ ] 6.2 Implement: Add tests for `manifestToFormState()` mapping omitted, `private: false`, and `private: true` source manifests to the correct public/private UI boolean.
+- [ ] 6.3 Implement: Add tests for `buildManifest()` covering all four privacy output rules (true→`private: true`; public+original-false→preserve `false`; public+original-omitted→omit; private-original→public→delete).
+- [ ] 6.4 Implement: Add `toCreateOptions()` tests asserting `private` is emitted only as `true` and only when `form.private` is true (absent otherwise), and add component/confirmation coverage for the toggle and privacy summary rows where existing Ink test patterns allow.
+- [ ] 6.5 Verify: Run `bun check` and confirm all new and existing tests pass with no type or lint regressions.
+
+## 7. Documentation — Research
+
+- [ ] 7.1 Explore: Read `docs/cli/authoring/create.md`, `docs/cli/authoring/edit.md`, `docs/guides/publish-a-facet.md`, `docs/specification/manifest.md`, and `docs/specification/publish.md`, plus the root `README.md`, to locate the exact sections describing the wizard fields and the current hand-edit-`facet.json` publish guidance that this change makes stale (Article III documentation-drift obligation).
+- [ ] 7.2 Propose: Define the precise doc edits: add Privacy/Public-vs-Private to the create and edit wizard descriptions (clarifying public default/omission), replace the publish guide's hand-edit-first guidance with `facet edit` as the primary interactive path while preserving rebuild and version-bump instructions, and add (only if warranted) a short TUI cross-reference in the specification docs without changing their semantics.
+
+## 8. Documentation — Implementation
+
+- [ ] 8.1 Implement: Update `docs/cli/authoring/create.md` to document the privacy choice, public default, and `private` omission.
+- [ ] 8.2 Implement: Update `docs/cli/authoring/edit.md` to document inspecting and changing privacy and the privacy confirmation row.
+- [ ] 8.3 Implement: Update `docs/guides/publish-a-facet.md` to present `facet edit` as the primary way to change visibility while retaining the rebuild + version-bump discipline; add optional cross-references in `docs/specification/manifest.md`/`publish.md` and root `README.md` only where they reference changed behavior.
+- [ ] 8.4 Verify: Re-read updated docs against the implemented behavior to confirm no residual hand-edit-first guidance or stale field descriptions, then run a final repo-root `bun check`.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/design-review.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/design-review.md
@@ -1,0 +1,76 @@
+# Comparison Review: `design` — expose-facet-privacy-toggle
+
+**Sources compared**
+- **Main**: `design.md` (authored by the main agent, status `done`)
+- **Adversary**: `adversarial/artifacts/design.md` (authored blind by `/run-adversary`)
+
+Both designs converge on the same load-bearing architecture: a dedicated boolean form value shared by create and edit; a new reusable focusable toggle component (not an overloaded `EditableField`); a true-only/truthy-check scaffold path; an explicit `delete manifest.private` on the edit public branch; hydrate from `manifest.private === true`; a "Visibility/Privacy" confirmation row; static rebuild/version-bump guidance at the toggle; and the same four-area documentation update. The proposal was already reconciled, so the disagreements here are not about *what* to build but about *how precisely the design pins the mechanics to the actual code* and *which downstream consequences become mandated spec scenarios*. That is exactly where the adversary pulls ahead.
+
+## Grading bar
+
+Scoped to a design artifact:
+1. **Decisions are real decisions** — each names the chosen approach, the rejected alternatives, and *why*, not just a restatement of the goal.
+2. **Illegal states unrepresentable** — the type/serialization model is audited (project Type-Design rules), not asserted.
+3. **Grounded in the actual code** — decisions cite the real files, functions, and existing patterns they extend, so an implementer can act without re-deriving the codebase.
+4. **Consequences surfaced as testable obligations** — edge cases (round-trips, normalization, focus order) become explicit spec scenarios / risks, not prose asides.
+5. **Correct artifact mechanics** — Context / Goals-Non-Goals / Decisions / Risks / Migration / Open Questions, all present and non-empty.
+6. **Open Questions discipline** — genuinely open items are flagged; settled items are stated as settled with the resolving authority.
+
+## Coverage comparison
+
+| Dimension | Main | Adversary |
+|---|---|---|
+| Decisions count / structure | 6 decisions, each with rationale + alternatives. Clean. | 6 decisions, each with rationale + alternatives. Decision 3 explicitly labeled "the load-bearing decision." |
+| Form-state model | `isPrivate: boolean` (or `private`), default `false`, hydrate `=== true`. Notes illegal-state avoidance. | `private: boolean` sibling of `fields` (not inside the string `fields` map), default `false`, `setPrivate` mutator. Calls out that `FieldState.value` is a *string* and reusing it is illegal-state-prone. |
+| Scaffold path | `ScaffoldOptions.private?: true` (true-only). `toCreateOptions` adds `private: true` only when set; generate writes only when present. | `ScaffoldOptions.private?: boolean`, truthy guard `if (opts.private) manifest.private = true`. Cites the existing `description` conditional precedent and field-order placement after `version`. |
+| Edit serialization | Decision 4: after `...original`, set `true` or `delete`. Mirrors "set/delete." | Decision 3: same set/`delete`, but explicitly says mirror the **asset-section** delete pattern **not** the `description` pattern, "which has a known stale-value quirk when a field is cleared." |
+| Edit hydration | Decision 1 folds in `manifestToFormState` hydrating `=== true`, `false`/omission both → public. | Decision 4 (dedicated): same, **plus** spells out the round-trip consequence — opening a `private: false` manifest and applying any edit rewrites it to omission — and mandates a spec scenario so it is intended, not surprising. |
+| Toggle component spec | "BooleanToggle/ToggleField" with `id`/`label`/`value`/`onToggle`/`hint`. Enter (and Space if consistent). Focus order named explicitly: `field-private` after `field-version`. | Modeled on `button.tsx`; reads `focusedId` from `useFocusOrder()`, binds `useInput` while focused, Enter/Space. Cites `select-prompt.tsx` "without selection toggle" as the rejected alternative. |
+| Focus-order mechanics | States the new order and the focus transitions (version-confirm → `field-private` → first asset add). | Names the *duplication*: `computeFocusIds(form)` is duplicated in `create-view.tsx` and `edit-view.tsx`, and both must be edited or one control is unreachable. |
+| Guidance messaging | Decision 5: static one-line note at toggle/confirmation; rejects per-toggle modal and docs-only. | Decision 5: static, unconditional note; rejects *registry round-trip to detect published state* (scope) and docs-only. Slightly sharper on *why* it can't be conditional. |
+| Risks section | 5 risks, each with mitigation. | 6 risks, each tied back to a decision and several mandating spec scenarios. |
+| Open Questions | "None" — declares the omit-when-public choice settled by proposal. | Two genuinely-open future-scope questions (third explicit-`false` state; non-interactive `--private` flag), each treated as resolved-against / out-of-scope with reasoning. |
+| `author` field aside | Not mentioned. | Notes in passing that `ScaffoldOptions` has "no `private` and no `author`" — minor, slightly out of scope. |
+
+## Material divergences
+
+### 1. The edit serialization pattern citation — Adversary is stronger, and code-verified
+
+Both designs mandate `delete manifest.private` on the public branch. But Main's Decision 4 lists "mirror the `description` pattern" as a *considered* approach (it doesn't pick it) without noting that `description` is a *bad* pattern to copy. I verified against `packages/cli/src/tui/views/edit/use-edit-session.ts`: `buildManifest` handles `description` as `if (form.fields.description.value) { manifest.description = ... }` with **no `else delete`**. Because of `...original`, clearing a description in the UI leaves the stale original description on disk. The asset sections, by contrast, use the correct set/`delete` shape (lines 30–38). The adversary explicitly says: mirror the asset-section set/`delete` pattern, *not* the `description` pattern, "which has a known stale-value quirk when a field is cleared." That is a precise, correct, code-grounded instruction that steers the implementer away from the one wrong local precedent. **Stronger: Adversary.** Fold the "mirror assets, not description" guidance into Main's Decision 4.
+
+### 2. The `private: false` → omission round-trip — Adversary is stronger
+
+Main hydrates `manifest.private === true` (Decision 1) and deletes on public (Decision 4), which means a manifest carrying an explicit `private: false` will, on the next edit-apply, be silently rewritten to omit `private`. This is a real observable behavior — an author sees a diff (`-"private": false`) they didn't intentionally make. Main never names it. The adversary makes it an explicit, deliberate normalization (Decision 4 + a dedicated risk) and **requires a spec scenario** documenting it as intended. This is the single most important coverage gap in Main: an undocumented behavior change that a reviewer or author could mistake for a bug. **Stronger: Adversary.** Recommend Main add this as an explicit design note and flag it for a specs scenario.
+
+### 3. Form-state placement specificity — Adversary is stronger, code-verified
+
+Main says add `isPrivate`/`private` to `FormState`. The adversary is more precise: keep the boolean a **sibling of `fields`, not a member of the string `fields` map**, because `FieldState.value` is typed `string` and consumers iterate `fields`. I confirmed in `form-state-context.ts`: `fields` is a fixed `{ name, description, version }` of `FieldState` (`value: string`), and there is no boolean primitive anywhere. The adversary also enumerates *all* the construction sites that must be touched in one change (defaults, `toCreateOptions`, `manifestToFormState`) so a `FieldState`-iterating consumer can't miss it. **Stronger: Adversary** on implementer-actionability. Main is not wrong, just less specific.
+
+### 4. Focus-order duplication call-out — Adversary is stronger
+
+Main correctly states the new focus order and the inter-field focus transitions — arguably *more* explicit than the adversary on the exact transition chain (version-confirm → `field-private` → first asset control). But Main does not name that the focus ID list is computed by a **duplicated `computeFocusIds(form)`** in both `create-view.tsx` and `edit-view.tsx`, so missing one view yields an unreachable control. The adversary names the duplication as a risk. **Mixed:** Main is stronger on the *desired* order/transitions; Adversary is stronger on the *implementation hazard* (the duplication). The merge should take both — Main's transition chain is genuinely useful and the adversary omits it.
+
+### 5. Where Main is actually stronger: focus-transition detail and the true-only scaffold type
+
+- **Focus transitions:** Main's Decision 3 spells out the runtime focus *movement* ("Version confirmation SHALL move focus to `field-private`, and toggling/confirming privacy SHALL move to the first asset add control"). The adversary describes the toggle's keybindings but not the confirm-chaining. This is real, fiddly behavior the tasks author needs. **Stronger: Main.**
+- **Scaffold option type:** Main types `ScaffoldOptions.private?: true` (true-only), which is a slightly *tighter* type than the adversary's `private?: boolean` — it makes a meaningless `private: false` unrepresentable at the engine boundary, consistent with the project's Type-Design rules. The adversary relies on a truthy guard at the call site to get the same on-disk result but leaves `false` representable in the type. **Stronger: Main** on type-design rigor here; this is a genuine point in Main's favor and should be kept.
+
+### 6. Open Questions discipline — roughly equal, slight edge Adversary
+
+Main declares "None" and states the omit-when-public choice is settled by the proposal — defensible, since the proposal *did* settle it. The adversary lists two genuinely *future-scope* questions (a third explicit-`false` state; a non-interactive `--private` flag) and resolves both against/out-of-scope with reasoning. Neither is a true open question for *this* change, so Main's "None" is acceptable. But the adversary's framing surfaces the `--private` flag as a cheap future affordance enabled by the threaded `ScaffoldOptions.private`, which is useful forward-looking context. **Slight edge: Adversary**, but not blocking — Main's "None" is honest.
+
+## Merge recommendation (per decision)
+
+Keep **Main as the base** — its focus-transition detail (Decision 3) and the tighter true-only `ScaffoldOptions.private?: true` type (Decision 2) are real assets the adversary lacks — and fold in the adversary's code-grounded sharpening:
+
+- **Decision 1 (form model):** Adopt the adversary's specificity — state the boolean is a **sibling of `fields`, not inside the string `fields` map**, and enumerate the construction sites (defaults, `toCreateOptions`, `manifestToFormState`) that must change together. Keep Main's wording otherwise.
+- **Decision 2 (scaffold):** **Keep Main's `private?: true` true-only type** — it is the stronger type-design choice. Optionally borrow the adversary's note about matching the existing `description` *conditional-assignment* precedent and placing the key after `version`.
+- **Decision 3/4 (edit serialization):** Fold in the adversary's **"mirror the asset-section set/`delete` pattern, NOT the `description` pattern (stale-value quirk)"** instruction — code-verified, and it steers away from the one wrong local precedent. Keep Main's explicit focus-transition chain.
+- **Decision 1/4 (hydration + round-trip):** Add the adversary's **explicit `private: false` → omission normalization** as a stated, intended behavior, and flag it to become a specs scenario. This is the top gap to close.
+- **Decision 3 (toggle component) + focus order:** Keep Main's named order and transitions; add the adversary's **`computeFocusIds` duplication** hazard (both `create-view.tsx` and `edit-view.tsx` must be edited) as a risk/implementation note.
+- **Decision 5 (messaging):** Equivalent; optionally borrow the adversary's sharper "no registry round-trip to detect published state (out of scope)" justification for why the note is unconditional.
+- **Open Questions:** Main's "None" is acceptable. Optionally record the adversary's two future-scope items (third explicit-`false` state; `--private` flag) as resolved-against/out-of-scope notes for forward context.
+
+## Blocking cross-cutting item
+
+**The `private: false` → omission round-trip behavior (§2) must be made explicit before this change is archived.** As designed by *both* versions, applying any edit to a manifest that carries `private: false` will rewrite it to omit the key — a real, observable diff. Main does not state it; the adversary does and mandates a spec scenario. This must be (a) acknowledged in `design.md` as intended and (b) carried forward into a specs scenario, or a reviewer will reasonably read it as an unintended side effect. Everything else in this review is improvement, not a gate.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/proposal-review.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/proposal-review.md
@@ -1,0 +1,71 @@
+# Comparison Review: `proposal` — expose-facet-privacy-toggle
+
+**Sources compared**
+- **Main**: `proposal.md` (authored by the main agent, status `done`)
+- **Adversary**: `adversarial/artifacts/proposal.md` (authored blind by `/run-adversary`)
+
+Both proposals agree on the core shape of the change: the `private` field already exists end-to-end (schema, build embedding, publish drift), and the only gap is that the interactive create wizard and edit workbench never surface it, forcing hand-editing of `facet.json`. Neither invents a new capability; both modify `authoring__facets`. The disagreement is in rigor, coverage of consequences, and adherence to the proposal rules.
+
+## Grading bar
+
+Scoped to a proposal artifact:
+1. **Value-centric** — frames the customer problem, not the implementation. (Article II / spec-governance.)
+2. **RFC 2119** — normative statements use MUST/SHALL/SHOULD/MAY. (Article I; enforcement says proposals without RFC 2119 in requirement-bearing sections SHALL be rejected.)
+3. **Correct artifact mechanics** — Why / What Changes / Non-goals / Capabilities (domain-named, new vs. modified) / Impact; capabilities map to real `openspec/specs/` domains.
+4. **Coverage** — names the downstream consequences a specs/design/tasks author must not miss.
+5. **Documentation citation** — Article III + the explicit rule require citing the `docs/` that informed the proposal and the updates required.
+6. **Word budget** — SHOULD 300–1000, MUST be < 1500.
+
+## Coverage comparison
+
+| Dimension | Main | Adversary |
+|---|---|---|
+| Why (problem framing) | Concise: "hidden functionality in the authoring workflow." Correct but thin. | Longer: names discoverability, current-visibility blindness, typo risk, and cites the doc that *instructs* hand-editing. |
+| RFC 2119 in What Changes | **Absent.** Uses "Add…", "Default…", "Preserve…", "Update…" — informal imperatives. | Every bullet uses SHALL. |
+| Public-by-default omission preserved | Yes (bullet 4 + non-goal). | Yes (bullet 3), and ties it explicitly to the existing "omission is not synthesized" spec rule. |
+| Private→public transition representation | Not addressed. | Explicitly flagged as a real case and **deferred to design.md** (omit `private` vs. write `private: false`). |
+| Rebuild + version-bump consequence | Not mentioned. | Bullet 5: author SHALL be shown that toggling is a manifest content change requiring rebuild + version bump if published. |
+| Documentation citation | Cites `create.md`, `edit.md`, `manifest.md`, `publish-a-facet.md`; says create/edit docs SHOULD be updated. | Cites `publish-a-facet.md` (with the exact misleading line), `manifest.md`, `publish.md`; specifies the *required* update to the hand-edit guide and the rebuild/version discipline. |
+| Non-goals | 4 bullets; adds "no composed/installed facet privacy" (good extra fence). | 4 bullets; adds "no new top-level `facet private`/`facet public` command" and "no auto-rebuild/republish" (both relevant fences the main omits). |
+| Word count | ~430 words — comfortably in budget. | ~620 words — in budget. |
+
+## Material divergences
+
+### 1. RFC 2119 keywords in "What Changes" — Adversary is stronger, and this is blocking
+
+Main's What Changes uses no RFC 2119 keywords ("Add an interactive privacy choice…", "Default newly created facets…", "Preserve the manifest schema's…"). Article I's enforcement clause is explicit: "Proposals without RFC 2119 keywords in requirements sections SHALL be rejected." The Capabilities/Modified bullet *does* use SHALL, so the proposal isn't wholly devoid of normative keywords — but the change-bearing bullets are the requirement substance and they read as informal imperatives. Adversary uses SHALL throughout What Changes. **Stronger: Adversary.** This is the one item I'd call blocking against the constitution.
+
+### 2. Rebuild + version-bump consequence — Adversary is stronger
+
+The biggest *product* gap in Main is silence on what happens after the author flips visibility. Privacy lives in the built/embedded manifest and is governed by publish-time drift + immutability rules; flipping the source toggle does nothing until rebuild, and re-publishing an already-published version is blocked. An author who toggles in the TUI and assumes it "took effect" will be confused at publish time. Adversary surfaces this as an explicit author-facing requirement (bullet 5). Main's non-goals even *touch* the adjacent fact ("will not change build or publish drift behavior") but never states the author must be *told*. **Stronger: Adversary.** Recommend folding this in as a What-Changes bullet, not just a non-goal.
+
+### 3. Private→public transition representation — Adversary is stronger
+
+Main bullet 10-equivalent only covers create-time defaulting and the public-omission rule. It never addresses the *edit* case where a facet was `private: true` and the author flips to public: do we delete the key or write `private: false`? The existing spec accepts both, but the on-disk result differs and someone must decide. Adversary names this and defers it to design.md — exactly the right move for a proposal. Main's Impact line ("public selections remove any existing `private` key") actually *makes* this decision implicitly, in the Impact section, without flagging it as a decision. **Stronger: Adversary** for surfacing it as a deferred decision; Main has pre-committed to "delete the key" buried in Impact, which is a design call leaking into a proposal.
+
+### 4. Where Main is actually stronger: Impact specificity on the code surface
+
+Main's Impact is more concrete about the *CLI form mechanics* that will actually carry this: "shared create/edit form state, focus order, confirmation summaries, and any new focusable toggle component," plus "Edit result construction … public selections remove any existing `private` key." This is sharper guidance for the eng/tasks author about *where the work lands in the TUI* than Adversary's more spec-and-engine-pathway-oriented Impact. Adversary lists more packages (`manifest/`) but is vaguer about the TUI focus-order/summary work, which is the genuinely fiddly part. **Stronger: Main** on implementation-surface concreteness — though note the caveat in §3 that one of these Impact lines smuggles a design decision.
+
+### 5. Non-goals fences — Adversary is slightly stronger, Main has one Adversary lacks
+
+Adversary fences off "no new `facet private` command" and "no auto-rebuild/republish on toggle" — both are realistic scope-creep vectors a reader might assume. Main fences off "no privacy controls for composed dependencies or installed facets" — a vector Adversary omits. The ideal non-goals section is the **union** of all three.
+
+### 6. Documentation citation — Adversary is stronger on the "drift" obligation
+
+Both cite docs. Adversary is sharper on Article III's *drift* obligation: it names the specific misleading sentence in `publish-a-facet.md` ("set 'private': true") and states that guidance MUST be updated, not just that docs SHOULD mention the new step. Main cites `publish-a-facet.md` in its informing-docs list but frames only create/edit docs as needing updates ("SHOULD be updated"), underselling that the publish guide currently gives instructions that the change makes obsolete. **Stronger: Adversary.**
+
+## Merge recommendation (per What-Changes bullet / section)
+
+Keep **Main as the base** (its word budget and TUI-surface Impact are assets) and fold in the following:
+
+- **What Changes — convert to RFC 2119.** Rewrite all five Main bullets with SHALL (matching Adversary). *Blocking* per Article I.
+- **What Changes — add the consequence bullet.** Add Adversary bullet 5: the tools SHALL inform the author, at the point of toggling, that visibility is a manifest content change requiring rebuild before effect and a version bump if the current version is already published. This is the most important coverage gap in Main.
+- **What Changes / Capabilities — surface the private→public representation as a deferred decision.** Adopt Adversary's framing (defer omit-vs-`false` to design.md). Remove Main's Impact line "public selections remove any existing `private` key," or move it into design.md as the proposed resolution rather than a pre-decided Impact fact.
+- **Non-goals — take the union.** Keep Main's "no composed/installed facet privacy"; add Adversary's "no new top-level `facet private`/`facet public` command" and "no automatic rebuild/republish on toggle."
+- **Impact — keep Main's TUI-surface detail**, and merge Adversary's explicit doc-drift requirement: state that `docs/guides/publish-a-facet.md`'s hand-edit guidance MUST be updated (not merely that create/edit docs may be), and that `docs/specification/manifest.md`'s Privacy section SHOULD note the field is now author-settable.
+- **Why — optional enrichment.** Main's Why is in-budget and adequate; optionally borrow Adversary's discoverability/typo-risk framing if word budget allows after the above additions.
+
+## Blocking cross-cutting item
+
+**RFC 2119 in What Changes (§1).** Per Article I's enforcement clause, a proposal whose requirement-bearing section lacks RFC 2119 keywords SHALL be rejected. Main's What Changes must be converted to SHALL/MUST language before this proposal is archived. Everything else is improvement, not a gate.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/specs-review.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/specs-review.md
@@ -1,0 +1,106 @@
+# Adversarial comparison review — `specs`
+
+**Change:** `expose-facet-privacy-toggle`
+**Artifact:** `specs` (capability `authoring__facets`)
+**Main** (the main agent's version): `openspec/changes/expose-facet-privacy-toggle/specs/authoring__facets/spec.md` — one `ADDED` requirement, 8 scenarios.
+**Adversary** (the authored version): `openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/specs/authoring__facets/spec.md` — three `MODIFIED` requirements + one `ADDED` requirement, ~25 scenarios.
+**Base spec** (existing, for delta semantics): `openspec/specs/authoring__facets/spec.md`.
+
+---
+
+## Grading bar
+
+Scoped to spec deltas:
+
+1. **Correct OpenSpec delta mechanics** — `MODIFIED`/`ADDED`/`REMOVED` headers used correctly; `MODIFIED` requirements reproduce the *full* requirement text (header + all retained scenarios), not just the changed lines, because the tooling replaces the whole named requirement.
+2. **RFC 2119** — normative SHALL/SHOULD/MAY, no ambiguous "should"/"will".
+3. **Atomic + testable scenarios** — one observable behavior per scenario, WHEN/THEN(/AND), no compound or untestable assertions.
+4. **Value-centric** — requirements describe author-observable outcomes, not implementation.
+5. **Coverage** — every behavior the proposal/design promised has a requirement + at least one scenario; no orphan scenarios.
+
+Both versions clear bars 2–4 cleanly. The decisive divergences are on **bar 1 (delta mechanics)** and **coverage completeness**, and there is one **direct behavioral contradiction** on the `private: false` edge case that is blocking.
+
+---
+
+## The headline divergence: delta strategy
+
+The two versions take fundamentally different structural approaches to the same change.
+
+**Main** adds a single self-contained requirement — *"Authors can set facet privacy intent during interactive authoring"* — that describes privacy behavior across create and edit in one place, with 8 scenarios. It does **not** touch the existing `Authors can scaffold…`, `Authors can edit…`, or `Edit is transactional with confirmation` requirements at all.
+
+**Adversary** instead `MODIFIED`s the three existing requirements to weave privacy into them inline (privacy as an optional wizard field, privacy display/toggle in edit, privacy in the confirmation preview), reproducing each requirement in full with its scenarios, and then `ADDED`s one requirement for the rebuild/republish consequence.
+
+**Which is stronger, and why — this is genuinely split:**
+
+- **Adversary is mechanically more correct about where privacy lives.** Privacy *is* a field of the create wizard and the edit workbench and the transactional confirmation summary. The base requirements already enumerate the wizard's fields ("Name", "Description", optional "Version") and the confirmation-summary contents. A reader of the *archived* spec who wants to know "what does the create wizard collect?" should find privacy in that requirement — not in a separate satellite requirement they might miss. The Adversary's confirmation-summary coverage (privacy shown in the create summary, the edit summary, and in "Confirmation summary shows all deltas") is coverage the Main version simply does not have as scenarios — Main folds it into single AND-clauses ("the confirmation summary SHALL show the facet as public/private") without a dedicated transactional-summary scenario.
+
+- **Main is dramatically lower-risk to apply and easier to review.** A single small `ADDED` requirement cannot corrupt the existing three requirements. The Adversary's `MODIFIED` approach reproduces ~200 lines of existing requirement text, and **any drift between that reproduction and the current base spec silently overwrites the base on archive.** I checked: the Adversary's reproductions are *mostly* faithful, but they are not the only delta in flight for this capability — the main spec file shows the base already carries unrelated requirements (build, collisions, front matter) that the Adversary correctly leaves untouched. The danger is concentrated in the three requirements it *does* reproduce: every retained scenario must match the base exactly except for the privacy additions. This is a real reconciliation cost and a real archive-time hazard.
+
+**Merge recommendation (structural):** Adopt the **Adversary's placement philosophy** — privacy belongs inside the create/edit/transactional requirements — but do it with surgical `MODIFIED` blocks and verify each reproduced requirement diff-matches the base spec line-for-line except for the deliberate privacy insertions. Keep Main's standalone-requirement clarity as the model for the *rebuild/republish* concept (see below), where a dedicated requirement genuinely is the right home. Do **not** ship Main's privacy behavior as a lone satellite requirement while the wizard/edit/summary requirements stay silent about privacy — that leaves the archived base spec describing a wizard that doesn't mention a field it now collects.
+
+---
+
+## Behavioral divergence #1 (BLOCKING): `private: false` on edit-left-public
+
+This is a direct contradiction, not a stylistic difference. The two versions specify **opposite** required behavior for the same input.
+
+- **Main** (`spec.md:32-37`, *"Edit preserves explicit public false when left public"*): when the source manifest contains `private: false` and the author leaves the facet public, the applied manifest **SHALL preserve `private: false`** — explicitly framing removal as "an incidental formatting change" to avoid.
+
+- **Adversary** (`spec.md:183-186`, *"Editing an explicit private:false manifest to public removes the field"*): same input, the written manifest **SHALL NOT contain a `private` field** — i.e. it removes `private: false`.
+
+These cannot both be archived. Note the design entry's reconciliation note (`state.json`) records that the *design* was reconciled toward **"explicit private:false-to-omission normalization and required spec scenario"** — i.e. the design landed on the **Adversary's** behavior (normalize to omission). If that design decision stands, **Main's `spec.md:32-37` scenario is wrong and must be replaced** with the Adversary's normalize-to-omission scenario.
+
+**Merge recommendation:** Resolve against the reconciled design. Per the design note, the intended behavior is normalize-`private:false`-to-omission, so adopt the **Adversary's** scenario (`spec.md:183-186`) and **delete Main's "Edit preserves explicit public false when left public."** Before finalizing, confirm the reconciled `design.md` actually says normalize-to-omission and that this does not conflict with the *base* requirement *"Manifest with explicit public publish intent is valid"* (`openspec/specs/authoring__facets/spec.md:37-41`), which says a loaded manifest **SHALL preserve `private: false`**. Loading-preserves-false and editing-normalizes-to-omission are compatible (load is read; edit is rewrite), but the spec should make that distinction explicit so a reader doesn't see a contradiction. **This is the one item that must be settled before archive.**
+
+---
+
+## Behavioral divergence #2: the rebuild/republish consequence
+
+- **Main** captures this as a single scenario (`spec.md:51-55`, *"Authoring guidance explains rebuild and version requirements"*) bolted to the privacy requirement, with two AND-clauses (rebuild needed; published version needs a version bump).
+
+- **Adversary** captures this as a dedicated `ADDED` requirement, *"Authoring workflows make a privacy change's rebuild and republish consequence visible"* (`spec.md:251-270`), with a normative body and **three** scenarios: (a) editing privacy does not rebuild or contact the registry, (b) author informed a rebuild is needed, (c) author informed a published version needs a version bump.
+
+**Adversary is clearly stronger here.** The proposal's reconciliation note explicitly called out "non-goal fences for no standalone privacy command or auto rebuild/republish" and "rebuild/version-bump author guidance." The Adversary's scenario (a) — *the system SHALL update the manifest only, SHALL NOT rebuild, SHALL NOT contact the registry* — is a directly testable negative guarantee that Main does not assert anywhere. Main only states the *positive* guidance ("tell the author…") and never fences the *negative* (no auto-rebuild, no registry contact). Given the proposal explicitly fenced this as a non-goal, the negative guarantee deserves to be a normative, tested requirement.
+
+**Merge recommendation:** Adopt the **Adversary's standalone `ADDED` requirement** verbatim, including all three scenarios. This is the one place where a dedicated requirement (not inline) is the right structure, and it covers a proposal-level non-goal that Main under-specifies.
+
+---
+
+## Behavioral divergence #3: scope of edited privacy scenarios
+
+Both versions cover the core matrix (public→private, private→public, omitted-stays-omitted, new-public-omits, new-private-writes-true). Differences:
+
+- **Adversary adds** *"Author selects private then reverts to public before completing"* (`spec.md:134-137`) — a create-flow round-trip that Main lacks. This is a genuine edge (transient selection must not leak into the manifest) and is testable. **Adversary stronger.**
+- **Adversary adds** *"Author inspects current privacy intent"* / *"…on a public facet"* as two separate display scenarios (`spec.md:162-170`). Main folds display into the toggle scenario's AND-clause. The Adversary's split is more atomic. **Adversary slightly stronger.**
+- **Main's** *"New facet defaults to public visibility intent"* asserts **both** manifest omission **and** confirmation-summary-shows-public in one scenario (two AND-clauses). The Adversary splits these into *"Privacy defaults to public-by-default with the field omitted"* and *"Confirmation summary reflects the selected privacy intent."* The Adversary split is more atomic and individually testable. **Adversary slightly stronger**, though Main's compound is acceptable.
+
+**Merge recommendation:** Pull the Adversary's create-flow revert scenario and the split display scenarios into the reconciled spec. They are additive and cost nothing.
+
+---
+
+## Where Main is stronger / cleaner
+
+Credit where due:
+
+1. **Main's lead requirement sentence is tighter.** Its single normative paragraph ("Newly scaffolded facets SHALL default to public visibility intent and SHALL omit `private`… Existing facets edited interactively SHALL show… allow… write…") is a crisp value-centric summary. The Adversary's behavior is spread across three requirement bodies and is harder to read end-to-end. If the reconciled spec keeps privacy inline (recommended), borrow Main's phrasing for the inserted privacy sentences so each `MODIFIED` requirement stays readable.
+2. **Main avoids the reproduction hazard entirely.** This is a real safety advantage of the satellite-requirement approach, even though I'm recommending against it on coverage grounds. The mitigation is mechanical diffing during reconciliation.
+3. **Main names the `private: false` preservation rationale** ("incidental formatting change") — useful framing even though its *conclusion* is the one in dispute (divergence #1). Carry the rationale-awareness forward even when flipping the conclusion.
+
+---
+
+## Per-section merge recommendation summary
+
+| Section | Action |
+|---|---|
+| **Create wizard requirement** | Use Adversary's placement (privacy as inline optional field + summary scenarios), with Main's tight phrasing. `MODIFIED` block must diff-match base except privacy insertions. |
+| **Edit workbench requirement** | Use Adversary's inline privacy display/toggle + the two atomic inspect scenarios. `MODIFIED` block must diff-match base. |
+| **Edit-transactional requirement** | Use Adversary's `MODIFIED` adding privacy to the preview + "summary shows privacy intent" + "shows all deltas" (with privacy in the delta list). Verify base reproduction. |
+| **`private: false` edit-to-public** | **BLOCKING.** Resolve against reconciled design (design note says normalize-to-omission → adopt Adversary, delete Main's preserve-false scenario). Make load-preserves vs edit-normalizes distinction explicit. |
+| **Rebuild/republish consequence** | Adopt Adversary's standalone `ADDED` requirement + all 3 scenarios verbatim (includes the no-auto-rebuild/no-registry negative guarantee Main lacks). |
+| **Create-flow private→public revert** | Add Adversary's scenario. |
+
+---
+
+## Blocking item before archive
+
+**One blocker:** the `private: false`-on-edit-left-public contradiction (divergence #1). The reconciled spec must pick exactly one behavior, it must agree with the reconciled `design.md`, and it must be reconciled against the base requirement *"Manifest with explicit public publish intent is valid"* so loading-preserves-false and editing-normalizes-to-omission are not read as a contradiction. Nothing else here blocks archive; the rest are additive coverage and a structural-placement choice.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/tasks-review.md
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/reviews/tasks-review.md
@@ -1,0 +1,85 @@
+# Adversarial Comparison Review — `tasks`
+
+**Sources compared**
+
+- **Main**: `openspec/changes/expose-facet-privacy-toggle/tasks.md` (the main agent's version).
+- **Adversary**: `openspec/changes/expose-facet-privacy-toggle/adversarial/artifacts/tasks.md` (authored blind under `/run-adversary`).
+
+Both are VIPER task lists for the same reconciled `proposal` / `design` / `specs`. The dependency artifacts (`specs`, `design`) are `reconciled`; this review judges the two task lists against that trustworthy state.
+
+## Grading bar (scoped to a tasks artifact)
+
+- **Traceability**: every reconciled spec scenario and design decision has a task that implements *and* verifies it.
+- **Atomic + testable**: each task is a single, checkable unit of work with a clear done condition.
+- **Correct VIPER mechanics**: Research blocks before Implementation; Explore/Propose are read-only gates; Verify steps run real checks; no Implement step hidden inside a Research block.
+- **Correct artifact mechanics**: tasks reference the actual files/symbols in this repo, respect the engine↔CLI boundary, and end with the OpenSpec verification obligation.
+- **Coverage**: the union of tasks covers the whole change with no orphaned spec scenario and no scope creep beyond the design's non-goals.
+
+## Coverage comparison
+
+Both lists share the same backbone and the same 8-section, Research-then-Implementation cadence. They diverge mainly in **specificity** and in **how the work is grouped**.
+
+| Area | Main | Adversary |
+|---|---|---|
+| Section grouping | 4 work areas: (1/2) form+scaffold, (3/4) TUI control, (5/6) **edit manifest output**, (7/8) docs+e2e | 4 work areas: (1/2) form+scaffold, (3/4) toggle+view wiring, (5/6) **tests**, (7/8) docs |
+| File/symbol naming | Mostly **abstract** ("shared create/edit form state", "engine scaffold option types") | **Concrete paths/symbols** (`form-state-context.ts`, `generateScaffoldManifest`, `manifest-to-form.ts`, `use-edit-session.ts`, `buildManifest`, `computeFocusIds`) |
+| `buildManifest` 3-way rule | Covered (6.2) and tested (6.4) but stated abstractly | Covered (2.4) + dedicated test 6.3 enumerating all four output rules, mirrors design Decision 4's set/preserve/delete branches verbatim |
+| Edit hydration (`manifestToFormState`) | 6.1, abstract | 2.3 + test 6.2, names the symbol and `manifest.private === true` rule |
+| Focus-chain lockstep risk | 4.2/4.3 separately wire create and edit | 3.2/3.4/4.2/4.3 explicitly call out **both duplicated `computeFocusIds` must change together** so no wizard ships an unreachable toggle (design Risk + Decision 3) |
+| Tests as their own block | Interleaved into each work area (2.4, 4.5, 6.4) | Consolidated into Section 5/6 with a per-scenario mapping Propose (5.2) |
+| Confirmation guidance string | 4.4 "concise rebuild/version-bump guidance" | 3.4/4.4 quotes the exact design string and names both confirm-view files |
+| Final OpenSpec verify | **8.6 present** ("Verify the OpenSpec change … before complete") | **Absent** — final step is `8.4` re-read docs + `bun check` |
+| `bun format` guidance | **8.5 present** (Biome formatting via `bun format`) | Absent |
+
+## Material divergences
+
+### D1 — Concreteness of file/symbol references (Adversary stronger)
+
+The adversary names exact files and functions (`form-state-context.ts`, `defaultForm`, `toCreateOptions()`, `generateScaffoldManifest`, `manifest-to-form.ts`, `use-edit-session.ts`/`buildManifest`, `computeFocusIds`, `confirm-view.tsx`/`edit-confirm-view.tsx`). The main list stays abstract ("shared create/edit form state", "edit-session manifest construction"). Both are *executable* because each begins with Explore steps, but the adversary's version removes a discovery round and pins implementers to the design's chosen seams. **Adversary stronger** on traceability and reducing the chance an implementer touches the wrong layer.
+
+### D2 — Final OpenSpec verification step (Main stronger — blocking)
+
+The main list ends with **8.6: "Verify the OpenSpec change with the appropriate OpenSpec validation command before implementation is considered complete."** The adversary list has **no** OpenSpec-validation terminal step — it ends at docs re-read + `bun check`. The OpenSpec apply/verify workflow expects a validation gate before a change is archived; omitting it is a real coverage hole. **Main stronger, and this is the one blocking item** (see below).
+
+### D3 — `bun format` / Biome guidance (Main stronger)
+
+Main 8.5 explicitly instructs using `bun format` for Biome formatting failures, matching this repo's AGENTS.md rule ("run `bun format` — do NOT hand-edit whitespace"). The adversary relies on bare `bun check`. Minor, but the main version encodes the house rule. **Main stronger.**
+
+### D4 — Test organization (toss-up, lean Adversary on mapping rigor)
+
+Main interleaves tests into each work area (closer to TDD-per-feature); the adversary isolates tests into Section 5/6 with an explicit **5.2 Propose that maps each spec scenario to a concrete test + location** and a decision on what is unit-testable vs. needs e2e for Ink components. The mapping Propose is the stronger artifact for guaranteeing scenario coverage; the interleaving is the stronger habit for keeping tests adjacent to the code. Neither is wrong. The adversary's explicit scenario-to-test map is the more valuable single feature here because it makes the spec's eight privacy scenarios auditable.
+
+### D5 — Focus-chain lockstep emphasis (Adversary stronger)
+
+The design lists "focus-order regressions" as the top risk and "both `computeFocusIds` lists in the same step" as the mitigation. The adversary surfaces this in four places (3.2 record both impls, 3.4 both lists change in same step, 4.2/4.3 in lockstep). Main 4.2/4.3 wires each view but does not name the duplication or the "same step" constraint. **Adversary stronger** on encoding a named design risk into the task contract.
+
+### D6 — `ScaffoldOptions` true-only contract callout (Adversary slightly stronger)
+
+Adversary 2.1 says to document the `private?: true` true-only contract *at the interface*, matching design Risk "true-only type is unfamiliar → document at interface boundary." Main 2.3 just adds the field. Minor.
+
+### D7 — Manifest field ordering (Adversary stronger, minor)
+
+Adversary 1.2/2.1/6.1 explicitly place `private` after `version`/`description` and before asset sections (design Decision 2 SHOULD) and test ordering. Main does not mention field position. Minor but it's a stated design SHOULD with a test attached only on the adversary side.
+
+## Where Main is genuinely stronger (not just "adversary wins")
+
+- **D2 OpenSpec verification gate** and **D3 `bun format`** are real, repo-correct obligations the adversary dropped.
+- Main's **interleaved Verify steps** (2.5, 4.6, 6.5) are scoped to focused package checks rather than only repo-root `bun check`, which is faster feedback during implementation.
+- Main keeps the **edit-output work as its own section (5/6)** with explicit unknown-field-preservation tasks (6.3 "preserve unrelated top-level manifest fields", 6.4 "unknown-field preservation"). The adversary folds edit output into Section 2 and, while it covers the four privacy rules, it does **not** call out unknown/unrelated top-level field preservation as a distinct task — the design's `...original` spread behavior. **Main stronger on this preservation guarantee.**
+
+## Merge recommendation (per work-area)
+
+Recommended base: **Main** (it already carries the OpenSpec verify gate, `bun format` rule, and explicit unknown-field-preservation tasks), folding in the adversary's concreteness and risk callouts.
+
+- **Sections 1/2 (form + scaffold)**: Adopt the adversary's concrete file/symbol references (D1), the true-only `private?: true` interface-doc note (D6), and the field-ordering placement + test (D7). Keep main's separate scaffold/form structure.
+- **Sections 3/4 (TUI toggle)**: Adopt the adversary's explicit **"update both `computeFocusIds` in the same step"** lockstep language (D5) and the exact confirmation guidance string + named `confirm-view.tsx`/`edit-confirm-view.tsx` files. Keep main's focused per-view Verify (4.6).
+- **Edit output**: **Keep main's dedicated edit-output section** including the unknown/unrelated-field-preservation task. Layer in the adversary's enumerated four-rule `buildManifest` test (D4/edit) and the `manifest-to-form.ts` symbol name.
+- **Tests**: Adopt the adversary's **5.2-style scenario→test mapping Propose** as a planning step even if tests stay interleaved — it makes the eight privacy spec scenarios auditable. Ensure the map includes the create *select-private-then-revert* scenario (spec line 135) and explicit `private: false` preservation, both of which the adversary calls out and main covers only implicitly.
+- **Docs (7/8)**: Equivalent; keep main. Both cover create/edit/publish-guide and optional spec cross-refs within design Decision 6's bounds.
+- **Final verification**: **Keep main 8.5 (`bun format`) and 8.6 (OpenSpec validation).** Do not let the adversary's omission propagate.
+
+## Blocking cross-cutting item
+
+**The merged tasks MUST retain a terminal OpenSpec-validation step (main 8.6).** The adversary's list lacks any OpenSpec verification gate before completion. Whatever structure is adopted, the change cannot be considered implementation-complete/archivable without that validation step. This is the single must-settle item before the artifact is finalized.
+
+Secondary (non-blocking but strongly recommended): ensure the merged list keeps an explicit **unknown/unrelated top-level manifest field preservation** task (main 6.3) — it traces to the design's `...original` spread behavior and the transactional-edit requirement, and the adversary's grouping loses it.

--- a/openspec/changes/expose-facet-privacy-toggle/adversarial/state.json
+++ b/openspec/changes/expose-facet-privacy-toggle/adversarial/state.json
@@ -1,0 +1,54 @@
+{
+  "change": "expose-facet-privacy-toggle",
+  "schema": "spec-driven",
+  "entries": {
+    "proposal": {
+      "artifactId": "proposal",
+      "mainPaths": ["proposal.md"],
+      "adversarialPaths": ["adversarial/artifacts/proposal.md"],
+      "reviewPath": "adversarial/reviews/proposal-review.md",
+      "dependencies": [],
+      "status": "reconciled",
+      "authoredAt": "2026-06-17T03:13:56Z",
+      "comparedAt": "2026-06-17T03:20:00Z",
+      "reconciledAt": "2026-06-17T03:26:39Z",
+      "notes": "Adopted RFC 2119 wording, rebuild/version-bump author guidance, stronger documentation drift coverage, and non-goal fences for no standalone privacy command or auto rebuild/republish. Kept main proposal's TUI impact specificity and the user-decided omit-when-public behavior."
+    },
+    "design": {
+      "artifactId": "design",
+      "mainPaths": ["design.md"],
+      "adversarialPaths": ["adversarial/artifacts/design.md"],
+      "reviewPath": "adversarial/reviews/design-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-06-17T03:31:58Z",
+      "comparedAt": "2026-06-17T03:34:52Z",
+      "reconciledAt": "2026-06-17T03:41:49Z",
+      "notes": "Adopted code-grounded design refinements: form boolean as sibling of string fields, focus-order duplication warning, asset-section set/delete guidance over description pattern, explicit private:false-to-omission normalization and required spec scenario, static guidance rationale, and future-scope notes. Kept main's true-only ScaffoldOptions.private?: true type and focus-transition chain."
+    },
+    "specs": {
+      "artifactId": "specs",
+      "mainPaths": ["specs/**/*.md"],
+      "adversarialPaths": ["adversarial/artifacts/specs/authoring__facets/spec.md"],
+      "reviewPath": "adversarial/reviews/specs-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-06-17T03:59:55Z",
+      "comparedAt": "2026-06-17T04:03:18Z",
+      "reconciledAt": "2026-06-17T04:09:38Z",
+      "notes": "Partially adopted adversary: moved privacy coverage into MODIFIED create/edit/transactional requirements, added create revert and confirmation scenarios, and added standalone rebuild/version-bump/no-registry requirement. Rejected adversary's private:false normalization because current reconciled design preserves explicit private:false when left public."
+    },
+    "tasks": {
+      "artifactId": "tasks",
+      "mainPaths": ["tasks.md"],
+      "adversarialPaths": ["adversarial/artifacts/tasks.md"],
+      "reviewPath": "adversarial/reviews/tasks-review.md",
+      "dependencies": ["specs", "design"],
+      "status": "reconciled",
+      "authoredAt": "2026-06-17T04:15:49Z",
+      "comparedAt": "2026-06-17T04:19:03Z",
+      "reconciledAt": "2026-06-17T04:21:36Z",
+      "notes": "Adopted adversary's concrete file/symbol references, lockstep computeFocusIds risk language, exact guidance string, field-ordering tests, true-only interface note, and scenario-to-test mapping. Kept main's terminal bun check/bun format and OpenSpec validation gates plus unrelated top-level field preservation coverage."
+    }
+  }
+}

--- a/openspec/changes/expose-facet-privacy-toggle/design.md
+++ b/openspec/changes/expose-facet-privacy-toggle/design.md
@@ -1,0 +1,153 @@
+## Context
+
+The manifest schema already accepts optional top-level `private?: boolean`, and build/publish flows already treat privacy as manifest content embedded in the built artifact. The missing surface is authoring: `facet create` currently collects `name`, `description`, `version`, and assets, while `facet edit` hydrates those fields from the manifest and preserves unknown/non-asset fields through `...original`, but neither flow lets the author inspect or change `private`.
+
+The affected implementation is intentionally split across layers:
+
+- `packages/engine/src/scaffold/index.ts` owns create-time scaffold data and generated `facet.json` bytes.
+- `packages/cli/src/tui/context/form-state-context.ts` owns shared create/edit wizard form state and conversion to `ScaffoldOptions`.
+- `packages/cli/src/tui/views/create/*` and `packages/cli/src/tui/views/edit/*` own focus order, rendered fields, confirmation summaries, and editor round-trips.
+- `packages/cli/src/tui/views/edit/manifest-to-form.ts` hydrates edit form state from `FacetManifest`.
+- `packages/cli/src/tui/views/edit/use-edit-session.ts` converts edit form state back into a manifest before `writeManifest` serializes JSON.
+
+User-facing documentation currently covers the manifest privacy field and publish implications, but authoring docs do not mention a TUI privacy control. `docs/guides/publish-a-facet.md` currently instructs authors to hand-edit `facet.json`; that guidance will diverge once the TUI exposes privacy.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a single shared public/private form value used by both create and edit flows.
+- Make privacy a focusable TUI control that behaves consistently with the existing keyboard-driven wizard model.
+- Generate or write `private: true` only when the author selects private.
+- Omit `private` when the author selects public, including when an existing manifest had `private: true` and is edited back to public.
+- Show privacy in confirmation summaries so authors can review the final manifest intent before writing.
+- Surface concise rebuild/version-bump guidance near the privacy choice or confirmation summary without changing build or publish behavior.
+- Update create/edit and publish-guide documentation so docs match the new authoring surface.
+
+**Non-Goals:**
+
+- No manifest schema change and no protocol validation change.
+- No registry API change, publish flag, access-control behavior, or registry-side enforcement work.
+- No standalone non-interactive command such as `facet private` or `facet public`.
+- No automatic rebuild or republish after a privacy edit.
+- No privacy controls for composed dependencies, installed facets, or per-asset visibility.
+
+## Decisions
+
+### 1. Model privacy as a required boolean sibling of the string fields map
+
+`FormState` SHALL gain a dedicated boolean named `private: boolean`. This boolean SHALL be a sibling of `fields`, not a member of `fields`, because `FormState.fields` is a fixed map of `FieldState` values whose `value` is a string. The default form SHALL set `private` to `false`.
+
+All form construction sites SHALL be updated together: `defaultForm`, `FormStateContext`'s default value, `toCreateOptions()`, and `manifestToFormState()`. `manifestToFormState()` SHALL hydrate the boolean with `private: manifest.private === true`, treating `false` and omission identically as the public UI state.
+
+Rationale: the authoring UI has exactly two visible states: public and private. The form state should mirror the manifest field name directly instead of introducing a second name such as `isPrivate`; TypeScript already carries the boolean type, so an `is` prefix adds no useful information and makes create/edit/output mappings less direct. A required `private: boolean` makes illegal UI states unrepresentable in the UI: the form cannot carry both a public choice and a separate serialization preference.
+
+The UI boolean does not mean edit output always rewrites public manifests to omission. Omission versus explicit `private: false` is a manifest serialization detail handled at output boundaries. Create defaults to omission for public, while edit preserves an original explicit `private: false` unless the user changes privacy to private.
+
+Alternatives considered:
+
+- **Tri-state (`public-omitted` / `public-false` / `private`) in the form**: rejected because it exposes schema trivia to authors and adds a third UI state even though the author-facing choice is binary.
+- **Name the form field `isPrivate`**: rejected because the manifest field is already named `private`, TypeScript already identifies it as a boolean, and using a second name creates unnecessary mapping friction.
+- **Store privacy in generic `fields` as a string**: rejected because `FieldState.value` is a string and would make invalid values such as `"maybe"` or an empty string representable.
+- **Store raw manifest privacy as `boolean | undefined` in the form**: rejected because the UI should model the author's binary visibility choice; omission versus explicit false is a serialization concern handled when writing manifests.
+
+### 2. Extend engine `ScaffoldOptions` with optional `private?: true`
+
+`ScaffoldOptions` SHALL carry privacy to the engine as an optional true-only field: `private?: true`. `toCreateOptions()` SHALL include `private: true` only when `form.private` is true. `generateScaffoldManifest()` SHALL write `manifest.private = true` only when that option is present, using the same conditional-assignment style as existing optional scaffold fields. The generated key SHOULD be placed after `version`/`description` and before asset sections to align with manifest field order.
+
+Rationale: the generated manifest should omit public privacy. Encoding the scaffold option as true-only mirrors the output contract and prevents callers from passing a meaningful `false` value that the engine would then need to interpret or discard.
+
+Alternatives considered:
+
+- **`private: boolean` on `ScaffoldOptions`**: rejected because it makes `false` look semantically meaningful even though scaffold output must omit it.
+- **Keep privacy entirely in CLI and post-process generated JSON**: rejected because scaffold generation belongs in engine, and create should pass structured intent into the engine rather than mutate generated JSON in the CLI layer.
+
+### 3. Add a small reusable focusable `BooleanToggle`/`ToggleField` TUI component
+
+The CLI SHALL add a dedicated focusable toggle component rather than overloading `EditableField`. The component SHALL accept an `id`, `label`, `value`, `onToggle`, and optional `hint`/`dimmed` props. It SHALL render public/private labels clearly, support keyboard activation with Enter (and Space if consistent with existing input handling), and use the existing focus-order/button visual language.
+
+Create and edit views SHALL insert the privacy toggle after `Version` and before asset sections. Focus order SHALL become `field-name`, `field-description`, `field-version`, `field-private`, then asset controls and the submit button. Version confirmation SHALL move focus to `field-private`, and toggling/confirming privacy SHALL move to the first asset add control. Because `computeFocusIds(form)` is duplicated in both `create-view.tsx` and `edit-view.tsx`, both lists SHALL be updated in the same implementation step so one wizard cannot ship with an unreachable toggle.
+
+Rationale: privacy is not free-form text; a boolean toggle avoids validation errors and makes both choices discoverable. Placing it before assets keeps it with identity/manifest metadata and ensures authors see it before confirmation.
+
+Alternatives considered:
+
+- **Reuse `select-prompt`**: rejected because the wizard already uses inline focus navigation rather than modal selection for form fields.
+- **Represent privacy as an `EditableField` expecting `true`/`false`**: rejected because it is easier to mistype and contradicts the goal of replacing hand-edited JSON with safe UI.
+
+### 4. Edit manifest output SHALL preserve explicit public `private: false`
+
+`buildManifest(original, form)` in the edit session SHALL continue preserving unrelated top-level fields from `original`, but privacy SHALL be handled after spreading `original`:
+
+- If `form.private` is true, set `manifest.private = true`.
+- If `form.private` is false and `original.private === false`, preserve `manifest.private = false`.
+- If `form.private` is false and `original.private !== false`, delete `manifest.private`.
+
+Rationale: the form has only two author-facing states, but the source manifest can legally represent public visibility either by omitting `private` or by writing `private: false`. Create should continue omitting public privacy, and toggling an originally private manifest back to public should remove `private: true`. However, if an author hand-authored `private: false`, opening and applying `facet edit` should not erase that explicit representation as an incidental formatting side effect.
+
+This SHALL still be explicit privacy handling after `...original`; relying on preservation alone is insufficient because a private-to-public edit must actively remove a spread-in `private: true`. The specs SHALL include scenarios for private-to-public deletion, omitted-public preservation, and explicit `private: false` preservation.
+
+Alternatives considered:
+
+- **Set `manifest.private = false` for every public edit output**: rejected by product decision and because create/public-by-default output should omit `private`.
+- **Normalize every public edit output to omitted `private`**: rejected because it erases an explicitly hand-authored `private: false` even when the author did not ask for formatting normalization.
+- **Only delete `private` when the user changed it**: rejected because the output rules should be derivable from the current form state plus the original manifest representation, not hidden UI touched-state.
+- **Copy the `description` conditional-assignment pattern**: rejected because it is the wrong local precedent for fields that must be removable after `...original`.
+
+### 5. Confirmation summaries SHALL show privacy and brief publish guidance
+
+Create and edit confirmation views SHALL include a `Privacy:` row with `Public` or `Private`. The form view or confirmation summary SHALL also include concise guidance that privacy is manifest content and takes effect in built/published artifacts only after rebuild; if the version is already published, visibility changes require a version bump. This text SHOULD be short enough not to overwhelm the wizard, for example: `Privacy is embedded at build time; rebuild after changing it. Published versions require a version bump.`
+
+Rationale: the proposal requires authors not to discover rebuild/version rules only at publish time. Confirmation is the last safe point before writing the source manifest and is an appropriate low-friction place to remind them.
+
+Alternatives considered:
+
+- **Warn only in docs**: rejected because the author can toggle privacy without reading publish docs.
+- **Add a blocking modal warning on every toggle**: rejected as too disruptive for a local manifest edit that does not itself publish anything.
+- **Warn conditionally only when the current version is already published**: rejected because that requires a registry lookup, credentials, and network failure handling inside an authoring flow. Build/publish state remains outside this change.
+
+### 6. Documentation updates SHALL align the new authoring flow with existing publish semantics
+
+The implementation SHALL update:
+
+- `docs/cli/authoring/create.md`: add Privacy/Public-vs-Private to the wizard flow and clarify public default/omission.
+- `docs/cli/authoring/edit.md`: add privacy editing to the editing phase and confirmation summary.
+- `docs/guides/publish-a-facet.md`: replace hand-edit-first guidance with `facet edit` as the primary interactive path, while preserving the rebuild and version-bump instructions.
+
+`docs/specification/manifest.md` and `docs/specification/publish.md` already describe the field and publish behavior correctly; they MAY receive a short cross-reference to the TUI, but they do not require semantic changes.
+
+Rationale: the design changes observable CLI behavior covered by authoring docs and changes the recommended workflow in the publish guide. The specification docs remain the source of truth for the manifest and publish contract.
+
+## Risks / Trade-offs
+
+- **Risk: Focus-order regressions in create/edit wizards** → Mitigation: update both duplicated `computeFocusIds(form)` implementations and add tests or focused component coverage where existing test patterns allow; manually verify keyboard order if no reliable Ink test exists.
+- **Risk: Public selection accidentally leaves stale `private: true` during edit** → Mitigation: make `buildManifest()` explicitly delete `manifest.private` whenever the form boolean is false; add a unit test for private-to-public editing.
+- **Risk: Explicit `private: false` preservation adds a small output-branch exception** → Mitigation: keep the UI state binary, document that omission versus explicit false is handled only at the manifest output boundary, and specify tests for omitted-public preservation, explicit-false preservation, and private-to-public deletion.
+- **Risk: Implementers copy the wrong local optional-field pattern** → Mitigation: design and tasks SHALL call out that privacy should mirror asset-section set/delete behavior, not description's truthy-only assignment after `...original`.
+- **Risk: `ScaffoldOptions` optional true-only type is unfamiliar** → Mitigation: document the type at the interface boundary and test both absent and true generation paths.
+- **Risk: Guidance text adds visual clutter** → Mitigation: keep guidance as a dimmed one-line hint near the toggle or confirmation summary rather than a modal or multi-paragraph explanation.
+- **Risk: Docs overstate publish behavior changes** → Mitigation: update docs to say authoring changed, while build, publish, registry enforcement, and version immutability remain unchanged.
+
+## Migration Plan
+
+This is an additive local authoring change. Existing manifests remain valid and require no migration.
+
+Implementation rollout:
+
+1. Add privacy state and scaffold generation support.
+2. Add the toggle component and wire it into create/edit views, focus order, snapshots, and confirmation summaries.
+3. Update edit manifest construction to make privacy state authoritative.
+4. Add/adjust tests for scaffold output, form hydration, edit output, and confirmation/toggle behavior where practical.
+5. Update docs listed above.
+6. Run `bun check` before implementation is considered complete.
+
+Rollback strategy: revert the TUI/scaffold/edit changes. Manifests created with `private: true` remain valid because schema support already exists independently of this change.
+
+## Open Questions
+
+None. The key product choice — public selections omit `private` rather than writing `private: false` — is resolved by the proposal and this design.
+
+Future-scope items explicitly resolved out of this change:
+
+- A third explicit-public state that writes `private: false` is out of scope because it reintroduces UI states this design intentionally avoids.
+- A non-interactive `facet create --private` flag is out of scope because the proposal targets interactive authoring flows. The true-only `ScaffoldOptions.private?: true` shape would support that future addition without changing manifest serialization.

--- a/openspec/changes/expose-facet-privacy-toggle/proposal.md
+++ b/openspec/changes/expose-facet-privacy-toggle/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Facet manifests already support a top-level `private` boolean, and publish documentation already tells authors to edit `facet.json` by hand to change visibility. That leaves private publish intent as hidden functionality in the authoring workflow: users can create and edit facets interactively, but they cannot set or inspect registry visibility intent without leaving the TUI.
+
+## What Changes
+
+- The `facet create` wizard SHALL add an interactive privacy choice so authors can decide whether a newly scaffolded facet declares private publish intent.
+- The `facet edit` workbench SHALL add the same privacy choice so authors can inspect and change an existing facet between public-by-default and private publish intent without hand-editing JSON.
+- Newly created facets SHALL default to public-by-default, and the generated manifest SHALL omit the `private` field unless the author selects private.
+- The authoring workflows SHALL preserve the manifest schema's existing serialization model: `private: true` is written when selected; public selections omit `private` rather than injecting `private: false`, including when editing a previously private facet back to public.
+- The authoring workflows SHALL make clear that changing privacy is a manifest content change that requires a rebuild before it affects the built artifact, and a version bump if the current version has already been published.
+- User-facing authoring documentation SHALL describe the new privacy step in `facet create` and `facet edit`, and publish guidance SHALL stop presenting hand-editing `facet.json` as the primary way to change visibility.
+
+## Non-goals
+
+- This change will not alter manifest validation semantics; `private` remains an optional boolean where omission and `false` are public-by-default.
+- This change will not add a separate publish flag, registry API behavior, or registry-side visibility enforcement. The registry continues to read privacy intent from the built artifact's embedded manifest.
+- This change will not add a standalone command such as `facet private` or `facet public`.
+- This change will not automatically rebuild or republish when the author toggles privacy; build and publish remain explicit steps.
+- This change will not add privacy controls for composed dependencies or installed facets.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `authoring__facets`: The interactive facet authoring workflows SHALL expose manifest privacy intent during both create and edit flows, while preserving public-by-default omission semantics.
+
+## Impact
+
+- CLI/TUI authoring code in `packages/cli`, especially the shared create/edit form state, focus order, confirmation summaries, and a new focusable privacy toggle component.
+- Engine scaffold generation in `packages/engine/src/scaffold`, so create options can carry the selected privacy state into generated `facet.json`.
+- Edit result construction in the CLI TUI, so privacy changes are written to the manifest and public selections omit any existing `private` key.
+- Tests covering scaffold manifest generation, create/edit form state mapping, privacy toggle behavior, and user-visible confirmation behavior where practical.
+- Documentation informed by `docs/cli/authoring/create.md`, `docs/cli/authoring/edit.md`, `docs/specification/manifest.md`, `docs/specification/publish.md`, and `docs/guides/publish-a-facet.md`. The create/edit docs SHALL be updated because they currently describe the wizard fields but do not mention privacy. The publish guide's hand-edit guidance SHALL be updated to describe the new in-tool toggle while preserving the existing rebuild and version-bump discipline.

--- a/openspec/changes/expose-facet-privacy-toggle/specs/authoring__facets/spec.md
+++ b/openspec/changes/expose-facet-privacy-toggle/specs/authoring__facets/spec.md
@@ -1,0 +1,282 @@
+## MODIFIED Requirements
+
+### Requirement: Authors can scaffold a new facet project interactively
+
+The system SHALL provide an interactive wizard that guides the author through creating a new facet project. The wizard SHALL collect the following required information:
+
+- **Name**: A valid facet identity name. The name SHALL be either an unscoped kebab-case name (`name`) or a scoped name (`@scope/name`). The system SHALL validate the name in real-time and reject invalid input.
+- **Description**: A non-empty description. The system SHALL NOT allow the author to complete the wizard without providing a description.
+
+The wizard SHALL also collect optional information:
+
+- **Version**: A valid SemVer version (N.N.N format). The system SHALL default to `0.0.0`. The author MAY accept the default or change it.
+- **Privacy**: A choice of whether the new facet declares private publish intent. The system SHALL default to public visibility intent. The author MAY accept the public default or choose private.
+
+The wizard SHALL also allow the author to manage assets (skills, commands, and agents):
+
+- The author SHALL be able to add multiple named assets of any type
+- The author SHALL be able to edit the name of an existing asset
+- The author SHALL be able to remove an existing asset
+- All asset names SHALL be validated as kebab-case in real-time
+- Asset names SHALL be unique within their type — the system SHALL reject duplicates within the same asset type
+- Assets of different types MAY share the same name
+- The first asset added to each type SHOULD default its name to the unscoped name segment of the facet identity as a suggestion
+
+The wizard SHALL require the author to add at least one **asset** before completing. Name, description, and at least one **asset** are all required.
+
+All fields SHALL remain editable throughout the wizard — the author SHALL be able to go back and change any previously entered value, including privacy.
+
+Before completing, the wizard SHALL display a confirmation summary showing only the asset types that have entries, the selected privacy intent, and a preview of the files to be created. The author SHALL be able to confirm or go back.
+
+The wizard SHALL provide an exit confirmation mechanism that prevents accidental loss of unsaved work.
+
+Upon confirmation, the system SHALL create a project directory containing a valid manifest and named starter files for each asset the author specified, with each starter file containing template content that guides authors on what belongs in each section. Skill starter files SHALL be created at `skills/<name>/SKILL.md`. Agent and command starter files SHALL be created at `agents/<name>.md` and `commands/<name>.md` respectively. All starter files SHALL contain no YAML front matter.
+
+When the author selects private visibility intent, the generated manifest SHALL contain `private: true`. When the author accepts public visibility intent, the generated manifest SHALL omit `private`.
+
+The scaffolded project SHALL be immediately buildable — running the build command on a freshly scaffolded project SHALL succeed with no errors.
+
+#### Scenario: Author scaffolds a scoped project with named skills
+
+- **WHEN** the author runs the create wizard, provides a name `@julian/cowsay` and description `Cowsay tools`, and adds a skill named `cowsay`
+- **THEN** the system SHALL create a project directory containing a manifest whose `name` is `@julian/cowsay`
+- **AND** a starter file SHALL be created at `skills/cowsay/SKILL.md`
+- **AND** the manifest SHALL reference all starter files correctly
+
+#### Scenario: Author scaffolds a project with named skills
+
+- **WHEN** the author runs the create wizard, provides a name "viper-plans" and description "VIPER planning tools", and adds two skills named "viper-planning" and "viper-execution-rules"
+- **THEN** the system SHALL create a project directory containing a manifest with the provided identity fields and skill descriptors
+- **AND** starter files SHALL be created at `skills/viper-planning/SKILL.md` and `skills/viper-execution-rules/SKILL.md`
+- **AND** the manifest SHALL reference all starter files correctly
+
+#### Scenario: Author scaffolds a minimal project accepting the default skill name
+
+- **WHEN** the author runs the create wizard, provides a name "code-review" and a description, then adds a skill accepting the default name suggestion
+- **THEN** the system SHALL create a project with a skill named "code-review" (matching the facet name)
+- **AND** the starter file SHALL be at `skills/code-review/SKILL.md`
+
+#### Scenario: Author cannot complete without a description
+
+- **WHEN** the author attempts to complete the wizard without providing a description
+- **THEN** the system SHALL NOT allow completion
+- **AND** the system SHALL indicate that a description is required
+
+#### Scenario: Scoped facet identity is accepted
+
+- **WHEN** the author enters `@acme/deploy-tools` as the facet name
+- **THEN** the system SHALL accept the name as a valid facet identity
+
+#### Scenario: Invalid facet identity is rejected
+
+- **WHEN** the author enters `@acme/Deploy_Tools` as the facet name
+- **THEN** the system SHALL indicate the name is invalid
+- **AND** the system SHALL NOT accept the invalid name
+
+#### Scenario: Asset names are validated as kebab-case
+
+- **WHEN** the author enters an asset name containing uppercase letters, spaces, underscores, slashes, or an at sign
+- **THEN** the system SHALL indicate the name is invalid
+- **AND** the system SHALL NOT accept the invalid name
+
+#### Scenario: Duplicate asset names within a type are rejected
+
+- **WHEN** the author attempts to add a skill with the same name as an existing skill
+- **THEN** the system SHALL reject the duplicate name
+
+#### Scenario: Same name across different asset types is allowed
+
+- **WHEN** the author adds a skill named "viper-plans" and an agent named "viper-plans"
+- **THEN** the system SHALL accept both assets without error
+
+#### Scenario: Author edits an existing asset name
+
+- **WHEN** the author selects an existing asset and changes its name to a valid, unique kebab-case name
+- **THEN** the system SHALL update the asset name
+
+#### Scenario: Author removes an asset
+
+- **WHEN** the author removes a previously added asset
+- **THEN** the asset SHALL no longer appear in the wizard or the confirmation summary
+
+#### Scenario: Author exits the wizard with unsaved work
+
+- **WHEN** the author triggers an exit action during the wizard
+- **THEN** the system SHALL confirm the author's intent to exit
+- **AND** if the author confirms exit, the system SHALL not create any files or directories
+
+#### Scenario: Version field accepts valid SemVer input
+
+- **WHEN** the author sets the version to a valid SemVer value (e.g., "1.0.0" or "100.2.1")
+- **THEN** the system SHALL accept the version
+
+#### Scenario: Version field rejects invalid input
+
+- **WHEN** the author enters a version that does not match the N.N.N pattern
+- **THEN** the system SHALL indicate the version is invalid
+
+#### Scenario: Version defaults to 0.0.0
+
+- **WHEN** the author does not change the version field
+- **THEN** the manifest SHALL contain version `0.0.0`
+
+#### Scenario: New facet defaults to public visibility intent
+
+- **WHEN** an author creates a facet interactively and accepts the default privacy choice
+- **THEN** the generated manifest SHALL omit `private`
+- **AND** the confirmation summary SHALL show the facet as public
+
+#### Scenario: New private facet writes private true
+
+- **WHEN** an author creates a facet interactively and selects private visibility intent
+- **THEN** the generated manifest SHALL contain `private: true`
+- **AND** the confirmation summary SHALL show the facet as private
+
+#### Scenario: Author selects private then reverts to public before completing
+
+- **WHEN** an author creates a facet interactively, selects private visibility intent, and then changes the privacy choice back to public before completing the wizard
+- **THEN** the generated manifest SHALL omit `private`
+- **AND** the confirmation summary SHALL show the facet as public
+
+#### Scenario: Target directory already contains a manifest
+
+- **WHEN** the author runs the create wizard and a manifest already exists in the target directory
+- **THEN** the system SHALL warn the author and ask for confirmation before overwriting
+
+### Requirement: Authors can edit a facet project interactively
+
+The system SHALL provide an interactive editing command that serves as the full authoring workbench for facet manifests. The editing command SHALL combine all capabilities of the scaffolding wizard (identity editing, privacy editing, asset creation, asset removal) with automatic reconciliation of disk contents against the manifest. The editing command SHALL scan conventional **asset** directories to detect discrepancies between disk contents and the manifest. If the manifest is invalid, the editing command SHALL display errors and exit. If drift is detected, the editing command SHALL present a reconciliation phase before proceeding to editing.
+
+The editing command SHALL display the facet's current privacy intent so the author can inspect it without opening the manifest file, and SHALL allow the author to change between public and private. When the author sets or leaves the facet as private, the written manifest SHALL contain `private: true`. When the author changes a private facet to public, the written manifest SHALL omit `private`. When the author leaves a facet public, the written manifest SHALL preserve whether the source manifest omitted `private` or explicitly contained `private: false`.
+
+#### Scenario: Author edits facet identity fields
+
+- **WHEN** the author runs the edit command on a facet project
+- **THEN** the system SHALL display the current name, description, and version
+- **AND** the author SHALL be able to change any of them
+- **AND** if version is absent, the system SHALL default it to `0.0.0`
+
+#### Scenario: Author inspects private manifest as private
+
+- **WHEN** the author runs the edit command on a facet whose source manifest contains `private: true`
+- **THEN** the system SHALL show the facet as private
+- **AND** the author SHALL be able to leave it private or switch it to public before applying changes
+
+#### Scenario: Author inspects omitted privacy as public
+
+- **WHEN** the author runs the edit command on a facet whose source manifest omits `private`
+- **THEN** the system SHALL show the facet as public
+
+#### Scenario: Author inspects explicit public false as public
+
+- **WHEN** the author runs the edit command on a facet whose source manifest contains `private: false`
+- **THEN** the system SHALL show the facet as public
+
+#### Scenario: Edit shows omitted privacy as public and preserves omission
+
+- **WHEN** an author edits a facet whose source manifest omits `private`
+- **AND** the author leaves the facet public
+- **THEN** the applied manifest SHALL omit `private`
+
+#### Scenario: Edit preserves explicit public false when left public
+
+- **WHEN** an author edits a facet whose source manifest contains `private: false`
+- **AND** the author leaves the facet public
+- **THEN** the applied manifest SHALL preserve `private: false`
+
+#### Scenario: Edit changes private facet to public omission
+
+- **WHEN** an author edits a facet whose source manifest contains `private: true`
+- **AND** the author switches the facet to public before applying changes
+- **THEN** the applied manifest SHALL omit `private`
+
+#### Scenario: Edit changes public facet to private
+
+- **WHEN** an author edits a facet whose source manifest omits `private` or contains `private: false`
+- **AND** the author switches the facet to private before applying changes
+- **THEN** the applied manifest SHALL contain `private: true`
+
+#### Scenario: Author changes a facet identity to a different scope
+
+- **WHEN** the author changes a facet's name from `@julian/cowsay` to `@acme/cowsay` during edit
+- **THEN** the system SHALL treat the change as a normal local identity edit
+- **AND** the system SHALL NOT warn specially about changing scopes
+
+#### Scenario: Author creates a new skill from scratch
+
+- **WHEN** the author uses the edit command to add a new skill named "code-review"
+- **THEN** the system SHALL create `skills/code-review/SKILL.md` with a starter template
+- **AND** the system SHALL add a skill descriptor to the manifest with the author-provided description
+
+#### Scenario: Author creates a new agent from scratch
+
+- **WHEN** the author uses the edit command to add a new agent named "reviewer"
+- **THEN** the system SHALL create `agents/reviewer.md` with a starter template
+- **AND** the system SHALL add an agent descriptor to the manifest with the author-provided description
+
+#### Scenario: Author creates a new command from scratch
+
+- **WHEN** the author uses the edit command to add a new command named "run-review"
+- **THEN** the system SHALL create `commands/run-review.md` with a starter template
+- **AND** the system SHALL add a command descriptor to the manifest with the author-provided description
+
+#### Scenario: Author deletes an existing asset
+
+- **WHEN** the author selects an existing asset for deletion during an edit session
+- **THEN** the system SHALL remove the asset's entry from the manifest
+- **AND** the system SHALL remove the asset's file (or directory, for skills) from disk
+
+#### Scenario: Asset names are validated during edit
+
+- **WHEN** the author enters an asset name during the edit session
+- **THEN** the system SHALL validate the name as kebab-case
+- **AND** the system SHALL reject names that are not unique within their asset type
+
+### Requirement: Edit is transactional with confirmation
+
+All changes during an edit session SHALL be queued — nothing SHALL be written to disk or manifest until the author explicitly confirms. Before confirmation, the system SHALL display a manifest preview showing identity fields (name, description, version), privacy intent, and **asset** sections (name and truncated description per **asset**). The author SHALL be able to confirm ("Apply") or go back to editing. The author SHALL be able to exit at any point before confirmation with no changes applied.
+
+#### Scenario: Author confirms changes
+
+- **WHEN** the author reviews the confirmation summary and confirms
+- **THEN** all queued changes SHALL be applied atomically to disk and manifest
+
+#### Scenario: Author exits before confirmation
+
+- **WHEN** the author exits the edit session before confirming
+- **THEN** no files SHALL be created, modified, or deleted
+- **AND** the manifest SHALL remain unchanged
+
+#### Scenario: Confirmation summary shows privacy intent
+
+- **WHEN** the author reaches the edit confirmation summary
+- **THEN** the confirmation summary SHALL show the facet's privacy intent alongside the identity fields
+
+#### Scenario: Confirmation summary shows all deltas
+
+- **WHEN** an edit session includes identity changes, a privacy change, two additions, one deletion, and one front matter strip
+- **THEN** the confirmation summary SHALL list all six changes with their details
+
+## ADDED Requirements
+
+### Requirement: Authoring workflows make privacy publish consequences visible
+
+Because privacy intent is manifest content embedded in the built artifact, changing it in the create or edit workflows SHALL NOT, on its own, alter any already-built artifact or any already-published version. The authoring workflows SHALL make clear to the author that a privacy change takes effect only after a rebuild, and that propagating the change to a version that has already been published requires a version bump and republish. The authoring workflows SHALL NOT automatically rebuild, republish, or contact the registry as a result of a privacy change.
+
+#### Scenario: Editing privacy does not rebuild or publish
+
+- **WHEN** the author changes a facet's privacy intent in the edit workflow and confirms
+- **THEN** the system SHALL update the source manifest only
+- **AND** the system SHALL NOT rebuild the facet
+- **AND** the system SHALL NOT publish the facet
+- **AND** the system SHALL NOT contact the registry
+
+#### Scenario: Author is informed that a privacy change needs a rebuild
+
+- **WHEN** the author reviews privacy intent during create or edit confirmation
+- **THEN** the system SHALL make clear that the change affects built artifacts only after the facet is rebuilt
+
+#### Scenario: Author is informed that a published version needs a version bump
+
+- **WHEN** the author reviews privacy intent during create or edit confirmation
+- **THEN** the system SHALL make clear that changing visibility for an already-published version requires a version bump and republish

--- a/openspec/changes/expose-facet-privacy-toggle/tasks.md
+++ b/openspec/changes/expose-facet-privacy-toggle/tasks.md
@@ -1,0 +1,80 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. Form State and Scaffold Privacy — Research
+
+- [ ] 1.1 Explore: Read `packages/cli/src/tui/context/form-state-context.ts` and catalog every `FormState` construction/mapping site, including `defaultForm`, `FormStateContext` defaults, provider initialization, and `toCreateOptions()`.
+- [ ] 1.2 Explore: Read `packages/engine/src/scaffold/index.ts` and catalog `ScaffoldOptions`, `generateScaffoldManifest()`, and optional-field serialization/ordering patterns for `description`, `skills`, `agents`, and `commands`.
+- [ ] 1.3 Explore: Review existing unit and TUI test patterns for scaffold generation, `toCreateOptions()`, and form-state conversion.
+- [ ] 1.4 Propose: Present the form-state and scaffold implementation approach, including `FormState.private: boolean`, `ScaffoldOptions.private?: true`, true-only interface documentation, manifest field ordering after `version`/`description` and before asset sections, and create-option conversion.
+
+## 2. Form State and Scaffold Privacy — Implementation
+
+- [ ] 2.1 Implement: Add `private: boolean` as a sibling of `fields` in `packages/cli/src/tui/context/form-state-context.ts` and initialize it to `false` in `defaultForm`, context defaults, and provider initialization.
+- [ ] 2.2 Implement: Update `toCreateOptions()` to pass `private: true` only when `form.private` is true.
+- [ ] 2.3 Implement: Add documented `private?: true` support to `ScaffoldOptions` in `packages/engine/src/scaffold/index.ts`, preserving the true-only contract at the interface boundary.
+- [ ] 2.4 Implement: Update `generateScaffoldManifest()` to write `manifest.private = true` only when present, with `private` placed after `version`/`description` and before asset sections.
+- [ ] 2.5 Implement: Add or update tests proving create defaults omit `private`, private create writes `private: true`, no meaningful `false` create option path exists, and scaffold output keeps the intended field ordering.
+- [ ] 2.6 Verify: Run the focused package checks or tests that cover scaffold generation and form-state conversion.
+
+## 3. Create/Edit TUI Privacy Control — Research
+
+- [ ] 3.1 Explore: Review `packages/cli/src/tui/components/button.tsx`, `editable-field.tsx`, `asset-section.tsx`, `useFocusOrder()`, and `useInput({ isActive })` patterns to choose the smallest consistent toggle implementation.
+- [ ] 3.2 Explore: Review `packages/cli/src/tui/views/create/create-view.tsx` and `packages/cli/src/tui/views/edit/edit-view.tsx`, recording both duplicated `computeFocusIds(form)` implementations, current focus chains, and Version `onConfirm` behavior.
+- [ ] 3.3 Explore: Review `packages/cli/src/tui/views/create/confirm-view.tsx` and `packages/cli/src/tui/views/edit/edit-confirm-view.tsx` to locate identity rows and summary guidance placement.
+- [ ] 3.4 Propose: Present the TUI approach for a focusable privacy toggle, including component API, labels, keyboard behavior, focus transitions, exact guidance string, and the requirement that both duplicated `computeFocusIds(form)` lists change in the same implementation pass.
+
+## 4. Create/Edit TUI Privacy Control — Implementation
+
+- [ ] 4.1 Implement: Add a reusable focusable boolean toggle component, such as `packages/cli/src/tui/components/boolean-toggle.tsx`, accepting `id`, `label`, `value`, `onToggle`, and optional `hint`/`dimmed` props.
+- [ ] 4.2 Implement: Wire the privacy toggle into `create-view.tsx` after Version and before asset controls, binding it to `form.private`, inserting `field-private` after `field-version` in `computeFocusIds(form)`, routing Version confirmation to `field-private`, and routing toggle activation to the first asset add control.
+- [ ] 4.3 Implement: Wire the privacy toggle into `edit-view.tsx` with the same placement, binding, `computeFocusIds(form)` insertion, and focus transitions so create/edit focus lists stay in lockstep.
+- [ ] 4.4 Implement: Update `confirm-view.tsx` and `edit-confirm-view.tsx` to show `Privacy: Public` or `Privacy: Private` plus the concise guidance string: `Privacy is embedded at build time; rebuild after changing it. Published versions require a version bump.`
+- [ ] 4.5 Implement: Add or update TUI/component tests where practical for toggle rendering, focus reachability, keyboard toggling, and confirmation-summary privacy display.
+- [ ] 4.6 Verify: Run the focused CLI tests or snapshots that cover create/edit TUI behavior.
+
+## 5. Edit Manifest Output and Scenario Test Mapping — Research
+
+- [ ] 5.1 Explore: Review `packages/cli/src/tui/views/edit/manifest-to-form.ts` and `packages/cli/src/tui/views/edit/use-edit-session.ts`, especially `buildManifest()` and its `...original` preservation plus asset-section set/delete behavior.
+- [ ] 5.2 Explore: Review existing edit-output tests and fixtures for identity fields, asset sections, unknown fields, transactional apply behavior, and current CLI integration/e2e coverage.
+- [ ] 5.3 Propose: Present the edit-output rules for privacy, including `manifest.private === true` hydration, omitted/false public hydration, private-to-public deletion, omitted-public preservation, explicit `private: false` preservation, public-to-private writing, and unrelated top-level field preservation.
+- [ ] 5.4 Propose: Map each privacy spec scenario to a concrete test and location, covering public-default omission, private-true generation, create private-then-public revert, edit omitted-public preservation, edit explicit `private: false` preservation, edit private-to-public deletion, edit public-to-private write, confirmation summaries, and no auto-rebuild/publish/registry contact.
+
+## 6. Edit Manifest Output and Tests — Implementation
+
+- [ ] 6.1 Implement: Update `manifestToFormState()` so `private: true` hydrates as private and both omission and `private: false` hydrate as public.
+- [ ] 6.2 Implement: Update `buildManifest()` so `form.private === true` writes `private: true`, public with original `private: false` preserves `private: false`, and public with original omission or `private: true` omits `private`.
+- [ ] 6.3 Implement: Ensure edit output preserves unrelated top-level manifest fields while making privacy state authoritative according to the approved output rules.
+- [ ] 6.4 Implement: Add or update tests covering `manifestToFormState()` privacy hydration for omitted, `false`, and `true`.
+- [ ] 6.5 Implement: Add or update tests covering `buildManifest()` privacy output for true→`private: true`, public+original-false→preserve false, public+original-omitted→omit, private-original→public→delete, and unknown-field preservation.
+- [ ] 6.6 Implement: Add or update create/scaffold/TUI tests from the scenario-to-test map, including create private-then-public revert, confirmation privacy rows, and no automatic rebuild/publish/registry contact where practical.
+- [ ] 6.7 Verify: Run the focused CLI and engine tests for manifest hydration, manifest output, scaffold output, and create/edit TUI behavior.
+
+## 7. Documentation and End-to-End Verification — Research
+
+- [ ] 7.1 Explore: Review `docs/cli/authoring/create.md`, `docs/cli/authoring/edit.md`, and `docs/guides/publish-a-facet.md` for privacy-authoring updates and stale hand-edit-first guidance.
+- [ ] 7.2 Explore: Review `docs/specification/manifest.md`, `docs/specification/publish.md`, `docs/guides/create-your-first-facet.md`, and root `README.md` for cross-references or wording that may need to mention the new TUI privacy control.
+- [ ] 7.3 Propose: Present the documentation update set, keeping manifest/publish semantics as the source of truth and avoiding claims of registry/API changes.
+
+## 8. Documentation and End-to-End Verification — Implementation
+
+- [ ] 8.1 Implement: Update create authoring docs to include the Privacy step, public default, omitted-public serialization, private `true` serialization, and confirmation-summary behavior.
+- [ ] 8.2 Implement: Update edit authoring docs to include privacy inspection/editing, explicit `private: false` preservation, private-to-public omission, and confirmation-summary guidance.
+- [ ] 8.3 Implement: Update the publish guide to prefer `facet edit` for changing visibility while preserving rebuild, version-bump, immutable-published-version, and content-drift guidance.
+- [ ] 8.4 Implement: Add short cross-references in manifest or publish specification docs only if needed to connect the existing privacy semantics to the new TUI authoring surface.
+- [ ] 8.5 Verify: Re-read updated docs against the implemented behavior and confirm no residual hand-edit-first guidance or stale wizard-field descriptions remain.
+- [ ] 8.6 Verify: Run `bun check` and fix any failing tests, type errors, lint errors, or formatting issues using `bun format` for Biome formatting failures.
+- [ ] 8.7 Verify: Verify the OpenSpec change with the appropriate OpenSpec validation command before implementation is considered complete.


### PR DESCRIPTION
### Why

The `facet create` wizard and `facet edit` workbench expose identity fields (name, description, version) and asset management, but never surface the manifest's `private` boolean. The only documented way to set or change publish visibility is to hand-edit `facet.json` directly, making privacy a hidden authoring concern that authors may not discover and cannot inspect while working in the TUI.

### Details

This change runs the full OpenSpec adversarial review cycle for exposing a privacy toggle in both interactive authoring flows. The resulting artifacts cover:

- A dedicated `private: boolean` sibling on `FormState` (not inside the string `fields` map) defaulting to `false`, with a `setPrivate` mutator and updates to all construction sites (`defaultForm`, context defaults, `toCreateOptions`, `manifestToFormState`).
- `ScaffoldOptions.private?: true` (true-only) in the engine, with `generateScaffoldManifest` writing `manifest.private = true` only when the option is present, placed after `version`/`description` and before asset sections.
- A new reusable focusable `BooleanToggle` component inserted after Version in both `create-view` and `edit-view`, with both duplicated `computeFocusIds` lists updated in the same pass to prevent an unreachable control.
- Edit output rules in `buildManifest`: `private: true` when private; `delete manifest.private` when switching from private to public; preserve `private: false` when the source manifest carried it explicitly and the author leaves the facet public.
- `manifestToFormState` hydrating `manifest.private === true`, treating omission and explicit `false` identically as the public UI state.
- Confirmation summaries in both `confirm-view` and `edit-confirm-view` showing a `Privacy:` row plus a static one-line rebuild/version-bump guidance note.
- Spec scenarios covering public-default omission, private write, create private-then-revert, edit private-to-public deletion, explicit `private: false` preservation, and the no-auto-rebuild/no-registry-contact guarantee.
- Documentation updates to `docs/cli/authoring/create.md`, `docs/cli/authoring/edit.md`, and `docs/guides/publish-a-facet.md` replacing hand-edit-first guidance with the in-tool toggle while preserving rebuild and version-bump discipline.

The `@julian/openspec-adversary` dependency is bumped to `2.3.2` to pick up the adversarial review tooling used to produce and reconcile these artifacts.