### PR TITLE
Update `Facet` tooltip to describe open-source spec built on Agent Skills

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,7 +3,7 @@ title: "Agent Facets"
 sidebarTitle: "Introduction"
 ---
 
-<Tooltip headline="Facet" tip="A modular, versioned bundle of skills, agents, and commands that extends an AI coding assistant." cta="Read the spec" href="/specification/architecture#facets">Facets</Tooltip> are modular, versioned bundles of skills, agents, and commands that extend AI coding assistants.
+<Tooltip headline="Facet" tip="The Agent Facet format specification is open-source and built on other standards like the Agent Skills specification." cta="Read the spec" href="/specification">Facets</Tooltip> are modular, versioned bundles of skills, agents, and commands that extend AI coding assistants.
 
 The `facet` CLI tool is a package manager for facets with a free public <Tooltip headline="Registry" tip="The public registry at agentfacets.io where facets are published, discovered, and installed." cta="Browse facets" href="https://agentfacets.io">registry</Tooltip>, https://agentfacets.io. The registry is a place to help discover and install facets without building them yourself. It's also a place to share facets you author **publicly** with the world or **privately** with your team.
 


### PR DESCRIPTION
### Why

The tooltip for "Facet" on the introduction page was describing the concept rather than highlighting what makes the format notable — that it's open-source and built on existing standards like the Agent Skills specification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and link change on the intro page with no runtime or product behavior impact.
> 
> **Overview**
> On the introduction page, the **Facet** tooltip copy now highlights that the Agent Facet format spec is **open-source** and builds on standards such as the **Agent Skills** specification, instead of restating the generic “modular bundle” definition.
> 
> The tooltip **Read the spec** link now points to `/specification` rather than `/specification/architecture#facets`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35d6a552dde71ee950c800e7a5c82c1592db3af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->