### PR TITLE
Add SEO metatags (description, language, color-scheme, reply-to, OG description) to docs config

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,7 +10,12 @@
   },
   "seo": {
     "metatags": {
-      "canonical": "https://docs.agentfacets.io"
+      "canonical": "https://docs.agentfacets.io",
+      "description": "Modular, versioned bundles of skills, agents, and commands that extend AI coding assistants",
+      "language": "en",
+      "color-scheme": "light dark",
+      "reply-to": "support@agentfacets.io",
+      "og:description": "Modular, versioned bundles of skills, agents, and commands that extend AI coding assistants"
     }
   },
   "appearance": {


### PR DESCRIPTION
### Why

The documentation site was missing key SEO metadata, reducing discoverability and social sharing quality.

### Details

Adds a `description`, `language`, `color-scheme`, `reply-to`, and `og:description` metatag to the docs configuration. The description used for both the standard meta and Open Graph tags is: *"Modular, versioned bundles of skills, agents, and commands that extend AI coding assistants"*.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Mintlify metadata; no application code, auth, or data paths change.
> 
> **Overview**
> Extends **`docs/docs.json`** `seo.metatags` beyond the existing canonical URL with **`description`**, **`language`** (`en`), **`color-scheme`** (`light dark`), **`reply-to`** (`support@agentfacets.io`), and **`og:description`**.
> 
> The standard and Open Graph descriptions reuse the same product copy already set at the top-level **`description`** field, so search snippets and link previews should align without changing site behavior or routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c96959766f6b8c81fda2144efce5bec033469a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->