### PR TITLE
Add JUnit reporters to all packages and always store CI test results

### DIFF
--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -75,6 +75,7 @@ jobs:
             - run-check
             - store_test_results:
                 path: test-results
+                when: always
     main-pipeline:
         docker:
             - image: cimg/base:current
@@ -86,6 +87,7 @@ jobs:
             - run-check
             - store_test_results:
                 path: test-results
+                when: always
             - run:
                 command: bun scripts/release/version.ts
                 name: Version Changesets

--- a/.circleci/development/jobs/check.yml
+++ b/.circleci/development/jobs/check.yml
@@ -6,3 +6,4 @@ steps:
   - run-check
   - store_test_results:
       path: test-results
+      when: always

--- a/.circleci/development/jobs/main-pipeline.yml
+++ b/.circleci/development/jobs/main-pipeline.yml
@@ -8,6 +8,7 @@ steps:
   - run-check
   - store_test_results:
       path: test-results
+      when: always
   - run:
       name: Version Changesets
       command: bun scripts/release/version.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,15 @@
 
 </CircleCI>
 
+<RunningBunCommands>
+
+Sometimes `bun` is not available in the shell. If that happens prefix the `bun`
+commands with `mise exec --` like the following: `mise exec -- bun format`.
+
+Mise will ensure you find the `bun` executable correctly.
+
+</RunningBunCommands>
+
 <SST>
 
 ## SST

--- a/packages/adapter/bunfig.toml
+++ b/packages/adapter/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../test-results/adapter-junit.xml"

--- a/packages/adapters/claude-code/bunfig.toml
+++ b/packages/adapters/claude-code/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../../test-results/adapter-claude-code-junit.xml"

--- a/packages/adapters/codex/bunfig.toml
+++ b/packages/adapters/codex/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../../test-results/adapter-codex-junit.xml"

--- a/packages/adapters/opencode/bunfig.toml
+++ b/packages/adapters/opencode/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../../test-results/adapter-opencode-junit.xml"

--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../test-results/cli-junit.xml"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,8 +17,8 @@
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
     "types": "tsc --noEmit",
-    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
-    "test:e2e": "bun run build && bun test --timeout 15000 src/__tests__/*.e2e.test.ts"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts' --reporter=junit --reporter-outfile=../../test-results/cli-junit.xml",
+    "test:e2e": "bun run build && bun test --timeout 15000 --reporter=junit --reporter-outfile=../../test-results/cli-e2e-junit.xml src/__tests__/*.e2e.test.ts"
   },
   "dependencies": {
     "@bomb.sh/args": "0.3.1",

--- a/packages/common/bunfig.toml
+++ b/packages/common/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../test-results/common-junit.xml"

--- a/packages/functions/bunfig.toml
+++ b/packages/functions/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../test-results/functions-junit.xml"

--- a/packages/landing/bunfig.toml
+++ b/packages/landing/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../test-results/landing-junit.xml"


### PR DESCRIPTION
### Why

Test results were not being stored in CircleCI when jobs failed, making it harder to diagnose failures. Additionally, several packages were missing JUnit reporter configuration, so their test results were never uploaded.

### Details

`store_test_results` in CircleCI only runs on success by default. Adding `when: always` ensures test results are collected and stored regardless of job outcome.

JUnit reporter output was moved from a `bunfig.toml` in the `cli` package to inline CLI flags in the `test` and `test:e2e` scripts, which also adds a separate output file for e2e results. New `bunfig.toml` files with JUnit reporter configuration were added for `adapter`, `claude-code`, `codex`, `opencode`, `common`, `functions`, and `landing` packages so their test results are also captured.

A note was added to `AGENTS.md` explaining that if `bun` is not available in the shell, commands should be prefixed with `mise exec --` to ensure the correct executable is found.

### Verification

CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test results are now saved more reliably in CI, even when earlier steps fail.
* **Chores**
  * Added or updated JUnit test output settings across several packages so test reports are consistently generated.
  * Improved test command settings for the CLI to better separate standard and end-to-end test runs.
* **Documentation**
  * Updated contributor guidance for running Bun commands in environments where Bun may not be directly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->