### PR TITLE
Bump `@julian/address-pr-feedback` to `0.2.3`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -4,6 +4,6 @@
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
     "@julian/openspec-adversary": "3.1.2",
-    "@julian/address-pr-feedback": "0.2.0"
+    "@julian/address-pr-feedback": "0.2.3"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.2.0",
-      "integrity": "sha256:85645173867ed685a5d0aa3965390246ac1c99c87c655622766307b43398234a",
+      "version": "0.2.3",
+      "integrity": "sha256:abdf9e262c2b139cf9d11f73cbc44340be477502d8913af011e35755eaf18b26",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Bumps `@julian/address-pr-feedback` from `0.2.0` to `0.2.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a package version to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->