### PR TITLE
Ignore Facet Adapter target directories in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ lefthook-local.yml
 mise.local.toml
 .DS_Store
 
+# Facet Adapter targets
+.agents/
+.claude/
+.codex/
+.opencode/
+
 .env
 
 *.bun-build


### PR DESCRIPTION
### Why

AI agent tool directories (`.agents/`, `.claude/`, `.codex/`, `.opencode/`) generated by Facet Adapter targets should not be tracked in version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files to exclude additional local tool directories, helping keep generated or workspace-specific files out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->