### PR TITLE
Streamline quickstart flow and clarify account token scope in setup guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -161,7 +161,7 @@
         "type": "button",
         "icon": "download",
         "label": "Download CLI",
-        "href": "https://agentfacets.io/install"
+        "href": "/quickstart"
       },
       {
         "type": "button",

--- a/docs/guides/setup.mdx
+++ b/docs/guides/setup.mdx
@@ -54,8 +54,8 @@ What you need before adding, authoring, or publishing facets. If you just want t
     </Note>
   </Step>
 
-  <Step title="Create a registry account + token (only to publish)">
-    Adding public facets needs no account. **Publishing** does: sign up at [agentfacets.io](https://agentfacets.io) and create a <Tooltip tip="A revocable credential you mint in the web UI to authenticate the CLI to the registry.">personal access token (PAT)</Tooltip> in your account settings. Sign in with [`facet login`](/cli/login) and confirm with [`facet whoami`](/cli/whoami):
+  <Step title="Create a registry account + token">
+    Adding public facets needs no account. A token is what unlocks the rest: **publishing** your own facets, plus **accessing private or organization-owned facets** you're authorized to use. Sign up at [agentfacets.io](https://agentfacets.io) and create a <Tooltip tip="A revocable credential you mint in the web UI to authenticate the CLI to the registry.">personal access token (PAT)</Tooltip> in your account settings. Sign in with [`facet login`](/cli/login) and confirm with [`facet whoami`](/cli/whoami):
 
     ```sh
     facet login                     # interactive; stores the token
@@ -70,7 +70,7 @@ What you need before adding, authoring, or publishing facets. If you just want t
 ```sh
 facet --version        # CLI is installed and recent
 facet adapter list     # at least one adapter connected
-facet whoami           # signed in (only needed for publishing)
+facet whoami           # signed in (needed to publish and to reach private facets)
 ```
 
 ## Next steps

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -49,7 +49,7 @@ By the end of this page you'll have the `facet` CLI installed, a facet added to 
   </Step>
 
   <Step title="Use it">
-    Run the command inside you agent harness OR from your terminal with Claude Code or OpenCode:
+    Run the command inside your agent harness OR from your terminal with Claude Code or OpenCode:
 
     <CodeGroup>
       ```text Inside an agent harness

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -28,20 +28,18 @@ By the end of this page you'll have the `facet` CLI installed, a facet added to 
     ```
   </Step>
 
-  <Step title="Connect your AI tool (once per machine)">
-    Install the <Tooltip tip="An adapter is the bridge between facet and a specific AI coding tool — it decides where assets and config land on disk.">adapter</Tooltip> for the tool you use with [`facet adapter install`](/cli/adapters/install):
-
-    ```sh
-    facet adapter install claude-code   # or: opencode, codex
-    ```
-  </Step>
-
   <Step title="Add a facet">
     From your project directory, add a facet by name from the registry with [`facet add`](/cli/add):
 
     ```sh
     facet add cowsay
     ```
+
+    <Note>
+      The first time you run this with no <Tooltip tip="An adapter is the bridge between facet and a specific AI coding tool — it decides where assets and config land on disk.">adapter</Tooltip> installed, `facet add` opens a picker to connect your AI tool (claude-code, opencode, or codex) before installing.
+    </Note>
+
+    Once an adapter is connected, `facet add` installs the facet into your tool:
 
     ```
     cowsay installed. Updated facets via 1 adapter  ✓
@@ -51,12 +49,22 @@ By the end of this page you'll have the `facet` CLI installed, a facet added to 
   </Step>
 
   <Step title="Use it">
-    The facet's commands are now available in your tool. Inside your AI coding tool, run:
+    Run the command inside you agent harness OR from your terminal with Claude Code or OpenCode:
 
-    ```
-    /cowsay hey there
-    /cowchat how's the weather?
-    ```
+    <CodeGroup>
+      ```text Inside an agent harness
+      /cowsay hey there
+      /cowchat how's the weather?
+      ```
+
+      ```sh Claude Code
+      claude -p "/cowsay hey there"
+      ```
+
+      ```sh OpenCode
+      opencode run --command cowsay "hey there"
+      ```
+    </CodeGroup>
 
     That's it — you've installed and used your first facet.
   </Step>


### PR DESCRIPTION
### Why

The quickstart and setup docs had a few gaps and inaccuracies: the adapter install step was presented as a prerequisite rather than something `facet add` handles automatically, the registry account step undersold the value of a token (only mentioning publishing, not private/org facet access), and the "Download CLI" nav button pointed to an external URL instead of the in-docs quickstart page.

### Details

- The explicit "Connect your AI tool" step is removed from the quickstart and replaced with a note explaining that `facet add` triggers an interactive adapter picker on first run, which better reflects the actual UX flow.
- The "Use it" step now shows tool-specific usage examples (agent harness, Claude Code CLI, OpenCode) in a `CodeGroup` rather than a single generic snippet.
- The setup guide's account/token step is retitled and reworded to make clear that a token is required for both publishing *and* accessing private or organization-owned facets.
- The `facet whoami` checklist item is updated with the same clarification.
- The "Download CLI" nav button now links to `/quickstart` instead of `agentfacets.io/install`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation link changes only; no product code or security behavior changes.
> 
> **Overview**
> **Quickstart** no longer lists a separate “connect your AI tool” step; it documents that the first `facet add` without an adapter opens an interactive tool picker, and expands **Use it** with a `CodeGroup` for harness slash commands, Claude Code (`claude -p`), and OpenCode (`opencode run --command`).
> 
> **Setup guide** retitles the registry step and states that a PAT is needed to **publish** and to use **private or organization-owned** facets; the verify checklist comment for `facet whoami` matches that.
> 
> **Docs nav:** **Download CLI** now points to `/quickstart` instead of `https://agentfacets.io/install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7376e8c9a2903c3d2b6c8b1ca23e8997502a31f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Download CLI” navigation link to open the Quickstart guide.
  * Clarified that registry tokens support publishing and accessing authorized private or organization-owned facets.
  * Streamlined the setup flow with an inline AI tool connection prompt on first use.
  * Added slash-command examples for agent harnesses, Claude Code, and OpenCode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->