### PR TITLE
Bump `@julian/address-pr-feedback` to `0.2.4`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -4,6 +4,6 @@
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
     "@julian/openspec-adversary": "3.1.2",
-    "@julian/address-pr-feedback": "0.2.3"
+    "@julian/address-pr-feedback": "0.2.4"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "0.2.3",
-      "integrity": "sha256:abdf9e262c2b139cf9d11f73cbc44340be477502d8913af011e35755eaf18b26",
+      "version": "0.2.4",
+      "integrity": "sha256:6ab722715aff1ae1182137d873b9e124b1f28139234245f9f362fbabd9f6fa01",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Bumps `@julian/address-pr-feedback` from `0.2.3` to `0.2.4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version for improved reliability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->