### PR TITLE
Preserve per-asset `adapters` config through `buildManifest` edit round-trips

### DIFF
--- a/.changeset/social-sites-follow.md
+++ b/.changeset/social-sites-follow.md
@@ -1,0 +1,7 @@
+---
+"agent-facets": minor
+---
+
+This fixes a bug with `facet edit` where configuration values outside the description and name were stripped for assets.
+
+They now should survive `facet edit` correctly

--- a/.changeset/social-sites-follow.md
+++ b/.changeset/social-sites-follow.md
@@ -1,5 +1,5 @@
 ---
-"agent-facets": minor
+"agent-facets": patch
 ---
 
 This fixes a bug with `facet edit` where configuration values outside the description and name were stripped for assets.

--- a/packages/cli/src/tui/views/edit/__tests__/privacy-output.test.ts
+++ b/packages/cli/src/tui/views/edit/__tests__/privacy-output.test.ts
@@ -71,3 +71,51 @@ describe('buildManifest privacy output', () => {
     expect('private' in out).toBe(false)
   })
 })
+
+describe('buildManifest adapter-config preservation', () => {
+  test('skill adapters survive an edit round-trip', () => {
+    const original = manifest({
+      skills: { cowsay: { description: 'A skill', adapters: { claude: { permission: { bash: 'ask' } } } } },
+    })
+    const out = buildManifest(original, formFrom(original))
+    expect(out.skills?.cowsay?.adapters).toEqual({ claude: { permission: { bash: 'ask' } } })
+  })
+
+  test('agent adapters survive an edit round-trip', () => {
+    const original = manifest({
+      skills: undefined,
+      agents: { reviewer: { description: 'An agent', adapters: { opencode: { model: 'gpt' } } } },
+    } as Partial<FacetManifest>)
+    const out = buildManifest(original, formFrom(original))
+    expect(out.agents?.reviewer?.adapters).toEqual({ opencode: { model: 'gpt' } })
+  })
+
+  test('command adapters survive an edit round-trip', () => {
+    const original = manifest({
+      skills: undefined,
+      commands: { deploy: { description: 'A command', adapters: { codex: { foo: 'bar' } } } },
+    } as Partial<FacetManifest>)
+    const out = buildManifest(original, formFrom(original))
+    expect(out.commands?.deploy?.adapters).toEqual({ codex: { foo: 'bar' } })
+  })
+
+  test('editable description updates while adapter config is preserved', () => {
+    const original = manifest({
+      skills: { cowsay: { description: 'old', adapters: { claude: { x: 1 } } } },
+    })
+    const form = manifestToFormState(original)
+    form.assets.skill.descriptions.cowsay = 'new'
+    const out = buildManifest(original, form)
+    expect(out.skills?.cowsay?.description).toBe('new')
+    expect(out.skills?.cowsay?.adapters).toEqual({ claude: { x: 1 } })
+  })
+
+  test('newly added asset has no adapters block', () => {
+    const original = manifest()
+    const form = manifestToFormState(original)
+    form.assets.skill.items.push('brand-new')
+    form.assets.skill.descriptions['brand-new'] = 'fresh'
+    const out = buildManifest(original, form)
+    expect(out.skills?.['brand-new']).toEqual({ description: 'fresh' })
+  })
+})

--- a/packages/cli/src/tui/views/edit/use-edit-session.ts
+++ b/packages/cli/src/tui/views/edit/use-edit-session.ts
@@ -40,9 +40,19 @@ export function buildManifest(original: FacetManifest, form: FormState): FacetMa
   ][]) {
     const items = form.assets[formKey].items
     if (items.length > 0) {
-      const section: Record<string, { description: string }> = {}
+      // Start each descriptor from the original so descriptor-level metadata
+      // (notably per-asset `adapters` front-matter, which the form never
+      // surfaces) survives the edit round-trip. Only `description` — the one
+      // field the form edits — is overwritten. New assets have no original
+      // descriptor, so they collapse to `{ description }`.
+      const originalSection = original[manifestKey]
+      const section: NonNullable<FacetManifest[typeof manifestKey]> = {}
       for (const name of items) {
-        section[name] = { description: form.assets[formKey].descriptions[name] ?? '' }
+        const originalDescriptor = originalSection?.[name]
+        section[name] = {
+          ...originalDescriptor,
+          description: form.assets[formKey].descriptions[name] ?? '',
+        }
       }
       manifest[manifestKey] = section
     } else {


### PR DESCRIPTION
### Why

When a manifest asset (skill, agent, or command) has per-asset `adapters` front-matter, that configuration was silently dropped whenever the manifest was rebuilt from the edit form. The form only surfaces `description`, so any fields it doesn't know about were being lost on save.

### Details

`buildManifest` now seeds each asset descriptor from the original manifest entry before applying the form's `description` on top. This means unknown fields like `adapters` are carried through unchanged. Assets that are newly added by the user have no original descriptor, so they correctly produce a minimal `{ description }` object with no extra fields.

### Verification

Five new unit tests cover the fix: adapter configs on skills, agents, and commands each survive a round-trip; a description edit updates correctly while preserving adapters; and a brand-new asset produces no spurious `adapters` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where editing facets could strip existing asset settings outside the name and description.
  * Asset configuration now remains intact after a facet edit, while description updates still apply as expected.
* **Tests**
  * Added coverage to verify that existing settings are preserved during edit round-trips and when adding new assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->