### PR TITLE
Bump `typescript` to `7.0.1-rc` and switch dts generation to `tsgo` mode

### DIFF
--- a/.changeset/tricky-news-crash.md
+++ b/.changeset/tricky-news-crash.md
@@ -1,0 +1,11 @@
+---
+"@agent-facets/adapter-claude-code": patch
+"@agent-facets/adapter-opencode": patch
+"@agent-facets/adapter-codex": patch
+"@agent-facets/protocol": patch
+"@agent-facets/adapter": patch
+"@agent-facets/brand": patch
+"agent-facets": patch
+---
+
+Use TypeScript 7.x (the tsgo variant) for type checking

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "mint": "4.2.655",
         "turbo": "2.9.18",
         "type-fest": "5.7.0",
-        "typescript": "6.0.3",
+        "typescript": "7.0.1-rc",
       },
     },
     "packages/adapter": {
@@ -33,7 +33,6 @@
       "devDependencies": {
         "@agent-facets/common": "workspace:*",
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
     },
     "packages/adapters/claude-code": {
@@ -43,7 +42,6 @@
         "@agent-facets/adapter": "workspace:*",
         "arktype": "2.2.0",
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
     },
     "packages/adapters/codex": {
@@ -54,7 +52,6 @@
         "arktype": "2.2.0",
         "smol-toml": "^1.7.0",
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
     },
     "packages/adapters/opencode": {
@@ -64,7 +61,6 @@
         "@agent-facets/adapter": "workspace:*",
         "arktype": "2.2.0",
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
     },
     "packages/brand": {
@@ -72,10 +68,9 @@
       "version": "0.5.7",
       "devDependencies": {
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6",
+        "typescript": "^5 || ^6 || ^7 || 7.0.1-rc",
       },
     },
     "packages/cli": {
@@ -105,7 +100,7 @@
         "ink-testing-library": "4.0.0",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6",
+        "typescript": "^5 || ^6 || ^7 || 7.0.1-rc",
       },
     },
     "packages/common": {
@@ -132,10 +127,9 @@
         "@types/ini": "4.1.1",
         "openapi-typescript": "7.13.0",
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6",
+        "typescript": "^5 || ^6 || ^7 || 7.0.1-rc",
       },
     },
     "packages/functions": {
@@ -175,10 +169,9 @@
       "devDependencies": {
         "@agent-facets/common": "workspace:*",
         "tsdown": "^0.22.3",
-        "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "typescript": "^5 || ^6",
+        "typescript": "^5 || ^6 || ^7 || 7.0.1-rc",
       },
     },
   },
@@ -838,6 +831,46 @@
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.1-rc", "", { "os": "aix", "cpu": "ppc64" }, "sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.1-rc", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.1-rc", "", { "os": "darwin", "cpu": "x64" }, "sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.1-rc", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.1-rc", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.1-rc", "", { "os": "linux", "cpu": "arm" }, "sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.1-rc", "", { "os": "linux", "cpu": "arm64" }, "sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.1-rc", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.1-rc", "", { "os": "linux", "cpu": "s390x" }, "sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.1-rc", "", { "os": "linux", "cpu": "x64" }, "sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.1-rc", "", { "os": "none", "cpu": "arm64" }, "sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.1-rc", "", { "os": "none", "cpu": "x64" }, "sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.1-rc", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.1-rc", "", { "os": "openbsd", "cpu": "x64" }, "sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.1-rc", "", { "os": "sunos", "cpu": "x64" }, "sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.1-rc", "", { "os": "win32", "cpu": "arm64" }, "sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.1-rc", "", { "os": "win32", "cpu": "x64" }, "sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA=="],
 
     "@typescript/vfs": ["@typescript/vfs@1.6.4", "", { "dependencies": { "debug": "^4.4.3" }, "peerDependencies": { "typescript": "*" } }, "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ=="],
 
@@ -2333,7 +2366,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@7.0.1-rc", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.1-rc", "@typescript/typescript-darwin-arm64": "7.0.1-rc", "@typescript/typescript-darwin-x64": "7.0.1-rc", "@typescript/typescript-freebsd-arm64": "7.0.1-rc", "@typescript/typescript-freebsd-x64": "7.0.1-rc", "@typescript/typescript-linux-arm": "7.0.1-rc", "@typescript/typescript-linux-arm64": "7.0.1-rc", "@typescript/typescript-linux-loong64": "7.0.1-rc", "@typescript/typescript-linux-mips64el": "7.0.1-rc", "@typescript/typescript-linux-ppc64": "7.0.1-rc", "@typescript/typescript-linux-riscv64": "7.0.1-rc", "@typescript/typescript-linux-s390x": "7.0.1-rc", "@typescript/typescript-linux-x64": "7.0.1-rc", "@typescript/typescript-netbsd-arm64": "7.0.1-rc", "@typescript/typescript-netbsd-x64": "7.0.1-rc", "@typescript/typescript-openbsd-arm64": "7.0.1-rc", "@typescript/typescript-openbsd-x64": "7.0.1-rc", "@typescript/typescript-sunos-x64": "7.0.1-rc", "@typescript/typescript-win32-arm64": "7.0.1-rc", "@typescript/typescript-win32-x64": "7.0.1-rc" }, "bin": { "tsc": "bin/tsc" } }, "sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dedent": "1.7.2",
     "mint": "4.2.655",
     "turbo": "2.9.18",
-    "typescript": "6.0.3",
+    "typescript": "7.0.1-rc",
     "@types/aws-lambda": "8.10.161",
     "type-fest": "5.7.0"
   },

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -25,8 +25,7 @@
   },
   "devDependencies": {
     "@agent-facets/common": "workspace:*",
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapter/tsdown.config.ts
+++ b/packages/adapter/tsdown.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: dtsTsconfigPath,
   dts: {
-    eager: true,
+    tsgo: { path: tscPath },
   },
   clean: true,
   deps: {

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -23,8 +23,7 @@
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",
     "arktype": "2.2.0",
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/claude-code/tsdown.config.ts
+++ b/packages/adapters/claude-code/tsdown.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: dtsTsconfigPath,
   dts: {
-    eager: true,
+    tsgo: { path: tscPath },
   },
   clean: true,
   // Inline runtime dependencies so the published dist/index.mjs is a fully

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -24,8 +24,7 @@
     "@agent-facets/adapter": "workspace:*",
     "arktype": "2.2.0",
     "smol-toml": "^1.7.0",
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/codex/tsdown.config.ts
+++ b/packages/adapters/codex/tsdown.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: dtsTsconfigPath,
   dts: {
-    eager: true,
+    tsgo: { path: tscPath },
   },
   clean: true,
   // Inline runtime dependencies so the published dist/index.mjs is a fully

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -23,8 +23,7 @@
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",
     "arktype": "2.2.0",
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/opencode/tsdown.config.ts
+++ b/packages/adapters/opencode/tsdown.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: dtsTsconfigPath,
   dts: {
-    eager: true,
+    tsgo: { path: tscPath },
   },
   clean: true,
   // Inline runtime dependencies so the published dist/index.mjs is a fully

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -21,11 +21,10 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6"
+    "typescript": "^5 || ^6 || ^7 || 7.0.1-rc"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/brand/tsdown.config.ts
+++ b/packages/brand/tsdown.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: { eager: true },
+  tsconfig: dtsTsconfigPath,
+  dts: { tsgo: { path: tscPath } },
   clean: true,
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,6 @@
     "ink-testing-library": "4.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6"
+    "typescript": "^5 || ^6 || ^7 || 7.0.1-rc"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -31,10 +31,9 @@
     "@agent-facets/common": "workspace:*",
     "@types/ini": "4.1.1",
     "openapi-typescript": "7.13.0",
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6"
+    "typescript": "^5 || ^6 || ^7 || 7.0.1-rc"
   }
 }

--- a/packages/engine/tsdown.config.ts
+++ b/packages/engine/tsdown.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: dtsTsconfigPath,
   dts: {
-    eager: true,
+    tsgo: { path: tscPath },
   },
   clean: true,
   // Engine is private — no published tarball to worry about. We still bundle

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -31,11 +31,10 @@
   },
   "devDependencies": {
     "@agent-facets/common": "workspace:*",
-    "tsdown": "^0.22.3",
-    "typescript": "^6.0.3"
+    "tsdown": "^0.22.3"
   },
   "peerDependencies": {
-    "typescript": "^5 || ^6"
+    "typescript": "^5 || ^6 || ^7 || 7.0.1-rc"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/protocol/tsdown.config.ts
+++ b/packages/protocol/tsdown.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'tsdown'
+import { dtsTsconfigPath, tscPath } from '../../tsdown.shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: dtsTsconfigPath,
   dts: {
-    eager: true,
+    tsgo: { path: tscPath },
   },
   clean: true,
   // @agent-facets/common is a private workspace package — inline its code

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "packages/common/src",
+    "packages/protocol/src",
+    "packages/engine/src",
+    "packages/adapter/src",
+    "packages/brand/src",
+    "packages/adapters/opencode/src",
+    "packages/adapters/codex/src",
+    "packages/adapters/claude-code/src"
+  ]
+}

--- a/tsdown.shared.ts
+++ b/tsdown.shared.ts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// TypeScript 7 (the Go-native compiler) ships only the `tsc` binary — no JS
+// API — so tsdown's default `eager` dts mode (which imports `typescript`)
+// can't run. rolldown-plugin-dts's `tsgo` mode instead spawns a compiler
+// binary; typescript@7's own `bin/tsc` IS that binary. Point the plugin at it.
+export const tscPath = path.join(path.dirname(fileURLToPath(import.meta.resolve('typescript/package.json'))), 'bin/tsc')
+
+// rolldown-plugin-dts derives `rootDir` from `dirname(tsconfig)` and looks up
+// emitted d.ts files relative to it. Packages that `alwaysBundle` workspace
+// sources (`@agent-facets/common`, `@agent-facets/adapter`) reference files
+// outside their own directory, so a per-package tsconfig can't cover them.
+// This shared config at the repo root includes every bundled source dir, so
+// its rootDir (the repo root) spans all of them.
+export const dtsTsconfigPath = fileURLToPath(new URL('./tsconfig.dts.json', import.meta.url))


### PR DESCRIPTION
### Why

TypeScript 7.x ships the Go-native compiler (`tsgo`), which is significantly faster. This upgrades the workspace to use `typescript@7.0.1-rc` for type checking across all packages.

### Details

TypeScript 7's Go-native compiler no longer ships a JavaScript API — only a `tsc` binary. This means tsdown's default `eager` DTS mode, which imports the `typescript` package programmatically, cannot work. Instead, `rolldown-plugin-dts`'s `tsgo` mode is used, which spawns the compiler binary directly. A shared `tsdown.shared.ts` helper resolves the path to TypeScript 7's `bin/tsc` and exports it for use across all package `tsdown.config.ts` files.

A root-level `tsconfig.dts.json` is introduced to address a `rootDir` scoping issue: packages that bundle workspace sources from outside their own directory (e.g. `@agent-facets/common`, `@agent-facets/adapter`) cannot be covered by a per-package tsconfig. The shared config at the repo root includes all bundled source directories so that `rootDir` spans the entire monorepo.

Per-package `typescript` dev dependencies are removed in favour of the single root-level installation, and peer dependency ranges are widened to `^5 || ^6 || ^7 || 7.0.1-rc` to accept the new major version.

### Verification

CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded TypeScript compatibility to include TypeScript 7 and the 7.0.1 release candidate.
  * Updated declaration/type generation to use the newer TypeScript toolchain across packages.

* **Bug Fixes**
  * Improved consistency of build and type-check settings across the workspace.
  * Added broader project coverage for generated type output, helping avoid missing declarations in bundled packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->