### PR TITLE
Add `--error-on-warnings` flag to `lint` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "types": "tsgo --noEmit",
     "check": "bun turbo check",
     "test:scripts": "bun test scripts/",
-    "lint": "biome check .",
+    "lint": "biome check --error-on-warnings .",
     "format": "biome check --write --unsafe .",
     "seed:cli": "bun scripts/release-cli/seed.ts",
     "seed:adapters": "bun scripts/release/seed-adapters.ts",


### PR DESCRIPTION
### Why

Warnings from Biome should be treated as errors to enforce stricter linting and prevent warnings from being silently ignored in CI or local runs.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single script-flag change with no runtime or security impact; may surface existing Biome warnings as failing builds until fixed.
> 
> **Overview**
> **Tightens the root `lint` script** so Biome warnings fail the command, not only errors.
> 
> The `lint` script in `package.json` now runs `biome check --error-on-warnings .` instead of `biome check .`. Any warning that previously exited 0 will now fail `bun run lint` and anything in the check pipeline that depends on `lint` (e.g. `bun check`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f30a5e9c247ada758a8a35a4cba1359221a7bf5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks so warnings are treated as errors during linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->