### PR TITLE
Tighten `main`-stage guard to key off `CIRCLECI` var and refuse non-staging `AWS_PROFILE` locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ developer machine can never mutate production:
 | Key            | Value                                              |
 |----------------|----------------------------------------------------|
 | App name       | `agent-facets`                                     |
-| Prod account   | `445459853351` (`agentfacets.io`) — `main`/apex only; profile `agent-facets-prod` |
+| Prod account   | `445459853351` (`agentfacets.io`) — `main`/apex only. SST never selects a profile for `main` (CircleCI deploys via OIDC; local `main` is refused). The `agent-facets-prod` profile is for manual AWS CLI operations against this account only. |
 | Staging account| `705557196199` (`staging.agentfacets.io`) — all non-main; profile `agent-facets-staging` |
 | Local profile  | `agent-facets-staging` (SSO, `ex-machina` session) |
 | Node runtime   | `nodejs24.x` (matches `mise.toml` — single source) |

--- a/facets.json
+++ b/facets.json
@@ -3,6 +3,7 @@
     "viper-plans": "0.2.1",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "3.1.2"
+    "@julian/openspec-adversary": "3.1.2",
+    "@julian/address-pr-feedback": "0.2.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -1,6 +1,31 @@
 {
   "lockfileVersion": 1,
   "facets": {
+    "@julian/address-pr-feedback": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.facet.cafe"
+      },
+      "version": "0.2.0",
+      "integrity": "sha256:85645173867ed685a5d0aa3965390246ac1c99c87c655622766307b43398234a",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "address-pr-feedback-rules"
+        },
+        {
+          "scope": "project",
+          "type": "agent",
+          "name": "address-pr-feedback"
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "address-pr-feedback"
+        }
+      ]
+    },
     "@julian/openspec-adversary": {
       "source": {
         "kind": "registry",

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -5,8 +5,9 @@
 //                  ONLY by CircleCI (apex agentfacets.io).
 //   - all others → `agent-facets-staging` account, under staging.agentfacets.io.
 //
-// `main` is CI-only. CI is detected via the `CI` env var (set by CircleCI);
-// any local attempt to operate on `main` throws. The `main` stage is also
+// `main` is CI-only. CircleCI is detected via the `CIRCLECI` env var (set only
+// by CircleCI, unlike the broad `CI` var that any CI provider or local shell may
+// set); any local attempt to operate on `main` throws. The `main` stage is also
 // permanently protected and its resources retained, so removing it requires a
 // deliberate edit to this file.
 // Dedicated, repo-owned profile name. We deliberately do NOT reuse the shared
@@ -20,27 +21,46 @@
 // the sibling `facet.cafe` app now.
 const STAGING_PROFILE = 'agent-facets-staging'
 
+// CircleCI sets `CIRCLECI=true`. We key the OIDC/no-profile branch off this
+// specific signal rather than the broad `CI` var, which any CI provider or a
+// local shell can set — that breadth would let a non-CircleCI run skip the
+// `main` guard below.
+const IS_CIRCLECI = process.env.CIRCLECI === 'true'
+
 function resolveAwsProfile(stage: string): string | undefined {
-  // In CI, credentials come from the environment (OIDC); never pin a profile.
-  if (process.env.CI) return undefined
+  // In CircleCI, credentials come from the environment (OIDC); never pin a profile.
+  if (IS_CIRCLECI) return undefined
 
   // `main` is CI-only; any local invocation throws.
   if (stage === 'main') {
     throw new Error('Refusing to operate on the `main` stage locally. `main` deploys run ' + 'through CircleCI only.')
   }
 
-  // An explicit AWS_PROFILE always wins for non-main stages. This lets an
-  // operator target a specific staging account for maintenance (e.g. tearing
-  // down an old stage) without the stage→account default getting in the way.
-  if (process.env.AWS_PROFILE) return process.env.AWS_PROFILE
+  // For non-`main` stages, an explicit AWS_PROFILE is honored ONLY if it is the
+  // staging profile. Any other value (e.g. a prod profile lingering in the
+  // shell) is refused, so a developer machine can never target a non-staging
+  // account. This is a footgun guard; the real isolation is the account/SSO
+  // boundary.
+  if (process.env.AWS_PROFILE && process.env.AWS_PROFILE !== STAGING_PROFILE) {
+    throw new Error(
+      `Refusing to use AWS profile "${process.env.AWS_PROFILE}" for a non-\`main\` stage. ` +
+        `Only "${STAGING_PROFILE}" is permitted; edit sst.config.ts if you genuinely need another.`,
+    )
+  }
 
-  // Non-main stages otherwise target the staging account.
-  return STAGING_PROFILE
+  // Non-main stages target the staging account.
+  return process.env.AWS_PROFILE ?? STAGING_PROFILE
 }
 
 export default $config({
   app(input) {
-    const isMain = input?.stage === 'main'
+    // A stage must always be resolved; an absent stage is an illegal state, so
+    // fail loud rather than silently defaulting it.
+    const stage = input?.stage
+    if (!stage) {
+      throw new Error('No SST stage resolved. A stage is always required; refusing to continue.')
+    }
+    const isMain = stage === 'main'
     return {
       name: 'agent-facets',
       // `main` resources are retained on destroy and the stage is protected
@@ -50,7 +70,7 @@ export default $config({
       home: 'aws',
       providers: {
         aws: {
-          profile: resolveAwsProfile(input?.stage),
+          profile: resolveAwsProfile(stage),
           version: '7.20.0',
         },
       },


### PR DESCRIPTION
### Why

The previous guard against local `main` deployments keyed off the `CI` environment variable, which is too broad — any CI provider, and even some local shell configurations, can set `CI=true`. This meant the OIDC/no-profile branch could be triggered outside of CircleCI, undermining the isolation guarantee.

Additionally, a non-staging `AWS_PROFILE` value in a developer's shell could previously be passed through silently for non-`main` stages, allowing a local machine to potentially target the wrong account.

### Details

- Switches the CircleCI detection signal from `CI` to `CIRCLECI`, which is set exclusively by CircleCI. This ensures the OIDC credential path and the `main` guard are only bypassed in genuine CircleCI runs.
- Tightens the `AWS_PROFILE` handling for non-`main` stages: any profile other than `STAGING_PROFILE` is now explicitly refused with a descriptive error, rather than silently accepted. A developer with a prod profile lingering in their shell will get a loud failure instead of an accidental prod operation.
- Adds an explicit guard against an unresolved SST stage, failing loudly rather than silently defaulting.
- Updates `AGENTS.md` to clarify that `agent-facets-prod` is for manual AWS CLI operations only, and that SST itself never selects that profile — `main` deploys are handled entirely via CircleCI OIDC.

### Verification

CI — the `main` stage is only ever deployed through CircleCI, and the new `CIRCLECI`-specific check will behave identically there while closing the gap locally.