### PR TITLE
codex: install commands as skills with openai.yaml sidecar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "smol-toml": "^1.7.0",
         "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
+        "yaml": "2.9.0",
       },
     },
     "packages/adapters/opencode": {

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -25,7 +25,8 @@
     "arktype": "2.2.0",
     "smol-toml": "^1.7.0",
     "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "yaml": "2.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/codex/src/__tests__/adapter.test.ts
+++ b/packages/adapters/codex/src/__tests__/adapter.test.ts
@@ -307,12 +307,28 @@ describe('codex adapter — project-scope command I/O', () => {
     expect(result.metadata).toEqual({ name: 'plan', description: 'plan things' })
   })
 
-  test('deleteAsset removes the whole command skill directory', async () => {
+  test('deleteAsset removes the command SKILL.md, sidecar, and empty dir', async () => {
     await adapter.installAsset('project', 'command', 'plan', '# body', { name: 'plan' })
     await adapter.deleteAsset('project', 'command', 'plan')
     expect(existsSync(join(workDir, '.agents/skills/plan/SKILL.md'))).toBe(false)
     expect(existsSync(join(workDir, '.agents/skills/plan/agents/openai.yaml'))).toBe(false)
     expect(existsSync(join(workDir, '.agents/skills/plan'))).toBe(false)
+  })
+
+  test('deleting a command does not recurse into a namespaced sibling skill', async () => {
+    // Command "space" lives at .agents/skills/space/; skill "space/spec" lives at
+    // .agents/skills/space/spec/ — i.e. inside the command's directory. Deleting
+    // the command must NOT remove the sibling skill via a recursive dir delete.
+    await adapter.installAsset('project', 'command', 'space', '# cmd', { name: 'space' })
+    await adapter.installAsset('project', 'skill', 'space/spec', '# skill', { name: 'spec' })
+
+    await adapter.deleteAsset('project', 'command', 'space')
+
+    // Command's own files are gone...
+    expect(existsSync(join(workDir, '.agents/skills/space/SKILL.md'))).toBe(false)
+    expect(existsSync(join(workDir, '.agents/skills/space/agents/openai.yaml'))).toBe(false)
+    // ...but the nested skill (and the shared parent dir) survive.
+    expect(readFileSync(join(workDir, '.agents/skills/space/spec/SKILL.md'), 'utf8')).toContain('# skill')
   })
 })
 

--- a/packages/adapters/codex/src/__tests__/adapter.test.ts
+++ b/packages/adapters/codex/src/__tests__/adapter.test.ts
@@ -211,7 +211,7 @@ describe('codex adapter — project-scope agent I/O', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Project-scope I/O — commands (Markdown)
+// Project-scope I/O — commands (installed as skills + openai.yaml sidecar)
 // ---------------------------------------------------------------------------
 
 describe('codex adapter — project-scope command I/O', () => {
@@ -229,10 +229,90 @@ describe('codex adapter — project-scope command I/O', () => {
     rmSync(workDir, { recursive: true, force: true })
   })
 
-  test('command installs at .agents/commands/<name>.md', async () => {
+  test('command installs as a skill at .agents/skills/<name>/SKILL.md', async () => {
     await adapter.installAsset('project', 'command', 'viper-plans/plan', 'command body', {})
-    const path = join(workDir, '.agents/commands/viper-plans/plan.md')
+    const path = join(workDir, '.agents/skills/viper-plans/plan/SKILL.md')
     expect(readFileSync(path, 'utf8')).toBe('command body')
+    // The legacy .agents/commands/ path must no longer be written.
+    expect(existsSync(join(workDir, '.agents/commands/viper-plans/plan.md'))).toBe(false)
+  })
+
+  test('command writes SKILL.md front-matter with name + description only', async () => {
+    await adapter.installAsset('project', 'command', 'plan', '# body', {
+      name: 'plan',
+      description: 'plan things',
+    })
+    const raw = readFileSync(join(workDir, '.agents/skills/plan/SKILL.md'), 'utf8')
+    expect(raw).toContain('name: plan')
+    expect(raw).toContain('description: plan things')
+    expect(raw).toContain('# body')
+    // openai.yaml-only keys never leak into SKILL.md front-matter.
+    expect(raw).not.toContain('allow_implicit_invocation')
+    expect(raw).not.toContain('interface')
+  })
+
+  test('command writes agents/openai.yaml disabling implicit invocation', async () => {
+    await adapter.installAsset('project', 'command', 'plan', '# body', {
+      name: 'plan',
+      description: 'plan things',
+    })
+    const yamlPath = join(workDir, '.agents/skills/plan/agents/openai.yaml')
+    const yaml = readFileSync(yamlPath, 'utf8')
+    expect(yaml).toContain('allow_implicit_invocation: false')
+    expect(yaml).toContain('display_name: plan')
+    expect(yaml).toContain('short_description: plan things')
+  })
+
+  test('command passes through author interface + dependencies blocks', async () => {
+    await adapter.installAsset('project', 'command', 'plan', '# body', {
+      name: 'plan',
+      description: 'auto desc',
+      interface: {
+        display_name: 'Planner',
+        icon_small: './assets/small.svg',
+        brand_color: '#3B82F6',
+      },
+      dependencies: {
+        tools: [{ type: 'mcp', value: 'docs', url: 'https://example.com/mcp' }],
+      },
+    })
+    const yaml = readFileSync(join(workDir, '.agents/skills/plan/agents/openai.yaml'), 'utf8')
+    // Author-provided display_name wins over the auto fallback.
+    expect(yaml).toContain('display_name: Planner')
+    // Auto short_description still fills the gap the author left.
+    expect(yaml).toContain('short_description: auto desc')
+    expect(yaml).toContain('icon_small: ./assets/small.svg')
+    expect(yaml).toContain('brand_color: "#3B82F6"')
+    expect(yaml).toContain('value: docs')
+    expect(yaml).toContain('allow_implicit_invocation: false')
+  })
+
+  test('command cannot re-enable implicit invocation via author policy', async () => {
+    await adapter.installAsset('project', 'command', 'plan', '# body', {
+      name: 'plan',
+      policy: { allow_implicit_invocation: true },
+    })
+    const yaml = readFileSync(join(workDir, '.agents/skills/plan/agents/openai.yaml'), 'utf8')
+    expect(yaml).toContain('allow_implicit_invocation: false')
+    expect(yaml).not.toContain('allow_implicit_invocation: true')
+  })
+
+  test('readAsset round-trips a command body from its SKILL.md', async () => {
+    await adapter.installAsset('project', 'command', 'plan', '# body', {
+      name: 'plan',
+      description: 'plan things',
+    })
+    const result = await adapter.readAsset('project', 'command', 'plan')
+    expect(result.content.trim()).toBe('# body')
+    expect(result.metadata).toEqual({ name: 'plan', description: 'plan things' })
+  })
+
+  test('deleteAsset removes the whole command skill directory', async () => {
+    await adapter.installAsset('project', 'command', 'plan', '# body', { name: 'plan' })
+    await adapter.deleteAsset('project', 'command', 'plan')
+    expect(existsSync(join(workDir, '.agents/skills/plan/SKILL.md'))).toBe(false)
+    expect(existsSync(join(workDir, '.agents/skills/plan/agents/openai.yaml'))).toBe(false)
+    expect(existsSync(join(workDir, '.agents/skills/plan'))).toBe(false)
   })
 })
 
@@ -269,10 +349,12 @@ describe('codex adapter — user-scope base dirs', () => {
     expect(existsSync(path)).toBe(true)
   })
 
-  test('user-scope command writes under ~/.agents/commands', async () => {
+  test('user-scope command writes under ~/.agents/skills as a skill', async () => {
     await adapter.installAsset('user', 'command', 'plan', 'command body', {})
-    const path = join(fakeHome, '.agents/commands/plan.md')
+    const path = join(fakeHome, '.agents/skills/plan/SKILL.md')
     expect(readFileSync(path, 'utf8')).toBe('command body')
+    const yaml = readFileSync(join(fakeHome, '.agents/skills/plan/agents/openai.yaml'), 'utf8')
+    expect(yaml).toContain('allow_implicit_invocation: false')
   })
 })
 

--- a/packages/adapters/codex/src/index.ts
+++ b/packages/adapters/codex/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from 'node:fs/promises'
+import { mkdir, readdir, rm, rmdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
@@ -130,9 +130,7 @@ export default defineAdapter({
     if (assetType === 'agent') {
       await rm(path, { force: true })
     } else if (assetType === 'command') {
-      // Remove the whole skill directory so the SKILL.md, the agents/openai.yaml
-      // sidecar, and the now-empty <name>/ folder all go on facet remove.
-      await rm(dirname(path), { recursive: true, force: true })
+      await deleteCommandSkill(path)
     } else {
       await deleteAssetFile({ file: path })
     }
@@ -256,6 +254,35 @@ function buildCommandYaml(metadata: Record<string, unknown>): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Delete a command that was installed as a skill.
+ *
+ * Only the files this adapter created are removed — `SKILL.md` and the
+ * `agents/openai.yaml` sidecar — followed by a best-effort cleanup of the two
+ * directories we created (`agents/` and the `<name>/` skill dir), each removed
+ * only when empty. This deliberately avoids a recursive delete of the skill
+ * directory: a recursive remove would also destroy an unrelated skill that
+ * shares the namespace prefix (e.g. deleting command `foo` must not wipe skill
+ * `foo/bar` living at `.agents/skills/foo/bar/SKILL.md`).
+ */
+async function deleteCommandSkill(skillMdPath: string): Promise<void> {
+  const skillDir = dirname(skillMdPath)
+
+  await deleteAssetFile({ file: skillMdPath })
+  await rm(join(skillDir, 'agents', 'openai.yaml'), { force: true })
+
+  await removeDirIfEmpty(join(skillDir, 'agents'))
+  await removeDirIfEmpty(skillDir)
+}
+
+/** Remove `dir` only if it exists and is empty. No-op otherwise (never recurses). */
+async function removeDirIfEmpty(dir: string): Promise<void> {
+  const entries = await readdir(dir).catch(() => null)
+  if (entries && entries.length === 0) {
+    await rmdir(dir).catch(() => {})
+  }
 }
 
 // --- TOML agent helpers ---

--- a/packages/adapters/codex/src/index.ts
+++ b/packages/adapters/codex/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from '@agent-facets/adapter'
 import { type } from 'arktype'
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
+import { stringify as stringifyYaml } from 'yaml'
 
 /**
  * Codex per-asset metadata schema.
@@ -21,11 +22,23 @@ import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
  *   - developer_instructions: string (system prompt / instructions body)
  *
  * Skills use standard YAML front-matter (same as claude-code / opencode).
+ *
+ * Commands are installed as skills with an `agents/openai.yaml` sidecar (see
+ * `installCommandSkill`). The optional `interface` and `dependencies` blocks
+ * are command-authored pass-through for that sidecar; `policy` is accepted but
+ * `allow_implicit_invocation` is always forced to `false` at install time so a
+ * command can never opt back into implicit invocation. These keys are only
+ * meaningful for commands — the build validator does not run command adapter
+ * metadata through this schema, so they exist here for defensive tolerance and
+ * documentation.
  */
 const CodexMetadataSchema = type({
   'name?': 'string',
   'description?': 'string',
   'developer_instructions?': 'string',
+  'interface?': 'object',
+  'dependencies?': 'object',
+  'policy?': 'object',
 })
 
 /**
@@ -36,19 +49,29 @@ const CodexMetadataSchema = type({
  *
  * Codex uses two separate directory trees depending on asset type:
  *
- *   Skills  (project)  → <cwd>/.agents/skills/<name>/SKILL.md
- *   Skills  (user)     → ~/.agents/skills/<name>/SKILL.md
+ *   Skills   (project) → <cwd>/.agents/skills/<name>/SKILL.md
+ *   Skills   (user)    → ~/.agents/skills/<name>/SKILL.md
  *
- *   Agents  (project)  → <cwd>/.codex/agents/<name>.toml
- *   Agents  (user)     → ~/.codex/agents/<name>.toml
+ *   Agents   (project) → <cwd>/.codex/agents/<name>.toml
+ *   Agents   (user)    → ~/.codex/agents/<name>.toml
  *
- *   Commands (project) → <cwd>/.agents/commands/<name>.md
- *   Commands (user)    → ~/.agents/commands/<name>.md
+ *   Commands (project) → <cwd>/.agents/skills/<name>/SKILL.md   (+ agents/openai.yaml)
+ *   Commands (user)    → ~/.agents/skills/<name>/SKILL.md       (+ agents/openai.yaml)
+ *
+ * ## Commands are skills
+ *
+ * Codex has no separate "command" concept — it only reads skills from
+ * `.agents/skills`. So a facet command is installed as a Codex *skill* whose
+ * `agents/openai.yaml` sets `policy.allow_implicit_invocation: false`. That
+ * makes Codex skip implicit matching while explicit `$name` invocation still
+ * works — i.e. command semantics on top of the skills mechanism. See
+ * https://developers.openai.com/codex/skills#optional-metadata.
  *
  * ## File formats
  *
  * Skills and commands use Markdown + YAML front-matter (same pattern as
  * claude-code and opencode — Codex follows the agentskills.io standard).
+ * Commands additionally write the `agents/openai.yaml` sidecar described above.
  *
  * Agents use TOML (Codex's native config format). The facet body is stored
  * as the `developer_instructions` field; other metadata keys are top-level
@@ -81,6 +104,8 @@ export default defineAdapter({
 
     if (assetType === 'agent') {
       await installAgentToml(path, content, metadata as Record<string, unknown>)
+    } else if (assetType === 'command') {
+      await installCommandSkill(path, content, metadata as Record<string, unknown>)
     } else {
       await installAssetFile({ file: path }, content, metadata as Record<string, unknown>)
     }
@@ -93,6 +118,9 @@ export default defineAdapter({
       return readAgentToml(path)
     }
 
+    // Commands are stored as skills (SKILL.md); the openai.yaml sidecar is
+    // deterministic and not part of the round-trip identity, so reading the
+    // SKILL.md is sufficient for materialize's skip-if-identical + rollback.
     return readAssetFile({ file: path })
   },
 
@@ -101,6 +129,10 @@ export default defineAdapter({
 
     if (assetType === 'agent') {
       await rm(path, { force: true })
+    } else if (assetType === 'command') {
+      // Remove the whole skill directory so the SKILL.md, the agents/openai.yaml
+      // sidecar, and the now-empty <name>/ folder all go on facet remove.
+      await rm(dirname(path), { recursive: true, force: true })
     } else {
       await deleteAssetFile({ file: path })
     }
@@ -139,8 +171,91 @@ function relativePathFor(assetType: AssetType, name: string): string {
     case 'agent':
       return join('agents', `${name}.toml`)
     case 'command':
-      return join('commands', `${name}.md`)
+      // Codex has no command concept — install commands as skills. The
+      // command-vs-skill distinction is carried by the agents/openai.yaml
+      // sidecar written in installCommandSkill, not by the path.
+      return join('skills', name, 'SKILL.md')
   }
+}
+
+// --- command-as-skill helpers ---
+
+/** Keys consumed by the `agents/openai.yaml` sidecar; kept out of SKILL.md front-matter. */
+const OPENAI_YAML_KEYS = ['interface', 'dependencies', 'policy'] as const
+
+/**
+ * Install a facet command as a Codex skill.
+ *
+ * Codex only reads skills (from `.agents/skills`), so a command is written as a
+ * skill directory:
+ *
+ *   .agents/skills/<name>/SKILL.md          — body + name/description front-matter
+ *   .agents/skills/<name>/agents/openai.yaml — invocation policy + UI metadata
+ *
+ * The sidecar always forces `policy.allow_implicit_invocation: false`, which is
+ * what gives the skill "command" semantics: Codex won't invoke it implicitly
+ * from a prompt, only via explicit `$name`. `interface` and `dependencies`
+ * blocks from the command author pass through untouched; `display_name` /
+ * `short_description` fall back to the command's `name` / `description` when the
+ * author didn't set them.
+ */
+async function installCommandSkill(
+  filePath: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const meta = metadata ?? {}
+
+  // SKILL.md carries only the standard skill front-matter (name/description).
+  // The openai.yaml-only keys are stripped so they don't leak into the body file.
+  const frontMatter: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(meta)) {
+    if (!OPENAI_YAML_KEYS.includes(key as (typeof OPENAI_YAML_KEYS)[number]) && key !== 'developer_instructions') {
+      frontMatter[key] = value
+    }
+  }
+  await installAssetFile({ file: filePath }, content, frontMatter)
+
+  const sidecarPath = join(dirname(filePath), 'agents', 'openai.yaml')
+  await mkdir(dirname(sidecarPath), { recursive: true })
+  await Bun.write(sidecarPath, buildCommandYaml(meta))
+}
+
+/**
+ * Build the `agents/openai.yaml` contents for a command-as-skill. Merges
+ * author-provided `interface` / `dependencies` / `policy` blocks with the
+ * required command semantics, then serialises to YAML.
+ */
+function buildCommandYaml(metadata: Record<string, unknown>): string {
+  const iface: Record<string, unknown> = { ...(isRecord(metadata.interface) ? metadata.interface : {}) }
+  if (iface.display_name === undefined && typeof metadata.name === 'string' && metadata.name.length > 0) {
+    iface.display_name = metadata.name
+  }
+  if (
+    iface.short_description === undefined &&
+    typeof metadata.description === 'string' &&
+    metadata.description.length > 0
+  ) {
+    iface.short_description = metadata.description
+  }
+
+  // allow_implicit_invocation is always forced false — a command must never opt
+  // back into implicit invocation, even if the author set it true.
+  const policy: Record<string, unknown> = {
+    ...(isRecord(metadata.policy) ? metadata.policy : {}),
+    allow_implicit_invocation: false,
+  }
+
+  const doc: Record<string, unknown> = {}
+  if (Object.keys(iface).length > 0) doc.interface = iface
+  doc.policy = policy
+  if (isRecord(metadata.dependencies)) doc.dependencies = metadata.dependencies
+
+  return `${stringifyYaml(doc).trimEnd()}\n`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 // --- TOML agent helpers ---

--- a/packages/adapters/codex/tsdown.config.ts
+++ b/packages/adapters/codex/tsdown.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
   // self-contained bundle. The CLI loads this file directly at install time
   // without needing a node_modules tree.
   deps: {
-    alwaysBundle: ['@agent-facets/adapter', 'arktype', 'smol-toml'],
+    alwaysBundle: ['@agent-facets/adapter', 'arktype', 'smol-toml', 'yaml'],
   },
 })


### PR DESCRIPTION
Codex has no command concept; it only reads skills from .agents/skills. Install facet commands as Codex skills whose agents/openai.yaml sets policy.allow_implicit_invocation: false, giving command semantics (explicit $name only) on top of the skills mechanism.

- relativePathFor: command -> skills/<name>/SKILL.md
- installAsset: write SKILL.md + agents/openai.yaml sidecar
- deleteAsset: remove the whole skill dir on facet remove
- full pass-through of author interface/dependencies blocks; display_name and short_description fall back to name/description; allow_implicit_invocation is always forced false

### Why

<!-- Why does this change exist? Link an issue or describe the motivation. Remove this section for trivial changes where the title says it all. -->

### Details

<!-- What should the reviewer know that isn't obvious from the diff? Approach, trade-offs, edge cases. Remove this section if the change is self-explanatory. -->

### Verification

<!-- How do you know it works? Manual test steps, deployment notes, or just "CI". Remove this section if CI covers it. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command assets now install as skill directories with a `SKILL.md` file and a companion YAML configuration file.
  * Command metadata is now surfaced more consistently, including display name and short description where available.

* **Bug Fixes**
  * Removing a command now deletes the entire related skill directory.
  * Command installs no longer create the old standalone commands path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->