### PR TITLE
Add `jsonFileText` helper and ensure all generated JSON files end with a trailing newline

### DIFF
--- a/.changeset/forty-jars-burn.md
+++ b/.changeset/forty-jars-burn.md
@@ -1,0 +1,5 @@
+---
+"agent-facets": patch
+---
+
+fix: ensure newline is at the end of all generated JSON files

--- a/packages/engine/src/__tests__/edit.test.ts
+++ b/packages/engine/src/__tests__/edit.test.ts
@@ -211,4 +211,18 @@ describe('writeManifest', () => {
     // 2-space indent means lines like '  "name": "test"'
     expect(content).toContain('  "name"')
   })
+
+  test('output ends with a trailing newline', async () => {
+    const dir = await createFixtureDir('write-newline')
+    const manifest: FacetManifest = {
+      name: 'test',
+      version: '1.0.0',
+      skills: { x: { description: 'X' } },
+    }
+
+    await writeManifest(manifest, dir)
+
+    const content = await Bun.file(join(dir, 'facet.json')).text()
+    expect(content.endsWith('}\n')).toBe(true)
+  })
 })

--- a/packages/engine/src/__tests__/json-file-text.test.ts
+++ b/packages/engine/src/__tests__/json-file-text.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+import { jsonFileText } from '../json-file-text.ts'
+
+describe('jsonFileText', () => {
+  test('serializes with 2-space indentation and a trailing newline', () => {
+    expect(jsonFileText({ a: 1 })).toBe('{\n  "a": 1\n}\n')
+  })
+
+  test('always ends with exactly one newline', () => {
+    const text = jsonFileText({ nested: { list: [1, 2] } })
+    expect(text.endsWith('\n')).toBe(true)
+    expect(text.endsWith('\n\n')).toBe(false)
+  })
+
+  test('round-trips through JSON.parse', () => {
+    const value = { facets: { cowsay: '0.1.1' } }
+    expect(JSON.parse(jsonFileText(value))).toEqual(value)
+  })
+})

--- a/packages/engine/src/__tests__/scaffold.test.ts
+++ b/packages/engine/src/__tests__/scaffold.test.ts
@@ -36,4 +36,9 @@ describe('generateScaffoldManifest privacy', () => {
     const keys = Object.keys(manifest)
     expect(keys).toEqual(['name', 'version', 'skills'])
   })
+
+  test('serialized manifest ends with a trailing newline', () => {
+    const json = generateScaffoldManifest(baseOptions())
+    expect(json.endsWith('}\n')).toBe(true)
+  })
 })

--- a/packages/engine/src/build/pipeline.ts
+++ b/packages/engine/src/build/pipeline.ts
@@ -14,6 +14,7 @@ import {
   validateCompactFacets,
   validateContentFiles,
 } from '@agent-facets/protocol'
+import { jsonFileText } from '../json-file-text.ts'
 import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
 import { buildArtifactFilename } from '../registry/artifact-path.ts'
 import { compressArchive } from './compress.ts'
@@ -156,7 +157,7 @@ export async function runBuildPipeline(
     integrity,
     assets: assetHashes,
   }
-  const manifestJson = JSON.stringify(buildManifest, null, 2)
+  const manifestJson = jsonFileText(buildManifest)
   const archiveBytes = assembleOuterTar(manifestJson, innerArchiveBytes)
 
   onProgress?.({ stage: 'Assembling archive', status: 'done' })

--- a/packages/engine/src/cache/operations.ts
+++ b/packages/engine/src/cache/operations.ts
@@ -19,6 +19,7 @@ import type {
 } from '@agent-facets/protocol'
 import { type ArchiveEntry, assembleTar, computeContentHash } from '@agent-facets/protocol'
 import { type } from 'arktype'
+import { jsonFileText } from '../json-file-text.ts'
 import { CACHE_INTEGRITY_FILE, type CacheIntegrity, CacheIntegritySchema } from './integrity.ts'
 import { cachePath, resolveCacheRoot } from './paths.ts'
 import type { CacheIdentity } from './types.ts'
@@ -337,7 +338,7 @@ export function cachePutVerified(
     integrity: computedIntegrity,
     assets: buildManifest.assets,
   }
-  writeFileSync(join(sourceDir, CACHE_INTEGRITY_FILE), JSON.stringify(sidecar, null, 2))
+  writeFileSync(join(sourceDir, CACHE_INTEGRITY_FILE), jsonFileText(sidecar))
 
   // 4. Delegate to cachePut.
   const putResult = cachePut(identity, sourceDir)

--- a/packages/engine/src/edit/manifest-writer.ts
+++ b/packages/engine/src/edit/manifest-writer.ts
@@ -1,12 +1,13 @@
 import { join } from 'node:path'
 import type { FacetManifest } from '@agent-facets/protocol'
 import { FACET_MANIFEST_FILE } from '@agent-facets/protocol'
+import { jsonFileText } from '../json-file-text.ts'
 
 /**
  * Writes a facet manifest to disk as `facet.json`.
- * Uses `JSON.stringify(data, null, 2)` per ADR-006.
+ * Uses `jsonFileText` (2-space indent per ADR-006, trailing newline).
  */
 export async function writeManifest(manifest: FacetManifest, rootDir: string): Promise<void> {
   const path = join(rootDir, FACET_MANIFEST_FILE)
-  await Bun.write(path, JSON.stringify(manifest, null, 2))
+  await Bun.write(path, jsonFileText(manifest))
 }

--- a/packages/engine/src/install/lockfile-guard.ts
+++ b/packages/engine/src/install/lockfile-guard.ts
@@ -3,6 +3,7 @@ import { closeSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync,
 import { rm } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { facetLocksDir } from '../facet-dir.ts'
+import { jsonFileText } from '../json-file-text.ts'
 
 /**
  * Atomic parallel-install advisory lock (Adjustment H + U).
@@ -78,7 +79,7 @@ export function acquireInstallLock(projectRoot: string): AcquireLockResult {
   // tree.
   mkdirSync(facetLocksDir(), { recursive: true })
 
-  const contents = JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })
+  const contents = jsonFileText({ pid: process.pid, acquiredAt: new Date().toISOString() })
 
   try {
     const fd = openSync(path, 'wx')

--- a/packages/engine/src/install/lockfile-io.ts
+++ b/packages/engine/src/install/lockfile-io.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { atomicWriteFileSync } from '@agent-facets/common'
 import { LOCKFILE_VERSION, type Lockfile, LockfileSchema } from '@agent-facets/protocol'
 import { type } from 'arktype'
+import { jsonFileText } from '../json-file-text.ts'
 
 /**
  * Bytes-level I/O for facets.lock. Keeps JSON parse/serialize in one place
@@ -74,7 +75,7 @@ export function writeLockfile(projectRoot: string, lockfile: Lockfile): void {
     sortedFacets[key] = entry
   }
   const canonical: Lockfile = { lockfileVersion: lockfile.lockfileVersion, facets: sortedFacets }
-  atomicWriteFileSync(path, `${JSON.stringify(canonical, null, 2)}\n`)
+  atomicWriteFileSync(path, jsonFileText(canonical))
 }
 
 export function emptyLockfile(): Lockfile {

--- a/packages/engine/src/install/receipt.ts
+++ b/packages/engine/src/install/receipt.ts
@@ -25,6 +25,7 @@ import { atomicWriteFileSync, validateAssetName } from '@agent-facets/common'
 import type { Lockfile, LockfileAssetEntry } from '@agent-facets/protocol'
 import { type } from 'arktype'
 import { facetReceiptsDir } from '../facet-dir.ts'
+import { jsonFileText } from '../json-file-text.ts'
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -221,7 +222,7 @@ export function writeReceipt(projectDir: string, receipt: Receipt): void {
   const filePath = receiptPath(projectDir)
   const canonical = canonicalProjectPath(projectDir)
   const normalized: Receipt = { ...receipt, path: canonical }
-  atomicWriteFileSync(filePath, `${JSON.stringify(normalized, null, 2)}\n`)
+  atomicWriteFileSync(filePath, jsonFileText(normalized))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/json-file-text.ts
+++ b/packages/engine/src/json-file-text.ts
@@ -1,0 +1,14 @@
+/**
+ * Serialize a value as the canonical on-disk JSON text for files this
+ * toolchain generates: 2-space indentation (per ADR-006) and a trailing
+ * newline, so generated files stay byte-stable in editors that
+ * auto-append a final newline.
+ *
+ * Every engine writer that emits a JSON file MUST serialize through this
+ * helper. The one exception is `serializeFacetsJson`, which must go
+ * through comment-json to preserve comments and independently upholds
+ * the same invariant.
+ */
+export function jsonFileText(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}

--- a/packages/engine/src/manifest/mutations.ts
+++ b/packages/engine/src/manifest/mutations.ts
@@ -53,6 +53,10 @@ export function parseFacetsJson(raw: string): Validated<FacetsJson> {
 /**
  * Serialize a FacetsJson value back to bytes, preserving any comment metadata
  * the value carries. Uses 2-space indentation to match ADR-006.
+ *
+ * Deliberately does NOT go through engine's `jsonFileText` helper: it must
+ * serialize via comment-json to preserve comments, so it upholds the same
+ * invariant (2-space indent, trailing newline) independently.
  */
 export function serializeFacetsJson(json: FacetsJson): string {
   return `${stringifyCommentJson(json, null, 2)}\n`

--- a/packages/engine/src/scaffold/index.ts
+++ b/packages/engine/src/scaffold/index.ts
@@ -2,6 +2,7 @@ import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { FACET_MANIFEST_FILE } from '@agent-facets/protocol'
 import { KEBAB_CASE } from '../edit/scanner.ts'
+import { jsonFileText } from '../json-file-text.ts'
 
 // --- Types ---
 
@@ -143,7 +144,7 @@ export function generateScaffoldManifest(opts: ScaffoldOptions): string {
     manifest.commands = commands
   }
 
-  return JSON.stringify(manifest, null, 2)
+  return jsonFileText(manifest)
 }
 
 // --- File listing preview ---


### PR DESCRIPTION
### Why

Generated JSON files were missing a trailing newline, causing editors that auto-append a final newline to produce diffs on otherwise unchanged files.

### Details

A new `jsonFileText` helper centralizes JSON serialization for all engine-generated files, enforcing 2-space indentation (per ADR-006) and a trailing newline. All engine writers that emit JSON files now go through this helper. The one exception is `serializeFacetsJson`, which must use comment-json to preserve comments but independently upholds the same invariant.

### Verification

New unit tests cover `jsonFileText` directly (indentation, exactly one trailing newline, round-trip parse), and existing test suites for `writeManifest` and `generateScaffoldManifest` have been extended to assert the trailing newline is present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Serialization-only change with no schema or business-logic edits; lockfile/receipt output may gain a consistent final newline where some writers already had one.
> 
> **Overview**
> Fixes spurious diffs when editors auto-append a final newline on generated JSON that previously ended without one.
> 
> Introduces **`jsonFileText`**, which serializes with 2-space indent (ADR-006) and exactly one trailing newline. Engine writers for **`facet.json`**, scaffold manifests, build manifests, cache integrity sidecars, install lock files, receipts, and parallel-install lock payloads now use it instead of bare **`JSON.stringify(..., null, 2)`** (some paths had already appended `\n` manually; those are consolidated).
> 
> **`serializeFacetsJson`** is explicitly left on comment-json for comment preservation but documents the same newline rule. Tests cover the helper and extend **`writeManifest`** / **`generateScaffoldManifest`** assertions for a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f36d703fcc0ad3c35e1ce646b3c2e9d4eb10a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized generated JSON files to use two-space indentation and exactly one trailing newline.
  * Applied consistent formatting to manifests, lockfiles, receipts, cache metadata, and scaffold output.

* **Tests**
  * Added coverage confirming formatting, newline behavior, and JSON round-trip validity.

* **Release**
  * Included a patch release for the `agent-facets` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->