### PR TITLE
Bump `@julian/openspec-adversary` to `3.1.0` and add `run-inline-adversary` command

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,6 @@
     "viper-plans": "0.2.0",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "3.0.0"
+    "@julian/openspec-adversary": "3.1.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "3.0.0",
-      "integrity": "sha256:fa804e44ce4554c35128a519af4705c541b0df29307d021aa777a11b9ac761b5",
+      "version": "3.1.0",
+      "integrity": "sha256:ec982d17392d71ee4f940434d58c7eba26010adaf64162b2fa0d99173121aa82",
       "assets": [
         {
           "scope": "project",
@@ -43,6 +43,11 @@
           "scope": "project",
           "type": "command",
           "name": "run-adversary"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "run-inline-adversary"
         }
       ]
     },


### PR DESCRIPTION
### Why

Upgrades `@julian/openspec-adversary` from `3.0.0` to `3.1.0`.

### Details

The new version introduces an additional `run-inline-adversary` command alongside the existing `run-adversary` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal component version to 3.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->