### PR TITLE
Add changeset guard for ignored and unknown package bumps with `parseChangesetBumps`, `findForbiddenBumps`, and a repository-level test

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -102,7 +102,7 @@ The CLI package (`agent-facets`) is marked `"private": true` in its `package.jso
 
 ## Workspace-only packages
 
-Some workspace packages — `@agent-facets/common`, `@agent-facets/landing`, `@agent-facets/functions` — are private helpers that are never published and have no companion release pipeline. `"private": true` alone isn't enough to skip them: the CLI package is also private but MUST be tagged (its tag triggers the binary release pipeline).
+Some workspace packages — `@agent-facets/engine`, `@agent-facets/common`, `@agent-facets/landing`, `@agent-facets/functions` — are private helpers that are never published and have no companion release pipeline. `"private": true` alone isn't enough to skip them: the CLI package is also private but MUST be tagged (its tag triggers the binary release pipeline).
 
 The contract for marking a package as "workspace-only, never release" has three parts:
 
@@ -111,6 +111,14 @@ The contract for marking a package as "workspace-only, never release" has three 
 3. **`prepack` strips `devDependencies` outright** via `stripDevDependencies` in `scripts/lib/prepack.ts` — this is the load-bearing protection that lets published packages keep `workspace:*` devDep references to versionless workspace-only packages (e.g. `@agent-facets/common` in `core` / `adapter` / `cli` devDeps). `bun pm pack` (used by the publish pipeline since PR #206) validates every `workspace:*` specifier — including those in `devDependencies` — and refuses to pack when one is unresolvable. `npm publish` strips devDeps from the tarball regardless, so deleting them at pack time has no effect on the published artifact, and `postpack` restores the original manifest. `DEP_FIELDS` excludes `devDependencies` from rewriting as belt-and-suspenders so the helper stays safe on any input shape. `prepack` and `postpack` write all diagnostic output to stderr (not stdout) so `bun pm pack --quiet`'s stdout stays parseable by `extractPackFilename` — see "Why pack-then-upload?" below.
 
 Together these keep workspace-only packages out of the release pipeline entirely — no tags, no npm publishes, no lingering "unpublished" state, and no prepack failures.
+
+### Hard guard: changesets must not bump ignored or unknown packages
+
+The Changesets UI sometimes adds a bump for a package in the `ignore` list, or for a fake/misnamed package (a typo'd name that isn't in the workspace). Either one breaks the release/deploy pipeline if merged — an ignored bump is silently dropped by `changeset version` (so the bump never ships), and an unknown package makes `changeset version` fail outright. `bun check` includes a hard guard against both: the `repository changeset guard` test in `scripts/lib/changesets.test.ts` reads the `ignore` list from `.changeset/config.json`, enumerates the valid workspace package names via `loadWorkspacePackages()`, parses every pending `.changeset/*.md` file's front-matter (`parseChangesetBumps`), and runs `findForbiddenBumps` (all in `scripts/lib/changesets.ts`). It fails with a per-file violation list — grouped into `ignored` vs `unknown` classes via `formatForbiddenBumps` — if any bump targets a package that is either in the `ignore` list or not a workspace package at all. `ignore` takes precedence over the workspace set, so an ignored package classifies as `ignored`, not `unknown`. The guard passes when there are no pending changesets.
+
+Note: `changeset status` already errors on unknown packages, but it is *blind* to ignored-package bumps (it reports "NO packages to be bumped" and exits 0). This guard is the only check that catches the ignored case, and it folds in the unknown case too so both live in one fast, pure, unit-tested place.
+
+`turbo.json`'s `//#test:scripts` task includes `.changeset/**` in its inputs so adding or editing a changeset reliably reruns the guard instead of serving a stale cache hit.
 
 ## Why pack-then-upload?
 

--- a/scripts/lib/changesets.test.ts
+++ b/scripts/lib/changesets.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, test } from 'bun:test'
+import { Glob } from 'bun'
 import dedent from 'dedent'
 import {
   buildVersionPrBody,
   comparePackageOrder,
   filterPendingChangesets,
+  findForbiddenBumps,
+  formatForbiddenBumps,
   hasUnpublishedVersions,
+  type ParsedChangeset,
+  parseChangesetBumps,
   replaceChangelogEntry,
   shouldPublish,
   transformChangelogContent,
   type WorkspacePackage,
 } from './changesets'
+import { loadWorkspacePackages } from './ci'
 
 describe('filterPendingChangesets', () => {
   test('returns empty array when no files', () => {
@@ -895,5 +901,190 @@ describe('comparePackageOrder', () => {
     const packages = ['agent-facets', '@agent-facets/protocol', '@agent-facets/brand']
     const sorted = [...packages].sort(comparePackageOrder)
     expect(sorted).toEqual(packages)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseChangesetBumps
+// ---------------------------------------------------------------------------
+
+describe('parseChangesetBumps', () => {
+  test('parses a single package bump', () => {
+    const content = dedent`
+      ---
+      "@agent-facets/protocol": patch
+      ---
+
+      Fix a bug
+    `
+    expect(parseChangesetBumps(content)).toEqual([{ name: '@agent-facets/protocol', bump: 'patch' }])
+  })
+
+  test('parses multiple package bumps', () => {
+    const content = dedent`
+      ---
+      "@agent-facets/protocol": minor
+      "agent-facets": patch
+      ---
+
+      Add a feature
+    `
+    expect(parseChangesetBumps(content)).toEqual([
+      { name: '@agent-facets/protocol', bump: 'minor' },
+      { name: 'agent-facets', bump: 'patch' },
+    ])
+  })
+
+  test('returns empty array when there is no front-matter', () => {
+    expect(parseChangesetBumps('just some prose without front-matter')).toEqual([])
+  })
+
+  test('returns empty array for an empty front-matter block', () => {
+    const content = dedent`
+      ---
+      ---
+
+      Body only
+    `
+    expect(parseChangesetBumps(content)).toEqual([])
+  })
+
+  test('ignores lines outside the front-matter block', () => {
+    const content = dedent`
+      ---
+      "agent-facets": patch
+      ---
+
+      "@agent-facets/engine": major
+    `
+    expect(parseChangesetBumps(content)).toEqual([{ name: 'agent-facets', bump: 'patch' }])
+  })
+
+  test('tolerates extra whitespace around the colon', () => {
+    const content = dedent`
+      ---
+      "agent-facets"   :   major
+      ---
+    `
+    expect(parseChangesetBumps(content)).toEqual([{ name: 'agent-facets', bump: 'major' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// findForbiddenBumps
+// ---------------------------------------------------------------------------
+
+describe('findForbiddenBumps', () => {
+  const ignore = ['@agent-facets/engine', '@agent-facets/common']
+  const known = [
+    'agent-facets',
+    '@agent-facets/protocol',
+    '@agent-facets/brand',
+    '@agent-facets/engine',
+    '@agent-facets/common',
+  ]
+
+  test('returns ok when every bump targets a known, non-ignored package', () => {
+    const changesets: ParsedChangeset[] = [
+      { file: 'brave-lion.md', bumps: [{ name: 'agent-facets', bump: 'patch' }] },
+      { file: 'funny-turtle.md', bumps: [{ name: '@agent-facets/protocol', bump: 'minor' }] },
+    ]
+    expect(findForbiddenBumps(changesets, ignore, known)).toEqual({ ok: true })
+  })
+
+  test('returns ok for an empty changeset list', () => {
+    expect(findForbiddenBumps([], ignore, known)).toEqual({ ok: true })
+  })
+
+  test('flags a single ignored-package bump with reason "ignored"', () => {
+    const changesets: ParsedChangeset[] = [{ file: 'bad.md', bumps: [{ name: '@agent-facets/engine', bump: 'patch' }] }]
+    const result = findForbiddenBumps(changesets, ignore, known)
+    if (result.ok) expect.unreachable()
+    expect(result.violations).toEqual([
+      { file: 'bad.md', name: '@agent-facets/engine', bump: 'patch', reason: 'ignored' },
+    ])
+  })
+
+  test('flags an unknown/fake package with reason "unknown"', () => {
+    const changesets: ParsedChangeset[] = [{ file: 'bad.md', bumps: [{ name: '@agent-facets/fake', bump: 'patch' }] }]
+    const result = findForbiddenBumps(changesets, ignore, known)
+    if (result.ok) expect.unreachable()
+    expect(result.violations).toEqual([
+      { file: 'bad.md', name: '@agent-facets/fake', bump: 'patch', reason: 'unknown' },
+    ])
+  })
+
+  test('ignore takes precedence: an ignored package is "ignored", not "unknown"', () => {
+    // @agent-facets/common is ignored AND a real workspace package; it must
+    // classify as ignored even though it is also in the known set.
+    const changesets: ParsedChangeset[] = [{ file: 'bad.md', bumps: [{ name: '@agent-facets/common', bump: 'patch' }] }]
+    const result = findForbiddenBumps(changesets, ignore, known)
+    if (result.ok) expect.unreachable()
+    if (result.violations[0]?.reason !== 'ignored') expect.unreachable()
+    expect(result.violations[0].name).toBe('@agent-facets/common')
+  })
+
+  test('flags both ignored and unknown bumps across multiple changesets', () => {
+    const changesets: ParsedChangeset[] = [
+      {
+        file: 'mixed.md',
+        bumps: [
+          { name: 'agent-facets', bump: 'patch' },
+          { name: '@agent-facets/common', bump: 'minor' },
+        ],
+      },
+      { file: 'fake.md', bumps: [{ name: '@agent-facets/nope', bump: 'major' }] },
+    ]
+    const result = findForbiddenBumps(changesets, ignore, known)
+    if (result.ok) expect.unreachable()
+    expect(result.violations).toEqual([
+      { file: 'mixed.md', name: '@agent-facets/common', bump: 'minor', reason: 'ignored' },
+      { file: 'fake.md', name: '@agent-facets/nope', bump: 'major', reason: 'unknown' },
+    ])
+  })
+
+  test('formatForbiddenBumps renders both classes with distinct guidance', () => {
+    const message = formatForbiddenBumps([
+      { file: 'a.md', name: '@agent-facets/engine', bump: 'patch', reason: 'ignored' },
+      { file: 'b.md', name: '@agent-facets/fake', bump: 'minor', reason: 'unknown' },
+    ])
+    expect(message).toContain('ignore')
+    expect(message).toContain('"@agent-facets/engine": patch')
+    expect(message).toContain('not in the workspace')
+    expect(message).toContain('"@agent-facets/fake": minor')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Repository guard: no pending changeset may bump an ignored or unknown package
+// ---------------------------------------------------------------------------
+
+describe('repository changeset guard', () => {
+  test('no pending changeset bumps an ignored or unknown package', async () => {
+    // scripts/lib/changesets.test.ts -> repo root is two levels up
+    const repoRoot = new URL('../../', import.meta.url).pathname
+    const changesetDir = `${repoRoot}.changeset`
+
+    const config = (await Bun.file(`${changesetDir}/config.json`).json()) as { ignore?: string[] }
+    const ignore = config.ignore ?? []
+    const knownPackages = (await loadWorkspacePackages()).map((p) => p.name)
+
+    const files: string[] = []
+    for await (const entry of new Glob('*.md').scan(changesetDir)) {
+      if (entry !== 'README.md') files.push(entry)
+    }
+
+    const changesets: ParsedChangeset[] = await Promise.all(
+      files.map(async (file) => ({
+        file,
+        bumps: parseChangesetBumps(await Bun.file(`${changesetDir}/${file}`).text()),
+      })),
+    )
+
+    const result = findForbiddenBumps(changesets, ignore, knownPackages)
+    if (!result.ok) {
+      expect.unreachable(formatForbiddenBumps(result.violations))
+    }
+    expect(result.ok).toBe(true)
   })
 })

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -439,3 +439,158 @@ export function replaceChangelogEntry(changelog: string, version: string, newCon
 
   return [...before, '', trimmedContent, '', ...after].join('\n')
 }
+
+// ---------------------------------------------------------------------------
+// Ignored-package guard
+// ---------------------------------------------------------------------------
+
+/** A single package bump declared in a changeset's front-matter. */
+export interface PackageBump {
+  name: string
+  bump: string
+}
+
+/**
+ * Parse the package bumps from a single changeset file's contents.
+ *
+ * Changeset front-matter looks like:
+ *
+ *   ---
+ *   "@agent-facets/protocol": patch
+ *   "agent-facets": minor
+ *   ---
+ *   Summary text...
+ *
+ * Returns one entry per quoted `"name": bump` line inside the leading
+ * front-matter block. Package names without surrounding quotes, or content
+ * outside the front-matter block, are ignored. The bump value is captured
+ * verbatim (e.g. `patch`, `minor`, `major`) for diagnostic reporting; this
+ * guard does not interpret it.
+ */
+export function parseChangesetBumps(content: string): PackageBump[] {
+  const lines = content.split('\n')
+
+  // Locate the front-matter block delimited by the first two `---` fences.
+  let openIdx = -1
+  let closeIdx = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]?.trim() === '---') {
+      if (openIdx === -1) {
+        openIdx = i
+      } else {
+        closeIdx = i
+        break
+      }
+    }
+  }
+
+  if (openIdx === -1 || closeIdx === -1) return []
+
+  const bumps: PackageBump[] = []
+  const lineRe = /^\s*"([^"]+)"\s*:\s*(\S+)\s*$/
+  for (let i = openIdx + 1; i < closeIdx; i++) {
+    const match = (lines[i] ?? '').match(lineRe)
+    if (match?.[1] && match[2]) {
+      bumps.push({ name: match[1], bump: match[2] })
+    }
+  }
+
+  return bumps
+}
+
+/** A pending changeset together with the bumps it declares. */
+export interface ParsedChangeset {
+  file: string
+  bumps: PackageBump[]
+}
+
+/**
+ * A forbidden bump found in a pending changeset.
+ *
+ * `reason` discriminates why the bump is illegal:
+ * - `ignored`  — the package exists in the workspace but is listed in
+ *   `.changeset/config.json` `ignore`; it is never released, and bumping it
+ *   breaks the release/deploy pipeline.
+ * - `unknown`  — the package is not a workspace package at all (a fake or
+ *   misnamed entry, e.g. from a typo in the Changesets UI). Versioning it
+ *   would fail outright.
+ */
+export interface ForbiddenBump {
+  file: string
+  name: string
+  bump: string
+  reason: 'ignored' | 'unknown'
+}
+
+/**
+ * Result of scanning pending changesets for forbidden package bumps.
+ *
+ * `ok: false` carries the structured violations so a caller (e.g. a test)
+ * can render a clear failure without parsing a message string. Failure here
+ * is part of the contract — a guard that finds a forbidden bump — not an
+ * exceptional condition, so it is modeled as data rather than a thrown error.
+ */
+export type ForbiddenBumpScanResult = { ok: true } | { ok: false; violations: ForbiddenBump[] }
+
+/**
+ * Scan parsed pending changesets for any bump that targets a package which
+ * either (a) is listed in the changesets `ignore` array, or (b) is not a
+ * known workspace package at all. Pure: callers supply the already-parsed
+ * changesets, the ignore list (from `.changeset/config.json`), and the set
+ * of valid workspace package names (from `loadWorkspacePackages()`).
+ *
+ * `ignore` takes precedence over `knownPackages`: an ignored package is a
+ * real workspace package, so it is classified as `ignored`, not `unknown`.
+ */
+export function findForbiddenBumps(
+  changesets: ParsedChangeset[],
+  ignore: string[],
+  knownPackages: string[],
+): ForbiddenBumpScanResult {
+  const ignored = new Set(ignore)
+  const known = new Set(knownPackages)
+  const violations: ForbiddenBump[] = []
+
+  for (const changeset of changesets) {
+    for (const { name, bump } of changeset.bumps) {
+      if (ignored.has(name)) {
+        violations.push({ file: changeset.file, name, bump, reason: 'ignored' })
+      } else if (!known.has(name)) {
+        violations.push({ file: changeset.file, name, bump, reason: 'unknown' })
+      }
+    }
+  }
+
+  return violations.length === 0 ? { ok: true } : { ok: false, violations }
+}
+
+/**
+ * Render a forbidden-bump scan failure as a human-readable, multi-line
+ * message for surfacing in CI / test output. Groups violations by reason so
+ * the operator sees the two distinct failure classes separately.
+ */
+export function formatForbiddenBumps(violations: ForbiddenBump[]): string {
+  const sections: string[] = []
+
+  const ignored = violations.filter((v) => v.reason === 'ignored')
+  if (ignored.length > 0) {
+    sections.push(
+      'Changeset(s) bump packages listed in `.changeset/config.json` `ignore`. ' +
+        'These packages are never released and bumping them breaks the release/deploy pipeline. ' +
+        'Remove the offending package(s) from the changeset(s):',
+      ...ignored.map((v) => `  - ${v.file}: "${v.name}": ${v.bump}`),
+    )
+  }
+
+  const unknown = violations.filter((v) => v.reason === 'unknown')
+  if (unknown.length > 0) {
+    if (sections.length > 0) sections.push('')
+    sections.push(
+      'Changeset(s) bump packages that are not in the workspace (fake or misnamed). ' +
+        'Fix the package name(s) in the changeset(s):',
+      ...unknown.map((v) => `  - ${v.file}: "${v.name}": ${v.bump}`),
+    )
+  }
+
+  return sections.join('\n')
+}

--- a/turbo.json
+++ b/turbo.json
@@ -42,7 +42,7 @@
       ]
     },
     "//#test:scripts": {
-      "inputs": ["scripts/**"],
+      "inputs": ["scripts/**", ".changeset/**"],
       "outputs": ["$TURBO_ROOT$/test-results/scripts-junit.xml"]
     },
     "//#types": {


### PR DESCRIPTION
### Why

The Changesets UI can silently add a bump for a package listed in the `ignore` array, or for a package name that doesn't exist in the workspace at all (e.g. a typo). An ignored bump is silently dropped by `changeset version` so the change never ships; an unknown package causes `changeset version` to fail outright. Neither is caught by `changeset status`, which exits 0 and reports "NO packages to be bumped" when only ignored packages are bumped.

### Details

Adds `parseChangesetBumps`, `findForbiddenBumps`, and `formatForbiddenBumps` to `scripts/lib/changesets.ts`. Together they parse the front-matter of every pending `.changeset/*.md` file, cross-reference the bump targets against the `ignore` list from `.changeset/config.json` and the real workspace package names from `loadWorkspacePackages()`, and return a structured violation list grouped into `ignored` vs `unknown` classes.

A repository-level test (`repository changeset guard` in `scripts/lib/changesets.test.ts`) wires these functions against the actual repo state so `bun check` fails with a per-file violation list if any pending changeset bumps an ignored or unknown package. `ignore` takes precedence over the workspace set, so a package that is both ignored and real classifies as `ignored` rather than `unknown`.

`turbo.json`'s `//#test:scripts` task now includes `.changeset/**` in its inputs so adding or editing a changeset reliably invalidates the Turbo cache and reruns the guard.

`@agent-facets/engine` is also added to the workspace-only package list in the README.

### Verification

CI — the new unit tests cover `parseChangesetBumps` and `findForbiddenBumps` exhaustively, including the precedence edge case, and the repository guard runs against the live changeset directory on every `bun check` invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repository-wide safety check for changesets that blocks updates to ignored or unknown packages.
  * Improved change detection so changeset edits now trigger the relevant validation automatically.

* **Documentation**
  * Clarified which helper packages are private and not published.
  * Added guidance on how the new changeset guard works and how violations are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->