### PR TITLE
Bump `viper-plans` to `0.2.1` with improved recursive plan directory cleanup instructions

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "0.2.0",
+    "viper-plans": "0.2.1",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
     "@julian/openspec-adversary": "3.1.0"

--- a/facets.lock
+++ b/facets.lock
@@ -106,8 +106,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.2.0",
-      "integrity": "sha256:343ff1fba77c66b934d89a5f544ecac2bcac9e15e57fa46885544a33c49bdcac",
+      "version": "0.2.1",
+      "integrity": "sha256:e15446f622365222d68eb8e94b3d628adff1b94c11f06c0b04c15f105807df26",
       "assets": [
         {
           "scope": "project",

--- a/fixtures/viper-plans/commands/viper-continue.md
+++ b/fixtures/viper-plans/commands/viper-continue.md
@@ -66,4 +66,4 @@ No plan was detected in conversation history. Fall back to the full selection fl
 
 Once complete, ask the user if they want to delete the plan with the `question` tool using a simple yes/no binary.
 
-If they answer yes: if the `viper-delete-plan` tool is available, use it. Otherwise, delete the `.opencode/plans/<name>/` directory directly with your file tools.
+If they answer yes: if the `viper-delete-plan` tool is available, use it. Otherwise, recursively remove the entire `.opencode/plans/<name>/` directory and all of its contents with your file tools, leaving no orphaned files or empty directory behind.

--- a/fixtures/viper-plans/commands/viper-run.md
+++ b/fixtures/viper-plans/commands/viper-run.md
@@ -35,4 +35,4 @@ Plan name (if provided): $ARGUMENTS
 
 Once complete, ask the user if they want to delete the plan with the `question` tool using a simple yes/no binary.
 
-If they answer yes: if the `viper-delete-plan` tool is available, use it. Otherwise, delete the `.opencode/plans/<name>/` directory directly with your file tools.
+If they answer yes: if the `viper-delete-plan` tool is available, use it. Otherwise, recursively remove the entire `.opencode/plans/<name>/` directory and all of its contents with your file tools, leaving no orphaned files or empty directory behind.

--- a/fixtures/viper-plans/facet.json
+++ b/fixtures/viper-plans/facet.json
@@ -1,6 +1,6 @@
 {
   "name": "viper-plans",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "VIPER planning and execution",
   "skills": {
     "viper-planning": {


### PR DESCRIPTION
### Why

When a plan directory is deleted using file tools as a fallback (i.e. when `viper-delete-plan` is unavailable), the previous instruction only said to "delete the directory," which could leave orphaned files or an empty directory behind depending on how the AI interpreted the instruction.

### Details

The deletion instruction in both `viper-run` and `viper-continue` now explicitly requires a recursive removal of the entire `.opencode/plans/<name>/` directory and all of its contents, ensuring no orphaned files or empty directories remain. This is a prompt-level fix bumped as `viper-plans` version `0.2.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan deletion fallback instructions to ensure the entire plan directory and its contents are removed when the delete tool isn’t available.
  * This helps prevent leftover files or empty folders during cleanup.

* **Chores**
  * Bumped the viper-plans version from `0.2.0` to `0.2.1` in the updated metadata and fixture files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->