### PR TITLE
Isolate prod and staging into separate AWS accounts with dedicated profiles and CI-only `main` guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,22 +15,58 @@
 
 ## SST
 
-This repo hosts `agentfacets.io` via SST. The SST app name is `agent-facets`. The AWS
-account is shared with the sibling `facet-cafe` repo.
+This repo hosts `agentfacets.io` via SST. The SST app name is `agent-facets`.
+
+Production and non-production stages live in **separate AWS accounts** so a
+developer machine can never mutate production:
+
+| Stage          | Domain                                | AWS account             | Who deploys     |
+|----------------|---------------------------------------|-------------------------|-----------------|
+| `main`         | `agentfacets.io` (apex)               | dedicated prod `agentfacets.io` (445459853351) | CircleCI only   |
+| `${stage}`     | `${stage}.staging.agentfacets.io`     | `agent-facets-staging`  | developers      |
+| `${user}`      | `${user}.staging.agentfacets.io`      | `agent-facets-staging`  | developers      |
 
 | Key            | Value                                              |
 |----------------|----------------------------------------------------|
 | App name       | `agent-facets`                                     |
-| AWS profile    | `facet-cafe` (shared account)                      |
+| Prod account   | `445459853351` (`agentfacets.io`) — `main`/apex only; profile `agent-facets-prod` |
+| Staging account| `705557196199` (`staging.agentfacets.io`) — all non-main; profile `agent-facets-staging` |
+| Local profile  | `agent-facets-staging` (SSO, `ex-machina` session) |
 | Node runtime   | `nodejs24.x` (matches `mise.toml` — single source) |
-| Main stage     | `main` → `agentfacets.io` (apex)                   |
-| Preview stage  | `${stage}` → `${stage}.agentfacets.io`              |
-| Personal stage | `${user}` → `${user}.agentfacets.io`                |
+
+> **Do not use the shared `facet-cafe` profile name** in this repo's tooling.
+> It lives in a shared `~/.aws/config` and the sibling `facet.cafe` repo
+> repoints it (e.g. to its own staging account). Use the repo-owned
+> `agent-facets-prod` / `agent-facets-staging` profiles, both keyed by account ID.
+> Production formerly shared the `facet.cafe` account (`726911960883`); it now
+> has its own dedicated `agentfacets.io` account (`445459853351`). The
+> `agent-facets-legacy-prod` profile (→ `726911960883`) exists only for
+> maintenance of any residual shared-account resources.
+
+`main` is deployed **only by CircleCI** (via OIDC; no AWS profile).
+`sst.config.ts` throws if you try to operate on the `main` stage locally, and
+the `main` stage is permanently `protect`ed and its resources `retain`ed so
+removing it requires a deliberate edit to `sst.config.ts`. The staging subdomain
+`staging.agentfacets.io` is a Route53
+hosted zone in the staging account, delegated via an `NS` record from the prod
+`agentfacets.io` zone.
 
 ### Prerequisites
 
-- **mise** must be active. `mise.development.toml` sets `AWS_PROFILE=facet-cafe` for
-  local development. There is no `.env.local`.
+- **mise** must be active. `mise.development.toml` sets
+  `AWS_PROFILE=agent-facets-staging` for local development. There is no `.env.local`.
+- You need SSO access to the `agent-facets-staging` account. Add this profile to
+  `~/.aws/config` (the `ex-machina` sso-session block already exists) and run
+  `aws sso login --sso-session ex-machina`:
+
+  ```ini
+  [profile agent-facets-staging]
+  sso_session = ex-machina
+  sso_account_id = 705557196199
+  sso_role_name = Admin
+  region = us-east-1
+  ```
+
 - `bun install` runs `sst install` automatically (skipped in CI).
 
 ### Commands
@@ -63,10 +99,15 @@ Manual deploys are still supported for ad-hoc stages via the `bun sst deploy
 
 ### DNS
 
-- `agentfacets.io` A → SST-managed CloudFront (apex).
+- `agentfacets.io` A → SST-managed CloudFront (apex). Zone lives in the
+  dedicated prod `agentfacets.io` account (`445459853351`).
 - `www.agentfacets.io` → 301 to apex via SST `domain.redirects`.
 - `docs.agentfacets.io` CNAME → Mintlify custom-domain target (managed by SST in
   `infra/dns.ts`).
+- `staging.agentfacets.io` → delegated (`NS`) from the prod zone to a hosted zone
+  in the `agent-facets-staging` account. All non-`main` stages get
+  `${stage}.staging.agentfacets.io` records created there by SST, so developer
+  deploys never write to the prod zone.
 
 </SST>
 

--- a/infra/helpers/domain.ts
+++ b/infra/helpers/domain.ts
@@ -1,3 +1,8 @@
-export const SITE_DOMAIN = $app.stage === 'main' ? 'agentfacets.io' : `${$app.stage}.agentfacets.io`
+// `main` is the production stage; it owns the apex `agentfacets.io` and lives in
+// the production AWS account (deployed only via CircleCI). All other stages are
+// non-production and live in the dedicated staging AWS account under the
+// delegated `staging.agentfacets.io` hosted zone, so a local developer deploy
+// can never touch production DNS or production resources.
+export const SITE_DOMAIN = $app.stage === 'main' ? 'agentfacets.io' : `${$app.stage}.staging.agentfacets.io`
 
 export const SITE_REDIRECTS = $app.stage === 'main' ? ['www.agentfacets.io'] : undefined

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -2,4 +2,8 @@
 circleci = "0.1.34950"
 
 [env]
-AWS_PROFILE = "facet-cafe"
+# Local development targets the dedicated staging AWS account. Non-`main` SST
+# stages deploy under staging.agentfacets.io in this account, so a developer
+# machine can never touch production (`main`/apex) resources. Production
+# (`main`) is deployed only by CircleCI. See AGENTS.md → SST.
+AWS_PROFILE = "agent-facets-staging"

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -2,6 +2,15 @@
 
 Continuous deployment (CD) of the SST `main` stage on every push to `main`.
 
+> **Account isolation:** `main` is the only stage that deploys to the dedicated
+> production AWS account (`agentfacets.io`, `445459853351`), and it is deployed
+> **only** by this CI pipeline via
+> OIDC (`AWS_ROLE_ARN`). All non-`main` stages deploy from developer machines to
+> the separate `agent-facets-staging` account under `staging.agentfacets.io`.
+> `sst.config.ts` refuses to run `main` locally, and the `main` stage is
+> permanently protected and retained. See AGENTS.md → SST for the full
+> account/stage matrix.
+
 ## Flow
 
 ```

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,15 +1,56 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
+// Production (`main`) and non-production stages live in separate AWS accounts:
+//   - `main`     → dedicated prod account 445459853351 (agentfacets.io), deployed
+//                  ONLY by CircleCI (apex agentfacets.io).
+//   - all others → `agent-facets-staging` account, under staging.agentfacets.io.
+//
+// `main` is CI-only. CI is detected via the `CI` env var (set by CircleCI);
+// any local attempt to operate on `main` throws. The `main` stage is also
+// permanently protected and its resources retained, so removing it requires a
+// deliberate edit to this file.
+// Dedicated, repo-owned profile name. We deliberately do NOT reuse the shared
+// `facet-cafe` profile name: it lives in a shared ~/.aws/config and the sibling
+// `facet.cafe` repo repoints it (e.g. to its own staging account), so depending
+// on that name would silently target the wrong account. `agent-facets-staging`
+// → staging account 705557196199 (staging.agentfacets.io). The dedicated prod
+// account 445459853351 (agentfacets.io) is never selected by a profile here:
+// `main` is CI-only and CI authenticates via OIDC (no profile). Production no
+// longer shares the `facet.cafe` account (726911960883); that account hosts only
+// the sibling `facet.cafe` app now.
+const STAGING_PROFILE = 'agent-facets-staging'
+
+function resolveAwsProfile(stage: string): string | undefined {
+  // In CI, credentials come from the environment (OIDC); never pin a profile.
+  if (process.env.CI) return undefined
+
+  // `main` is CI-only; any local invocation throws.
+  if (stage === 'main') {
+    throw new Error('Refusing to operate on the `main` stage locally. `main` deploys run ' + 'through CircleCI only.')
+  }
+
+  // An explicit AWS_PROFILE always wins for non-main stages. This lets an
+  // operator target a specific staging account for maintenance (e.g. tearing
+  // down an old stage) without the stage→account default getting in the way.
+  if (process.env.AWS_PROFILE) return process.env.AWS_PROFILE
+
+  // Non-main stages otherwise target the staging account.
+  return STAGING_PROFILE
+}
+
 export default $config({
   app(input) {
+    const isMain = input?.stage === 'main'
     return {
       name: 'agent-facets',
-      removal: input?.stage === 'main' ? 'retain' : 'remove',
-      protect: ['main'].includes(input?.stage),
+      // `main` resources are retained on destroy and the stage is protected
+      // against removal.
+      removal: isMain ? 'retain' : 'remove',
+      protect: isMain,
       home: 'aws',
       providers: {
         aws: {
-          profile: process.env.SST_LIVE ? 'facet-cafe' : undefined,
+          profile: resolveAwsProfile(input?.stage),
           version: '7.20.0',
         },
       },


### PR DESCRIPTION
### Why

Production was previously deployed to a shared AWS account (`facet-cafe`, `726911960883`) alongside the sibling `facet.cafe` app. This created a risk of developer machines accidentally mutating production resources, and the shared profile name could be silently repointed by the sibling repo's tooling. Production now lives in its own dedicated AWS account (`agentfacets.io`, `445459853351`), and all non-`main` stages deploy to a separate staging account (`agent-facets-staging`, `705557196199`).

### Details

- Non-`main` stages now deploy under `${stage}.staging.agentfacets.io` instead of `${stage}.agentfacets.io`. The `staging.agentfacets.io` subdomain is a Route 53 hosted zone in the staging account, delegated via an `NS` record from the prod zone, so developer deploys never write to the production DNS zone.
- `sst.config.ts` introduces `resolveAwsProfile`, which throws if anyone attempts to operate on the `main` stage locally. In CI, no profile is pinned (credentials come via OIDC). For all other local stages, it defaults to `agent-facets-staging` unless `AWS_PROFILE` is explicitly set.
- The `main` stage remains permanently `protect`ed with `retain` removal, requiring a deliberate edit to `sst.config.ts` to remove it.
- `mise.development.toml` now sets `AWS_PROFILE=agent-facets-staging` instead of `facet-cafe`.
- The `agent-facets-legacy-prod` profile (pointing to `726911960883`) exists only for maintenance of any residual shared-account resources.
- Developers need SSO access to the `agent-facets-staging` account and must add the `agent-facets-staging` profile to `~/.aws/config` as documented in `AGENTS.md`.

### Verification

CI deploys `main` via OIDC to the production account. Developer staging deploys can be verified by running `bun sst deploy` with the `agent-facets-staging` profile and confirming the stage resolves under `${stage}.staging.agentfacets.io`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Separated production and staging deployments, with production now limited to CI and developer deployments using a dedicated staging environment.
  * Non-production sites now use staging subdomains, keeping them distinct from the live site.

* **Bug Fixes**
  * Prevented accidental local deployment of the production environment.
  * Improved DNS routing guidance for `www`, `docs`, and staged environments.

* **Documentation**
  * Updated setup and deployment instructions to reflect the new account and DNS structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->