### PR TITLE
Bump `@julian/openspec-adversary` to `3.1.3`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,7 +3,7 @@
     "viper-plans": "0.2.1",
     "cowsay": "0.2.0",
     "@julian/review-openspec-design": "1.1.0",
-    "@julian/openspec-adversary": "3.1.2",
+    "@julian/openspec-adversary": "3.1.3",
     "@julian/address-pr-feedback": "0.2.4"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -31,8 +31,8 @@
         "kind": "registry",
         "registry": "https://api.facet.cafe"
       },
-      "version": "3.1.2",
-      "integrity": "sha256:af8c255844d9e24d4603de468b94e50de3712e37c7c0f758883f580619e26714",
+      "version": "3.1.3",
+      "integrity": "sha256:f0b77dbfc52c299247afe2a3ebc4d82fe4c1c60a93381342fc5816b6635389ed",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Bumps `@julian/openspec-adversary` from `3.1.2` to `3.1.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled component to a newer version, bringing the latest available improvements and compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->