### PR TITLE
Fix `parseChangesetBumps` to require leading front-matter, support single-quoted keys, and expand `test:scripts` turbo inputs

### DIFF
--- a/scripts/lib/changesets.test.ts
+++ b/scripts/lib/changesets.test.ts
@@ -968,6 +968,52 @@ describe('parseChangesetBumps', () => {
     `
     expect(parseChangesetBumps(content)).toEqual([{ name: 'agent-facets', bump: 'major' }])
   })
+
+  test('allows leading blank lines before the front-matter', () => {
+    const content = '\n\n---\n"agent-facets": patch\n---\n\nBody'
+    expect(parseChangesetBumps(content)).toEqual([{ name: 'agent-facets', bump: 'patch' }])
+  })
+
+  test('ignores prose before a later thematic break (no leading front-matter)', () => {
+    const content = dedent`
+      Some intro prose that is not front-matter.
+
+      ---
+      "agent-facets": patch
+      ---
+    `
+    expect(parseChangesetBumps(content)).toEqual([])
+  })
+
+  test('returns empty array when the closing fence is missing', () => {
+    const content = dedent`
+      ---
+      "agent-facets": patch
+    `
+    expect(parseChangesetBumps(content)).toEqual([])
+  })
+
+  test('parses single-quoted package keys', () => {
+    const content = dedent`
+      ---
+      '@agent-facets/engine': patch
+      ---
+    `
+    expect(parseChangesetBumps(content)).toEqual([{ name: '@agent-facets/engine', bump: 'patch' }])
+  })
+
+  test('parses a mix of single- and double-quoted keys', () => {
+    const content = dedent`
+      ---
+      '@agent-facets/engine': minor
+      "agent-facets": patch
+      ---
+    `
+    expect(parseChangesetBumps(content)).toEqual([
+      { name: '@agent-facets/engine', bump: 'minor' },
+      { name: 'agent-facets', bump: 'patch' },
+    ])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1042,8 +1088,14 @@ describe('findForbiddenBumps', () => {
       { file: 'fake.md', name: '@agent-facets/nope', bump: 'major', reason: 'unknown' },
     ])
   })
+})
 
-  test('formatForbiddenBumps renders both classes with distinct guidance', () => {
+// ---------------------------------------------------------------------------
+// formatForbiddenBumps
+// ---------------------------------------------------------------------------
+
+describe('formatForbiddenBumps', () => {
+  test('renders both classes with distinct guidance', () => {
     const message = formatForbiddenBumps([
       { file: 'a.md', name: '@agent-facets/engine', bump: 'patch', reason: 'ignored' },
       { file: 'b.md', name: '@agent-facets/fake', bump: 'minor', reason: 'unknown' },

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -461,37 +461,45 @@ export interface PackageBump {
  *   ---
  *   Summary text...
  *
- * Returns one entry per quoted `"name": bump` line inside the leading
- * front-matter block. Package names without surrounding quotes, or content
- * outside the front-matter block, are ignored. The bump value is captured
- * verbatim (e.g. `patch`, `minor`, `major`) for diagnostic reporting; this
- * guard does not interpret it.
+ * Returns one entry per quoted `"name": bump` (or `'name': bump`) line inside
+ * the leading front-matter block. The block must be the first non-empty
+ * content in the file: the first non-blank line has to be a `---` fence, and a
+ * matching closing `---` fence must follow. Content with prose before the
+ * front-matter, or with no opening/closing fence, yields no entries. Lines
+ * with unquoted keys, or content outside the front-matter block, are ignored.
+ * Both single- and double-quoted package keys are accepted (Changesets and
+ * YAML allow either). The bump value is captured verbatim (e.g. `patch`,
+ * `minor`, `major`) for diagnostic reporting; this guard does not interpret it.
  */
 export function parseChangesetBumps(content: string): PackageBump[] {
   const lines = content.split('\n')
 
-  // Locate the front-matter block delimited by the first two `---` fences.
-  let openIdx = -1
+  // The front-matter must lead the file: the first non-blank line has to be
+  // the opening `---` fence. Anything else (prose, a later thematic break)
+  // means there is no leading front-matter block to parse.
+  const openIdx = lines.findIndex((line) => line.trim() !== '')
+  if (openIdx === -1 || lines[openIdx]?.trim() !== '---') return []
+
+  // Find the closing `---` fence after the opening one.
   let closeIdx = -1
-  for (let i = 0; i < lines.length; i++) {
+  for (let i = openIdx + 1; i < lines.length; i++) {
     if (lines[i]?.trim() === '---') {
-      if (openIdx === -1) {
-        openIdx = i
-      } else {
-        closeIdx = i
-        break
-      }
+      closeIdx = i
+      break
     }
   }
-
-  if (openIdx === -1 || closeIdx === -1) return []
+  if (closeIdx === -1) return []
 
   const bumps: PackageBump[] = []
-  const lineRe = /^\s*"([^"]+)"\s*:\s*(\S+)\s*$/
+  // Accept either single- or double-quoted keys: "name": bump | 'name': bump.
+  const lineRe = /^\s*"([^"]+)"\s*:\s*(\S+)\s*$|^\s*'([^']+)'\s*:\s*(\S+)\s*$/
   for (let i = openIdx + 1; i < closeIdx; i++) {
     const match = (lines[i] ?? '').match(lineRe)
-    if (match?.[1] && match[2]) {
-      bumps.push({ name: match[1], bump: match[2] })
+    if (!match) continue
+    const name = match[1] ?? match[3]
+    const bump = match[2] ?? match[4]
+    if (name && bump) {
+      bumps.push({ name, bump })
     }
   }
 

--- a/turbo.json
+++ b/turbo.json
@@ -42,7 +42,13 @@
       ]
     },
     "//#test:scripts": {
-      "inputs": ["scripts/**", ".changeset/**"],
+      "inputs": [
+        "scripts/**",
+        ".changeset/**",
+        "package.json",
+        "packages/*/package.json",
+        "packages/adapters/*/package.json"
+      ],
       "outputs": ["$TURBO_ROOT$/test-results/scripts-junit.xml"]
     },
     "//#types": {


### PR DESCRIPTION
### Why

`parseChangesetBumps` had two correctness gaps: it accepted front-matter blocks that appeared anywhere in a file (not just at the top), and it only recognised double-quoted package keys, silently dropping scoped packages written with single quotes (e.g. `'@scope/pkg': patch`).

### Details

The opening `---` fence is now required to be the first non-blank line in the file. If any prose appears before it, the function returns an empty array rather than matching a later thematic break as front-matter. A missing closing fence also returns an empty array.

The line regex is extended to match both single- and double-quoted keys, with the capture groups unified so the rest of the parsing logic stays the same.

`formatForbiddenBumps` tests are moved into their own `describe` block to match the structure used by the rest of the test file.

The Turbo `test:scripts` task inputs are expanded to include root and per-package `package.json` files so that cache invalidation fires correctly when package metadata changes.

### Verification

New unit tests cover: leading blank lines before front-matter, prose before a later thematic break, a missing closing fence, single-quoted keys, and a mix of single- and double-quoted keys. CI runs the full test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Changeset parsing so only properly formatted front-matter is accepted, avoiding false matches in regular text.
  * Added support for both single-quoted and double-quoted package names in changeset entries.

* **Tests**
  * Expanded coverage for edge cases around front-matter formatting and quote styles.
  * Updated task inputs so relevant package manifest changes are included in script-related checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->