### PR TITLE
Add `@julian/address-pr-feedback` at `0.2.0`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,7 @@
     "viper-plans": "0.2.1",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "3.1.2"
+    "@julian/openspec-adversary": "3.1.2",
+    "@julian/address-pr-feedback": "0.2.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -1,6 +1,31 @@
 {
   "lockfileVersion": 1,
   "facets": {
+    "@julian/address-pr-feedback": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.facet.cafe"
+      },
+      "version": "0.2.0",
+      "integrity": "sha256:85645173867ed685a5d0aa3965390246ac1c99c87c655622766307b43398234a",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "address-pr-feedback-rules"
+        },
+        {
+          "scope": "project",
+          "type": "agent",
+          "name": "address-pr-feedback"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "address-pr-feedback"
+        }
+      ]
+    },
     "@julian/openspec-adversary": {
       "source": {
         "kind": "registry",


### PR DESCRIPTION
### Why

Adds the `@julian/address-pr-feedback` facet to enable tooling for addressing pull request feedback.

### Details

Installs version `0.2.0` of `@julian/address-pr-feedback`, which provides an `address-pr-feedback-rules` skill and an `address-pr-feedback` command at the project scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to include a new facet entry, expanding support for an additional packaged component.
  * Kept the existing facet entry unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->