### PR TITLE
Bump `@julian/openspec-adversary` to `3.0.0`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,6 @@
     "viper-plans": "0.2.0",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "2.3.2"
+    "@julian/openspec-adversary": "3.0.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,9 +6,14 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "2.3.2",
-      "integrity": "sha256:abedfa1f9247a3808007acdc75b5721969de97089aa31aee139cf7c4d8bb7ac8",
+      "version": "3.0.0",
+      "integrity": "sha256:fa804e44ce4554c35128a519af4705c541b0df29307d021aa777a11b9ac761b5",
       "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "openspec-adversary-author"
+        },
         {
           "scope": "project",
           "type": "skill",
@@ -17,12 +22,12 @@
         {
           "scope": "project",
           "type": "skill",
-          "name": "openspec-adversary-continue"
+          "name": "openspec-adversary-reconcile"
         },
         {
           "scope": "project",
           "type": "skill",
-          "name": "review-openspec-adversary"
+          "name": "openspec-adversary-run"
         },
         {
           "scope": "project",
@@ -32,12 +37,7 @@
         {
           "scope": "project",
           "type": "command",
-          "name": "compare-adversary"
-        },
-        {
-          "scope": "project",
-          "type": "command",
-          "name": "reconcile-adversary-review"
+          "name": "reconcile-adversary"
         },
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Upgrades `@julian/openspec-adversary` from `2.3.2` to `3.0.0`.

### Details

This major version bump includes changes to the asset manifest:

- Adds a new `openspec-adversary-author` skill
- Renames `openspec-adversary-continue` to `openspec-adversary-run`
- Renames `review-openspec-adversary` to `openspec-adversary-reconcile`
- Replaces the `compare-adversary` command with a skill of the same purpose (`openspec-adversary-compare`)
- Renames the `reconcile-adversary-review` command to `reconcile-adversary`