### PR TITLE
Bump `cowsay` to `1.0.1`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,7 +1,7 @@
 {
   "facets": {
     "viper-plans": "latest",
-    "cowsay": "latest",
+    "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "latest",
     "@agentfacets/address-pr-feedback": "latest"

--- a/facets.lock
+++ b/facets.lock
@@ -101,8 +101,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.0.0",
-      "integrity": "sha256:70fe8f9f0ba16132c70826d1cda70af9f0b4e63f3394178d2d5b4c374c833818",
+      "version": "1.0.1",
+      "integrity": "sha256:aa526ad78d470605791c99204792df8afe81fb497778e4d1712261da6f517e67",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Pins the `cowsay` facet to version `1.0.1` instead of tracking `latest`.

### Details

The lock file has been updated to reflect the new version and its corresponding integrity hash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and lockfile refresh only; no application or runtime code changes.
> 
> **Overview**
> Pins the **`cowsay`** facet from **`latest`** to **`1.0.1`** in `facets.json` so installs resolve to a fixed release instead of whatever the registry currently labels as latest.
> 
> **`facets.lock`** is updated to match: version **`1.0.0` → `1.0.1`** and the integrity hash is replaced with the one for the new artifact. The locked asset list (skills, agent, commands) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 617a6022234d9518324fe5026267f034f35c4828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the `cowsay` facet to version 1.0.1 for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->