### PR TITLE
Add CircleCI project info config for `agent-facets/facets`

### DIFF
--- a/.circleci/info.yml
+++ b/.circleci/info.yml
@@ -1,0 +1,7 @@
+organization:
+    id: bfa561da-d33e-4a2a-a46d-48e096a828e0
+    name: agent-facets
+project:
+    id: 46274a40-97ed-41fd-a745-9702a7131ccc
+    slug: gh/agent-facets/facets
+    name: facets


### PR DESCRIPTION
### Why

Adds CircleCI project metadata to link the repository to the `agent-facets` organization and `facets` project for proper CI pipeline association.

### Verification

CI