### PR TITLE
Validate adapter metadata for `commands` entries in `validateAdapterMetadata`

### DIFF
--- a/.changeset/thirty-rivers-grab.md
+++ b/.changeset/thirty-rivers-grab.md
@@ -1,0 +1,7 @@
+---
+"agent-facets": patch
+---
+
+Validate `adapters` blocks on command assets during `facet build`.
+
+Command descriptors have always been allowed to declare an `adapters` block (symmetric with skills and agents), but the build pipeline only ran adapter-metadata validation over skills and agents — command adapter config was silently accepted without being checked. `facet build` now validates command `adapters` blocks the same way: an installed adapter that rejects the metadata fails the build with a `commands.<name>.adapters.<adapter>.<field>` error path, and an unknown adapter on a command produces the usual "metadata will not be validated" warning.

--- a/packages/engine/src/__tests__/build-pipeline.test.ts
+++ b/packages/engine/src/__tests__/build-pipeline.test.ts
@@ -234,6 +234,61 @@ describe('validateAdapterMetadata', () => {
     expect(result.errors).toHaveLength(0)
     expect(result.warnings).toHaveLength(0)
   })
+
+  test('valid command adapter metadata passes', () => {
+    const manifest = {
+      name: 'test',
+      version: '1.0.0',
+      commands: {
+        deploy: {
+          description: 'Deploy command',
+          adapters: {
+            'mock-adapter': { tools: { grep: true } },
+          },
+        },
+      },
+    } as FacetManifest
+    const result = validateAdapterMetadata(manifest, [mockAdapter])
+    expect(result.errors).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  test('invalid command adapter metadata fails', () => {
+    const manifest = {
+      name: 'test',
+      version: '1.0.0',
+      commands: {
+        deploy: {
+          description: 'Deploy command',
+          adapters: {
+            'rejecting-adapter': { tools: 'not-a-record' },
+          },
+        },
+      },
+    } as FacetManifest
+    const result = validateAdapterMetadata(manifest, [rejectingAdapter])
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0]?.path).toContain('commands.deploy')
+  })
+
+  test('unknown adapter on a command produces warning', () => {
+    const manifest = {
+      name: 'test',
+      version: '1.0.0',
+      commands: {
+        deploy: {
+          description: 'Deploy command',
+          adapters: {
+            'unknown-adapter': { foo: 'bar' },
+          },
+        },
+      },
+    } as FacetManifest
+    const result = validateAdapterMetadata(manifest, [])
+    expect(result.errors).toHaveLength(0)
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0]).toContain('unknown-adapter')
+  })
 })
 
 // --- Build pipeline (end-to-end) ---

--- a/packages/engine/src/build/validate-adapters.ts
+++ b/packages/engine/src/build/validate-adapters.ts
@@ -40,6 +40,15 @@ export function validateAdapterMetadata(manifest: FacetManifest, adapters: Adapt
     }
   }
 
+  // Check commands
+  if (manifest.commands) {
+    for (const [name, command] of Object.entries(manifest.commands)) {
+      if (command.adapters) {
+        validateAssetAdapters(`commands.${name}`, command.adapters, adapterMap, errors, warnings)
+      }
+    }
+  }
+
   return { errors, warnings }
 }
 


### PR DESCRIPTION
### Why

Command-level adapter metadata in the manifest was not being validated, meaning invalid or unknown adapters defined under `commands` would pass through silently without errors or warnings.

### Details

`validateAdapterMetadata` now iterates over `manifest.commands` and runs the same `validateAssetAdapters` check already used for other manifest sections. Errors are reported with a path prefixed by `commands.<name>` to make them easy to locate. Unknown adapters on a command produce a warning rather than an error, consistent with existing behavior elsewhere.

### Verification

Three new tests cover the added logic: valid command adapter metadata, invalid metadata that should produce errors, and an unknown adapter that should produce a warning. CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time validation parity only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **`facet build` now validates `adapters` on command assets**, matching skills and agents. Command manifests could already declare `adapters`, but `validateAdapterMetadata` only walked skills and agents, so bad or unknown command adapter config slipped through silently.
> 
> The build step loops `manifest.commands` and reuses `validateAssetAdapters` with paths like `commands.<name>`. Installed adapters that reject metadata fail the build; unknown adapters still emit the existing warning only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21b2e0758ad39fd2e821db620d1d81282c3ae6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `facet build` now validates adapter metadata configured for commands.
  * Invalid command adapter metadata produces a clear build error identifying the affected command and field.
  * Unknown adapters on commands continue to generate warnings without failing the build.

* **Tests**
  * Added coverage for valid, invalid, and unknown command adapter configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->