### PR TITLE
Spec: unify skill and command namespace within a facet

### DIFF
--- a/openspec/changes/unify-skill-command-namespace/design.md
+++ b/openspec/changes/unify-skill-command-namespace/design.md
@@ -1,0 +1,49 @@
+# Design: unify skill and command namespace
+
+## Context
+
+The facet artifact specification currently defines naming collisions per asset type: skills must be unique among skills, commands among commands, agents among agents, and cross-type duplicates are explicitly allowed. This was a reasonable default when every adapter mapped each asset type to its own directory. It breaks for tools that collapse skills and commands into one on-disk namespace — most notably Codex, which has no command concept and installs a command as a skill at `.agents/skills/<name>/SKILL.md`, the same path a skill of that name uses.
+
+The observable failure (validated against a real Codex adapter + install pipeline): a facet with a skill and a command both named `plan` installs one over the other, reports a permanent "repaired" loop on every subsequent install, and deletes the surviving file when either asset is removed. The facet builds and publishes without error today, so the defect is discovered only at install time on one tool.
+
+## Goals
+
+- Make the invalid pairing impossible to produce: a facet that shares a name between a skill and a command fails at build and fails archive verification.
+- Keep the rule adapter-agnostic and enforced once, in the protocol build validator, so every consumer (build, archive verification, publish verification) tightens together.
+- Preserve the agent namespace as independent — agents do not collide with skills or commands on disk in the tools we target.
+
+## Decisions
+
+### D1 — Enforce at the protocol level, not per-adapter
+
+A skill/command name clash is unresolvable on a shared-namespace tool without renaming. Rather than have each adapter detect and reject (or worse, disambiguate) the clash at install time, the facet contract itself forbids it. This makes portability correct by construction: a facet that passes build is installable on any conforming tool, including shared-namespace ones.
+
+Rejected alternative — per-adapter path disambiguation (suffixes, alternate directories): leaves a residual injectivity hole (two distinct authored names could still map to one path), imposes migration cost on already-installed assets, and diverges layout per tool. This was discussed and rejected during PR review.
+
+Rejected alternative — a runtime install-time guard in the engine (an adapter `resolvePath` hook plus an install preflight that fails on colliding paths). This was prototyped and works, but it detects the problem late (at install, per consumer) rather than preventing the invalid artifact, and it pushes an adapter-specific concern into the shared install pipeline. The protocol invariant supersedes it.
+
+### D2 — Skills and commands share one namespace; agents stay separate
+
+The shared namespace is exactly skills ∪ commands, because that is the set collapsed to one directory on the affected tools. Agents live in a distinct tree (e.g. Codex `.codex/agents/<name>.toml`) and do not collide, so an agent MAY continue to share a name with a skill or a command. The collision is defined on **exact** name equality; distinct nested names (command `space`, skill `space/spec`) are different names and do not collide.
+
+### D3 — One enforcement point
+
+`detectNamingCollisions` is already the single build validator for naming, consumed by the build pipeline and by archive verification. Adding the skill↔command check there tightens both paths, and publish verification inherits it because it applies the same archive-verification checks. No separate publishing spec change is required; the publishing spec already delegates to "the same checks a facet-compatible system applies to a `.facet` archive."
+
+## Spec impact
+
+- `authoring__facets` — the "Build detects naming collisions between local assets" requirement gains the skill/command shared-namespace rule; the "Skill and command share a name" scenario inverts from success to build failure. Skill/agent and command/agent scenarios stay as success.
+- `protocol__integrity` — the archive-verification requirement's artifact-content-rules clause and its content-rule-violation scenario add the skill/command name-sharing case.
+
+## Documentation impact (Article III)
+
+- `docs/cli/authoring/build.mdx` states the collision check "Fails if the same name is used more than once within the same asset type." This MUST be updated to state that skills and commands share one namespace (a name used by both a skill and a command fails the build), while agents remain independent.
+- `docs/alpha/onboarding.mdx` mentions cross-facet collisions as a post-alpha fast-follow; that is a different concern and is left unchanged.
+
+## Migration / compatibility
+
+An existing facet that today declares a skill and a command with the same name will begin to fail the build after this change. This is intended: such a facet was never installable correctly on shared-namespace tools. Authors resolve it by renaming one of the two assets. Already-built `.facet` artifacts containing the clash will fail archive verification and therefore fail publish verification — again intended, surfacing a previously-silent defect.
+
+## Non-goals
+
+Interactive prevention in `facet create` / `facet edit`, cross-facet collision detection, and any runtime install-time guard are out of scope (see proposal Non-goals). The build gate is the enforcement boundary for this change.

--- a/openspec/changes/unify-skill-command-namespace/proposal.md
+++ b/openspec/changes/unify-skill-command-namespace/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Some coding tools install skills and commands into one shared on-disk namespace. Codex is the clearest case: it has no separate "command" concept, so a command is delivered as a skill at `.agents/skills/<name>/SKILL.md` — the exact path a skill of the same name uses. When a facet declares a skill and a command with the same name, they resolve to the same file: one clobbers the other at install, repeated installs ping-pong "repairs" between them, and removing either deletes the other's file.
+
+Today the facet artifact specification explicitly permits this pairing — a skill and a command MAY share a name, and the build succeeds. That makes such a facet impossible to install correctly on Codex and silently lossy. This is a portability hole in the facet contract itself, not a single tool's bug: a facet that builds and publishes cleanly cannot be installed faithfully everywhere.
+
+## What Changes
+
+- Building a facet SHALL treat a skill and a command that share a name as a naming collision and fail the build with an error identifying the shared name and the sections involved.
+- Skills and commands SHALL share a single name namespace within a facet: a command name MUST NOT equal any skill name, and a skill name MUST NOT equal any command name.
+- Agents SHALL keep an independent namespace — an agent MAY still share a name with a skill or a command.
+- Archive verification SHALL apply the tightened content rules, so a `.facet` whose inner content contains a skill/command name clash SHALL fail verification rather than being treated as trusted. Publish verification inherits this because it applies the same archive-verification checks.
+- User-facing build documentation SHALL describe that skills and commands share one namespace.
+
+## Non-goals
+
+- This change will NOT introduce per-adapter path disambiguation, name suffixes, or per-tool layout divergence to let same-named skills and commands coexist. That approach was rejected for its residual injectivity hole, migration cost, and per-adapter divergence.
+- This change will NOT alter the agent namespace — an agent MAY still share a name with a skill or a command.
+- This change will NOT add interactive prevention in the `facet create` / `facet edit` wizards; the build gate catches the collision, and interactive prevention is a follow-up.
+- This change will NOT add cross-facet collision detection (two facets each shipping the same asset name); that remains a separate post-alpha concern.
+- This change will NOT add a runtime install-time guard; enforcement is at build and verification, so an invalid facet cannot be produced in the first place.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `authoring__facets`: Building a facet SHALL reject a skill and a command that share a name, treating skills and commands as one name namespace while leaving agents independent.
+- `protocol__integrity`: Archive verification SHALL reject a built artifact whose inner content shares a name between a skill and a command, as part of the artifact content rules.
+
+## Impact
+
+- Protocol build validator `detectNamingCollisions` (`packages/protocol/src/build/detect-collisions.ts`) gains a skill↔command cross-namespace check. It is consumed by the build pipeline (`packages/engine/src/build/pipeline.ts`) and by archive verification (`packages/protocol/src/integrity/validate-archive.ts`), so both paths tighten from one change.
+- Tests: invert `packages/engine/src/__tests__/build-pipeline.test.ts` ("skill and command sharing a name is allowed") and add regressions — skill/command clash rejected; skill/agent and command/agent still allowed; distinct nested names (command `space`, skill `space/spec`) unaffected.
+- Documentation: `docs/cli/authoring/build.mdx` currently states the build "Fails if the same name is used more than once within the same asset type"; it SHALL be updated to state that skills and commands share one namespace. The `docs/alpha/onboarding.mdx` cross-facet collision note is unrelated and left as-is.
+- Publishing behavior follows from the archive-verification change (publish verification applies the same checks); no separate publishing spec delta is required.

--- a/openspec/changes/unify-skill-command-namespace/specs/authoring__facets/spec.md
+++ b/openspec/changes/unify-skill-command-namespace/specs/authoring__facets/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Build detects naming collisions between local assets
+
+The system SHALL detect naming collisions among a facet's locally declared assets. Skills SHALL have unique names within the skills section, agents SHALL have unique names within the agents section, and commands SHALL have unique names within the commands section.
+
+In addition, skills and commands SHALL share a single name namespace: a command name MUST NOT equal any skill name, and a skill name MUST NOT equal any command name. This is because some tools install skills and commands into one shared location, where a shared name is not deliverable. Agents SHALL keep an independent namespace — an agent MAY share a name with a skill or a command. The collision is defined on exact name equality; distinct names that share a prefix (for example a command `space` and a skill `space/spec`) SHALL NOT be treated as a collision.
+
+Any collision SHALL cause the build to fail with an error identifying the conflicting name and the sections involved.
+
+#### Scenario: Two skills share a name
+
+- **WHEN** a facet declares two skills with the same name
+- **THEN** the build SHALL fail
+- **AND** the error SHALL identify the collision within the skills section
+
+#### Scenario: Skill and command share a name
+
+- **WHEN** a facet declares a skill and a command with the same name
+- **THEN** the build SHALL fail
+- **AND** the error SHALL identify the collision between the skills and commands sections
+
+#### Scenario: Skill and agent share a name
+
+- **WHEN** a facet declares a skill and an agent with the same name
+- **THEN** the build SHALL succeed with no collision errors
+
+#### Scenario: Command and agent share a name
+
+- **WHEN** a facet declares a command and an agent with the same name
+- **THEN** the build SHALL succeed with no collision errors
+
+#### Scenario: Distinct nested names across skills and commands do not collide
+
+- **WHEN** a facet declares a command named `space` and a skill named `space/spec`
+- **THEN** the build SHALL succeed with no collision errors
+
+#### Scenario: No collisions across distinct names within each type
+
+- **WHEN** a facet declares assets with distinct names within each asset type
+- **THEN** the build SHALL succeed with no collision errors

--- a/openspec/changes/unify-skill-command-namespace/specs/protocol__integrity/spec.md
+++ b/openspec/changes/unify-skill-command-namespace/specs/protocol__integrity/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: A single archive-verification operation produces a structured result for any consumer of a built `.facet`
+
+A facet-compatible system SHALL expose, on its protocol surface, a single archive-verification operation that takes the bytes of a built `.facet` and produces a structured result indicating whether the archive is a valid, self-consistent facet artifact. The operation SHALL perform the full chain of checks required to treat the archive as trusted: it SHALL parse the outer container into its two declared entries, decompress the inner archive, verify that the recomputed inner-archive content hash equals the integrity value recorded in the build manifest, verify that the per-asset hashes recorded in the build manifest each equal the actual hash of the corresponding file inside the inner archive, validate the embedded facet manifest against the manifest schema, and apply the artifact content rules (no empty declared assets, no naming collisions within an asset type, and no name shared between a skill and a command). The operation SHALL return a structured pass-or-fail result and SHALL NOT throw on any of these failure modes; failures SHALL be surfaced as data the caller can render or branch on.
+
+The operation SHALL be the single, shared mechanism by which any facet-compatible system verifies a built archive before treating it as trusted. A system SHALL NOT reimplement the verification chain by stringing together lower-level primitives in a way that allows the implementation to drift from the one specified here.
+
+Decompression is not part of the protocol surface — the protocol does not perform compression or decompression. The archive-verification operation SHALL accept a caller-supplied decompressor as an input parameter and SHALL use it to decompress the inner archive. The operation SHALL NOT itself decompress, gzip, or perform any ambient input or output. The caller-supplied decompressor SHALL be permitted, but SHALL NOT be required, to enforce a maximum decompressed size; the verification result's failure surface SHALL include a way to report that the decompressor refused to decompress an inner archive whose decompressed size exceeded the caller's allowance.
+
+#### Scenario: A self-consistent built archive verifies as valid
+
+- **WHEN** a caller invokes the archive-verification operation with the bytes of a built `.facet` whose build manifest's integrity hash matches the recomputed inner-archive content hash, whose build manifest's per-asset hash map matches every actual per-asset hash inside the inner archive, whose embedded facet manifest is schema-valid, and whose inner content satisfies the artifact content rules
+- **THEN** the operation SHALL produce a successful result
+- **AND** the successful result SHALL carry the parsed build manifest and per-asset information needed by the caller
+
+#### Scenario: A tampered inner archive is rejected
+
+- **WHEN** a caller invokes the archive-verification operation with the bytes of a built `.facet` whose inner-archive content has been modified after the build manifest was written, so that the recomputed inner-archive content hash no longer equals the build manifest's recorded integrity value
+- **THEN** the operation SHALL produce a failure result identifying the integrity mismatch as the reason
+- **AND** the operation SHALL NOT throw
+
+#### Scenario: A per-asset hash mismatch is rejected
+
+- **WHEN** a caller invokes the archive-verification operation with the bytes of a built `.facet` in which one or more individual asset files inside the inner archive do not hash to the value recorded for that asset in the build manifest's per-asset hash map
+- **THEN** the operation SHALL produce a failure result identifying which assets failed and the expected and observed hashes
+- **AND** the operation SHALL NOT throw
+
+#### Scenario: An invalid embedded facet manifest is rejected
+
+- **WHEN** a caller invokes the archive-verification operation with the bytes of a built `.facet` whose embedded facet manifest does not satisfy the manifest schema
+- **THEN** the operation SHALL produce a failure result identifying the embedded manifest as invalid
+- **AND** the operation SHALL NOT throw
+
+#### Scenario: A content rule violation in the inner archive is rejected
+
+- **WHEN** a caller invokes the archive-verification operation with the bytes of a built `.facet` whose inner content violates the artifact content rules — for example, a declared asset file that is empty, two assets sharing the same name within an asset type, or a skill and a command sharing the same name
+- **THEN** the operation SHALL produce a failure result identifying the content violation
+- **AND** the operation SHALL NOT throw
+
+#### Scenario: A caller-supplied decompressor refuses to decompress
+
+- **WHEN** a caller invokes the archive-verification operation with a decompressor that refuses to decompress an inner archive whose decompressed size exceeds the caller's allowance
+- **THEN** the operation SHALL produce a failure result indicating that the decompressor refused
+- **AND** the operation SHALL NOT throw
+
+#### Scenario: A malformed outer container is rejected
+
+- **WHEN** a caller invokes the archive-verification operation with bytes that cannot be parsed as the canonical two-entry outer container
+- **THEN** the operation SHALL produce a failure result identifying the malformed container
+- **AND** the operation SHALL NOT throw

--- a/openspec/changes/unify-skill-command-namespace/tasks.md
+++ b/openspec/changes/unify-skill-command-namespace/tasks.md
@@ -1,0 +1,13 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## 1. Enforce skill/command namespace — Research
+
+- [ ] 1.1 Explore: Re-read `packages/protocol/src/build/detect-collisions.ts`, its callers (`packages/engine/src/build/pipeline.ts`, `packages/protocol/src/integrity/validate-archive.ts`), the existing collision tests (`packages/engine/src/__tests__/build-pipeline.test.ts`), and `docs/cli/authoring/build.mdx` to confirm the exact change surface and error shape.
+- [ ] 1.2 Propose: Present the `detectNamingCollisions` change (skill↔command cross-namespace check, error message identifying both sections), the test inversion + additions, and the doc update. Gate before writing.
+
+## 2. Enforce skill/command namespace — Implementation
+
+- [ ] 2.1 Implement: Add a skill↔command shared-namespace check to `detectNamingCollisions` — a command name equal to any skill name (and vice versa) SHALL produce a collision error identifying the shared name and the skills/commands sections. Leave agents independent; match on exact name equality only.
+- [ ] 2.2 Implement: Invert the `build-pipeline.test.ts` "skill and command sharing a name is allowed" test to expect a collision, and add regressions — skill/command clash rejected; skill/agent and command/agent still allowed; distinct nested names (command `space`, skill `space/spec`) not a collision.
+- [ ] 2.3 Implement: Update `docs/cli/authoring/build.mdx` to state that skills and commands share one namespace (a name used by both fails the build), while agents remain independent.
+- [ ] 2.4 Verify: Run `bun check` (lint, types, unit, e2e). If anything fails, STOP and notify the user.


### PR DESCRIPTION
## Summary

OpenSpec change `unify-skill-command-namespace` — specification only, no implementation code (deferred to `tasks.md`).

A skill and a command that share a name collide on tools that install both into one location. Codex is the clearest case: it has no separate "command" concept, so a command is delivered as a skill at `.agents/skills/<name>/SKILL.md` — the exact path a same-named skill uses. The result: one clobbers the other at install, repeated installs ping-pong "repairs", and removing either deletes the other's file. The artifact spec currently *permits* this pairing (build succeeds), so the defect only surfaces at install time on one tool — a portability hole in the facet contract.

This change specifies that **skills and commands share a single name namespace within a facet** (agents stay independent), enforced at **build** and **archive verification** so the invalid artifact cannot be produced in the first place. Publish verification inherits it via its "same checks" delegation.

## What's in this PR

- `proposal.md` — Why / What Changes / Non-goals / Capabilities / Impact
- `design.md` — protocol-not-per-adapter rationale (records the rejected suffix approach and the reverted engine-preflight prototype), skills∪commands vs. independent agents, single enforcement point, docs + migration impact
- `specs/authoring__facets/spec.md` — MODIFIED "Build detects naming collisions": adds the skill↔command shared-namespace rule and **inverts** the "skill and command share a name" scenario (was success → now build fails); skill/agent + command/agent stay allowed; adds a distinct-nested-name boundary scenario
- `specs/protocol__integrity/spec.md` — MODIFIED the archive-verification requirement: artifact content rules now include "no name shared between a skill and a command"
- `tasks.md` — the deferred implementation work (detect-collisions check, test inversion + regressions, doc update, `bun check`)

## Non-goals

- No per-adapter path disambiguation / suffixes
- No change to the agent namespace
- No interactive `create`/`edit` prevention (build gate catches it)
- No cross-facet collision detection
- No runtime install-time guard

## Validation

`bun openspec validate unify-skill-command-namespace --strict` → valid (2 MODIFIED deltas, all scenarios parsed).

## Context

Follow-up split out of #410 per review: the reviewer asked that the skill/command exact-name collision be driven as a separate protocol-level OpenSpec change rather than fixed per-adapter in that PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and protocol spec only; no runtime or validator code changes in this PR. Intended breaking behavior for invalid facets applies only after implementation lands.
> 
> **Overview**
> **Specification-only** OpenSpec change `unify-skill-command-namespace` (implementation deferred in `tasks.md`). It closes a portability gap where a facet could **build and publish** with a skill and a command sharing the same name, then **fail or corrupt installs** on tools (e.g. Codex) that map both to one path.
> 
> The contract now requires **skills and commands to share one name namespace** within a facet (exact name match; agents stay independent). **Build** and **archive verification** must reject that pairing; publish verification inherits via existing delegation. The **skill + command same name** scenario **inverts** from allowed to **build failure**; skill/agent and command/agent remain allowed, with an explicit boundary for distinct nested names (e.g. command `space` vs skill `space/spec`).
> 
> Adds `proposal.md`, `design.md` (protocol-level enforcement vs per-adapter disambiguation or install-time guards), MODIFIED deltas for `authoring__facets` and `protocol__integrity`, and `tasks.md` for `detectNamingCollisions`, test updates, and `docs/cli/authoring/build.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426fa2da90b948a4bc5d59d670e803ae21001e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills and commands within the same facet now share a namespace and must have unique names.
  * Archive verification now returns structured pass/fail results covering integrity, manifest, content, and decompression checks.

* **Bug Fixes**
  * Invalid skill–command name collisions are rejected during builds, archive verification, and publishing.
  * Agents remain independent and may share names with skills or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->