### PR TITLE
Pin `@agentfacets/openspec-adversary` to `3.2.1`

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -3,7 +3,7 @@
     "viper-plans": "1.1.4",
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
-    "@agentfacets/openspec-adversary": "latest",
+    "@agentfacets/openspec-adversary": "3.2.1",
     "@agentfacets/address-pr-feedback": "latest"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -31,8 +31,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.0.0",
-      "integrity": "sha256:124f6045f8959d69f9a7116d342a799094bc03fc638c76cab536f9db803d4a94",
+      "version": "3.2.1",
+      "integrity": "sha256:410c1c2e17c459f0acdd13991c512926f9b06b8856de7a1812150574ddeebdc5",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Pins `@agentfacets/openspec-adversary` to version `3.2.1` instead of `latest` to ensure a stable, reproducible build.

### Details

Using `latest` can introduce unexpected breaking changes when the package is updated. Locking to `3.2.1` guarantees consistent behavior across environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version pin only; no application or runtime logic changes.
> 
> **Overview**
> **Pins `@agentfacets/openspec-adversary` from `latest` to `3.2.1`** in `facets.json` and refreshes `facets.lock` (resolved version **1.0.0 → 3.2.1** with a new integrity hash).
> 
> This locks the OpenSpec adversary facet package so installs are reproducible instead of floating on registry updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060ed5405745197e7dae5fe6df9ca7bca0d4b97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenSpec Adversary facet to a specific version for more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->