### PR TITLE
Prune empty parent directories in `deleteAssetFile` when `pruneBoundary` is set

### DIFF
--- a/.changeset/soft-lions-slide.md
+++ b/.changeset/soft-lions-slide.md
@@ -1,0 +1,7 @@
+---
+"@agent-facets/adapter-claude-code": minor
+"@agent-facets/adapter-opencode": minor
+"@agent-facets/adapter": minor
+---
+
+Prune empty directories when removing assets and nothing is left in the directory

--- a/packages/adapter/src/__tests__/asset-fs.test.ts
+++ b/packages/adapter/src/__tests__/asset-fs.test.ts
@@ -122,6 +122,74 @@ describe('deleteAssetFile', () => {
   })
 })
 
+describe('deleteAssetFile — empty-directory pruning', () => {
+  test('prunes the skill folder when it becomes empty after deletion', async () => {
+    const file = join(workDir, 'skills/planning/SKILL.md')
+    await installAssetFile({ file }, '# planning')
+    await deleteAssetFile({ file, pruneBoundary: workDir })
+    expect(existsSync(file)).toBe(false)
+    expect(existsSync(join(workDir, 'skills/planning'))).toBe(false)
+  })
+
+  test('preserves the skill folder when it still contains an unrelated file', async () => {
+    const file = join(workDir, 'skills/planning/SKILL.md')
+    await installAssetFile({ file }, '# planning')
+    const sibling = join(workDir, 'skills/planning/notes.md')
+    writeFileSync(sibling, 'keep me')
+    await deleteAssetFile({ file, pruneBoundary: workDir })
+    expect(existsSync(file)).toBe(false)
+    expect(existsSync(sibling)).toBe(true)
+    expect(existsSync(join(workDir, 'skills/planning'))).toBe(true)
+  })
+
+  test('prunes nested namespace parents when they all become empty', async () => {
+    const file = join(workDir, 'skills/vendor/planning/SKILL.md')
+    await installAssetFile({ file }, '# planning')
+    await deleteAssetFile({ file, pruneBoundary: workDir })
+    expect(existsSync(join(workDir, 'skills/vendor/planning'))).toBe(false)
+    expect(existsSync(join(workDir, 'skills/vendor'))).toBe(false)
+    expect(existsSync(join(workDir, 'skills'))).toBe(false)
+  })
+
+  test('stops pruning at a nested namespace parent that still has a sibling', async () => {
+    const file = join(workDir, 'skills/vendor/planning/SKILL.md')
+    await installAssetFile({ file }, '# planning')
+    const siblingSkill = join(workDir, 'skills/vendor/other/SKILL.md')
+    await installAssetFile({ file: siblingSkill }, '# other')
+    await deleteAssetFile({ file, pruneBoundary: workDir })
+    expect(existsSync(join(workDir, 'skills/vendor/planning'))).toBe(false)
+    expect(existsSync(join(workDir, 'skills/vendor'))).toBe(true)
+    expect(existsSync(siblingSkill)).toBe(true)
+  })
+
+  test('never removes the configured boundary directory itself', async () => {
+    const file = join(workDir, 'agents/reviewer.md')
+    await installAssetFile({ file }, '# reviewer')
+    await deleteAssetFile({ file, pruneBoundary: workDir })
+    // agents/ becomes empty and is pruned, but the boundary (workDir) stays.
+    expect(existsSync(join(workDir, 'agents'))).toBe(false)
+    expect(existsSync(workDir)).toBe(true)
+  })
+
+  test('remains idempotent when the file and parents are already absent', async () => {
+    const file = join(workDir, 'skills/planning/SKILL.md')
+    await installAssetFile({ file }, '# planning')
+    await deleteAssetFile({ file, pruneBoundary: workDir })
+    // Second delete of an already-gone asset + already-pruned dirs.
+    await expect(deleteAssetFile({ file, pruneBoundary: workDir })).resolves.toBe(file)
+    expect(existsSync(join(workDir, 'skills'))).toBe(false)
+  })
+
+  test('does no directory pruning when no boundary is supplied', async () => {
+    const file = join(workDir, 'skills/planning/SKILL.md')
+    await installAssetFile({ file }, '# planning')
+    await deleteAssetFile({ file })
+    expect(existsSync(file)).toBe(false)
+    // Empty directory is left behind — back-compat with boundary-less callers.
+    expect(existsSync(join(workDir, 'skills/planning'))).toBe(true)
+  })
+})
+
 describe('assembleAssetContent / splitAssetContent — round-trip', () => {
   // Inverse-property contract: split(assemble(body, metadata)) === { content: body, metadata }.
   // If this ever drifts, every consumer that compares a write-then-read-

--- a/packages/adapter/src/asset-fs.ts
+++ b/packages/adapter/src/asset-fs.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { mkdir, readFile, rm, rmdir, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { splitFrontMatter, validateAssetName } from '@agent-facets/common'
 import { stringify as stringifyYaml } from 'yaml'
 
@@ -40,6 +40,18 @@ import { stringify as stringifyYaml } from 'yaml'
 export interface AssetPath {
   /** Absolute path to the asset file on disk. */
   file: string
+  /**
+   * Absolute path to the adapter-controlled root directory. When set,
+   * `deleteAssetFile` prunes now-empty parent directories of `file`
+   * upward, stopping *before* it would remove `pruneBoundary` itself.
+   * When absent, no directory pruning occurs (back-compat).
+   *
+   * Pruning is best-effort and non-recursive: a directory that still
+   * contains unrelated files is left untouched, and any removal failure
+   * (`ENOTEMPTY`, `ENOENT`, `ENOTDIR`, `EEXIST`, …) simply stops the walk
+   * without failing the delete.
+   */
+  pruneBoundary?: string
 }
 
 /**
@@ -78,11 +90,55 @@ export async function readAssetFile(path: AssetPath): Promise<{ content: string;
  * Delete the asset file at `path.file`. No-op if absent (idempotent by
  * contract — see Adjustment B). Also removes any legacy `.meta.json`
  * sidecar left behind by earlier versions so upgrades reconverge cleanly.
+ *
+ * When `path.pruneBoundary` is set, empty parent directories of the
+ * deleted file are removed upward until (but not including) the boundary
+ * — so nested layouts like `skills/<name>/SKILL.md` don't leave empty
+ * `skills/<name>/` folders behind. See {@link pruneEmptyParents}.
  */
 export async function deleteAssetFile(path: AssetPath): Promise<string> {
   await rm(path.file, { force: true })
   await rm(`${path.file}.meta.json`, { force: true })
+  if (path.pruneBoundary !== undefined) {
+    await pruneEmptyParents(dirname(path.file), path.pruneBoundary)
+  }
   return path.file
+}
+
+/**
+ * Remove empty directories from `startDir` upward, stopping *before*
+ * `boundary` (the boundary itself is never removed) and never climbing
+ * above it. Best-effort: a non-empty directory throws `ENOTEMPTY` from
+ * the non-recursive `rmdir`, which — like any other error — stops the
+ * walk without failing. This is what keeps unrelated sibling files safe
+ * (their directory refuses to be removed) and makes the whole operation
+ * idempotent (an already-absent directory throws `ENOENT` and stops).
+ *
+ * The non-recursive `rmdir` is load-bearing: it can only ever remove a
+ * directory that is genuinely empty, so pruning can never delete a file
+ * the adapter didn't already delete itself.
+ */
+async function pruneEmptyParents(startDir: string, boundary: string): Promise<void> {
+  const stop = resolve(boundary)
+  let current = resolve(startDir)
+  while (current !== stop && isStrictlyInside(current, stop)) {
+    try {
+      await rmdir(current)
+    } catch {
+      return
+    }
+    current = dirname(current)
+  }
+}
+
+/**
+ * True when `child` is a strict descendant of `parent` (not equal to it,
+ * not outside it). Guards the prune walk so it can never escape the
+ * adapter-controlled tree via `..` or an unrelated absolute path.
+ */
+function isStrictlyInside(child: string, parent: string): boolean {
+  const rel = relative(parent, child)
+  return rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel)
 }
 
 // --- front-matter helpers (exported for adapter-level customization) ---

--- a/packages/adapters/claude-code/src/index.ts
+++ b/packages/adapters/claude-code/src/index.ts
@@ -51,7 +51,7 @@ export default defineAdapter({
   },
 
   async deleteAsset(scope, assetType, name) {
-    return deleteAssetFile({ file: resolvePath(scope, assetType, name) })
+    return deleteAssetFile({ file: resolvePath(scope, assetType, name), pruneBoundary: baseDirFor(scope) })
   },
 })
 

--- a/packages/adapters/opencode/src/index.ts
+++ b/packages/adapters/opencode/src/index.ts
@@ -69,7 +69,7 @@ export default defineAdapter({
   },
 
   async deleteAsset(scope, assetType, name) {
-    return deleteAssetFile({ file: resolvePath(scope, assetType, name) })
+    return deleteAssetFile({ file: resolvePath(scope, assetType, name), pruneBoundary: baseDirFor(scope) })
   },
 })
 

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -56,6 +56,37 @@ function buildFakeAdapter(name: string): Adapter {
 }
 
 /**
+ * Fake adapter whose skill layout matches the first-party nested shape
+ * (`skills/<name>/SKILL.md`) and passes `pruneBoundary` into the shared
+ * delete helper. Used to exercise install-level empty-directory pruning
+ * end-to-end through `runInstall`. Agents/commands use the flat layout,
+ * mirroring the real Claude Code / OpenCode adapters.
+ */
+function buildNestedFakeAdapter(name: string): Adapter {
+  const baseDir = join(projectRoot, `.${name}`)
+  const relFor = (type: string, n: string): string =>
+    type === 'skill' ? join('skills', n, 'SKILL.md') : join(`${type}s`, `${n}.md`)
+  const path = (type: string, n: string) => ({
+    file: join(baseDir, relFor(type, n)),
+    pruneBoundary: baseDir,
+  })
+  return {
+    name,
+    supportsInstall: true,
+    buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
+    async installAsset(_scope, type, n, content, metadata) {
+      await installAssetFile(path(type, n), content, metadata as Record<string, unknown> | undefined)
+    },
+    async readAsset(_scope, type, n) {
+      return readAssetFile(path(type, n))
+    },
+    async deleteAsset(_scope, type, n) {
+      await deleteAssetFile(path(type, n))
+    },
+  }
+}
+
+/**
  * Adapter that throws on the Nth `installAsset` call. Used to exercise
  * mid-install rollback and partial-write recovery.
  */
@@ -507,6 +538,82 @@ describe('runInstall — asset-level drift across versions', () => {
     expect(second.ok).toBe(true)
     expect(existsSync(join(projectRoot, '.test/skills/planning.md'))).toBe(true)
     expect(existsSync(join(projectRoot, '.test/skills/extras.md'))).toBe(false)
+  })
+})
+
+describe('runInstall — empty skill directory pruning (nested layout)', () => {
+  test('removing a skill deletes its SKILL.md and prunes the now-empty directory', async () => {
+    // First install: facet declares two skills, materialized to the nested
+    // `skills/<name>/SKILL.md` layout the real first-party adapters use.
+    const fixture = buildLocalFixtureWithSkills('viper-plans', ['planning', 'extras'])
+    const relPath = `./${fixture.split('/').pop()}`
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { 'viper-plans': relPath } }))
+    const first = await runInstall({
+      projectRoot,
+      adapters: [buildNestedFakeAdapter('nested')],
+    })
+    expect(first.ok).toBe(true)
+    expect(existsSync(join(projectRoot, '.nested/skills/planning/SKILL.md'))).toBe(true)
+    expect(existsSync(join(projectRoot, '.nested/skills/extras/SKILL.md'))).toBe(true)
+
+    // Drop the `extras` skill from the fixture.
+    rmSync(join(fixture, 'skills/extras'), { recursive: true, force: true })
+    writeFileSync(
+      join(fixture, 'facet.json'),
+      JSON.stringify({
+        name: 'viper-plans',
+        version: '0.2.0',
+        skills: { planning: { description: 'planning skill' } },
+      }),
+    )
+
+    const second = await runInstall({
+      projectRoot,
+      adapters: [buildNestedFakeAdapter('nested')],
+    })
+    expect(second.ok).toBe(true)
+    // SKILL.md is gone AND the now-empty skill directory is pruned.
+    expect(existsSync(join(projectRoot, '.nested/skills/extras/SKILL.md'))).toBe(false)
+    expect(existsSync(join(projectRoot, '.nested/skills/extras'))).toBe(false)
+    // The surviving skill is untouched.
+    expect(existsSync(join(projectRoot, '.nested/skills/planning/SKILL.md'))).toBe(true)
+  })
+
+  test('a skill directory containing an unrelated file is preserved on removal', async () => {
+    const fixture = buildLocalFixtureWithSkills('viper-plans', ['planning', 'extras'])
+    const relPath = `./${fixture.split('/').pop()}`
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: { 'viper-plans': relPath } }))
+    const first = await runInstall({
+      projectRoot,
+      adapters: [buildNestedFakeAdapter('nested')],
+    })
+    expect(first.ok).toBe(true)
+
+    // A user drops an unrelated file into the extras skill directory.
+    const stray = join(projectRoot, '.nested/skills/extras/user-notes.md')
+    writeFileSync(stray, 'do not delete me')
+
+    // Drop the `extras` skill from the fixture.
+    rmSync(join(fixture, 'skills/extras'), { recursive: true, force: true })
+    writeFileSync(
+      join(fixture, 'facet.json'),
+      JSON.stringify({
+        name: 'viper-plans',
+        version: '0.2.0',
+        skills: { planning: { description: 'planning skill' } },
+      }),
+    )
+
+    const second = await runInstall({
+      projectRoot,
+      adapters: [buildNestedFakeAdapter('nested')],
+    })
+    expect(second.ok).toBe(true)
+    // The managed SKILL.md is gone, but the directory survives because of
+    // the unrelated file — non-recursive prune refuses to remove it.
+    expect(existsSync(join(projectRoot, '.nested/skills/extras/SKILL.md'))).toBe(false)
+    expect(existsSync(stray)).toBe(true)
+    expect(existsSync(join(projectRoot, '.nested/skills/extras'))).toBe(true)
   })
 })
 


### PR DESCRIPTION
### Why

When a skill or other asset is removed, the adapter-controlled directory it lived in (e.g. `skills/<name>/`) was left behind as an empty folder. This is noisy and inconsistent with the expectation that uninstalling an asset leaves no trace.

### Details

A `pruneBoundary` field has been added to `AssetPath`. When set, `deleteAssetFile` walks upward from the deleted file's parent directory, removing each directory that is now empty, stopping before it would remove the boundary itself.

The pruning relies on the non-recursive `rmdir`, which only succeeds on genuinely empty directories. Any failure — `ENOTEMPTY` (sibling files or directories still present), `ENOENT` (already gone), or anything else — silently stops the walk. This means:

- Directories containing unrelated user files are never touched.
- The operation is naturally idempotent.
- The boundary directory itself is protected by an explicit `isStrictlyInside` guard, so the walk can never escape the adapter-controlled tree.

When `pruneBoundary` is omitted, behaviour is unchanged (back-compat for callers that don't pass it). The Claude Code and OpenCode adapters now pass `baseDirFor(scope)` as the boundary in their `deleteAsset` implementations.

### Verification

New unit tests cover: pruning a now-empty skill folder, preserving a folder that still contains a sibling file, cascading pruning of nested empty parents, stopping at a parent with a surviving sibling, never removing the boundary directory, idempotency on a second delete, and the no-op case when no boundary is supplied. End-to-end tests through `runInstall` verify the nested layout used by the real adapters, including the case where a user-placed file in a skill directory prevents pruning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Filesystem delete behavior is extended with best-effort, non-recursive empty-dir cleanup bounded to the adapter root; user files in non-empty dirs are preserved and callers without `pruneBoundary` are unchanged.
> 
> **Overview**
> **Asset removal** can now clean up empty folders left behind (e.g. `skills/<name>/` after deleting `SKILL.md`), instead of leaving empty directories on disk.
> 
> `AssetPath` gains optional **`pruneBoundary`**. When set, `deleteAssetFile` walks upward from the deleted file’s parent and removes empty directories with non-recursive `rmdir`, stopping before the boundary and guarded by `isStrictlyInside` so the walk cannot escape the adapter tree. Failures (`ENOTEMPTY`, `ENOENT`, etc.) end the walk without failing the delete; omitting `pruneBoundary` keeps prior behavior.
> 
> **Claude Code** and **OpenCode** pass `baseDirFor(scope)` as the boundary in `deleteAsset`. Unit tests cover pruning, siblings, nested parents, boundary safety, idempotency, and opt-out; `runInstall` tests exercise nested skill layout end-to-end, including directories kept when a user file remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aeafba48f34c4c79d7a02a187226e2a82b522de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->