### PR TITLE
docs: add quickstart, setup, and troubleshooting guides; refresh manifest schema

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: Facet CLI
 sidebarTitle: CLI
-description: "`facet` is an open-source CLI for managing and installing **facets**"
+description: The open-source CLI for managing facets
 tag: facet
 ---
 

--- a/docs/cli/add.mdx
+++ b/docs/cli/add.mdx
@@ -1,6 +1,6 @@
 ---
 title: facet add
-description: Adds one or more facets to `facets.json` and installs them
+description: Add facets to a project and install them
 ---
 
 ## Usage

--- a/docs/cli/authoring/build.mdx
+++ b/docs/cli/authoring/build.mdx
@@ -34,6 +34,10 @@ If the build fails, errors are displayed inline under the failed pipeline stage,
 
 ## Validate without building: `--verify`
 
+<Note>
+  The `--verify` and `--json` flags require the facet CLI **v0.24.0 or newer**. Update with <code>[facet self-update](/cli/self-update)</code> if your build doesn't recognize them.
+</Note>
+
 `facet build --verify` runs the full validation pipeline (stages 1–5 above) **without writing any output** — a no-op build. Nothing is written to `dist/`. Use it to confirm that `facet.json` and every asset file are valid and buildable, without producing an artifact.
 
 ```sh

--- a/docs/cli/authoring/create.mdx
+++ b/docs/cli/authoring/create.mdx
@@ -15,6 +15,10 @@ If a `facet.json` already exists in the target directory, the command prompts fo
 
 ## Headless mode
 
+<Note>
+  Headless scaffolding requires the facet CLI **v0.24.0 or newer**. On older CLIs only the interactive wizard is available; update with <code>[facet self-update](/cli/self-update)</code>.
+</Note>
+
 Pass any authoring flag and `facet create` skips the interactive wizard and scaffolds directly — the path AI agents and scripts should use. See <code>[facet instructions authoring](/cli/instructions)</code>.
 
 ```sh

--- a/docs/cli/authoring/edit.mdx
+++ b/docs/cli/authoring/edit.mdx
@@ -1,6 +1,6 @@
 ---
 title: facet edit
-description: Interactive editor for reconciling and authoring a facet
+description: Interactively edit a facet
 ---
 
 ## Usage

--- a/docs/cli/authoring/modify.mdx
+++ b/docs/cli/authoring/modify.mdx
@@ -13,6 +13,10 @@ facet modify <target> [name] [directory] [flags]
 
 `<target>` is one of `skill`, `agent`, `command`, or `facet`. `[directory]` defaults to the current directory and must contain a `facet.json`.
 
+<Note>
+  Requires the facet CLI **v0.24.0 or newer**. If `facet modify` reports *"Unknown command"*, update with <code>[facet self-update](/cli/self-update)</code>.
+</Note>
+
 ## Editing an asset
 
 For the asset targets (`skill`, `agent`, `command`), pass the asset name and exactly one lifecycle action, optionally with field changes.

--- a/docs/cli/authoring/publish.mdx
+++ b/docs/cli/authoring/publish.mdx
@@ -1,6 +1,6 @@
 ---
 title: facet publish
-description: Verify a built facet and upload it to the registry
+description: Verify and upload a built facet
 ---
 
 ## Usage

--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment Variables
-description: Environment variables that configure where facet stores state
+description: Where the facet CLI stores its state
 ---
 
 ## Environment Variables

--- a/docs/cli/instructions.mdx
+++ b/docs/cli/instructions.mdx
@@ -13,6 +13,10 @@ facet instructions [topic]
 
 The default topic is `overview`. It routes the agent to the right domain — authoring a facet, or using facets in a project — and indexes the other topics.
 
+<Note>
+  Requires the facet CLI **v0.24.0 or newer**. If `facet instructions` reports *"Unknown command"*, update with <code>[facet self-update](/cli/self-update)</code>.
+</Note>
+
 ## Topics
 
 <ResponseField name="overview" type="default">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,16 +52,18 @@
           {
             "group": "Agent Facets",
             "icon": "box",
-            "pages": ["index", "docs/learn/index"]
+            "pages": ["index", "quickstart", "docs/learn/index"]
           },
           {
             "group": "Guides",
             "icon": "rocket",
             "pages": [
+              "guides/setup",
               "guides/install-facets",
               "guides/create-your-first-facet",
               "guides/publish-a-facet",
-              "guides/custom-adapters"
+              "guides/custom-adapters",
+              "guides/troubleshooting"
             ]
           },
           {

--- a/docs/docs/learn/index.mdx
+++ b/docs/docs/learn/index.mdx
@@ -7,20 +7,20 @@ This page introduces the core concepts behind Facets. For normative requirements
 
 ## Facets
 
-A **facet** is a versioned collection of [assets](#assets) defined by a facet manifest (`facet.json`). What the author creates locally, what gets published to the registry, and what gets extracted after install.
+A **facet** is a versioned collection of [assets](#assets) defined by a facet manifest (`facet.json`) — the same bundle an author creates locally, publishes to the registry, and installs into a project.
 
 ## Assets
 
-A discrete unit of content within a facet. Consisting of any combination of skills, agents, and commands.
+An asset is a discrete unit of content within a facet. A facet bundles any combination of the three asset types below. All three are text assets that follow the [Agent Skills](https://agentskills.io/specification) specification.
 
 <Columns col={2}>
   <Card title='Skills' href='/docs/learn/skills'>
-    Text assets that follow the [Agent Skills](https://agentskills.io/specification) specification.
+    Reusable knowledge and guidelines the assistant applies passively.
   </Card>
   <Card title='Commands' href='/docs/learn/commands'>
-    Text assets that follow the [Agent Skills](https://agentskills.io/specification) specification.
+    User-invokable workflows, exposed as slash commands.
   </Card>
   <Card title='Agents' href='/docs/learn/agents'>
-    Text assets that follow the [Agent Skills](https://agentskills.io/specification) specification.
+    Personas with a defined role, behavior, and tool access.
   </Card>
 </Columns>

--- a/docs/guides/install-facets.mdx
+++ b/docs/guides/install-facets.mdx
@@ -186,6 +186,20 @@ Your project now has two files  -- commit both to version control so teammates a
   The lockfile honors the manifest. A pinned entry is reused as long as it still satisfies `facets.json`; when you bump a version or widen a wildcard, `facet install` re-resolves and updates the lock.
 </Note>
 
+## Where assets land
+
+`facet add` also writes each asset into every connected adapter's **project-local** directory, so your tool picks them up immediately. With the `opencode` adapter, adding `cowsay` writes:
+
+```
+.opencode/
+├── skills/cowsay-rules/SKILL.md
+├── agents/cowsay.md
+├── commands/cowsay.md
+└── commands/cowchat.md
+```
+
+Other adapters use their own conventional location (Claude Code under `.claude/`, and so on). These files are `project`-scoped  -- the same `scope` you see in the lockfile  -- so they belong to the checkout, not your machine. `facet remove` deletes them again, and `facet install` recreates them from the lockfile after a clone.
+
 ## Reinstall after a git clone
 
 When you clone a project that already has `facets.json` and `facets.lock`, materialize into your adapters with:

--- a/docs/guides/setup.mdx
+++ b/docs/guides/setup.mdx
@@ -1,0 +1,74 @@
+---
+title: Setup & Prerequisites
+description: Install the CLI, an adapter, and a token
+---
+
+What you need before adding, authoring, or publishing facets. If you just want to try a facet, the [Quickstart](/quickstart) is faster.
+
+<Steps>
+  <Step title="Install the CLI">
+    <CodeGroup>
+      ```sh curl
+      curl -fsSL https://agentfacets.io/install | bash
+      ```
+
+      ```sh npm
+      npm install -g agent-facets
+      ```
+
+      ```sh bun
+      bun add -g agent-facets
+      ```
+    </CodeGroup>
+
+    Keep it current — the newer authoring commands need **v0.24.0+**:
+
+    ```sh
+    facet --version
+    facet self-update   # update in place if needed
+    ```
+  </Step>
+
+  <Step title="Connect an adapter (required before `facet add`)">
+    A facet is only useful once it's materialized into an AI tool, which the <Tooltip tip="An adapter is the bridge between facet and a specific AI coding tool.">adapter</Tooltip> handles. Install one per machine:
+
+    ```sh
+    facet adapter install claude-code   # or: opencode, codex
+    facet adapter list
+    ```
+
+    <Note>
+      Without an adapter, `facet add` shows a picker in a terminal — and **fails** in a non-interactive shell (CI). Install one first.
+    </Note>
+  </Step>
+
+  <Step title="Create a registry account + token (only to publish)">
+    Adding public facets needs no account. **Publishing** does: sign up at [agentfacets.io](https://agentfacets.io) and create a <Tooltip tip="A revocable credential you mint in the web UI to authenticate the CLI to the registry.">personal access token (PAT)</Tooltip> in your account settings.
+
+    ```sh
+    facet login                     # interactive; stores the token
+    export FACET_TOKEN=fct_pub_…    # or, preferred for CI/scripts
+    facet whoami                    # confirm the signed-in identity
+    ```
+  </Step>
+</Steps>
+
+## Verify your setup
+
+```sh
+facet --version        # CLI is installed and recent
+facet adapter list     # at least one adapter connected
+facet whoami           # signed in (only needed for publishing)
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Install facets" icon="download" href="/guides/install-facets">
+    Add, pin, reinstall, and remove facets.
+  </Card>
+
+  <Card title="Create your first facet" icon="hammer" href="/guides/create-your-first-facet">
+    Scaffold, author, build, and verify.
+  </Card>
+</CardGroup>

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -1,0 +1,80 @@
+---
+title: Troubleshooting
+description: Fix common facet CLI errors
+---
+
+Common errors, what causes them, and how to fix them. Each entry mirrors the CLI's own `error: … fix: …` output.
+
+<AccordionGroup>
+  <Accordion title='"Unknown command" (e.g. facet instructions / modify)'>
+    **Cause:** your installed CLI predates the command. `facet instructions`, `facet modify`, headless `facet create`, and `facet build --verify/--json` require **v0.24.0 or newer**.
+
+    **Fix:** update in place, then re-run:
+
+    ```sh
+    facet self-update
+    facet --version
+    ```
+  </Accordion>
+
+  <Accordion title='"could not reach the registry"'>
+    **Cause:** `facet search`, a registry `facet add`, and `facet publish` need network access to the registry. Offline, they **fail closed** rather than write an unconfirmed entry.
+
+    **Fix:** check your connection and retry. Note that **local paths** (`./my-facet`) and **git sources** (`github:owner/repo`) resolve without the registry, so you can keep working offline with those.
+  </Accordion>
+
+  <Accordion title='"no adapters installed" when running facet add (non-interactive)'>
+    **Cause:** a facet has to be materialized into at least one adapter, but none is connected. In a real terminal `facet add` shows a picker; in a non-interactive shell (CI, piped stdin) it exits with an error instead.
+
+    **Fix:** install an adapter first:
+
+    ```sh
+    facet adapter install claude-code
+    facet adapter list
+    ```
+  </Accordion>
+
+  <Accordion title='"not signed in — no registry credential found"'>
+    **Cause:** `facet publish` (and `facet whoami`) need a registry credential and none was found.
+
+    **Fix:** authenticate, then retry. In CI, prefer the environment variable:
+
+    ```sh
+    facet login              # interactive
+    export FACET_TOKEN=fct_pub_…   # or, for CI/scripts
+    facet whoami             # confirm the identity
+    ```
+  </Accordion>
+
+  <Accordion title='Publish rejected: version already exists (HTTP 409)'>
+    **Cause:** published `(name, version)` pairs are **immutable** — you can't republish a version with different content.
+
+    **Fix:** bump the version, rebuild, and publish again:
+
+    ```sh
+    facet modify facet --version 1.2.0
+    facet build
+    facet publish
+    ```
+  </Accordion>
+
+  <Accordion title='Build fails: skills["0"] must be an object'>
+    **Cause:** `skills` is written as an array of strings. It must be a **map** of name → descriptor.
+
+    **Fix:**
+
+    ```json
+    {
+      "skills": {
+        "code-review": { "description": "Guidelines for reviewing code changes" }
+      }
+    }
+    ```
+
+    Then re-check with `facet build --verify`. See the [Manifest reference](/specification/manifest).
+  </Accordion>
+</AccordionGroup>
+
+## Still stuck?
+
+Ask in the [community Discord](https://discord.gg/qXQYaYna5w) or open an issue on [GitHub](https://github.com/agent-facets/facets).

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -20,7 +20,7 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
   <Accordion title='"could not reach the registry"'>
     **Cause:** `facet search`, a registry `facet add`, and `facet publish` need network access to the registry. Offline, they **fail closed** rather than write an unconfirmed entry.
 
-    **Fix:** check your connection and retry. Note that **local paths** (`./my-facet`) and **git sources** (`github:owner/repo`) resolve without the registry, so you can keep working offline with those.
+    **Fix:** check your connection and retry. Note that **local paths** (`./my-facet`) and **git sources** (`github:owner/repo`) resolve without the registry, so you do not need registry access to install/add from these sources.
   </Accordion>
 
   <Accordion title='"no adapters installed" when running facet add (non-interactive)'>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -51,7 +51,7 @@ facet --version
 facet adapter install
 ```
 
-Bundled adapters are hosted on GitHub. There is an [adapter SDK](https://github.com/agent-facets/facets/tree/main/packages/adapter) you can use to <Tooltip headline="Facet Adapter SDK" tip="The SDK can be used to build custom adapters. Adapters completely manage the lifecycle of facet installation." cta="Learn More" href="/guides/custom-adapters">build custom adapters</Tooltip>.
+Bundled <Tooltip headline="Adapter" tip="The bridge between facet and a specific AI coding tool — it decides where a facet's assets and config land on disk." cta="Adapter reference" href="/cli/adapters/install">adapters</Tooltip> are hosted on GitHub. There is an [adapter SDK](https://github.com/agent-facets/facets/tree/main/packages/adapter) you can use to <Tooltip headline="Facet Adapter SDK" tip="The SDK can be used to build custom adapters. Adapters completely manage the lifecycle of facet installation." cta="Learn More" href="/guides/custom-adapters">build custom adapters</Tooltip>.
 
 </Step>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,83 @@
+---
+title: Quickstart
+description: Install, add, and use your first facet
+---
+
+By the end of this page you'll have the `facet` CLI installed, a facet added to your project, and a new slash command working in your AI coding tool — in under five minutes.
+
+<Steps>
+  <Step title="Install the CLI">
+    <CodeGroup>
+      ```sh curl
+      curl -fsSL https://agentfacets.io/install | bash
+      ```
+
+      ```sh npm
+      npm install -g agent-facets
+      ```
+
+      ```sh bun
+      bun add -g agent-facets
+      ```
+    </CodeGroup>
+
+    Verify it:
+
+    ```sh
+    facet --version
+    ```
+  </Step>
+
+  <Step title="Connect your AI tool (once per machine)">
+    Install the <Tooltip tip="An adapter is the bridge between facet and a specific AI coding tool — it decides where assets and config land on disk.">adapter</Tooltip> for the tool you use:
+
+    ```sh
+    facet adapter install claude-code   # or: opencode, codex
+    ```
+  </Step>
+
+  <Step title="Add a facet">
+    From your project directory, add a facet by name from the registry:
+
+    ```sh
+    facet add cowsay
+    ```
+
+    ```
+    cowsay installed. Updated facets via 1 adapter  ✓
+      1 installed · 4 assets written
+      + 1 skill · 1 agent · 2 commands
+    ```
+  </Step>
+
+  <Step title="Use it">
+    The facet's commands are now available in your tool. Run:
+
+    ```
+    /cowsay
+    /cowchat
+    ```
+
+    That's it — you've installed and used your first facet.
+  </Step>
+</Steps>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Set up publishing" icon="key" href="/guides/setup">
+    Install adapters and mint a token so you can publish your own facets.
+  </Card>
+
+  <Card title="Create your first facet" icon="hammer" href="/guides/create-your-first-facet">
+    Scaffold, author, build, and verify a facet of your own.
+  </Card>
+
+  <Card title="Install facets" icon="download" href="/guides/install-facets">
+    Add, pin, reinstall, and remove facets in a project.
+  </Card>
+
+  <Card title="Hit a snag?" icon="life-buoy" href="/guides/troubleshooting">
+    Fixes for the most common CLI errors.
+  </Card>
+</CardGroup>

--- a/docs/roadmap/stable.mdx
+++ b/docs/roadmap/stable.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stable Release
 sidebarTitle: Stable
-description: Criteria for the v1.0.0 general-availability release
+description: Criteria for the v1.0.0 release
 ---
 
 The stable release will be announced as **v1.0.0** and flags general availability. It ships when the [beta](/roadmap/beta) feature set has proven itself in public use.

--- a/docs/specification/architecture.mdx
+++ b/docs/specification/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Architecture"
-description: "Actors, artifact types, distribution model, and design principles."
+description: Actors, artifacts, and design principles
 ---
 
 The Facets system distributes AI assistant extensions through a registry-based model. The artifact type is the **facet**: a versioned bundle of text assets.

--- a/docs/specification/manifest.mdx
+++ b/docs/specification/manifest.mdx
@@ -2,10 +2,12 @@
 title: "Facet Manifest – facet.json"
 sidebarTitle: Facet Manifest
 tag: facet.json
-description: "The manifest format schema -- fields, types, and constraints."
+description: The facet.json schema and name grammar
 ---
 
 The facet manifest (`facet.json`) is the source of truth for a facet's identity and the text assets it contains. This page defines every field in the manifest schema and is the canonical reference for the facet name grammar.
+
+For conceptual guides to each asset type, see [Skills](/docs/learn/skills), [Commands](/docs/learn/commands), and [Agents](/docs/learn/agents).
 
 ## Example
 
@@ -15,11 +17,13 @@ The facet manifest (`facet.json`) is the source of truth for a facet's identity 
   "version": "1.0.0",
   "description": "Acme org developer toolkit",
   "author": "acme-org",
-  "skills": ["code-standards", "pr-template"],
+  "skills": {
+    "code-standards": { "description": "House coding standards" },
+    "pr-template": { "description": "Pull request description template" }
+  },
   "agents": {
     "reviewer": {
       "description": "Org code reviewer",
-      "prompt": { "file": "agents/reviewer.md" },
       "adapters": {
         "opencode": {
           "tools": { "grep": true, "bash": true }
@@ -29,8 +33,7 @@ The facet manifest (`facet.json`) is the source of truth for a facet's identity 
   },
   "commands": {
     "review": {
-      "description": "Run a code review",
-      "prompt": { "file": "commands/review.md" }
+      "description": "Run a code review"
     }
   }
 }
@@ -95,39 +98,56 @@ Text assets are the locally authored content included in the facet.
 
 | Field      | Required | Type                              | Description                                                                  |
 | ---------- | -------- | --------------------------------- | ---------------------------------------------------------------------------- |
-| `skills`   | No       | array of strings                  | Skill names. Each corresponds to a file in the facet.                        |
-| `agents`   | No       | map of string → agent descriptor  | Agent name → agent descriptor (description, prompt, adapter config).         |
-| `commands` | No       | map of string → command descriptor| Command name → command descriptor (description, prompt).                     |
+| `skills`   | No       | map of string → skill descriptor  | Skill name → skill descriptor (description, adapter config).                  |
+| `agents`   | No       | map of string → agent descriptor  | Agent name → agent descriptor (description, adapter config).                  |
+| `commands` | No       | map of string → command descriptor| Command name → command descriptor (description, adapter config).             |
+| `facets`   | No       | array of facets entries           | References to other facets (composition). Not yet implemented -- see [Publish Flow](/specification/publish). |
+| `servers`  | No       | map of string → server reference  | MCP server references (source-mode version string or ref-mode `{ image }`). Server support is in development. |
 
-A facet MUST have at least one locally authored text asset. A manifest with no text assets MUST be rejected.
+A facet MUST have at least one text asset -- skills, agents, commands, or facets. A manifest with none of these MUST be rejected.
+
+### Skill Descriptor
+
+<ResponseField name="description" type="string" required>
+  Human-readable description of the skill.
+</ResponseField>
+
+<ResponseField name="adapters" type="map of string → adapter config">
+  Adapter name → adapter-specific skill configuration.
+</ResponseField>
+
+The skill's prompt is the content of `skills/<name>/SKILL.md`, resolved by convention at build time -- it is not a manifest field.
 
 ### Agent Descriptor
 
-| Field         | Required | Type                          | Description                                                            |
-| ------------- | -------- | ----------------------------- | ---------------------------------------------------------------------- |
-| `description` | No       | string                        | Human-readable description of the agent.                               |
-| `prompt`      | Yes      | string or `{file: path}`       | The agent's prompt content or a reference to it.              |
-| `adapters`   | No       | map of string → adapter config | Adapter name → adapter-specific agent configuration.                 |
+<ResponseField name="description" type="string" required>
+  Human-readable description of the agent.
+</ResponseField>
 
-The `prompt` field MUST be present. It MAY be:
-- A string containing the prompt text directly
-- An object with a `file` key containing a path relative to the facet root
+<ResponseField name="adapters" type="map of string → adapter config">
+  Adapter name → adapter-specific agent configuration.
+</ResponseField>
+
+The agent's prompt is the content of `agents/<name>.md`, resolved by convention at build time -- it is not a manifest field.
 
 The `adapters` section is OPTIONAL. It contains adapter-specific configuration (tool access, permissions, model preferences) keyed by adapter name. Each installed adapter validates its own metadata schema at build time. Unknown adapters produce a warning. Invalid metadata for an installed adapter is a build error.
 
 ### Command Descriptor
 
-| Field         | Required | Type                          | Description                                                            |
-| ------------- | -------- | ----------------------------- | ---------------------------------------------------------------------- |
-| `description` | No       | string                        | Human-readable description of the command.                             |
-| `prompt`      | Yes      | string or `{file: path}`       | The command's prompt content or a reference to it.            |
+<ResponseField name="description" type="string" required>
+  Human-readable description of the command.
+</ResponseField>
 
-The `prompt` field follows the same rules as the agent descriptor's `prompt`.
+<ResponseField name="adapters" type="map of string → adapter config">
+  Adapter name → adapter-specific command configuration.
+</ResponseField>
+
+The command's prompt is the content of `commands/<name>.md`, resolved by convention at build time -- it is not a manifest field.
 
 ## Schema Constraints
 
 1. The `name` MUST be a valid facet identity (see [Facet Name Grammar](#facet-name-grammar)), and the `version` MUST be a semver string.
-2. A facet MUST have at least one locally authored text asset.
+2. A facet MUST have at least one text asset -- skills, agents, commands, or facets.
 3. The `@` character marks a scope (`@scope/name`) and also separates a name from a version when a facet is referenced elsewhere (`name@version`, `@scope/name@version`).
 4. Consumers MUST tolerate unrecognized fields. Unknown fields MUST be ignored.
 5. If present, `private` MUST be a boolean; non-boolean values are rejected. Omission is not rewritten to `private: false` (see [Privacy](#privacy)).

--- a/docs/specification/publish.mdx
+++ b/docs/specification/publish.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Publish Flow"
-description: "How facets are built and published to the registry."
+description: How facets are built and published
 ---
 
 `facet build` produces the canonical `.facet` archive on disk from your source tree. `facet publish` reads that built archive, verifies it against the facet artifact specification, and uploads it to the registry. Building and publishing are distinct steps with a single source of truth for what a `.facet` is: the protocol-defined two-layer format whose content-hash contract is described in the [Integrity Model](/specification/integrity).

--- a/docs/specification/terminology.mdx
+++ b/docs/specification/terminology.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Terminology"
-description: "Canonical terms used throughout the Facets specification."
+description: Canonical terms used in the spec
 ---
 
 Canonical terms used throughout the specification. Implementations SHOULD use the same terms in user-facing interfaces and documentation.


### PR DESCRIPTION
### Why

Improve onboarding and reference docs: adds a quickstart plus setup and troubleshooting guides, and brings the facet manifest schema reference in line with the current `facet.json` shape (skills/agents/commands as descriptor maps, `facets`/`servers` fields).

### Details

- New pages: `docs/quickstart.mdx`, `docs/guides/setup.mdx`, `docs/guides/troubleshooting.mdx` (wired into `docs.json` nav).
- `specification/manifest.mdx`: skills now a descriptor map; documents `facets` and `servers`; adds skill/response field references.
- `guides/install-facets.mdx`: adds a "Where assets land" section.
- Assorted copy/description touch-ups across CLI reference pages.

### Verification

CI (`docs:validate` + `docs:broken-links` pass locally). Mintlify preview deploy on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; manifest page changes align docs with existing CLI/schema behavior rather than altering runtime code.
> 
> **Overview**
> Adds **onboarding docs** and wires them into Mintlify nav: a **Quickstart** (`quickstart`), **Setup & Prerequisites** (`guides/setup`), and **Troubleshooting** (`guides/troubleshooting`). The install guide gains a **Where assets land** section (project-local adapter paths, e.g. `.opencode/`).
> 
> **`specification/manifest.mdx`** is brought in line with current `facet.json`: **`skills` as a name → descriptor map** (not a string array), prompts documented as **conventional files** (`SKILL.md`, `agents/<name>.md`, etc.) rather than inline `prompt` fields, plus **`facets`** and **`servers`** fields and a dedicated skill descriptor section.
> 
> Several **CLI reference pages** get shorter frontmatter descriptions, **v0.24.0+** notes for `instructions`, `modify`, headless `create`, and `build --verify`/`--json`, and light copy updates on learn concepts and the home page adapter tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b391dc5d2d1e9d4e769e2dc257b73dddb9d73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new CLI guides: Quickstart, Setup & Prerequisites, and Troubleshooting.
  * Updated CLI command and flag notes to clearly call out minimum CLI version requirements (and when to run self-update).
  * Expanded guidance on where installed facet assets land in connected adapter projects, including removal/reinstall behavior.
  * Refreshed docs navigation and wording across concepts, terminology, architecture, and publish/roadmap pages.
  * Updated the facet manifest/schema guidance with revised `skills` shape and text-asset specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->