### PR TITLE
Replace `isValidKebabCase` with `validateAssetNameSegment` from `@agent-facets/protocol`, enforcing the Agent Skills name grammar across CLI, engine, and manifest schema

### DIFF
--- a/.changeset/fresh-hands-join.md
+++ b/.changeset/fresh-hands-join.md
@@ -1,0 +1,12 @@
+---
+"@agent-facets/protocol": minor
+"agent-facets": minor
+---
+
+Enforce the Agent Skills name grammar for skill, command, and agent names everywhere names enter the system.
+
+`@agent-facets/protocol` gains a canonical asset-name grammar (`schemas/asset-name.ts`) modeled on the [Agent Skills spec](https://agentskills.io/specification#name-field). New exports: `parseAssetName`, `parseAssetNameSegment`, `validateAssetName`, and `validateAssetNameSegment`, along with the `AssetNameResult` and `AssetNameSegmentResult` types. A single segment is 1–64 characters of lowercase ASCII letters, digits, and hyphens, must not start or end with a hyphen, and must not contain consecutive hyphens. Full asset names may carry `/`-separated namespace segments (`viper-plans/planning`), each validated independently; the parsers return discriminated-union results instead of throwing.
+
+BREAKING CHANGE: `FacetManifestSchema` now validates every asset name against this grammar instead of the previous path-safety-only check. Manifests declaring non-conforming asset names (uppercase like `MySkill`, underscores like `foo_bar`, leading/trailing or consecutive hyphens, names over 64 characters) now fail at build **and** install — the schema validates fetched manifests too — rather than passing silently. Digit-start names (`2fa`) are now valid, diverging from the stricter facet-identity slug grammar. Lockfile asset names intentionally keep the weaker path-safety guard so existing installs continue to load and can be removed.
+
+The `agent-facets` CLI routes `facet create` (wizard and headless), the create/edit TUI views, and `facet modify` (`--add` and `--rename`) through the shared validator, surfacing the grammar's own reason strings in errors. `facet modify --update`/`--remove` still accept legacy non-conforming names so users can fix or remove them.

--- a/docs/specification/manifest.mdx
+++ b/docs/specification/manifest.mdx
@@ -52,7 +52,7 @@ Every top-level field of `facet.json`. The `name` and `version` fields MUST be p
 ### Fields
 
 <ResponseField name="name" type="string" required>
-  Facet identity: an unscoped name (`cowsay`) or a scoped name (`@scope/name`). Validated, never normalized — see [Facet name grammar](#facet-name-grammar). Asset names — skill, command, and agent names alike — are validated independently as local kebab-case identifiers per the [Agent Skills name grammar](https://agentskills.io/specification#name-field) and are never scoped.
+  Facet identity: an unscoped name (`cowsay`) or a scoped name (`@scope/name`). Validated, never normalized — see [Facet name grammar](#facet-name-grammar). Asset names — skill, command, and agent names alike — are validated independently against the [Agent Skills name grammar](https://agentskills.io/specification#name-field): each `/`-separated segment is 1–64 characters of lowercase ASCII letters, digits, and hyphens, must not start or end with a hyphen, and must not contain consecutive hyphens. Slashes separate namespace segments (`viper-plans/planning`); asset names are never scoped with `@`.
 </ResponseField>
 
 <ResponseField name="version" type="string" required>

--- a/packages/cli/src/commands/create/__tests__/headless.test.ts
+++ b/packages/cli/src/commands/create/__tests__/headless.test.ts
@@ -68,6 +68,19 @@ describe('decideCreate — headless validation', () => {
     expect(d.error.what).toContain('invalid skill name')
   })
 
+  test('digit-start asset name is accepted (Agent Skills grammar)', () => {
+    const d = decideCreate({ name: 'my-facet', skill: ['2fa'] })
+    if (d.mode !== 'headless') expect.unreachable()
+    expect(d.options.skills).toEqual(['2fa'])
+  })
+
+  test('over-long asset name (>64 chars) is an error', () => {
+    const d = decideCreate({ name: 'my-facet', skill: ['a'.repeat(65)] })
+    if (d.mode !== 'error') expect.unreachable()
+    expect(d.error.what).toContain('invalid skill name')
+    expect(d.error.detail).toContain('at most 64')
+  })
+
   test('no assets is an error', () => {
     const d = decideCreate({ name: 'my-facet' })
     if (d.mode !== 'error') expect.unreachable()

--- a/packages/cli/src/commands/create/headless.ts
+++ b/packages/cli/src/commands/create/headless.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_VERSION, isValidKebabCase, isValidSemVer, type ScaffoldOptions } from '@agent-facets/engine'
-import { validateFacetName } from '@agent-facets/protocol'
+import { DEFAULT_VERSION, isValidSemVer, type ScaffoldOptions } from '@agent-facets/engine'
+import { validateAssetNameSegment, validateFacetName } from '@agent-facets/protocol'
 import type { CliError } from '../../util/errors.ts'
 
 /**
@@ -74,12 +74,13 @@ export function decideCreate(flags: Record<string, unknown>): CreateDecision {
     ['command', commands],
   ] as const) {
     for (const assetName of names) {
-      if (!isValidKebabCase(assetName)) {
+      const check = validateAssetNameSegment(assetName)
+      if (!check.ok) {
         return {
           mode: 'error',
           error: {
             what: `invalid ${group} name "${assetName}"`,
-            detail: 'asset names must be kebab-case (lowercase letters, digits, single hyphens)',
+            detail: `asset name ${check.reason}`,
             fix: `pass a valid name, e.g. --${group} my-${group}`,
           },
         }

--- a/packages/cli/src/commands/modify/__tests__/parse.test.ts
+++ b/packages/cli/src/commands/modify/__tests__/parse.test.ts
@@ -33,6 +33,27 @@ describe('parseModifyArgs — legal operations', () => {
     expect(r.op.to).toBe('welcome')
   })
 
+  test('add with a digit-start name is accepted (Agent Skills grammar)', () => {
+    const r = parseModifyArgs(['skill', '2fa'], { add: true })
+    if (!r.ok) expect.unreachable()
+    if (r.op.kind !== 'add') expect.unreachable()
+    expect(r.op.name).toBe('2fa')
+  })
+
+  test('update on a legacy non-kebab name is still allowed', () => {
+    // --update/--remove must keep working on existing non-kebab names so users
+    // can fix or remove them; only --add and --rename validate the new name.
+    const r = parseModifyArgs(['skill', 'Legacy_Name'], { description: 'x' })
+    if (!r.ok) expect.unreachable()
+    expect(r.op.kind).toBe('update')
+  })
+
+  test('remove on a legacy non-kebab name is still allowed', () => {
+    const r = parseModifyArgs(['skill', 'Legacy_Name'], { remove: true })
+    if (!r.ok) expect.unreachable()
+    expect(r.op.kind).toBe('remove')
+  })
+
   test('remove with no mutations', () => {
     const r = parseModifyArgs(['command', 'run'], { remove: true })
     if (!r.ok) expect.unreachable()
@@ -102,6 +123,12 @@ describe('parseModifyArgs — illegal combinations rejected at the boundary', ()
     const r = parseModifyArgs(['skill', 'greet'], { rename: 'Not Kebab' })
     if (r.ok) expect.unreachable()
     expect(r.error.what).toContain('invalid rename target')
+  })
+
+  test('add with an invalid asset name is rejected at the boundary', () => {
+    const r = parseModifyArgs(['skill', 'Not Kebab'], { add: true })
+    if (r.ok) expect.unreachable()
+    expect(r.error.what).toContain('invalid skill name')
   })
 
   test('adapter JSON that is not an object', () => {

--- a/packages/cli/src/commands/modify/parse.ts
+++ b/packages/cli/src/commands/modify/parse.ts
@@ -1,5 +1,5 @@
 import type { AssetTarget, FacetMetaFields, FieldMutation, ModifyOp } from '@agent-facets/engine'
-import { isValidKebabCase } from '@agent-facets/engine'
+import { validateAssetNameSegment } from '@agent-facets/protocol'
 import type { CliError } from '../../util/errors.ts'
 
 /**
@@ -108,10 +108,11 @@ export function parseModifyArgs(positionals: string[], flags: Record<string, unk
   }
 
   if (renameTo !== undefined) {
-    if (!isValidKebabCase(renameTo)) {
+    const check = validateAssetNameSegment(renameTo)
+    if (!check.ok) {
       return err(
         `invalid rename target "${renameTo}"`,
-        'asset names must be kebab-case',
+        `asset name ${check.reason}`,
         'pass a name like --rename my-asset',
       )
     }
@@ -119,6 +120,18 @@ export function parseModifyArgs(positionals: string[], flags: Record<string, unk
   }
 
   if (hasAdd) {
+    // Validate the new asset's name at the CLI boundary so `--add` gets the
+    // same clear error as `--rename`. `--update` and `--remove` intentionally
+    // skip this: they operate on existing (possibly legacy non-kebab) names,
+    // which users must still be able to fix or remove.
+    const check = validateAssetNameSegment(name)
+    if (!check.ok) {
+      return err(
+        `invalid ${target} name "${name}"`,
+        `asset name ${check.reason}`,
+        `pass a name like --add ${target === 'skills' ? 'my-skill' : `my-${target.slice(0, -1)}`}`,
+      )
+    }
     return { ok: true, op: { kind: 'add', target: assetTarget, name, mutations } }
   }
 

--- a/packages/cli/src/tui/context/form-state-context.ts
+++ b/packages/cli/src/tui/context/form-state-context.ts
@@ -1,4 +1,5 @@
-import { type ScaffoldOptions as CreateOptions, isValidKebabCase } from '@agent-facets/engine'
+import type { ScaffoldOptions as CreateOptions } from '@agent-facets/engine'
+import { validateAssetNameSegment } from '@agent-facets/protocol'
 import type { ReactNode } from 'react'
 import { createContext, createElement, useCallback, useContext, useMemo, useState } from 'react'
 
@@ -131,7 +132,7 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
   }, [])
 
   const addAsset = useCallback((section: AssetSectionKey, name: string) => {
-    if (!isValidKebabCase(name)) return
+    if (!validateAssetNameSegment(name).ok) return
     setForm((prev) => {
       const current = prev.assets[section]
       if (current.items.includes(name)) return prev
@@ -170,7 +171,7 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
   }, [])
 
   const renameAsset = useCallback((section: AssetSectionKey, oldName: string, newName: string) => {
-    if (!isValidKebabCase(newName)) return
+    if (!validateAssetNameSegment(newName).ok) return
     setForm((prev) => {
       const current = prev.assets[section]
       if (current.items.includes(newName)) return prev

--- a/packages/cli/src/tui/views/create/create-view.tsx
+++ b/packages/cli/src/tui/views/create/create-view.tsx
@@ -1,5 +1,5 @@
-import { DEFAULT_VERSION, isValidKebabCase } from '@agent-facets/engine'
-import { parseFacetName, validateFacetName } from '@agent-facets/protocol'
+import { DEFAULT_VERSION } from '@agent-facets/engine'
+import { parseFacetName, validateAssetNameSegment, validateFacetName } from '@agent-facets/protocol'
 import { Box, Text } from 'ink'
 import { useCallback, useEffect } from 'react'
 import type { AssetType } from '../../../commands/create/types'
@@ -152,7 +152,8 @@ export function CreateView({
             dimmed={!assetsReady}
             onEditDescription={onEditDescription}
             validate={(v) => {
-              if (!isValidKebabCase(v)) return 'Must be kebab-case'
+              const check = validateAssetNameSegment(v)
+              if (!check.ok) return `Name ${check.reason}`
               const editing = form.assets[type].editing
               if (form.assets[type].items.some((item) => item === v && item !== editing)) return `"${v}" already exists`
               return undefined

--- a/packages/cli/src/tui/views/edit/edit-view.tsx
+++ b/packages/cli/src/tui/views/edit/edit-view.tsx
@@ -1,5 +1,5 @@
-import { DEFAULT_VERSION, isValidKebabCase } from '@agent-facets/engine'
-import { validateFacetName } from '@agent-facets/protocol'
+import { DEFAULT_VERSION } from '@agent-facets/engine'
+import { validateAssetNameSegment, validateFacetName } from '@agent-facets/protocol'
 import { Box, Text } from 'ink'
 import { useCallback, useEffect } from 'react'
 import { AssetSection } from '../../components/asset-section.tsx'
@@ -126,7 +126,8 @@ export function EditView({
             label={ASSET_LABELS[type]}
             onEditDescription={onEditDescription}
             validate={(v) => {
-              if (!isValidKebabCase(v)) return 'Must be kebab-case'
+              const check = validateAssetNameSegment(v)
+              if (!check.ok) return `Name ${check.reason}`
               const editing = form.assets[type].editing
               if (form.assets[type].items.some((item) => item === v && item !== editing)) return `"${v}" already exists`
               return undefined

--- a/packages/common/src/asset-name.ts
+++ b/packages/common/src/asset-name.ts
@@ -1,13 +1,21 @@
 /**
- * Asset-name validation shared across core (manifest + lockfile schemas) and
- * the adapter SDK (defensive check before filesystem use).
+ * Path-safety guard for asset names used as relative filesystem paths.
  *
- * An asset name is used as a relative filesystem path under the adapter's
- * base directory (e.g. `<baseDir>/skills/<name>/SKILL.md`). Unsafe names can
- * escape the base directory via `..` segments or platform-specific
- * separators. This helper is the single source of truth for what "safe"
- * means so the manifest schema, the lockfile schema, and the adapter I/O
- * helpers agree — manifest-time and lockfile-time inputs get the same guard.
+ * This is the **path-safety** check, NOT the authoring grammar. It rejects
+ * names that could escape an adapter's base directory when used as a path
+ * (e.g. `<baseDir>/skills/<name>/SKILL.md`), but it deliberately permits
+ * non-kebab names like `MySkill` or `foo_bar` — enforcing the Agent Skills
+ * name grammar is a separate, stricter concern that lives in
+ * `@agent-facets/protocol` (`validateAssetName` / `parseAssetName` in
+ * `schemas/asset-name.ts`).
+ *
+ * This guard remains the right tool where the input is a *filesystem path*
+ * rather than an author-declared name: archive-manifest keys and inner-tar
+ * entry names (protocol's integrity validation), cache-audit paths and
+ * receipt asset entries (engine), and lockfile asset names — the lockfile
+ * intentionally stays on path safety so legacy installs with non-kebab names
+ * still load and can be removed. The protocol manifest schema, by contrast,
+ * uses the stricter grammar because manifest keys are author-declared names.
  *
  * Rules (rejects):
  *  - contains a backslash (`\`) — Windows path separator

--- a/packages/engine/src/__tests__/edit.test.ts
+++ b/packages/engine/src/__tests__/edit.test.ts
@@ -2,23 +2,35 @@ import { describe, expect, test } from 'bun:test'
 import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isValidKebabCase } from '@agent-facets/engine'
 import type { FacetManifest } from '@agent-facets/protocol'
+import { validateAssetNameSegment } from '@agent-facets/protocol'
 import { writeManifest } from '../edit/manifest-writer.ts'
 import { reconcile } from '../edit/reconcile.ts'
 import type { DiscoveredAsset } from '../edit/scanner.ts'
 import { scanAssets } from '../edit/scanner.ts'
 
-// --- Asset-name grammar (diverges from facet identity grammar) ---
+// --- Asset-name grammar at authoring surfaces (single segment) ---
+//
+// The scanner and other authoring surfaces validate a SINGLE segment via
+// protocol's `validateAssetNameSegment` — namespacing (`/`) is a build/install
+// concern, not something these surfaces accept. The grammar itself is tested
+// exhaustively in protocol's asset-name.test.ts; this block pins the behavior
+// the engine relies on (digit-start accepted; scope markers/slashes rejected).
 
-describe('isValidKebabCase — asset-name grammar', () => {
-  test.each(['cowsay', 'code-review', 'viper-plans', 'x1', 'a'])('accepts kebab asset name %p', (name) => {
-    expect(isValidKebabCase(name)).toBe(true)
+describe('validateAssetNameSegment — authoring-surface grammar', () => {
+  test.each([
+    'cowsay',
+    'code-review',
+    'viper-plans',
+    'x1',
+    'a',
+    '2fa',
+  ])('accepts single-segment asset name %p', (name) => {
+    expect(validateAssetNameSegment(name).ok).toBe(true)
   })
 
-  // Asset names stay local kebab identifiers and are NOT scoped facet
-  // identities: the scope marker `@` and the scope separator `/` are both
-  // rejected, along with uppercase, underscores, and spaces.
+  // Authoring surfaces accept a single segment only: the scope marker `@`, the
+  // segment separator `/`, uppercase, underscores, and spaces are all rejected.
   test.each([
     '@scope',
     '@scope/name',
@@ -27,8 +39,8 @@ describe('isValidKebabCase — asset-name grammar', () => {
     'cow_say',
     'cow say',
     'cow/say',
-  ])('rejects non-kebab asset name %p (e.g. @ and /)', (name) => {
-    expect(isValidKebabCase(name)).toBe(false)
+  ])('rejects non-kebab or multi-segment asset name %p', (name) => {
+    expect(validateAssetNameSegment(name).ok).toBe(false)
   })
 })
 

--- a/packages/engine/src/edit/scanner.ts
+++ b/packages/engine/src/edit/scanner.ts
@@ -1,7 +1,5 @@
-/** Kebab-case pattern for valid asset names. */
-export const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
-
 import type { AssetType } from '@agent-facets/common'
+import { validateAssetNameSegment } from '@agent-facets/protocol'
 
 /**
  * Plural manifest key derived from the canonical singular AssetType.
@@ -34,7 +32,7 @@ export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
     // match is e.g. 'skills/review/SKILL.md'
     const parts = match.split('/')
     const name = parts[1]
-    if (name && KEBAB_CASE.test(name)) {
+    if (name && validateAssetNameSegment(name).ok) {
       assets.push({ type: 'skills', name, path: match })
     }
   }
@@ -43,7 +41,7 @@ export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
   const agentGlob = new Bun.Glob('agents/*.md')
   for await (const match of agentGlob.scan({ cwd: rootDir, onlyFiles: true })) {
     const name = match.replace('agents/', '').replace('.md', '')
-    if (KEBAB_CASE.test(name)) {
+    if (validateAssetNameSegment(name).ok) {
       assets.push({ type: 'agents', name, path: match })
     }
   }
@@ -52,7 +50,7 @@ export async function scanAssets(rootDir: string): Promise<DiscoveredAsset[]> {
   const commandGlob = new Bun.Glob('commands/*.md')
   for await (const match of commandGlob.scan({ cwd: rootDir, onlyFiles: true })) {
     const name = match.replace('commands/', '').replace('.md', '')
-    if (KEBAB_CASE.test(name)) {
+    if (validateAssetNameSegment(name).ok) {
       assets.push({ type: 'commands', name, path: match })
     }
   }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -73,7 +73,7 @@ export { applyEditOperations, applyModifyFileOps } from './edit/operations.ts'
 export type { MatchedAsset, MissingAsset, ReconciliationResult } from './edit/reconcile.ts'
 export { reconcile } from './edit/reconcile.ts'
 export type { AssetManifestKey, DiscoveredAsset } from './edit/scanner.ts'
-export { KEBAB_CASE, scanAssets } from './edit/scanner.ts'
+export { scanAssets } from './edit/scanner.ts'
 export type {
   EditContext,
   EditOperation,
@@ -200,7 +200,6 @@ export {
   commandTemplate,
   DEFAULT_VERSION,
   generateScaffoldManifest,
-  isValidKebabCase,
   isValidSemVer,
   previewScaffoldFiles,
   SEMVER,

--- a/packages/engine/src/scaffold/index.ts
+++ b/packages/engine/src/scaffold/index.ts
@@ -1,7 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { FACET_MANIFEST_FILE } from '@agent-facets/protocol'
-import { KEBAB_CASE } from '../edit/scanner.ts'
 import { jsonFileText } from '../json-file-text.ts'
 
 // --- Types ---
@@ -27,12 +26,10 @@ export const DEFAULT_VERSION = '0.0.0'
 
 // --- Validation ---
 
-export { KEBAB_CASE }
+// Asset-name validation lives in `@agent-facets/protocol`
+// (`validateAssetNameSegment`). Callers import it directly rather than through
+// engine, since engine must not re-export protocol.
 export const SEMVER = /^\d+\.\d+\.\d+$/
-
-export function isValidKebabCase(value: string): boolean {
-  return KEBAB_CASE.test(value)
-}
 
 export function isValidSemVer(value: string): boolean {
   return SEMVER.test(value)

--- a/packages/protocol/src/__tests__/asset-name.test.ts
+++ b/packages/protocol/src/__tests__/asset-name.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+import { parseAssetName, parseAssetNameSegment } from '../schemas/asset-name.ts'
+
+// A segment of exactly the maximum permitted length (64) and one over (65).
+const MAX_SEGMENT = 'a'.repeat(64)
+const OVER_MAX_SEGMENT = 'a'.repeat(65)
+
+describe('parseAssetNameSegment — Agent Skills grammar', () => {
+  // Accept cases: the agentskills.io spec examples plus the deliberate
+  // divergences from parseSlug (single-char, digit-start).
+  test.each(['pdf-processing', 'data-analysis', 'code-review', 'a', '2fa', 'x1', MAX_SEGMENT])('accepts %p', (name) => {
+    expect(parseAssetNameSegment(name)).toEqual({ ok: true, value: name })
+  })
+
+  test.each([
+    ['', 'must not be empty'],
+    [OVER_MAX_SEGMENT, 'must be at most 64 characters'],
+    ['-pdf', 'must not start with a hyphen'],
+    ['pdf-', 'must not end with a hyphen'],
+    ['pdf--processing', 'must not contain consecutive hyphens'],
+    ['PDF-Processing', 'must contain only lowercase ASCII letters, digits, and hyphens'],
+    ['MySkill', 'must contain only lowercase ASCII letters, digits, and hyphens'],
+    ['foo_bar', 'must contain only lowercase ASCII letters, digits, and hyphens'],
+    ['cow say', 'must contain only lowercase ASCII letters, digits, and hyphens'],
+    ['a/b', 'must contain only lowercase ASCII letters, digits, and hyphens'],
+  ])('rejects %p with reason', (name, reason) => {
+    const result = parseAssetNameSegment(name)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe(reason)
+  })
+})
+
+describe('parseAssetName — full (possibly namespaced) name', () => {
+  test.each(['pdf-processing', 'a', '2fa', 'viper-plans/planning', 'viper-plans/review/deep'])('accepts %p', (name) => {
+    expect(parseAssetName(name)).toEqual({ ok: true, value: name })
+  })
+
+  test('rejects an empty name', () => {
+    const result = parseAssetName('')
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('must not be empty')
+  })
+
+  // Path-safety edges the grammar subsumes: empty segments (leading/trailing/
+  // double slash), dot segments, and uppercase/underscore segments.
+  test.each(['a//b', './x', '../x', 'a/', '/a'])('rejects %p (empty or dot segment)', (name) => {
+    expect(parseAssetName(name).ok).toBe(false)
+  })
+
+  test('reason names the offending segment for a multi-segment name', () => {
+    const result = parseAssetName('viper-plans/Bad_Name')
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toContain('segment "Bad_Name"')
+  })
+
+  test('rejects a backslash (Windows path separator) within a segment', () => {
+    const result = parseAssetName('a\\b')
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toContain('lowercase ASCII letters')
+  })
+
+  test('accepts a segment of exactly 64 characters, rejects 65', () => {
+    expect(parseAssetName(MAX_SEGMENT).ok).toBe(true)
+    expect(parseAssetName(OVER_MAX_SEGMENT).ok).toBe(false)
+  })
+})

--- a/packages/protocol/src/__tests__/facet-manifest.test.ts
+++ b/packages/protocol/src/__tests__/facet-manifest.test.ts
@@ -199,7 +199,9 @@ describe('FacetManifestSchema — invalid manifests', () => {
   })
 
   // Path-traversal gate (F1): asset-name keys are used as filesystem paths in
-  // the install pipeline. Any `..` segment would escape the adapter base dir.
+  // the install pipeline. Any `..` or empty segment would escape or dead-end
+  // the adapter base dir. The Agent Skills grammar rejects these as invalid
+  // segments, so the message names the grammar rather than "path segments".
   test.each([
     ['..', 'skills'],
     ['../escape', 'skills'],
@@ -213,7 +215,34 @@ describe('FacetManifestSchema — invalid manifests', () => {
     const result = FacetManifestSchema(input)
     expect(result).toBeInstanceOf(type.errors)
     const errors = result as InstanceType<typeof type.errors>
-    expect(errors.some((e) => e.message.includes('path segments'))).toBe(true)
+    // The offending key is named, and the grammar reason is surfaced.
+    expect(errors.some((e) => e.message.includes(`"${name}"`))).toBe(true)
+  })
+
+  // Non-kebab names now fail (the deliberate breaking change): the manifest
+  // schema enforces the Agent Skills grammar at build AND install.
+  test.each([
+    ['MySkill', 'skills'],
+    ['foo_bar', 'agents'],
+    ['UPPER', 'commands'],
+    ['has space', 'skills'],
+    ['trailing-', 'agents'],
+    ['-leading', 'commands'],
+    ['double--hyphen', 'skills'],
+  ])('non-kebab asset name %p in %s is rejected', (name, group) => {
+    const input: Record<string, unknown> = { name: 'ok', version: '1.0.0' }
+    input[group] = { [name]: { description: 'x' } }
+    const result = FacetManifestSchema(input)
+    expect(result).toBeInstanceOf(type.errors)
+    const errors = result as InstanceType<typeof type.errors>
+    expect(errors.some((e) => e.message.includes(`"${name}"`))).toBe(true)
+  })
+
+  // Digit-start names are valid per the Agent Skills spec (divergence from the
+  // facet identity slug grammar, which requires a letter start).
+  test('digit-start asset names are valid', () => {
+    const input = { name: 'ok', version: '1.0.0', skills: { '2fa': { description: 'x' } } }
+    expect(FacetManifestSchema(input)).not.toBeInstanceOf(type.errors)
   })
 
   test('deep-nested namespaced asset names (no traversal) stay valid', () => {
@@ -229,9 +258,8 @@ describe('FacetManifestSchema — invalid manifests', () => {
     expect(result).not.toBeInstanceOf(type.errors)
   })
 
-  // Windows-style path-traversal gate: a backslash slips through the
-  // segment-wise `/` split, so we reject it up front. Mirrors the
-  // `validateAssetName` rule enforced for lockfile asset names too.
+  // Windows-style path-traversal gate: a backslash is not in the grammar's
+  // charset, so a segment containing one is rejected up front.
   test.each([
     ['..\\escape', 'skills'],
     ['a\\b', 'agents'],
@@ -242,7 +270,7 @@ describe('FacetManifestSchema — invalid manifests', () => {
     const result = FacetManifestSchema(input)
     expect(result).toBeInstanceOf(type.errors)
     const errors = result as InstanceType<typeof type.errors>
-    expect(errors.some((e) => e.message.includes('backslash'))).toBe(true)
+    expect(errors.some((e) => e.message.includes(`"${name}"`))).toBe(true)
   })
 })
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -54,6 +54,17 @@ export type { ResolvedFacetManifest } from './loaders/facet.ts'
 export { FACET_MANIFEST_FILE, resolvePromptsFromMap, validateFacetManifest } from './loaders/facet.ts'
 export { SERVER_MANIFEST_FILE, validateServerManifest } from './loaders/server.ts'
 export { mapArkErrors, parseJson } from './loaders/validate.ts'
+// asset-name grammar (Agent Skills spec) — exported so build validators, the
+// CLI, and the engine's edit/scaffold machinery all validate skill/command/
+// agent names against one canonical grammar. Distinct from facet identity
+// (facet-name.ts): asset names are local, never scoped, and allow digit-start.
+export type { AssetNameResult, AssetNameSegmentResult } from './schemas/asset-name.ts'
+export {
+  parseAssetName,
+  parseAssetNameSegment,
+  validateAssetName,
+  validateAssetNameSegment,
+} from './schemas/asset-name.ts'
 // schemas
 export type { BuildManifest } from './schemas/build-manifest.ts'
 export { BuildManifestSchema } from './schemas/build-manifest.ts'

--- a/packages/protocol/src/schemas/asset-name.ts
+++ b/packages/protocol/src/schemas/asset-name.ts
@@ -1,0 +1,139 @@
+/**
+ * Asset-name grammar — the canonical rules for what a skill, command, or
+ * agent is called. Distinct from the facet *identity* grammar (`parseSlug` in
+ * `facet-name.ts`): asset names are local, never scoped with `@`, and follow
+ * the Agent Skills specification name field exactly:
+ * https://agentskills.io/specification#name-field
+ *
+ * An asset name is one or more `/`-separated **segments**. A single segment
+ * is the atomic unit and obeys the Agent Skills grammar:
+ *
+ *  - 1-64 characters
+ *  - lowercase ASCII letters, ASCII digits, and hyphens only (`a-z`, `0-9`, `-`)
+ *  - must not start or end with a hyphen (`-`)
+ *  - must not contain consecutive hyphens (`--`)
+ *
+ * Deliberate divergences from `parseSlug` (the facet identity grammar):
+ *  - **min length 1**, not 2 — Agent Skills allows single-char names (`a`).
+ *  - **digit-start is allowed** — `2fa` is a valid asset name; a facet slug
+ *    must start with a letter.
+ *
+ * Multi-segment names (`viper-plans/planning`) are permitted for facet
+ * namespacing: assets contributed by an included facet land under a
+ * `<namespace>/<name>` path. Every segment is validated independently, so
+ * empty segments, `.`/`..` segments, and backslashes are all rejected — the
+ * grammar subsumes the path-safety guard (`@agent-facets/common`'s
+ * `validateAssetName`) for manifest keys. Authoring surfaces (create, modify,
+ * the wizard) validate a **single** segment only via
+ * `parseAssetNameSegment` / `validateAssetNameSegment`.
+ *
+ * Input is validated, never normalized: uppercase letters and non-ASCII
+ * characters are rejected rather than down-cased or transliterated. Both
+ * parsers return discriminated-union results rather than throwing, so callers
+ * handle malformed names as data.
+ */
+
+/** Minimum length of a single asset-name segment (inclusive). */
+const SEGMENT_MIN_LENGTH = 1
+/** Maximum length of a single asset-name segment (inclusive). */
+const SEGMENT_MAX_LENGTH = 64
+
+/**
+ * The canonical asset-name segment grammar: a single character that is a
+ * lowercase ASCII letter or digit, OR a run that starts and ends with a
+ * lowercase ASCII letter or digit with letters, digits, and non-consecutive
+ * hyphens in between. The `-(?!-+)` negative lookahead rejects consecutive
+ * hyphens. Length is checked explicitly in `parseAssetNameSegment` so callers
+ * get a clearer error than a bare pattern mismatch.
+ */
+const SEGMENT_RE = /^[a-z0-9]$|^[a-z0-9]([a-z0-9]|-(?!-+))*[a-z0-9]$/
+
+/** Result of validating a single asset-name segment. Errors are data, not exceptions. */
+export type AssetNameSegmentResult = { ok: true; value: string } | { ok: false; reason: string }
+
+/**
+ * Validate a single asset-name segment against the Agent Skills grammar. This
+ * is the atomic unit shared by skill, command, and agent names. It is
+ * intentionally case-sensitive and ASCII-only.
+ *
+ * The checks run from most specific to most general so the returned reason is
+ * actionable for build, CLI, and edit callers.
+ */
+export function parseAssetNameSegment(value: string): AssetNameSegmentResult {
+  if (value === '') {
+    return { ok: false, reason: 'must not be empty' }
+  }
+  if (value.length < SEGMENT_MIN_LENGTH) {
+    return { ok: false, reason: `must be at least ${SEGMENT_MIN_LENGTH} character` }
+  }
+  if (value.length > SEGMENT_MAX_LENGTH) {
+    return { ok: false, reason: `must be at most ${SEGMENT_MAX_LENGTH} characters` }
+  }
+  if (value.startsWith('-')) {
+    return { ok: false, reason: 'must not start with a hyphen' }
+  }
+  if (value.endsWith('-')) {
+    return { ok: false, reason: 'must not end with a hyphen' }
+  }
+  if (value.includes('--')) {
+    return { ok: false, reason: 'must not contain consecutive hyphens' }
+  }
+  if (!SEGMENT_RE.test(value)) {
+    return { ok: false, reason: 'must contain only lowercase ASCII letters, digits, and hyphens' }
+  }
+  return { ok: true, value }
+}
+
+/** Result of validating a full (possibly namespaced) asset name. Errors are data, not exceptions. */
+export type AssetNameResult = { ok: true; value: string } | { ok: false; reason: string }
+
+/**
+ * Parse a full asset name: one or more `/`-separated segments, each obeying
+ * the Agent Skills grammar via `parseAssetNameSegment`. A namespaced name
+ * (`viper-plans/planning`) is valid iff every segment is valid; there is no
+ * looser grammar for the segments of a multi-segment name.
+ *
+ * An empty name, a leading/trailing slash (which produces an empty segment),
+ * and consecutive slashes (`a//b`) are all rejected because they yield an
+ * empty segment. When a multi-segment name has an invalid segment, the reason
+ * names the offending segment so callers can point at it.
+ */
+export function parseAssetName(value: string): AssetNameResult {
+  if (value === '') {
+    return { ok: false, reason: 'must not be empty' }
+  }
+  const segments = value.split('/')
+  const multi = segments.length > 1
+  for (const segment of segments) {
+    const result = parseAssetNameSegment(segment)
+    if (!result.ok) {
+      return {
+        ok: false,
+        reason: multi ? `segment "${segment}" ${result.reason}` : result.reason,
+      }
+    }
+  }
+  return { ok: true, value }
+}
+
+/**
+ * Thin boolean-style wrapper over `parseAssetName` for arktype `.narrow()`
+ * call sites and CLI/engine call sites that only need pass/fail + a reason.
+ * Mirrors the shape of `validateFacetName` so the two compose identically
+ * into `ctx.mustBe(...)`. Validates the full (possibly namespaced) name.
+ */
+export function validateAssetName(value: string): { ok: true } | { ok: false; reason: string } {
+  const result = parseAssetName(value)
+  return result.ok ? { ok: true } : { ok: false, reason: result.reason }
+}
+
+/**
+ * Thin boolean-style wrapper over `parseAssetNameSegment` for authoring
+ * surfaces (create, modify, the wizard) that accept a single segment only —
+ * namespacing is a build/install-time concern, not something a user types
+ * when scaffolding one asset.
+ */
+export function validateAssetNameSegment(value: string): { ok: true } | { ok: false; reason: string } {
+  const result = parseAssetNameSegment(value)
+  return result.ok ? { ok: true } : { ok: false, reason: result.reason }
+}

--- a/packages/protocol/src/schemas/facet-manifest.ts
+++ b/packages/protocol/src/schemas/facet-manifest.ts
@@ -1,5 +1,5 @@
-import { validateAssetName } from '@agent-facets/common'
 import { type } from 'arktype'
+import { validateAssetName } from './asset-name.ts'
 import { validateFacetName } from './facet-name.ts'
 
 // --- Sub-schemas ---
@@ -52,11 +52,16 @@ const ServerReference = type('string').or({ image: 'string' })
  * Structural validation covers field types and shapes. Narrow constraints enforce:
  * 1. At least one text asset (skills, agents, commands, or facets) must be present
  * 2. Selective facets entries must include at least one asset type selection
- * 3. Asset names must be filesystem-safe (validateAssetName)
+ * 3. Asset names must satisfy the Agent Skills grammar (validateAssetName from
+ *    ./asset-name.ts): per `/`-separated segment, 1-64 chars, lowercase
+ *    letters/digits/hyphens, no leading/trailing/consecutive hyphens. This
+ *    grammar subsumes path safety (empty, `.`, `..`, and backslash segments
+ *    all fail), so it replaces the weaker path-only guard for manifest keys.
  * 4. The facet identity `name` must be a valid facet name — an unscoped slug
  *    or a scoped `@scope/name` (validateFacetName). Asset names and facet
- *    identities intentionally diverge: asset names stay local kebab-ish path
- *    identifiers; facet identities may carry a registry scope.
+ *    identities intentionally diverge: asset names stay local kebab segments
+ *    (digit-start allowed, never scoped); facet identities may carry a
+ *    registry scope.
  */
 export const FacetManifestSchema = type({
   name: 'string',
@@ -112,12 +117,15 @@ export const FacetManifestSchema = type({
     }
   }
 
-  // Constraint 3: asset names must be filesystem-safe. Install writes to
-  // join(baseDir, relativePathFor(type, name)) — an unchecked `..` segment or
-  // Windows backslash escapes the adapter base directory. Rejecting here
-  // stops the manifest before any filesystem work begins. The check is
-  // shared with LockfileSchema via `@agent-facets/common` so manifest-time
-  // and lockfile-time inputs get identical treatment.
+  // Constraint 3: asset names must satisfy the Agent Skills grammar (see
+  // ./asset-name.ts). This tightens the previous path-safety-only check: a
+  // manifest declaring `MySkill` or `foo_bar` now fails at build AND install
+  // (this schema validates fetched manifests too). Because the grammar rejects
+  // empty, `.`, `..`, and backslash segments, it also subsumes the filesystem
+  // safety the install pipeline needs when writing join(baseDir,
+  // relativePathFor(type, name)). LockfileSchema intentionally keeps the
+  // weaker `@agent-facets/common` path-safety guard so legacy installs with
+  // non-kebab asset names still load and can be removed.
   const assetNameGroups: [string, Record<string, unknown> | undefined][] = [
     ['skills', data.skills],
     ['agents', data.agents],


### PR DESCRIPTION
### Why

Asset names in `facet.json` were previously validated against a loose kebab-case regex (`/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`) that diverged from the Agent Skills specification in two ways: it rejected valid digit-start names like `2fa`, and it had no maximum length enforcement. This change aligns asset-name validation with the Agent Skills grammar across all authoring surfaces — the manifest schema, the CLI (`create` and `modify`), the TUI wizard, and the filesystem scanner.

### Details

A new canonical grammar module (`packages/protocol/src/schemas/asset-name.ts`) implements `parseAssetNameSegment` and `parseAssetName` with discriminated-union results rather than booleans. The rules per segment are: 1–64 characters, lowercase ASCII letters/digits/hyphens only, no leading/trailing/consecutive hyphens, digit-start permitted. Multi-segment names (`viper-plans/planning`) split on `/` and validate each segment independently.

`validateAssetName` in `@agent-facets/protocol` now replaces the weaker path-safety guard from `@agent-facets/common` for manifest schema keys. This is a deliberate breaking change: manifests declaring non-kebab asset names like `MySkill` or `foo_bar` are now rejected at both build and install time. The grammar subsumes path safety (empty, `.`, `..`, and backslash segments all fail the charset check), so no separate path-traversal guard is needed for manifest keys.

The `LockfileSchema` intentionally retains the weaker `@agent-facets/common` path-safety guard so that existing installs with legacy non-kebab asset names can still be loaded and removed.

`isValidKebabCase` and the `KEBAB_CASE` export are removed from `@agent-facets/engine`. All call sites — headless CLI, modify parser, TUI form state, create/edit views, and the asset scanner — now import `validateAssetNameSegment` directly from `@agent-facets/protocol`. Error messages from the CLI now surface the specific grammar reason (e.g. `"must be at most 64 characters"`) rather than a generic kebab-case hint.

The `--update` and `--remove` paths in `parseModifyArgs` intentionally skip the new grammar check so users can still fix or remove assets that were created under the old, looser rules.

### Verification

New and updated tests cover: digit-start names accepted everywhere, names over 64 characters rejected with a clear message, non-kebab names rejected in the manifest schema, legacy non-kebab names still accepted by `--update`/`--remove`, and the full `parseAssetNameSegment`/`parseAssetName` grammar exhaustively in `protocol/src/__tests__/asset-name.test.ts`. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking manifest validation can fail builds/installs for facets with legacy asset names; behavior is intentional but affects any non-conforming published manifests.
> 
> **Overview**
> Adds a canonical **Agent Skills** asset-name module in `@agent-facets/protocol` (`parseAssetName` / `parseAssetNameSegment` and `validate*` wrappers) and routes skill, command, and agent naming through it instead of the old engine kebab regex.
> 
> **BREAKING:** `FacetManifestSchema` now rejects non-conforming manifest keys (e.g. `MySkill`, `foo_bar`, bad hyphens, >64 chars) at build and install; namespaced keys like `viper-plans/planning` still validate per segment. Digit-start names such as `2fa` are now allowed. Lockfile validation intentionally keeps `@agent-facets/common` path-safety so legacy installed names still load.
> 
> The CLI and TUI (`create`, `modify --add`/`--rename`, wizard) and engine scanner use `validateAssetNameSegment` and surface grammar-specific errors; `facet modify` update/remove still accept legacy asset names. `isValidKebabCase` and `KEBAB_CASE` are removed from `@agent-facets/engine`. Spec docs describe the new grammar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7b5d9899bfad8f0503f21d65dee56a8883557b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->