### PR TITLE
Fix CircleCI YAML indentation and bump `circleci-cli` to `1.0.43468-pre`

### DIFF
--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -1,150 +1,149 @@
 commands:
-    notify-failure:
-        steps:
-            - run:
-                command: bun scripts/lib/notify-failure.ts
-                name: Notify failure
-                when: on_fail
-    run-check:
-        steps:
-            - restore_cache:
-                keys:
-                    - v1-mint-{{ checksum "bun.lock" }}
-                    - v1-mint-
-            - run:
-                command: bun turbo check
-                environment:
-                    TURBO_CONCURRENCY: "1"
-                name: Check
-            - save_cache:
-                key: v1-mint-{{ checksum "bun.lock" }}
-                paths:
-                    - ~/.mintlify
-    setup-mise:
-        steps:
-            - checkout
-            - run:
-                command: |
-                    curl https://mise.run | sh
-                    echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
-                name: Install mise
-            - restore_cache:
-                keys:
-                    - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
-                    - v1-mise-{{ .Environment.MISE_ENV }}-
-            - run:
-                command: mise install --yes
-                name: Install tools
-            - save_cache:
-                key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
-                paths:
-                    - ~/.local/share/mise/installs
-                    - ~/.local/share/mise/downloads
-            - restore_cache:
-                keys:
-                    - v1-facet-{{ checksum "facets.lock" }}
-                    - v1-facet-
-            - restore_cache:
-                keys:
-                    - v1-deps-{{ checksum "bun.lock" }}
-                    - v1-deps-
-            - run:
-                command: bun install --frozen-lockfile
-                name: Install dependencies
-            - save_cache:
-                key: v1-deps-{{ checksum "bun.lock" }}
-                paths:
-                    - node_modules
-                    - ~/.bun/install/cache
-            - save_cache:
-                key: v1-facet-{{ checksum "facets.lock" }}
-                paths:
-                    - ~/.facet/cache
-jobs:
-    check:
-        docker:
-            - image: cimg/base:current
-        resource_class: medium
-        steps:
-            - setup-mise
-            - run-check
-            - store_test_results:
-                path: test-results
-                when: always
-    main-pipeline:
-        docker:
-            - image: cimg/base:current
-        environment:
-            LEFTHOOK: "0"
-        resource_class: medium
-        steps:
-            - setup-mise
-            - run-check
-            - store_test_results:
-                path: test-results
-                when: always
-            - run:
-                command: bun scripts/release/version.ts
-                name: Version Changesets
-            - run:
-                command: bun scripts/release/tag.ts
-                name: Tag Release
-            - notify-failure
-    openapi-freshness:
-        docker:
-            - image: cimg/base:current
-        resource_class: small
-        steps:
-            - setup-mise
-            - run:
-                command: bun run --cwd packages/engine codegen:registry --check --strict
-                name: OpenAPI snapshot freshness
-    release:
-        docker:
-            - image: cimg/base:current
-        environment:
-            LEFTHOOK: "0"
-            MISE_ENV: release
+  notify-failure:
+    steps:
+      - run:
+          command: bun scripts/lib/notify-failure.ts
+          name: Notify failure
+          when: on_fail
+  run-check:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-mint-{{ checksum "bun.lock" }}
+            - v1-mint-
+      - run:
+          command: bun turbo check
+          environment:
             TURBO_CONCURRENCY: "1"
-        resource_class: medium
-        steps:
-            - setup-mise
-            - run:
-                command: bun scripts/release/publish.ts
-                name: Publish
-            - notify-failure
+          name: Check
+      - save_cache:
+          key: v1-mint-{{ checksum "bun.lock" }}
+          paths:
+            - ~/.mintlify
+  setup-mise:
+    steps:
+      - checkout
+      - run:
+          command: |
+            curl https://mise.run | sh
+            echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
+          name: Install mise
+      - restore_cache:
+          keys:
+            - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+            - v1-mise-{{ .Environment.MISE_ENV }}-
+      - run:
+          command: mise install --yes
+          name: Install tools
+      - save_cache:
+          key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+          paths:
+            - ~/.local/share/mise/installs
+            - ~/.local/share/mise/downloads
+      - restore_cache:
+          keys:
+            - v1-facet-{{ checksum "facets.lock" }}
+            - v1-facet-
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "bun.lock" }}
+            - v1-deps-
+      - run:
+          command: bun install --frozen-lockfile
+          name: Install dependencies
+      - save_cache:
+          key: v1-deps-{{ checksum "bun.lock" }}
+          paths:
+            - node_modules
+            - ~/.bun/install/cache
+      - save_cache:
+          key: v1-facet-{{ checksum "facets.lock" }}
+          paths:
+            - ~/.facet/cache
+jobs:
+  check:
+    docker:
+      - image: cimg/base:current
+    resource_class: medium
+    steps:
+      - setup-mise
+      - run-check
+      - store_test_results:
+          path: test-results
+          when: always
+  main-pipeline:
+    docker:
+      - image: cimg/base:current
+    environment:
+      LEFTHOOK: "0"
+    resource_class: medium
+    steps:
+      - setup-mise
+      - run-check
+      - store_test_results:
+          path: test-results
+          when: always
+      - run:
+          command: bun scripts/release/version.ts
+          name: Version Changesets
+      - run:
+          command: bun scripts/release/tag.ts
+          name: Tag Release
+      - notify-failure
+  openapi-freshness:
+    docker:
+      - image: cimg/base:current
+    resource_class: small
+    steps:
+      - setup-mise
+      - run:
+          command: bun run --cwd packages/engine codegen:registry --check --strict
+          name: OpenAPI snapshot freshness
+  release:
+    docker:
+      - image: cimg/base:current
+    environment:
+      LEFTHOOK: "0"
+      MISE_ENV: release
+      TURBO_CONCURRENCY: "1"
+    resource_class: medium
+    steps:
+      - setup-mise
+      - run:
+          command: bun scripts/release/publish.ts
+          name: Publish
+      - notify-failure
 parameters:
-    package:
-        default: ""
-        type: string
+  package:
+    default: ""
+    type: string
 version: 2.1
 workflows:
-    ci:
-        jobs:
-            - check:
-                context:
-                    - turbo-cache
-                    - github
-                filters:
-                    branches:
-                        ignore:
-                            - main
-            - openapi-freshness:
-                context:
-                    - github
-                filters:
-                    branches:
-                        ignore:
-                            - main
-            - main-pipeline:
-                context:
-                    - turbo-cache
-                    - bot-context
-                    - slack-secrets
-                    - github
-                filters:
-                    branches:
-                        only:
-                            - main
-                serial-group: << pipeline.project.slug >>/main-pipeline
-
+  ci:
+    jobs:
+      - check:
+          context:
+            - turbo-cache
+            - github
+          filters:
+            branches:
+              ignore:
+                - main
+      - openapi-freshness:
+          context:
+            - github
+          filters:
+            branches:
+              ignore:
+                - main
+      - main-pipeline:
+          context:
+            - turbo-cache
+            - bot-context
+            - slack-secrets
+            - github
+          filters:
+            branches:
+              only:
+                - main
+          serial-group: << pipeline.project.slug >>/main-pipeline

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -1,197 +1,196 @@
 commands:
-    notify-failure:
-        steps:
-            - run:
-                command: bun scripts/lib/notify-failure.ts
-                name: Notify failure
-                when: on_fail
-    setup-mise:
-        steps:
-            - checkout
-            - run:
-                command: |
-                    curl https://mise.run | sh
-                    echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
-                name: Install mise
-            - restore_cache:
-                keys:
-                    - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
-                    - v1-mise-{{ .Environment.MISE_ENV }}-
-            - run:
-                command: mise install --yes
-                name: Install tools
-            - save_cache:
-                key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
-                paths:
-                    - ~/.local/share/mise/installs
-                    - ~/.local/share/mise/downloads
-            - restore_cache:
-                keys:
-                    - v1-facet-{{ checksum "facets.lock" }}
-                    - v1-facet-
-            - restore_cache:
-                keys:
-                    - v1-deps-{{ checksum "bun.lock" }}
-                    - v1-deps-
-            - run:
-                command: bun install --frozen-lockfile
-                name: Install dependencies
-            - save_cache:
-                key: v1-deps-{{ checksum "bun.lock" }}
-                paths:
-                    - node_modules
-                    - ~/.bun/install/cache
-            - save_cache:
-                key: v1-facet-{{ checksum "facets.lock" }}
-                paths:
-                    - ~/.facet/cache
+  notify-failure:
+    steps:
+      - run:
+          command: bun scripts/lib/notify-failure.ts
+          name: Notify failure
+          when: on_fail
+  setup-mise:
+    steps:
+      - checkout
+      - run:
+          command: |
+            curl https://mise.run | sh
+            echo 'eval "$(~/.local/bin/mise activate bash)"' >> "$BASH_ENV"
+          name: Install mise
+      - restore_cache:
+          keys:
+            - v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+            - v1-mise-{{ .Environment.MISE_ENV }}-
+      - run:
+          command: mise install --yes
+          name: Install tools
+      - save_cache:
+          key: v1-mise-{{ .Environment.MISE_ENV }}-{{ checksum "mise.toml" }}-{{ checksum "mise.development.toml" }}
+          paths:
+            - ~/.local/share/mise/installs
+            - ~/.local/share/mise/downloads
+      - restore_cache:
+          keys:
+            - v1-facet-{{ checksum "facets.lock" }}
+            - v1-facet-
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "bun.lock" }}
+            - v1-deps-
+      - run:
+          command: bun install --frozen-lockfile
+          name: Install dependencies
+      - save_cache:
+          key: v1-deps-{{ checksum "bun.lock" }}
+          paths:
+            - node_modules
+            - ~/.bun/install/cache
+      - save_cache:
+          key: v1-facet-{{ checksum "facets.lock" }}
+          paths:
+            - ~/.facet/cache
 jobs:
-    build-cli:
-        docker:
-            - image: cimg/base:current
-        environment:
-            LEFTHOOK: "0"
-            MISE_ENV: release
-        resource_class: small
-        steps:
-            - setup-mise
-            - run:
-                command: bun scripts/release-cli/build.ts
-                name: Build CLI binaries
-            - persist_to_workspace:
-                paths:
-                    - packages/cli/dist
-                root: .
-            - notify-failure
-    finalize-cli:
-        docker:
-            - image: cimg/base:current
-        environment:
-            LEFTHOOK: "0"
-            MISE_ENV: release
-        resource_class: small
-        steps:
-            - setup-mise
-            - attach_workspace:
-                at: .
-            - run:
-                command: bun scripts/release-cli/finalize.ts
-                name: Finalize CLI Release
-            - notify-failure
-    publish-platform:
-        docker:
-            - image: cimg/base:current
-        environment:
-            LEFTHOOK: "0"
-            MISE_ENV: release
-        parameters:
-            target:
-                type: string
-        resource_class: small
-        steps:
-            - setup-mise
-            - attach_workspace:
-                at: .
-            - run:
-                command: bun scripts/release-cli/publish-platform.ts << parameters.target >>
-                name: Publish << parameters.target >>
-            - notify-failure
-    release:
-        docker:
-            - image: cimg/base:current
-        environment:
-            LEFTHOOK: "0"
-            MISE_ENV: release
-            TURBO_CONCURRENCY: "1"
-        resource_class: medium
-        steps:
-            - setup-mise
-            - run:
-                command: bun scripts/release/publish.ts
-                name: Publish
-            - notify-failure
-parameters:
-    package:
-        default: ""
+  build-cli:
+    docker:
+      - image: cimg/base:current
+    environment:
+      LEFTHOOK: "0"
+      MISE_ENV: release
+    resource_class: small
+    steps:
+      - setup-mise
+      - run:
+          command: bun scripts/release-cli/build.ts
+          name: Build CLI binaries
+      - persist_to_workspace:
+          paths:
+            - packages/cli/dist
+          root: .
+      - notify-failure
+  finalize-cli:
+    docker:
+      - image: cimg/base:current
+    environment:
+      LEFTHOOK: "0"
+      MISE_ENV: release
+    resource_class: small
+    steps:
+      - setup-mise
+      - attach_workspace:
+          at: .
+      - run:
+          command: bun scripts/release-cli/finalize.ts
+          name: Finalize CLI Release
+      - notify-failure
+  publish-platform:
+    docker:
+      - image: cimg/base:current
+    environment:
+      LEFTHOOK: "0"
+      MISE_ENV: release
+    parameters:
+      target:
         type: string
+    resource_class: small
+    steps:
+      - setup-mise
+      - attach_workspace:
+          at: .
+      - run:
+          command: bun scripts/release-cli/publish-platform.ts << parameters.target >>
+          name: Publish << parameters.target >>
+      - notify-failure
+  release:
+    docker:
+      - image: cimg/base:current
+    environment:
+      LEFTHOOK: "0"
+      MISE_ENV: release
+      TURBO_CONCURRENCY: "1"
+    resource_class: medium
+    steps:
+      - setup-mise
+      - run:
+          command: bun scripts/release/publish.ts
+          name: Publish
+      - notify-failure
+parameters:
+  package:
+    default: ""
+    type: string
 version: 2.1
 workflows:
-    release:
-        jobs:
-            - release:
-                context:
-                    - turbo-cache
-                    - bot-context
-                    - slack-secrets
-                    - github
-                filters:
-                    branches:
-                        ignore:
-                            - /.*/
-                    tags:
-                        only:
-                            - /^@agent-facets\/.+@\d+\..+/
-                serial-group: << pipeline.project.slug >>/release/<< pipeline.parameters.package >>
-    release-cli:
-        jobs:
-            - build-cli:
-                context:
-                    - turbo-cache
-                    - bot-context
-                    - slack-secrets
-                    - github
-                filters:
-                    branches:
-                        ignore:
-                            - /.*/
-                    tags:
-                        only:
-                            - /^agent-facets@\d+\..+/
-                serial-group: << pipeline.project.slug >>/release-cli-build
-            - publish-platform:
-                context:
-                    - turbo-cache
-                    - bot-context
-                    - slack-secrets
-                    - github
-                filters:
-                    branches:
-                        ignore:
-                            - /.*/
-                    tags:
-                        only:
-                            - /^agent-facets@\d+\..+/
-                matrix:
-                    parameters:
-                        target:
-                            - cli-darwin-arm64
-                            - cli-darwin-x64
-                            - cli-darwin-x64-baseline
-                            - cli-linux-arm64
-                            - cli-linux-arm64-musl
-                            - cli-linux-x64
-                            - cli-linux-x64-baseline
-                            - cli-linux-x64-baseline-musl
-                            - cli-linux-x64-musl
-                            - cli-windows-arm64
-                            - cli-windows-x64
-                            - cli-windows-x64-baseline
-                requires:
-                    - build-cli
-            - finalize-cli:
-                context:
-                    - turbo-cache
-                    - bot-context
-                    - slack-secrets
-                    - github
-                filters:
-                    branches:
-                        ignore:
-                            - /.*/
-                    tags:
-                        only:
-                            - /^agent-facets@\d+\..+/
-                requires:
-                    - publish-platform
-                serial-group: << pipeline.project.slug >>/release-cli-finalize
-
+  release:
+    jobs:
+      - release:
+          context:
+            - turbo-cache
+            - bot-context
+            - slack-secrets
+            - github
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^@agent-facets\/.+@\d+\..+/
+          serial-group: << pipeline.project.slug >>/release/<< pipeline.parameters.package >>
+  release-cli:
+    jobs:
+      - build-cli:
+          context:
+            - turbo-cache
+            - bot-context
+            - slack-secrets
+            - github
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^agent-facets@\d+\..+/
+          serial-group: << pipeline.project.slug >>/release-cli-build
+      - publish-platform:
+          context:
+            - turbo-cache
+            - bot-context
+            - slack-secrets
+            - github
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^agent-facets@\d+\..+/
+          matrix:
+            parameters:
+              target:
+                - cli-darwin-arm64
+                - cli-darwin-x64
+                - cli-darwin-x64-baseline
+                - cli-linux-arm64
+                - cli-linux-arm64-musl
+                - cli-linux-x64
+                - cli-linux-x64-baseline
+                - cli-linux-x64-baseline-musl
+                - cli-linux-x64-musl
+                - cli-windows-arm64
+                - cli-windows-x64
+                - cli-windows-x64-baseline
+          requires:
+            - build-cli
+      - finalize-cli:
+          context:
+            - turbo-cache
+            - bot-context
+            - slack-secrets
+            - github
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^agent-facets@\d+\..+/
+          requires:
+            - publish-platform
+          serial-group: << pipeline.project.slug >>/release-cli-finalize

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -1,2 +1,2 @@
 [tools]
-circleci = "0.1.34950"
+"github:CircleCI-Public/circleci-cli" = { version = "1.0.43468-pre", prerelease = "true" }


### PR DESCRIPTION
### Why

The CircleCI CLI tool recently released a new version that reformats YAML configuration files to use 2-space indentation instead of 4-space indentation. This PR updates the CircleCI config files to match the new formatting style and upgrades the CLI tool version to reflect this change.

### Details

The `mise.development.toml` tool reference for the CircleCI CLI has been switched from the mise registry entry (`circleci = "0.1.34950"`) to a direct GitHub release reference (`github:CircleCI-Public/circleci-cli`) pointing to a prerelease version (`1.0.43468-pre`). This newer version produces YAML output with 2-space indentation, which is reflected in the reformatted `development.yml` and `release.yml` configs. No logic or workflow behavior has changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline configuration formatting for development and release workflows; behavior remains unchanged.
  * Adjusted the local tool version pin for the CircleCI CLI to a newer prerelease build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->