### PR TITLE
Bump `@julian/openspec-adversary` to `3.1.2`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,6 @@
     "viper-plans": "0.2.1",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "3.1.0"
+    "@julian/openspec-adversary": "3.1.2"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "3.1.0",
-      "integrity": "sha256:ec982d17392d71ee4f940434d58c7eba26010adaf64162b2fa0d99173121aa82",
+      "version": "3.1.2",
+      "integrity": "sha256:af8c255844d9e24d4603de468b94e50de3712e37c7c0f758883f580619e26714",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Bumps `@julian/openspec-adversary` from `3.1.0` to `3.1.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `@julian/openspec-adversary` facet to version `3.1.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->