### PR TITLE
Add adapter API version negotiation with compatible npm resolution, atomic placement, and managed installation provenance

### DIFF
--- a/openspec/changes/add-adapter-api-version-negotiation/.openspec.yaml
+++ b/openspec/changes/add-adapter-api-version-negotiation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/design.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/design.md
@@ -1,0 +1,237 @@
+## Context
+
+The adapter boundary is currently unversioned end to end:
+
+- `defineAdapter()` (`packages/adapter/src/define-adapter.ts`) returns a frozen `Adapter` with no contract identifier; the `Adapter` interface (`packages/adapter/src/types.ts`) carries only `name`, `supportsInstall`, and the positional methods.
+- npm adapter installs resolve `GET https://registry.npmjs.org/<name>/latest` unconditionally (`packages/engine/src/sources/adapter/npm.ts`), so the newest published release is always chosen regardless of contract shape.
+- `verifyAdapter()` (`packages/engine/src/adapters/verify.ts`) checks only that a default export with `name` and `buildAssetMetadata` exists, and it still throws instead of returning a result.
+- `placeAdapter()` (`packages/engine/src/adapters/placement.ts`) copies `adapter.js` directly over the installed bundle — a non-atomic, no-provenance overwrite. The only on-disk record of an installed adapter is the bundle itself.
+- `loadInstalledAdapters()` (`packages/engine/src/adapters/loader.ts`) dynamically imports whatever bundles exist and hands them to `ensureAdapters()`, `facet build`, and the install pipeline as the current TypeScript `Adapter` type, unchecked.
+- `parseAdapterSpecifier()` (`packages/engine/src/sources/adapter/specifier.ts`) has no version syntax for npm specifiers — `opencode`, `@scope/pkg`, `git+…`, and paths only.
+
+The reconciled proposal designates the current positional contract as adapter API `0.0`, makes the CLI support exactly `0.0`, replaces `/latest` resolution with compatibility-aware selection from package metadata, gates placement and loading on a runtime declaration, and treats undeclared bundles as incompatible. The project is forward-only: published CLIs cannot be retrofitted, so the design optimizes for a clean boundary from this release onward, not for protecting old CLIs.
+
+Constraint inventory relevant to the design:
+
+- Engine is Bun-native (may use `Bun.semver`, `Bun.file`); the adapter SDK is published, Node-friendly, and must stay a leaf (no engine/CLI deps).
+- Errors are values: every new failure mode MUST be a discriminated-union member, not a throw. Existing throwing seams (`verifyAdapter`, `placeAdapter`, bundler) that this change touches SHOULD be converted at the same time, since their failure modes become part of the user-facing contract.
+- The protocol package is for spec-defined facet primitives; the adapter API version is a CLI/SDK concern and MUST NOT leak into `@agent-facets/protocol`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a single canonical source of truth for the adapter API identifier and stamp it onto every runtime adapter without author involvement.
+- Make npm resolution select the highest package version whose declared adapter API the CLI supports, honoring explicit ranges and failing loudly on explicit incompatible exact versions.
+- Gate bundle placement and installed-bundle loading on an exact-equality API check, with structured failures before any adapter method is invoked.
+- Make installed-bundle replacement atomic: stage, verify, swap; any failure leaves the previous bundle untouched.
+- Persist installation provenance (specifier, resolved package/version, API version, integrity) alongside the installed bundle.
+- Surface compatibility in `facet adapter list` and fail facet installation before materialization writes when a selected adapter is incompatible.
+- Keep `docs/` aligned (see "Documentation impact").
+
+**Non-Goals:**
+
+- No change to the positional method signatures that become API `0.0`, and no second API version.
+- No multi-version side-by-side adapter storage.
+- No automatic upgrade of an incompatible installed adapter during `facet install`.
+- No npm dist-tag manipulation, and no attempt to make pre-existing CLI releases compatibility-aware.
+- No coupling of the adapter API to facet archive versions, facet package versions, or the SDK package's own semver.
+
+## Decisions
+
+### D1: The API identifier is an opaque string constant owned by the SDK
+
+`@agent-facets/adapter` exports:
+
+```ts
+/** The adapter API contract this SDK implements. Compared by exact string equality — never a semver range. */
+export const ADAPTER_API_VERSION = '0.0'
+```
+
+`defineAdapter()` stamps it: the returned `Adapter` gains `readonly apiVersion: string`, set unconditionally from the constant. Authors cannot (and need not) supply it — the *input* type becomes `AdapterDefinition = Omit<Adapter, 'apiVersion'>`, so an author-supplied `apiVersion` is a type error rather than a silently honored lie. This is the illegal-states rule applied to the SDK surface: an adapter whose stamped version disagrees with the SDK that built it is unrepresentable at the type level.
+
+**Why a plain string, not `{ major, minor }`:** the proposal mandates exact-equality semantics with no range interpretation. A structured type invites callers to compare components ("same major ⇒ compatible"), which is precisely the semantics the proposal forbids. An opaque string makes the only possible comparison the correct one.
+
+**Alternatives considered:**
+- *Author-declared `apiVersion` in the definition:* rejected — authors would drift from the SDK actually bundled; the SDK is the only party that knows which contract it implements.
+- *Deriving the API from the SDK package semver:* rejected by the proposal (independence requirement) — SDK releases fix bugs without changing the call contract.
+
+### D2: Engine owns the supported set; the identifier string is imported, not restated
+
+Engine (which already depends on `@agent-facets/adapter` for the `Adapter` type) defines:
+
+```ts
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+export const SUPPORTED_ADAPTER_API_VERSIONS: readonly string[] = [ADAPTER_API_VERSION]
+```
+
+Membership is exact string equality. The *set* lives in engine because "which APIs this CLI can invoke" is a property of the invoker, not the SDK: a future CLI could support `['0.0', '1.0']` while the SDK's canonical version is `1.0`. The *identifier* is imported so `'0.0'` is written exactly once in the monorepo.
+
+**Alternative — CLI-owned set:** rejected; the compatibility gates live in engine (verify, loader, resolution), and engine must not read CLI state. The CLI only renders engine's structured output.
+
+### D3: npm metadata declaration via a top-level `facetAdapter` field, full-packument resolution
+
+First-party adapter packages (and third-party ones that want pre-download selection) declare in `package.json`:
+
+```json
+"facetAdapter": { "apiVersion": "0.0" }
+```
+
+For the monorepo's own adapters, `defineAdapter`'s stamping covers the runtime side automatically; the `package.json` field is added to each `packages/adapters/*` package and validated by a repo test that compares it against `ADAPTER_API_VERSION` (single-source enforcement at CI time, since JSON cannot import the constant — this is the documented exception to the duplication rule, with the test as the guard).
+
+Resolution fetches the **full packument** (`GET https://registry.npmjs.org/<name>`) instead of `/<name>/latest`. The abbreviated "corgi" packument (`application/vnd.npm.install-v1+json`) strips custom top-level fields, so it cannot carry `facetAdapter`; the full packument preserves each version's `package.json` fields, letting the CLI read `versions[v].facetAdapter.apiVersion` before downloading anything.
+
+**Selection algorithm** (new `resolveCompatibleNpmVersion` in `packages/engine/src/sources/adapter/npm.ts`):
+
+1. Fetch full packument; failure modes extend the existing `DownloadNpmResult`-style discriminated unions.
+2. Candidate set = all versions, excluding prereleases unless the user's explicit spec includes/names one.
+3. If the specifier carries a range → intersect candidates with the range (via `Bun.semver.satisfies`).
+4. If the specifier carries an exact version → the candidate set is exactly that version; if its declared API is missing/malformed/unsupported, fail with `adapter-api-incompatible` (never substitute another release).
+5. Order remaining candidates descending with `Bun.semver.order`; pick the first whose `facetAdapter.apiVersion` is a string in `SUPPORTED_ADAPTER_API_VERSIONS`. Versions with a missing or malformed declaration are simply not candidates (they are incompatible by definition, per the proposal).
+6. If nothing qualifies → structured failure carrying: the newest considered release, its declared (or missing) adapter API, and the CLI's supported set — exactly the fields the proposal requires for diagnostics.
+
+The tarball for the selected version is then downloaded from that version's `dist` entry, with the existing SRI/shasum + tar-slip hardening unchanged.
+
+**Alternatives considered:**
+- *Custom npm dist-tags per API (e.g. `facet-api-0.0`):* rejected — the proposal forbids depending on tag movement, and tags are mutable registry state that can drift from version metadata.
+- *Downloading `latest` and checking after extraction:* rejected — the proposal requires pre-download determination and highest-*compatible* selection, which requires per-version metadata.
+- *Keywords or `engines` abuse:* rejected — not structured, collides with existing tooling semantics.
+
+### D4: Adapter specifier grammar gains an npm version suffix
+
+`parseAdapterSpecifier` learns `name@<spec>` / `@scope/name@<spec>` / `opencode@<spec>` (alias + suffix). Parsing splits on the last `@` past position 0 (scope-safe). The parsed npm variant becomes:
+
+```ts
+{ type: 'npm'; packageName: string; versionSpec: NpmVersionSpec }
+type NpmVersionSpec =
+  | { kind: 'none' }              // plain install → highest compatible
+  | { kind: 'exact'; version: string }
+  | { kind: 'range'; range: string }
+```
+
+`exact` vs `range` is distinguished because the proposal assigns them different failure semantics (exact must fail rather than substitute). A suffix that is a valid exact semver → `exact`; anything else that `Bun.semver` accepts as a range → `range`; otherwise a new `invalid-version-spec` failure arm on `ParseAdapterSpecifierResult`.
+
+Git and local specifiers take no version suffix — they cannot be version-selected (proposal Impact) and rely wholly on runtime verification (D6).
+
+### D5: Runtime declaration is final; metadata is only a selection aid
+
+After bundling/loading a candidate, verification checks the runtime export's `apiVersion`:
+
+- missing or non-string → incompatible (`declared: null`),
+- not in `SUPPORTED_ADAPTER_API_VERSIONS` → incompatible,
+- for npm installs where package metadata declared a version: metadata ≠ runtime declaration → `api-declaration-conflict` failure (fail rather than pick either side).
+
+`verifyAdapter` is converted from throwing to a result type as part of this change:
+
+```ts
+type VerifyAdapterResult =
+  | { ok: true; adapter: Adapter; apiVersion: string }
+  | { ok: false; failure:
+      | { kind: 'load-failed'; cause: string }
+      | { kind: 'no-default-export' }
+      | { kind: 'invalid-shape'; field: string }
+      | { kind: 'api-missing' }
+      | { kind: 'api-unsupported'; declared: string; supported: readonly string[] }
+      | { kind: 'api-declaration-conflict'; packageDeclared: string; runtimeDeclared: string } }
+```
+
+These arms flow into `AdapterInstallFailure` (replacing the current stringly `verify-failed` arm's `cause` with the structured union) so the CLI can render the adapter name, declared/missing API, supported APIs, and the compatible-install command without parsing messages. This ordering also satisfies the proposal's "before any adapter method is invoked" requirement: verification only reads data properties of the default export.
+
+**Why convert now rather than keep wrapping throws:** the incompatibility arms are user-facing contract (the CLI must render specific fields from them); threading them through `Error.message` strings would violate the errors-are-values rule at the exact seam this change exists to formalize.
+
+### D6: Git and local sources pass through the same runtime gate
+
+Git/local adapters skip D3 entirely (no packument) and MUST pass D5's runtime verification as supplied. There is no metadata/runtime conflict check for them (no metadata side exists — the conflict arm is unrepresentable for these sources, which the failure type reflects by carrying the npm-declared value only in the npm path).
+
+### D7: Provenance receipt `adapter.json` beside the bundle
+
+Placement writes a receipt at `$FACET_DIR/adapters/<name>/adapter.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "specifier": "opencode",
+  "source": { "type": "npm", "package": "@agent-facets/adapter-opencode", "version": "0.9.0" },
+  "apiVersion": "0.0",
+  "integrity": "sha512-…",
+  "installedAt": "2026-07-21T00:00:00Z"
+}
+```
+
+- `source` is a tagged union mirroring `ResolvedAdapterSpecifier` (`npm` with resolved exact version, `git` with url+commit, `local` with path).
+- `integrity` is the npm tarball SRI when the source is npm; for git/local (and for rebundled npm fast-path fallbacks) it is a sha512 of the placed `adapter.js` bytes, tagged so the two kinds are not conflated.
+- A missing or unparsable receipt next to an existing bundle is treated as "provenance unknown" — the bundle is still governed by runtime verification (D5); the receipt only enriches diagnostics and powers replacement/`list` output. This keeps pre-change installs representable without a migration step.
+
+**Alternative — central registry file (`$FACET_DIR/adapters.json`):** rejected; per-adapter receipts live and die with `rm -rf` of the adapter directory (the existing `removeAdapter` semantics) and cannot desynchronize from the set of installed bundle directories.
+
+### D8: Atomic replacement via stage-and-swap
+
+`placeAdapter` becomes stage-based and result-typed:
+
+1. Verify the candidate bundle (D5) **before** touching the installed location — verification already happens in `locateAndVerifyAdapter`; placement re-receives the verified `apiVersion` and receipt data rather than re-verifying.
+2. Write `adapter.js` + `adapter.json` into a staging dir on the same filesystem: `$FACET_DIR/adapters/.staging-<name>-<random>/`.
+3. Swap: rename the existing `adapters/<name>/` (if any) to `.old-<name>-<random>`, rename staging to `adapters/<name>/`, then delete the old dir. If the second rename fails, rename the old dir back — the previous install is restored.
+4. Any failure in steps 1–2 deletes only the staging dir; the installed adapter is never touched. Failure arms (`stage-write-failed`, `swap-failed`) join `AdapterInstallFailure`.
+
+**Why dir-rename rather than file-overwrite:** the unit of installation is the directory (bundle + receipt); two sequential file writes can be torn by a crash between them. Directory rename on one filesystem is the cheapest all-or-nothing primitive available without a lockfile. The `.staging-`/`.old-` prefixes are filtered out of `listInstalledAdapters` (which already requires an `adapter.js` to count a directory, but the filter is made explicit so a crashed swap never surfaces a half-install).
+
+### D9: Loader classifies instead of filtering silently
+
+`loadInstalledAdapters` currently returns `Adapter[]` and swallows failures into optional warnings. It is replaced (engine-internal rename, CLI updated) by a classifying loader:
+
+```ts
+type InstalledAdapterStatus =
+  | { name: string; status: 'compatible'; adapter: Adapter; apiVersion: string; receipt: AdapterReceipt | null }
+  | { name: string; status: 'incompatible'; declaredApi: string | null; supported: readonly string[]; receipt: AdapterReceipt | null }
+  | { name: string; status: 'load-failed'; cause: string }
+```
+
+Consumers then choose policy explicitly:
+
+- `ensureAdapters` (add/remove/install) and `facet build`/publish flows: any *selected* adapter that is not `compatible` produces a structured pre-materialization failure naming the adapter, its declared/missing API, the supported set, and the fix command (`facet adapter install <specifier>`), and the command exits before any materialization or build writes. Facet installation MUST NOT partially materialize and then discover incompatibility — the gate runs when adapters are gathered, which is before `runInstall` receives them.
+- `facet adapter list`: renders every entry — compatible adapters as today plus their API and resolved version (from the receipt), incompatible ones marked unsupported with declared-vs-supported detail, load-failures with their cause. This satisfies the proposal's list requirement without a second disk scan.
+
+**Why classify at the loader rather than gate inside `runInstall`:** `runInstall` receives adapters as a parameter and is also driven by tests with fakes; the trust boundary is where bundles come off disk. Gating at load keeps `runInstall`'s contract unchanged (it only ever sees compatible adapters) while `list` still gets the full classification. The incompatible arm remains representable so `list` and diagnostics can describe it — it just never crosses into materializing code paths.
+
+### D10: First-party picker and aliases ride the same npm path
+
+`FIRST_PARTY_ADAPTERS` entries and `BUILTIN_ALIASES` resolve to npm packages and therefore inherit D3's compatible-highest selection with no special casing. The picker's failure rendering reuses the same structured no-compatible-release data.
+
+## Risks / Trade-offs
+
+- **[Full packument size]** Full packuments are larger than `/latest` responses (all versions inline). → Adapter packages are young and small; fetch happens once per install, not per facet operation. If this ever matters, a `?write=false` cached fetch or per-version `GET /<name>/<version>` fallback can be added without changing the contract.
+- **[Custom field stripped or wrong in metadata]** Some publish pipelines rewrite `package.json`; a registry entry could omit or misstate `facetAdapter`. → Omission just removes that version from candidacy (correct per the proposal's "undeclared = incompatible"); misstatement is caught by D5's metadata/runtime conflict check before placement. The runtime declaration is always final.
+- **[Repo-side duplication of `0.0` in adapter package.json files]** JSON can't import `ADAPTER_API_VERSION`. → CI test asserts every `packages/adapters/*/package.json` `facetAdapter.apiVersion` equals the SDK constant (documented exception to single-source rule, with the guard).
+- **[`Bun.semver` semantics]** Range/prerelease behavior must match npm's expectations closely enough for adapter authors. → Selection only needs ordering + satisfaction, both provided; prerelease exclusion is explicit in D3 step 2 rather than delegated to range semantics. Unit tests pin the edge cases (prerelease-only packages, build metadata).
+- **[Swap non-atomicity across the two renames]** A crash between rename-old and rename-new leaves no installed adapter (though both dirs still exist under prefixed names). → Window is microseconds and recovery is a re-install; the previous state is recoverable manually from `.old-*`. A journal was considered and rejected as disproportionate for a single-user local directory.
+- **[Breaking existing installs]** Every currently installed bundle predates stamping and becomes incompatible on CLI upgrade. → Intended (proposal BREAKING). The loader's `incompatible` arm plus `ensureAdapters` messaging turns this into a one-command fix; release ordering (below) guarantees a compatible release exists to install before any CLI that requires it ships.
+- **[Third-party adapters without metadata]** They never match pre-download selection once published CLIs require it, even if their runtime would verify. → Accepted: the proposal makes metadata declaration a requirement for npm-distributed adapters; git/local installs remain the escape hatch during author migration.
+- **[Loader API change ripples]** `loadInstalledAdapters` has ~6 call sites across engine tests and CLI. → Mechanical; the classifying return type makes every caller's policy explicit, which is the point.
+
+## Migration Plan
+
+Order matters because the CLI must never ship requiring declarations that no published adapter release carries:
+
+1. **SDK release** — `ADAPTER_API_VERSION`, `apiVersion` stamping, `AdapterDefinition` input type. Backward-compatible for authors (no definition changes required).
+2. **First-party adapter releases** — rebuild `packages/adapters/*` against the new SDK, add `facetAdapter.apiVersion` to each `package.json`, publish. These releases are compatible with both old CLIs (which ignore the new field and extra export property) and the new CLI.
+3. **CLI/engine release** — compatible resolution, verification gate, atomic placement, receipts, classifying loader, list/diagnostics output, docs.
+4. **Rollback** — each step is independently revertible: the SDK stamp and metadata field are inert for old CLIs; reverting the CLI release restores `/latest` behavior. No data migration exists to roll back; receipts are additive and ignored by older CLIs.
+
+Existing users upgrading the CLI see incompatible-adapter diagnostics on first use and run the suggested `facet adapter install <name>` per adapter; no automatic rewrite of `$FACET_DIR` occurs.
+
+## Documentation impact
+
+Per the proposal and a check of current `docs/` content:
+
+- `docs/cli/adapters/install.mdx` — document the `@version`/`@range` specifier suffix, compatible-highest selection for plain installs, exact-version incompatibility failure, and the no-compatible-release diagnostic. Currently documents specifier forms only, with no version syntax.
+- `docs/cli/adapters/list.mdx` — new columns/annotations: adapter API version, resolved package version, supported/unsupported marker. (Not named in the proposal's doc list, but its output changes; leaving it stale would violate Article III.)
+- `docs/guides/custom-adapters.mdx` — SDK section gains the API-version model: `defineAdapter` stamps `apiVersion`; npm-published adapters must declare `facetAdapter.apiVersion`; git/local development flows rely on runtime verification.
+- `docs/guides/troubleshooting.mdx` — new entries for `api-missing`/`api-unsupported`/`api-declaration-conflict` failures and the incompatible-installed-adapter pre-materialization failure, each with the fix command.
+- `docs/specification/install.mdx` — describe the compatibility gate ordering: selection → download → verify → place → (facet install) pre-materialization check.
+- Root `README.md` — no changes required; it does not describe adapter resolution behavior.
+
+## Open Questions
+
+- **Prerelease policy edge:** when a user requests a range that only prerelease versions satisfy, should selection consider them (npm's `semver` requires explicit prerelease tags in the range)? Current design says yes only when the range names a prerelease; confirm against `Bun.semver.satisfies` behavior before locking tests.
+- **Receipt for pre-existing installs:** should the new CLI backfill a minimal receipt (`source: unknown`) when it verifies a legacy bundle it is about to replace, or leave receipt creation purely to new installs? Design assumes the latter (receipts only from new placements).
+- **`adapter remove` of a half-swapped state:** should `removeAdapter` also sweep `.staging-*`/`.old-*` orphans for its adapter name? Proposed: yes, as a cheap self-heal, but it is not required by any proposal requirement.

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/proposal.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+A facet install crashed against a stale installed adapter bundle with an opaque `paths[0]` error: the engine and the bundle disagreed about the adapter call contract, and nothing in the system could detect the disagreement before invoking a method. Adapter bundles cross a publishing and persistence boundary — npm, git, local paths, files on disk that outlive CLI upgrades — yet the contract they implement is invisible: no version is declared, selected against, or verified anywhere. With a breaking contract revision already staged, this boundary MUST become versioned before any incompatible release exists.
+
+## What Changes
+
+- **Adapter API `0.0`.** The current positional adapter contract SHALL be designated adapter API `0.0`. Adapter API identifiers SHALL be discrete tokens compared for exact equality — not semver ranges — and SHALL be independent of the SDK package's npm version, the CLI version, and adapter package versions.
+- **The SDK declares the version, not the author.** `defineAdapter()` SHALL stamp the SDK's canonical API version (`0.0`) onto every adapter it returns. Adapter authors SHALL NOT hand-write the version; rebuilding against a newer SDK is what changes it.
+- **The CLI declares its support set.** This CLI release SHALL support exactly `{0.0}`. A bundle whose runtime declaration is missing, malformed, or outside the support set SHALL be rejected with structured data before any adapter method is invoked — in facet install, build, and every other consumer, regardless of how the bundle reached disk (npm, git, local path, manual copy, or a bundle left behind by an older CLI).
+- **npm releases advertise their API.** New adapter releases SHALL declare their adapter API version in npm package metadata so compatibility is knowable before download. First-party adapters SHALL publish releases declaring `0.0`. The loaded bundle's runtime declaration remains authoritative; a mismatch between package metadata and the runtime export SHALL fail verification.
+- **Compatibility-aware resolution.** `facet adapter install` SHALL stop resolving the npm `latest` dist-tag and SHALL select the highest package version whose declared API the CLI supports. When the user pins an exact package version or range, the CLI SHALL honor it and fail on incompatibility — never silently substitute. When no published release is compatible, resolution SHALL fail with a structured error naming the newest release's declared API and the CLI's support set.
+- **`latest` stays normal.** Publishing SHALL keep advancing npm `latest` normally; compatibility is the CLI's responsibility, not a dist-tag policy.
+- **Staged atomic replacement.** A candidate bundle SHALL be verified before it replaces an installed bundle, and replacement SHALL be atomic: a failed install leaves the existing working bundle untouched.
+- **Provenance.** Installation SHALL record, beside the bundle: the install specifier, resolved source, resolved package name/version when known, adapter API version, and bundle integrity — the anchor for offering a compatible reinstall or upgrade later.
+- **Actionable diagnostics.** Incompatibility failures SHALL name the adapter, the API found (or that none was declared), the supported set, and the exact reinstall command. Facet installation with an incompatible selected adapter SHALL fail before any materialization writes. `facet adapter list` SHOULD surface each installed adapter's API version and compatibility.
+- **BREAKING.** Existing unversioned bundles — everything installed today and every already-published adapter release — SHALL be incompatible with this CLI and SHALL require reinstalling a `0.0`-declaring release. This is deliberate: the project is forward-only, and a one-time reinstall is cheaper than carrying a permanent undeclared-legacy compatibility class.
+
+Documentation (Article III): `docs/cli/adapters/install.mdx`, `docs/guides/custom-adapters.mdx`, `docs/guides/troubleshooting.mdx`, and `docs/specification/install.mdx` informed this proposal; none currently document API declarations, compatibility-aware selection, or the pre-materialization gate, and all four SHALL be updated.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `adapter__sdk`: the positional contract becomes adapter API `0.0`; the factory SHALL stamp the canonical API version onto every runtime adapter it returns.
+- `adapter__management`: install resolution SHALL select the highest compatible release; verification SHALL check the API declaration; replacement SHALL be staged and atomic; provenance SHALL be recorded; loading SHALL reject unsupported bundles with structured failures; listing SHOULD surface compatibility.
+- `installation`: facet installation SHALL fail with a structured incompatible-adapter diagnostic before any materialization writes occur.
+
+## Impact
+
+- `packages/adapter/`: canonical API version constant, `apiVersion` on the runtime adapter type, stamping in `defineAdapter()`.
+- `packages/adapters/*`: new first-party releases published with metadata and runtime declarations.
+- `packages/engine/src/sources/adapter/`: full-metadata npm resolution replacing `/latest`.
+- `packages/engine/src/adapters/`: verification, placement (staged atomic replacement, provenance record), loader rejection, install-service failure types.
+- CLI: adapter install/list output; facet-install and build failure rendering.
+- Users: a one-time reinstall of currently installed adapters.
+
+## Non-goals
+
+- This change SHALL NOT alter the positional method signatures designated `0.0` and SHALL NOT introduce any later adapter API contract.
+- This change SHALL NOT manipulate npm dist-tags and SHALL NOT attempt retroactive protection of already-shipped CLIs.
+- This change SHALL NOT store multiple adapter versions side by side.
+- This change SHALL NOT automatically upgrade an incompatible installed adapter; the failure directs the user to the fix.
+- This change SHALL NOT couple adapter API identifiers to facet archive versions, facet package versions, or the SDK package's own semver.

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/specs/adapter__management/spec.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/specs/adapter__management/spec.md
@@ -1,0 +1,177 @@
+## ADDED Requirements
+
+### Requirement: npm adapter installation selects the highest compatible release
+
+When installing an adapter from an npm package name or a built-in first-party name, the system SHALL determine adapter API compatibility from package-version metadata before downloading, and SHALL select the highest package version whose declared adapter API is supported. An explicit package version range SHALL constrain selection to compatible versions within that range. An explicit exact package version SHALL be installed only if that release declares a supported adapter API; when it does not, the system SHALL fail rather than substitute a different release. The npm `latest` dist-tag SHALL continue to identify the latest published release; compatibility selection SHALL NOT depend on moving, pinning, or withholding that tag.
+
+When no package version in the requested set declares a supported adapter API, the system SHALL fail with structured data identifying the newest considered release, its declared or missing adapter API, and the supported adapter APIs.
+
+#### Scenario: Plain npm install skips a newer incompatible release
+
+- **WHEN** a user installs an npm adapter without specifying a version
+- **AND** the newest published release declares an unsupported adapter API
+- **AND** an older release declares a supported adapter API
+- **THEN** the system SHALL select the highest release that declares a supported adapter API
+- **AND** the system SHALL NOT install the newer incompatible release
+
+#### Scenario: Explicit range constrains compatible selection
+
+- **WHEN** a user installs an npm adapter with an explicit package version range
+- **THEN** the system SHALL select the highest release within that range whose declared adapter API is supported
+
+#### Scenario: Explicit exact version that is incompatible fails
+
+- **WHEN** a user installs an npm adapter pinned to an exact package version
+- **AND** that release declares a missing or unsupported adapter API
+- **THEN** the system SHALL fail without installing anything
+- **AND** the system SHALL NOT substitute a different release
+
+#### Scenario: No compatible release fails with structured data
+
+- **WHEN** a user installs an npm adapter
+- **AND** no release in the requested set declares a supported adapter API
+- **THEN** the system SHALL fail with structured data identifying the newest considered release, its declared or missing adapter API, and the supported adapter APIs
+
+#### Scenario: Release without a declared adapter API is not a compatible candidate
+
+- **WHEN** the system evaluates npm releases for compatible selection
+- **AND** a release's package metadata declares no adapter API
+- **THEN** that release SHALL NOT be selected as a compatible candidate
+
+#### Scenario: Git and local adapters are not version-selected
+
+- **WHEN** a user installs an adapter from a Git URL or a local path
+- **THEN** the system SHALL NOT perform compatible version selection
+- **AND** the supplied source SHALL be bundled and SHALL pass runtime adapter API verification before placement
+
+### Requirement: Installed adapter replacement is atomic
+
+When an adapter installation would replace an already-installed adapter bundle, the system SHALL stage and verify the candidate bundle before replacement, and the replacement SHALL be atomic. Any verification or placement failure SHALL leave the existing installed bundle unchanged and loadable.
+
+#### Scenario: Verified candidate replaces the existing bundle atomically
+
+- **WHEN** the system installs an adapter whose name matches an already-installed adapter
+- **AND** the candidate bundle passes verification
+- **THEN** the system SHALL replace the installed bundle atomically
+- **AND** at no point SHALL the adapter directory contain a partially written bundle for that adapter
+
+#### Scenario: Failed candidate leaves the existing bundle untouched
+
+- **WHEN** the system installs an adapter whose name matches an already-installed adapter
+- **AND** the candidate bundle fails verification or placement
+- **THEN** the system SHALL report the failure
+- **AND** the previously installed bundle SHALL remain unchanged and loadable
+
+### Requirement: Adapter installation records provenance
+
+For every installed adapter, the system SHALL retain installation provenance sufficient to identify and replace an incompatible adapter later: the source specifier the user supplied, the resolved npm package name and version when the source was an npm package or built-in name, the adapter API version the bundle declares, and the package integrity of the installed content.
+
+#### Scenario: npm install records resolved package provenance
+
+- **WHEN** a user installs an adapter from an npm package or built-in name
+- **THEN** the retained provenance SHALL include the source specifier, the resolved package name and version, the declared adapter API version, and the package integrity
+
+#### Scenario: Git or local install records its source provenance
+
+- **WHEN** a user installs an adapter from a Git URL or a local path
+- **THEN** the retained provenance SHALL include the source specifier, the declared adapter API version, and the package integrity
+- **AND** the provenance SHALL NOT record a resolved npm package version
+
+### Requirement: Adapter incompatibility failures are actionable
+
+Every adapter API incompatibility failure SHALL identify the adapter, its declared or missing adapter API, the supported adapter APIs, and the command that installs a compatible release.
+
+#### Scenario: Incompatibility diagnostic names the remedy
+
+- **WHEN** any operation fails because an adapter's declared adapter API is missing, malformed, or unsupported
+- **THEN** the failure SHALL identify the adapter, its declared or missing adapter API, and the supported adapter APIs
+- **AND** the failure SHALL include the command the user can run to install a compatible release
+
+## MODIFIED Requirements
+
+### Requirement: Adapter installation verifies the bundle before placement
+
+The system SHALL verify that a produced adapter bundle is valid before placing it in the adapter directory. Verification SHALL check that the bundle exports a valid adapter object and that the adapter object declares a supported adapter API version. A bundle whose adapter API declaration is missing, malformed, or unsupported SHALL fail verification with structured data before any adapter method is invoked. Package metadata SHALL be treated as a selection aid only: the loaded bundle's own declaration is the final compatibility check, and a conflict between the package metadata's declared adapter API and the bundle's runtime declaration SHALL fail verification.
+
+#### Scenario: Valid bundle passes verification
+
+- **WHEN** the system bundles an adapter that correctly exports an adapter object via the SDK factory
+- **AND** the adapter object declares a supported adapter API version
+- **THEN** verification SHALL succeed
+- **AND** the bundle SHALL be placed in the adapter directory
+
+#### Scenario: Invalid bundle fails verification
+
+- **WHEN** the system bundles an adapter that does not export a valid adapter object
+- **THEN** verification SHALL fail
+- **AND** the system SHALL report which validation checks failed
+- **AND** the bundle SHALL NOT be placed in the adapter directory
+
+#### Scenario: Bundle without an adapter API declaration fails verification
+
+- **WHEN** the system bundles an adapter whose exported adapter object declares no adapter API version
+- **THEN** verification SHALL fail with structured data identifying the missing declaration
+- **AND** the bundle SHALL NOT be placed in the adapter directory
+- **AND** no adapter method of the bundle SHALL be invoked
+
+#### Scenario: Bundle with an unsupported adapter API fails verification
+
+- **WHEN** the system bundles an adapter whose exported adapter object declares an adapter API version that is not supported
+- **THEN** verification SHALL fail with structured data identifying the declared and supported adapter APIs
+- **AND** the bundle SHALL NOT be placed in the adapter directory
+
+#### Scenario: Metadata and runtime declaration conflict fails verification
+
+- **WHEN** an npm release's package metadata declares one adapter API version
+- **AND** the bundled adapter object's runtime declaration differs from it
+- **THEN** verification SHALL fail
+- **AND** the system SHALL NOT silently select either declared call shape
+
+### Requirement: The system loads installed adapter bundles at runtime
+
+The system SHALL load installed adapter bundles from the adapter directory at runtime. Before returning a loaded bundle to a build or installation workflow, the system SHALL verify that the bundle declares a supported adapter API version. A bundle whose declaration is missing, malformed, or unsupported SHALL fail with structured data before any adapter method is invoked. Loaded, verified adapters SHALL be passed to the build pipeline for metadata building.
+
+#### Scenario: Load installed adapters for a build
+
+- **WHEN** the system runs a build command
+- **THEN** the system SHALL scan the adapter directory for installed adapter bundles
+- **AND** load each bundle
+- **AND** verify each loaded bundle declares a supported adapter API version
+- **AND** pass the loaded adapter objects to the build pipeline
+
+#### Scenario: No adapters installed during build
+
+- **WHEN** the system runs a build command
+- **AND** no adapters are installed
+- **THEN** the build SHALL proceed
+- **AND** any adapter metadata in the manifest SHALL produce warnings for unknown adapters
+
+#### Scenario: Installed bundle without a supported API is not returned for use
+
+- **WHEN** the system loads an installed adapter bundle whose adapter API declaration is missing, malformed, or unsupported
+- **THEN** the load SHALL fail with structured data identifying the adapter, its declared or missing adapter API, and the supported adapter APIs
+- **AND** no adapter method of that bundle SHALL be invoked
+
+### Requirement: Users can list installed adapters
+
+The system SHALL provide a command to list all adapters currently installed in the adapter directory. For each installed adapter, the listing SHALL surface the adapter's declared adapter API version — or that the declaration is missing — and whether that adapter API is supported.
+
+#### Scenario: List with installed adapters
+
+- **WHEN** a user runs the list command
+- **AND** adapters are installed
+- **THEN** the system SHALL display the name of each installed adapter
+- **AND** the system SHALL display each adapter's declared adapter API version, or that it is missing
+- **AND** the system SHALL indicate whether each adapter's adapter API is supported
+
+#### Scenario: List with no installed adapters
+
+- **WHEN** a user runs the list command
+- **AND** no adapters are installed
+- **THEN** the system SHALL indicate that no adapters are installed
+
+#### Scenario: List surfaces an incompatible installed adapter
+
+- **WHEN** a user runs the list command
+- **AND** an installed adapter declares a missing or unsupported adapter API
+- **THEN** the listing SHALL identify that adapter as not supported by the current CLI

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/specs/adapter__sdk/spec.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/specs/adapter__sdk/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: The adapter contract is identified by a discrete API version
+
+The adapter call contract SHALL be identified by a discrete adapter API version. The current positional adapter method contract SHALL be designated adapter API `0.0`. Adapter API versions SHALL be compared for exact equality, SHALL NOT be interpreted as semantic-version ranges, and SHALL be independent of the CLI version, the adapter package version, and the Adapter SDK package's own semantic version.
+
+#### Scenario: API versions compare by exact equality
+
+- **WHEN** an adapter's declared API version is checked against the set of supported adapter APIs
+- **THEN** the declaration SHALL be treated as supported only when it exactly equals a supported API version
+- **AND** no range, ordering, or partial-match semantics SHALL be applied to the comparison
+
+#### Scenario: API version is independent of package versions
+
+- **WHEN** an adapter package or the Adapter SDK package publishes a new semantic version without changing the adapter call contract
+- **THEN** the adapter API version those releases declare SHALL remain unchanged
+
+### Requirement: The SDK exposes its canonical adapter API version
+
+The Adapter SDK SHALL expose `0.0` as its canonical adapter API version so that adapter authors and release tooling can declare the API version a release targets from a single authoritative value rather than repeating it by hand.
+
+#### Scenario: Author reads the canonical API version from the SDK
+
+- **WHEN** an adapter author imports the Adapter SDK
+- **THEN** the SDK SHALL provide the canonical adapter API version `0.0` as a readable exported value
+
+## MODIFIED Requirements
+
+### Requirement: Adapter authors can define an adapter using the SDK
+
+An adapter author SHALL be able to create an adapter by importing the SDK and calling a factory function with a definition object. The factory SHALL validate the definition shape and return an adapter object. The definition SHALL accept a name, a function to build per-asset adapter metadata (validating and enriching with defaults), and asset install/read/delete methods. The factory SHALL stamp the SDK's canonical adapter API version onto every returned adapter object; adapter authors SHALL NOT be required to declare the adapter API version in their definitions.
+
+#### Scenario: Author creates a valid adapter
+
+- **WHEN** an author calls the factory function with a complete definition
+- **THEN** the factory SHALL return a valid adapter object with all provided properties and methods
+
+#### Scenario: Author provides an invalid definition
+
+- **WHEN** an author calls the factory function with a definition missing required fields
+- **THEN** the factory SHALL throw an error describing which fields are missing
+
+#### Scenario: Returned adapter carries the canonical API version
+
+- **WHEN** an author calls the factory function with a complete definition that does not mention an adapter API version
+- **THEN** the returned adapter object SHALL declare the SDK's canonical adapter API version `0.0`

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/specs/installation/spec.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/specs/installation/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Facet installation rejects an incompatible selected adapter before writing
+
+When a facet install or add operation would materialize assets into a selected adapter whose installed bundle declares a missing, malformed, or unsupported adapter API version, the system SHALL fail before any materialization writes occur. The failure SHALL include structured, actionable diagnostics identifying the adapter, its declared or missing adapter API, the supported adapter APIs, and the command that installs a compatible adapter release. The system SHALL NOT automatically upgrade or replace the incompatible adapter as part of the facet operation.
+
+#### Scenario: Incompatible selected adapter fails before materialization
+
+- **WHEN** a user runs a facet install or add
+- **AND** a selected adapter's installed bundle declares a missing or unsupported adapter API version
+- **THEN** the operation SHALL fail before any asset is written to any adapter tree
+- **AND** the system SHALL leave the project manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Incompatibility diagnostics direct the user to a compatible install
+
+- **WHEN** a facet install or add fails because a selected adapter is incompatible
+- **THEN** the diagnostics SHALL identify the adapter, its declared or missing adapter API, and the supported adapter APIs
+- **AND** the diagnostics SHALL include the command the user can run to install a compatible adapter release
+- **AND** the system SHALL NOT install a different adapter release automatically
+
+#### Scenario: Compatible selected adapters install normally
+
+- **WHEN** a user runs a facet install or add
+- **AND** every selected adapter's installed bundle declares a supported adapter API version
+- **THEN** the operation SHALL proceed through fetch, verification, materialization, and lockfile update as specified elsewhere in this spec

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/tasks.md
@@ -1,0 +1,134 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. SDK API `0.0` Declaration — Research
+
+- [ ] 1.1 Explore `packages/adapter/` (`types.ts`, `define-adapter.ts`, `index.ts`, `__tests__/`): the current `Adapter` type, factory validation, public exports, and how tests are structured
+- [ ] 1.2 Explore how the `Adapter` type and `defineAdapter()` are consumed across `packages/adapters/*`, `packages/engine/`, and `packages/cli/` (type imports, call sites, re-exports) to find every surface the new required `apiVersion` field touches
+- [ ] 1.3 Propose the SDK change: `ADAPTER_API_VERSION` constant (`0.0`), exported npm metadata field name (`facetAdapterApiVersion`), required readonly `apiVersion` on the runtime `Adapter`, factory input type excluding `apiVersion`, and the export surface for engine consumption
+
+## 2. SDK API `0.0` Declaration — Implementation
+
+- [ ] 2.1 Implement `ADAPTER_API_VERSION = "0.0"` and the metadata field-name constant in `packages/adapter/`, exported from the package entry point
+- [ ] 2.2 Implement the required readonly `apiVersion` field on the runtime `Adapter` type, stamped by `defineAdapter()`, with the factory definition input type excluding it so authors cannot supply a conflicting value
+- [ ] 2.3 Implement SDK tests: factory stamps `0.0` onto every returned adapter; the definition object neither requires nor accepts an API identifier; the exported canonical constant equals `0.0`
+- [ ] 2.4 Verify: run `bun check` for `packages/adapter` and dependent type-checks across the workspace
+
+## 3. First-Party Release Metadata — Research
+
+- [ ] 3.1 Explore `scripts/prepack.ts`, `scripts/postpack.ts`, `scripts/lib/`, and `scripts/release/` to understand the existing first-party manifest transformation and where packed-tarball tests live
+- [ ] 3.2 Propose how prepack derives `facetAdapterApiVersion` from `ADAPTER_API_VERSION` (no duplicated `0.0` literal) and how packed-tarball tests prove both the npm field and the SDK-stamped runtime export are present
+
+## 4. First-Party Release Metadata — Implementation
+
+- [ ] 4.1 Implement prepack injection of `facetAdapterApiVersion` (derived from the SDK constant) into first-party adapter package manifests during the existing prepack transformation
+- [ ] 4.2 Implement packed-tarball tests proving each first-party adapter artifact contains the top-level `facetAdapterApiVersion` field and a runtime bundle whose default export carries `apiVersion: "0.0"`
+- [ ] 4.3 Update `scripts/README.md` to document first-party API metadata injection during prepack
+- [ ] 4.4 Verify: run the scripts test suite and a local pack of one first-party adapter to confirm the transformed manifest
+
+## 5. Compatibility Classification & Runtime Verification — Research
+
+- [ ] 5.1 Explore `packages/engine/src/adapters/verify.ts` and its current throw-based failure behavior, plus every current caller (bundler, install-service, loader)
+- [ ] 5.2 Explore the repo's discriminated-result conventions (`IntegrityResult`, `LoadLockfileResult`, `RunInstallFailure`) and where a shared pure compatibility classifier should live in engine
+- [ ] 5.3 Explore the "prebuilt failed, rebundle from source" fallback path in `packages/engine/src/adapters/install-service.ts` to determine exactly which failure classes may still trigger fallback
+- [ ] 5.4 Propose: the API-identifier parser (`MAJOR.MINOR`, no signs/suffixes/leading zeroes), the shared compatibility failure union (missing / malformed / unsupported / metadata-runtime mismatch, each carrying identity, found declaration, support set), the engine support set defined as exactly `{ ADAPTER_API_VERSION }`, and the ordered `VerifyAdapterResult` checks (import → default export → declaration present/valid → in support set → equals expected npm API → `0.0` name/method shape)
+
+## 6. Compatibility Classification & Runtime Verification — Implementation
+
+- [ ] 6.1 Implement the adapter API identifier parser and pure compatibility classifier as a shared engine module, with the support set derived from the SDK constant (no duplicated `0.0` literal) and exhaustive unit tests for well-formed, missing, malformed, unsupported, and mismatch classifications
+- [ ] 6.2 Implement `verifyAdapter` returning a discriminated `VerifyAdapterResult` with the ordered checks from the proposal; success carries the verified adapter and its supported API; no adapter contract method runs before verification succeeds
+- [ ] 6.3 Implement fallback gating in the install service: compatibility failures never trigger source-rebundling fallback; fallback remains only for loadability/bundling failures that do not contradict a declared contract
+- [ ] 6.4 Implement unit tests for verifier ordering (mismatch classified before any method invocation), npm expected-API equality, and fallback gating
+- [ ] 6.5 Verify: run `bun check` for `packages/engine`
+
+## 7. npm Specifier & Compatible Version Resolution — Research
+
+- [ ] 7.1 Explore `packages/engine/src/sources/adapter/specifier.ts` and `npm.ts`: current specifier parsing, the `/latest` fetch, download/extract, and integrity handling
+- [ ] 7.2 Explore `packages/engine/src/adapters/first-party.ts` (alias catalog) and every consumer of the alias map, including the zero-adapter picker
+- [ ] 7.3 Explore the protocol `VersionSpec` grammar and satisfaction predicate (`packages/protocol/src/sources/version-spec.ts`) for reuse as the single source of truth for package selectors
+- [ ] 7.4 Propose: the tagged specifier union (bare/first-party-alias implicit selector, exact version, explicit wildcard/`latest`, Git, local) with scoped-name delimiter handling; alias derivation from the first-party catalog; full-packument fetch (never the abbreviated install-v1 representation) parsing only version/API/dist fields; highest-compatible selection; exact-version no-substitution; and the structured no-compatible-release failure carrying package, selector, support set, and newest considered release with its declaration state
+- [ ] 7.5 Propose how the resolved success value (exact package version, declared API, tarball URL, registry SRI/shasum) flows into download so selection and provenance use the same record, and how an exact request may optimize with exact-version metadata while preserving identical validation and failure data
+
+## 8. npm Specifier & Compatible Version Resolution — Implementation
+
+- [ ] 8.1 Implement the tagged adapter specifier parser with structured parse failures for caret, tilde, comparator, OR, hyphen, prerelease, and `x` syntax that name the supported exact/wildcard/`latest` forms; derive first-party aliases from the catalog
+- [ ] 8.2 Implement full-packument resolution: constrain stable `MAJOR.MINOR.PATCH` entries by the package selector, discard releases with missing/malformed/unsupported `facetAdapterApiVersion`, choose the highest remaining version; exact requests consider only that version and fail rather than substitute
+- [ ] 8.3 Implement the resolved-candidate success value carrying package version, declared API, tarball URL, and registry integrity anchor, and thread it through download so provenance uses the selected record
+- [ ] 8.4 Implement the structured no-compatible-release failure (package, requested selector, CLI support set, newest considered release with its missing/malformed/unsupported declaration)
+- [ ] 8.5 Implement unit tests: bare-name skips newer incompatible release; wildcard constrains compatible selection; exact incompatible fails without substitution; unsupported range syntax rejected with accepted forms; no-compatible-release failure data; scoped-name specifier splitting; explicit `latest` ignores the dist-tag and selects highest compatible
+- [ ] 8.6 Verify: run `bun check` for `packages/engine`
+
+## 9. Managed Installation Layout & Atomic Replacement — Research
+
+- [ ] 9.1 Explore `packages/engine/src/adapters/placement.ts` and `install-service.ts`: current direct `adapter.js` placement, `$FACET_DIR/adapters/` handling, and any existing lock or atomic-write helpers (including `@agent-facets/common` atomic file writes)
+- [ ] 9.2 Explore how Git and local adapter installs produce bundles (`sources/adapter/git.ts`, `local.ts`) and what provenance is available at placement time for each source kind
+- [ ] 9.3 Propose: the `installation.json` receipt schema (schema version, active generation id, verified API, tagged npm/Git/local source record with source-specific fields only on their variant), generation-id validation as a single safe path segment with containment-checked derived paths, the six-step replacement sequence (temp verify → per-adapter lock → stage generation → verify from staged path → atomic receipt replace → cleanup), post-activation cleanup-failure-as-warning semantics, and unmanaged direct-bundle classification
+
+## 10. Managed Installation Layout & Atomic Replacement — Implementation
+
+- [ ] 10.1 Implement the receipt schema types as a tagged union (npm with resolved package/version and registry SRI/shasum; Git with URL and optional ref; local with resolved path) plus receipt read/write with structured invalid-receipt failures
+- [ ] 10.2 Implement generation staging and atomic activation: unique generation directory on the same filesystem, verification from the final staged path, single-file atomic `installation.json` replacement, per-adapter replacement lock acquired after the runtime name is known
+- [ ] 10.3 Implement post-activation cleanup: remove the previous generation and legacy direct bundle after the receipt switch; report cleanup failure as a warning, never as a failed installation; never delete the generation named by the current receipt; clean safe inactive crash leftovers during later placement/removal
+- [ ] 10.4 Implement pre-activation failure preservation: any resolution, build, verification, staging, or receipt-write failure leaves the existing receipt and active generation byte-for-byte unchanged
+- [ ] 10.5 Implement unit tests: atomic replacement success and every pre-activation failure class preserving the previous installation; receipt tagged-variant invariants; generation-id path-segment validation and containment; unmanaged direct-bundle handling; reinstall converting a direct layout to the managed layout
+- [ ] 10.6 Verify: run `bun check` for `packages/engine`
+
+## 11. Installed Inspection, Loading & Command Gates — Research
+
+- [ ] 11.1 Explore `packages/engine/src/adapters/loader.ts` and every `loadInstalledAdapters` consumer across engine and CLI (build pipeline, `runInstall`, add/remove/install commands, adapter list) including the current warn-and-skip behavior
+- [ ] 11.2 Explore `packages/engine/src/install/run-install.ts` (`RunInstallFailure` variants, the no-mutation path before the per-facet loop, where Git/local facet builds invoke adapter metadata methods) and `packages/engine/src/build/pipeline.ts` failure data
+- [ ] 11.3 Explore the zero-adapter picker trigger in `facet add`/`remove`/`install` to ensure the incompatible-adapter state does not launch it
+- [ ] 11.4 Propose: the shared per-directory inspection outcome (compatible with verified adapter and API / incompatible with structured failure and repair source / broken with structured receipt-import-shape failure), managed-receipt pre-import rejection of unsupported recorded APIs and runtime-vs-receipt comparison, unique generation paths defeating dynamic-import caching, unmanaged inspection without invented provenance, `loadInstalledAdapters` as a result value collecting all failures, the repair discriminator (managed → recorded specifier; unmanaged first-party → canonical alias; other unmanaged → directory/runtime name with explicit no-provenance note), and each command gate (build/publish-build before `runBuildPipeline`; add/remove/install before `runInstall`; `ADAPTER_INCOMPATIBLE` on `RunInstallFailure` through the no-mutation path; defense-in-depth preflights; materialization in-loop assertion as invariant only; `adapter remove` untouched)
+
+## 12. Installed Inspection, Loading & Command Gates — Implementation
+
+- [ ] 12.1 Implement shared installed-adapter inspection returning the tagged compatible/incompatible/broken outcome, handling managed receipts (validate, reject unsupported recorded API before import, import active generation by unique path, compare runtime declaration with receipt) and unmanaged direct bundles (import and verify without provenance)
+- [ ] 12.2 Implement `loadInstalledAdapters` returning a result value that fails with all collected failures when any entry is incompatible or broken, and attach the repair discriminator to each compatibility failure
+- [ ] 12.3 Implement the build gates: `facet build` and publish-build stop before `runBuildPipeline` on inspection failure; build failure data distinguishes adapter incompatibility from content validation; `runBuildPipeline` retains a defense-in-depth API preflight
+- [ ] 12.4 Implement the facet-operation gates: add/remove/install stop before `runInstall` on inspection failure without launching the zero-adapter picker; add `ADAPTER_INCOMPATIBLE` to `RunInstallFailure` routed through the existing no-mutation path before the per-facet loop; keep the in-loop materialization assertion as an invariant check
+- [ ] 12.5 Implement unit tests: incompatible adapter blocks build/add/remove/install before any adapter contract method or mutation; multiple failures collected and reported together; facet removal still requires compatible adapters while remaining cache- and network-independent; compatible adapters proceed; no-adapters build still proceeds with unknown-adapter warnings
+- [ ] 12.6 Verify: run `bun check` for `packages/engine`
+
+## 13. CLI Diagnostics & Adapter List — Research
+
+- [ ] 13.1 Explore `packages/cli/src/commands/adapter/` (install, list, remove flows) and the TUI/list rendering used by `facet adapter list`
+- [ ] 13.2 Explore `packages/cli/src/util/errors.ts` and existing CLI failure rendering to determine where compatibility-failure prose is produced (engine returns values; CLI renders strings)
+- [ ] 13.3 Propose: prose rendering for each compatibility-failure variant (adapter/package identity, found declaration, supported APIs, repair command), no-compatible-release and unsupported-selector error rendering for `facet adapter install`, and the `facet adapter list` columns (declared API as exact identifier / `missing` / `malformed`; status as `supported` / `unsupported` / `broken`) that remain rendered when entries are incompatible
+
+## 14. CLI Diagnostics & Adapter List — Implementation
+
+- [ ] 14.1 Implement CLI renderers mapping every compatibility-failure variant to actionable prose including the best available compatible-install command; engine code constructs no user-facing strings
+- [ ] 14.2 Implement `facet adapter list` API and compatibility-status output covering supported, unsupported, and broken entries while keeping the command available for recovery
+- [ ] 14.3 Implement `facet adapter install` output for compatible selection (resolved package version and API) and for structured selector-parse and no-compatible-release failures
+- [ ] 14.4 Implement end-to-end tests: install with selector forms; list output across compatible/incompatible/broken states; build and facet operations failing with repair guidance against an undeclared bundle
+- [ ] 14.5 Verify: run `bun check` for `packages/cli`
+
+## 15. Documentation — Research
+
+- [ ] 15.1 Explore the affected docs for statements contradicted by this change: `docs/cli/adapters/install.mdx`, `docs/cli/adapters/list.mdx`, `docs/guides/custom-adapters.mdx`, `docs/guides/troubleshooting.mdx`, `docs/specification/install.mdx`, `docs/specification/commit.mdx`, `docs/specification/build.mdx`, `docs/cli/env.mdx`, and root `README.md` (expected: picker statement stays accurate, no change)
+- [ ] 15.2 Propose the documentation diff set matching the observable contract (selectors, highest-compatible resolution, incompatibility failures, atomic replacement, managed layout, list statuses, publishing requirements, troubleshooting recovery, compatibility gates)
+
+## 16. Documentation — Implementation
+
+- [ ] 16.1 Implement updates to `docs/cli/adapters/install.mdx` (package selectors, highest-compatible resolution, incompatibility failures, atomic replacement, managed layout) and `docs/cli/adapters/list.mdx` (API and compatibility-status output)
+- [ ] 16.2 Implement updates to `docs/guides/custom-adapters.mdx` (SDK stamping, `facetAdapterApiVersion`, publishing, rebuilding/reinstalling) and `docs/guides/troubleshooting.mdx` (missing, malformed, unsupported, metadata/runtime-mismatch recovery)
+- [ ] 16.3 Implement updates to `docs/specification/install.mdx` and `docs/specification/commit.mdx` (compatibility gate before the per-facet loop and materialization), `docs/specification/build.mdx` (failure on incompatible installed adapter before metadata validation), and `docs/cli/env.mdx` (receipt/generation layout under `$FACET_DIR/adapters/`)
+- [ ] 16.4 Verify: docs build/lint passes and each updated page matches the implemented behavior
+
+## 17. Migration Readiness & Final Verification
+
+- [ ] 17.1 Implement a release-ordering note in the release tooling or checklist: first-party `0.0`-declaring adapter releases (Claude Code, OpenCode, Codex) are published before the compatibility-aware CLI ships, with unchanged method contracts so existing CLIs keep working
+- [ ] 17.2 Verify: run `bun check` across the full workspace (lint, types, unit, e2e) and confirm the undeclared-legacy-bundle path fails closed with the reinstall diagnostic

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/design-review.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/design-review.md
@@ -1,0 +1,91 @@
+# Comparison Review: `design`
+
+**Main:** `openspec/changes/add-adapter-api-version-negotiation/design.md`
+**Adversary:** `openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/design.md`
+
+Both were derived from the same reconciled proposal; the adversarial version was authored blind.
+
+## Grading bar
+
+- **Artifact mechanics:** required design sections (Context, Goals/Non-Goals, Decisions with alternatives, Risks → Mitigation, Migration Plan, Open Questions) present and substantive.
+- **RFC 2119:** normative design statements use keyword vocabulary (Article I).
+- **Documentation rules:** design MUST identify affected `docs/`/README files and required updates (Article III + artifact rules).
+- **Proposal coverage:** every proposal "What Changes" bullet has a design-level answer (API identity, metadata declaration, compatible selection, exact-version failure, runtime authority, atomic replacement, provenance, pre-materialization gate, list output, diagnostics).
+- **House constraints:** errors-as-values, illegal-states-unrepresentable type design, layer boundaries (SDK leaf / engine machinery / CLI rendering), single source of truth.
+
+Both artifacts satisfy mechanics, RFC 2119, and layer boundaries. The material differences are in specific decisions.
+
+## Coverage comparison
+
+| Area | Main | Adversary |
+| --- | --- | --- |
+| Canonical `ADAPTER_API_VERSION` + stamping, input type excludes `apiVersion` | D1 | D1 (identical conclusion) |
+| API identifier syntax | Canonical `MAJOR.MINOR` grammar; distinguishes missing/malformed/unsupported | Fully opaque string; no malformed class |
+| Supported set vs canonical version separation | D1 (set derived from SDK constant) | D2 (same conclusion) |
+| npm metadata field | Top-level `facetAdapterApiVersion`, field name exported by SDK, injected at prepack, packed-tarball tests | Nested `facetAdapter.apiVersion`, hand-added, CI equality test |
+| Version selector grammar | Reuses Facet `VersionSpec` grammar (exact / wildcard / `latest`); rejects npm semver ranges | npm-style ranges via `Bun.semver` |
+| Specifier parsing | Tagged non-overlapping variants; aliases derived from first-party catalog | Tagged variants; alias map left duplicated |
+| Full-packument rationale | Asserted | Explained (corgi packument strips custom fields) |
+| Rebundle-fallback interaction | Explicitly forbids fallback on compatibility failure | Not addressed |
+| Installed layout | Generations + `installation.json` receipt pointer; single-file atomic activation; per-adapter lock; import-cache busting; unmanaged-bundle classification | `adapter.js` + `adapter.json` sidecar; two-rename dir swap with acknowledged crash window |
+| Provenance integrity for git/local | Not recorded (npm SRI only) | Placed-bundle sha512, tagged by kind |
+| Loader policy | Fail closed: any incompatible/broken installed adapter fails loading with collected failures | Classifying loader; gate on adapters actually used |
+| Defense-in-depth | Preflight inside `runBuildPipeline`/`runInstall` (`ADAPTER_INCOMPATIBLE` variant) plus command gates | Gate at load boundary only; `runInstall` contract unchanged |
+| Docs impact | 8 targets incl. `commit.mdx`, `build.mdx`, `env.mdx`, `scripts/README.md`; README cleared | 5 targets + README cleared |
+| Open questions | None (all resolved) | Three (prerelease policy, receipt backfill, orphan sweep) |
+
+## Material divergences and judgment
+
+### 1. Version selector grammar — **Main stronger**
+
+Main reuses the existing Facet `VersionSpec` grammar and `satisfies` predicate as the single source of truth, and returns structured parse failures for npm-style ranges. The adversary reached for `Bun.semver` npm ranges. Main wins on single-source-of-truth grounds and avoids importing npm's caret/tilde/prerelease semantics into a second grammar in the same product. Main also correctly documents the UX risk (authors expect npm conventions) with a mitigation. The adversary's open question about prerelease policy is dissolved by main's "stable `MAJOR.MINOR.PATCH` entries only" rule — a sign the main decision is the more complete one.
+
+### 2. Metadata declaration mechanism — **Main stronger**
+
+Both chose a custom top-level `package.json` field with runtime-declaration authority. Main's mechanism is better on two counts: the SDK exports the *field name* alongside the version (no string literal duplication in engine), and first-party manifests get the field injected during the existing prepack transformation, derived from `ADAPTER_API_VERSION` — eliminating the hand-maintained JSON duplication the adversary could only guard with a CI equality test. Merge from the adversary: the explicit rationale that the abbreviated ("corgi") packument strips custom top-level fields, which is *why* full-packument fetch is required — main asserts the fetch but never justifies it.
+
+### 3. Installed layout and atomic replacement — **Main clearly stronger**
+
+The adversary's stage-and-swap (rename old away, rename staging in, delete old) admits a crash window between the two renames and had to document it as a risk. Main's generation directories plus an `installation.json` pointer make activation a single-file atomic rename, add a per-adapter lock, and — decisively — solve a problem the adversary missed entirely: **ESM dynamic-import caching**. Replacing `adapter.js` at a stable path can return the stale cached module within the same process; unique generation paths make that unrepresentable. Main also classifies unmanaged (hand-copied) bundles gracefully. One trade-off runs the other way: the adversary's layout keeps `adapter.js` at the historical path, so rolling back to an older CLI still finds the adapter; main's layout hides managed installs from older CLIs. Main acknowledges this in risks and the project is forward-only — acceptable, but reconciliation should keep that risk bullet intact.
+
+### 4. Provenance integrity for non-npm sources — **Adversary stronger (merge this)**
+
+The proposal requires provenance including "package integrity." Main records the npm SRI/shasum on the npm variant but records **no content integrity at all** for git and local variants (url/ref/path only) — and none for npm installs that fall back to rebundling, where the placed bundle is not the tarball's bytes. The adversary records a sha512 of the placed `adapter.js` for exactly these cases, tagged so tarball-integrity and bundle-hash cannot be conflated. Recommend adding a tagged bundle-content-hash field to main's receipt for git/local (and optionally for rebundled npm placements).
+
+### 5. Loader policy — **Main stronger, with one caveat**
+
+Main's fail-closed `loadInstalledAdapters` (collect all failures, fail loading) is stricter than the proposal's "selected adapter" wording, but in the current UX every installed installable adapter participates in add/remove/install/build, so "installed" ≈ "selected" and fail-closed prevents the misreporting failure modes main names (incompatible adapter misread as "no adapters installed" → picker). Main also explicitly suppresses the zero-adapter picker in this state — a real UX hole the adversary didn't consider. Caveat for the future: if adapter selection ever becomes per-command, fail-closed-on-any will over-block; the design's shared-inspection structure (tagged per-directory outcomes) already supports relaxing this, so no change needed now.
+
+### 6. Defense-in-depth preflight — **Main stronger**
+
+The adversary deliberately kept `runInstall`'s contract unchanged ("it only ever sees compatible adapters"), gating solely at the load boundary. Main gates at commands *and* adds an `ADAPTER_INCOMPATIBLE` preflight inside `runBuildPipeline`/`runInstall`, routed through the existing no-mutation path before the per-facet loop. Main's belt-and-suspenders is the better call: engine entry points are also driven by tests and future callers that bypass the CLI's load path, and the proposal's "before any materialization writes" guarantee should not depend on every caller remembering the gate. Main also catches a subtle ordering fact the adversary missed: the preflight must precede Git/local facet builds that invoke adapter metadata methods.
+
+### 7. Rebundle-fallback interaction — **Main only (keep)**
+
+Main explicitly forbids the prebuilt-failed→rebundle-from-source fallback from masking a compatibility failure (fallback only for loadability/bundling failures). The adversary never considered this interaction; it is a genuine behavioral hole in the adversarial design. Keep main's rule.
+
+### 8. API identifier syntax — **Main stronger**
+
+Main's canonical `MAJOR.MINOR` grammar gives "malformed" a precise meaning, enables pre-import rejection from the receipt's recorded API, and still mandates exact-equality-only comparison. The adversary's fully opaque string cannot distinguish malformed from merely-unknown, which weakens the proposal-required diagnostics ("declared or missing API").
+
+### 9. Documentation coverage — **Main stronger**
+
+Main identifies all five proposal-named files plus `list.mdx` (which the adversary independently caught) and four more the adversary missed: `docs/specification/commit.mdx`, `docs/specification/build.mdx`, `docs/cli/env.mdx` (required by the layout change), and `scripts/README.md` (prepack injection). Both cleared root `README.md`. No merge needed; main is a superset.
+
+### 10. Context grounding — **Adversary marginally stronger (optional merge)**
+
+The adversary's Context inventories the current seams with concrete file paths (`define-adapter.ts`, `npm.ts`, `verify.ts`, `placement.ts`, `loader.ts`, `specifier.ts`). Main's Context is accurate but abstract. Optional: fold the file-path inventory into main's Context to speed up the tasks artifact and implementation.
+
+## Merge recommendation (per decision)
+
+1. **D1/D2 (identity, supported set, metadata):** keep Main. Add one sentence of rationale from the adversary: full-packument fetch is required because the abbreviated packument strips custom top-level fields.
+2. **D3 (specifiers/selection):** keep Main (Facet grammar, catalog-derived aliases, tagged variants).
+3. **D4 (verifier):** keep Main; ordering and the metadata/runtime-mismatch arm match the adversary's independent conclusion — high confidence here.
+4. **D5 (layout/atomicity):** keep Main's generation+receipt design. **Add** a tagged bundle-content-hash (sha512 of the placed bundle) to the receipt for git/local sources and rebundled npm placements, per adversary D7 — this closes the proposal's "package integrity" provenance requirement for non-npm sources. Consider adding the adversary's `installedAt` timestamp as a cheap diagnostic field.
+5. **D6 (inspection/gates):** keep Main, including picker suppression and the in-engine preflight.
+6. **D7 (docs):** keep Main's list unchanged.
+7. **Context:** optionally merge the adversary's concrete file-path inventory.
+
+## Blocking items
+
+None blocking. The single substantive gap in Main — missing content-integrity provenance for git/local/rebundled installs (item 4) — should be folded in during reconciliation, but it is a receipt-field addition, not a structural change.

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/proposal-review.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/proposal-review.md
@@ -1,0 +1,61 @@
+# Comparison Review: proposal — add-adapter-api-version-negotiation (round 2)
+
+**Main**: `openspec/changes/add-adapter-api-version-negotiation/proposal.md`
+**Adversary**: `openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/proposal.md`
+
+Context and caveat: the prior adversarial pass was deleted after the proposal pivoted from `legacy-unversioned` to explicit adapter API `0.0`. This round was authored inline without re-reading the main proposal, but the same session produced the main version, so independence is weaker than a spawned blind run — convergence on the core model is expected and observed. The review therefore weights the genuine divergences.
+
+## Grading bar
+
+- Value-centric framing (user-visible behavior, not implementation)
+- RFC 2119 keyword discipline (Article I)
+- Proposal mechanics (Why / What Changes with **BREAKING** markers / Capabilities mapped to real domains / Impact / Non-goals; Article III docs citation; word limits)
+- Coverage of the agreed `0.0` model: designation, SDK stamping, CLI support set, metadata + runtime declarations, compatible resolution, atomic replacement, provenance, pre-materialization gate, npm-`latest` neutrality, intentional break for undeclared bundles
+- Sharpness of scope: only this change, no follow-on leakage
+
+## Coverage comparison
+
+Both versions agree on the entire core model: API `0.0` designation independent of package/CLI/SDK semver; `defineAdapter()` stamping without author involvement; CLI support of exactly `0.0`; missing/malformed/unsupported declarations rejected before any method call; npm metadata as pre-download selection aid with the runtime declaration authoritative and conflicts failing verification; highest-compatible selection replacing `/latest`; exact pins failing rather than substituting; unchanged npm `latest` semantics; staged atomic replacement; provenance retention; pre-materialization facet-install gate; the same four documentation pages; the same three modified capabilities; and matching non-goals.
+
+Material divergences:
+
+| Area | Main | Adversary |
+|---|---|---|
+| API identifier comparison rule | "Discrete contract identifiers," comparison semantics unstated | Explicit: exact-equality token comparison, never semver ranges |
+| No-compatible-release outcome | Covers incompatible exact pins only | Also covers "no published release is compatible": structured failure naming the newest release's API and the support set |
+| **BREAKING** marker | Breaking-ness stated in a trailing paragraph, unmarked | Explicit **BREAKING** bullet per the artifact instructions |
+| `facet adapter list` | Absent | SHOULD surface each installed adapter's API version and compatibility |
+| Git/local resolution exemption | Explicit: cannot be version-selected; MUST pass runtime verification as supplied | Implied by "every consumer" but the resolution-side exemption is unstated |
+| Why framing | Forward-only rationale for building the versioned boundary now instead of a legacy class | Concrete crash incident + "invisible contract" argument |
+
+## Judgments
+
+**Adversary is stronger on selection/comparison precision.** The exact-equality rule is the guard that stops a future implementer from "helpfully" applying range logic to API identifiers; leaving comparison semantics unstated invites exactly that. The no-compatible-release failure is a real user-reachable outcome (an old CLI facing a package whose every recent release declares a future API) that Main's resolution bullet does not name; without it, the specs phase could omit the scenario.
+
+**Adversary follows the artifact mechanics more precisely on the breaking change.** The proposal instructions require breaking changes to be marked **BREAKING**. Main's trailing paragraph says the right things but skips the marker.
+
+**The `facet adapter list` surfacing is the one genuinely new idea.** It is small, user-visible, and directly serves the diagnostic story (a user told "adapter X is incompatible" can see at a glance which installed adapters are). It is also scope the main version deliberately never had — adopting it or explicitly deferring it is a judgment call, but it should be decided, not lost.
+
+**Main is stronger on the strategic Why and the resolution exemption.** Main's forward-only rationale explains *why now and why not a legacy class* — the actual decision this change embodies — where the Adversary's incident framing re-argues the symptom (which the prior reconciliation already chose to exclude as implementation-specific). Main's explicit statement that git/local adapters cannot be version-selected and must pass runtime verification as supplied closes a gap the Adversary leaves implicit.
+
+**Mechanics.** Both are within word limits and use RFC 2119 keywords consistently. Capabilities map to the same three existing domains in `openspec/specs/` in both versions.
+
+## Merge recommendation (per section)
+
+- **Why**: Keep Main unchanged.
+- **What Changes**:
+  - Extend Main's first bullet with the comparison rule: adapter API identifiers SHALL be compared for exact equality and SHALL NOT be treated as semver ranges.
+  - Extend Main's resolution bullet with the no-compatible-release outcome: when no published release declares a supported API, resolution SHALL fail with structured data naming the newest release's declared API and the CLI's supported set.
+  - Mark the trailing breaking statement **BREAKING** (or restate it as a marked bullet).
+  - Decide on `facet adapter list` compatibility surfacing: adopt as a SHOULD bullet, or record its exclusion deliberately.
+- **Capabilities**: Keep Main's three deltas. If list surfacing is adopted, fold it into the `adapter__management` delta.
+- **Impact**: Keep Main (it is a superset). If list surfacing is adopted, add adapter-list output to the CLI line.
+- **Non-goals**: Keep Main unchanged.
+
+## Blocking items
+
+None are hard blockers. One decision item before specs: **adopt or explicitly defer the `facet adapter list` API-version/compatibility surfacing**, since it determines whether the `adapter__management` delta spec contains a listing requirement.
+
+## State
+
+- `proposal`: pending_reconciliation (this review)

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/specs-review.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/specs-review.md
@@ -1,0 +1,81 @@
+# Comparison Review: `specs` — add-adapter-api-version-negotiation
+
+**Main**: `specs/adapter__sdk/spec.md`, `specs/adapter__management/spec.md`, `specs/installation/spec.md`
+**Adversary**: `adversarial/artifacts/specs/adapter__sdk/spec.md`, `adversarial/artifacts/specs/adapter__management/spec.md`, `adversarial/artifacts/specs/installation/spec.md`
+
+Both were derived from the reconciled proposal; the adversary authored blind to the main version.
+
+## Grading bar
+
+- **Value-centric** (spec-governance): observable behavior for users/adapter authors, no internal module or class names, no domain-name subjects.
+- **RFC 2119**: normative keywords in every requirement.
+- **Atomic + testable**: one concern per requirement; scenarios concrete enough to test.
+- **Artifact mechanics**: correct ADDED/MODIFIED usage; MODIFIED blocks carry full updated content with exactly-matching headers; 4-hashtag scenarios.
+- **Coverage**: every proposal clause (`What Changes` bullets, BREAKING note, non-goals) represented.
+
+Both versions pass mechanics: headers of MODIFIED requirements match the permanent specs exactly, all scenarios use `####`, and full requirement blocks are carried. The differences are in coverage depth, vocabulary rigor, and two policy divergences.
+
+## Coverage comparison
+
+| Concern | Main | Adversary |
+|---|---|---|
+| `0.0` designation + exact equality | ✓ (ADDED, with identifier grammar) | ✓ (ADDED, no grammar) |
+| Identifier grammar (`MAJOR.MINOR`, no suffixes/leading zeroes) | ✓ | ✗ |
+| Missing/malformed/unsupported/supported classification | ✓ (explicit vocabulary, used consistently across all three files) | partial (missing/malformed/unsupported appear but are never defined) |
+| SDK canonical export | ✓ (scenario inside MODIFIED define-adapter req) | ✓ (separate ADDED requirement) |
+| Factory stamping | ✓ (`apiVersion` required readonly field; definition SHALL NOT *require or accept* an author identifier) | ✓ (stamp only; SHALL NOT *require* — silent on whether authors may supply a conflicting value) |
+| API independence from package versions | requirement text only | requirement text **and** a dedicated scenario |
+| npm selector grammar (exact/`1.*`/`1.2.*`/`*`/`latest`; reject `^`, `~`, comparators) | ✓ | ✗ ("explicit package version range", unspecified) |
+| Package metadata field name (`facetAdapterApiVersion`) | ✓ (named — this is the published contract adapter authors must write) | ✗ (described abstractly) |
+| Package vs runtime declaration conflict | ✓ | ✓ |
+| Undeclared release ineligible (BREAKING) | ✓ | ✓ |
+| No-compatible-release structured failure | ✓ (also: fail *before download*) | ✓ |
+| Atomic replacement | ✓ (MODIFIED the existing "Adapter identity" requirement so the old plain-overwrite scenario is superseded; plus combined ADDED req) | ✓ (separate ADDED requirement; left "Adapter name conflict overwrites" scenario untouched) |
+| Provenance | ✓ (npm: resolved version + registry integrity; repair-command scenario) | ✓ (explicit git/local scenario: no npm version recorded) |
+| Diagnostics | ✓ (plus misclassification guard: never reported as "no adapters installed" / unknown metadata schema; multi-failure aggregation) | ✓ (single-failure shape only) |
+| Git/local checked as supplied | ✓ (in verification MODIFIED) | ✓ (in selection ADDED) |
+| Load-time gate before any adapter method | ✓ (fail with **all collected** failures) | ✓ (per-bundle failure) |
+| List surfaces compatibility | ✓ (status vocabulary incl. `broken`; list stays available for recovery) | ✓ (simpler) |
+| Facet-install gate before materialization | ✓ (**extends to remove**; names receipt; aggregates all incompatible adapters) | ✓ (install/add only; positive-path scenario) |
+
+## Material divergences and which side is stronger
+
+1. **Identifier grammar and classification vocabulary (SDK)** — **Main stronger.** Main's ADDED requirement defines the `MAJOR.MINOR` form and the missing/malformed/unsupported/supported classification, making "malformed" testable and giving all three capability files a shared vocabulary. The adversary uses these words without defining them — a real gap: "malformed" is untestable without a grammar.
+
+2. **Factory forbids author-supplied identifiers (SDK)** — **Main stronger.** "SHALL NOT require **or accept**" eliminates a whole conflict class (author-declared version disagreeing with the SDK). The adversary only relieved authors of the obligation, leaving conflicting declarations representable.
+
+3. **npm selector grammar (management)** — **Main stronger.** Main reuses the established four-form + `latest` grammar from the installation spec and explicitly rejects `^`/`~`/comparators, with a scenario. The adversary's "explicit package version range" is exactly the kind of vague surface the permanent specs already refused for facets. Main's "highest **stable** release" also settles prerelease handling, which the adversary never addresses.
+
+4. **Replacement mechanics (management)** — **Main stronger on mechanics, adversary stronger on atomicity of requirements.** Main correctly MODIFIED "Adapter identity is determined by the adapter itself" so the permanent "Adapter name conflict overwrites" scenario is replaced by an atomic-activation scenario — the adversary left that plain-overwrite scenario standing, which would survive archive alongside the new staged-replacement requirement and read as contradictory. That is a genuine defect in the adversary version. However, main's combined ADDED requirement ("Adapter replacement is atomic **and retains repair provenance**") packs two concerns (atomicity; provenance) into one requirement, against the atomicity rule. The adversary's split (replacement / provenance / diagnostics as three requirements) is the better decomposition.
+
+5. **Aggregated failure reporting (management + installation)** — **Main stronger.** Reporting *all* incompatible adapters at once (load and facet-install paths) and the misclassification guard ("SHALL NOT be reported as 'no adapters installed'") are user-observable guarantees the adversary lacks.
+
+6. **Removal gating (installation)** — **Divergent policy; needs a decision.** Main gates add, install, **and remove** behind adapter compatibility. The adversary gates only add/install, per the proposal ("facet installation SHALL fail before any materialization writes"). The permanent installation spec deliberately makes removal receipt-driven and dependency-free ("Removal needs neither cache nor network... SHALL succeed"). If removal deletes receipt-recorded paths without invoking adapter contract methods, main's gate strands users: an incompatible adapter would block *removing* facets — the one operation that should always work. If removal does invoke adapter delete methods, main's gate is correct and the adversary under-specified. This must be settled against the design's actual removal path before archive.
+
+7. **Positive-path installation scenario** — **Adversary only.** "Compatible selected adapters install normally" pins that the gate is a pass-through, not a new interactive step. Cheap and worth having.
+
+8. **Git/local provenance scenario** — **Adversary only.** Main's provenance requirement says "source-specific provenance" but scenarios only cover npm; the adversary's scenario (git/local records specifier + API + integrity, and SHALL NOT record an npm version) closes the loop.
+
+9. **`broken` status (management list / installation)** — **Main gap.** Main introduces `broken` ("or is otherwise broken") as a compatibility status without defining it anywhere. Its classification requirement defines only missing/malformed/unsupported/supported. Define `broken` (e.g., bundle fails to load or does not export a valid adapter) or drop the word.
+
+## Merge recommendation (per capability)
+
+**`adapter__sdk`** — keep Main as the base.
+- Add the adversary's scenario *"API version is independent of package versions"* to Main's ADDED classification requirement (the independence clause currently has no scenario).
+- Optional: extract the canonical-export scenario into its own ADDED requirement (adversary's shape) for atomicity; low priority.
+
+**`adapter__management`** — keep Main as the base.
+- Split Main's combined "Adapter replacement is atomic and retains repair provenance" into two requirements (adversary's decomposition): one for atomic verified replacement, one for installation provenance. Keep all of Main's scenarios, redistributing them.
+- Add the adversary's git/local provenance scenario (records specifier, declared API, integrity; SHALL NOT record a resolved npm version).
+- Define `broken` in the status vocabulary or remove it from the list requirement.
+
+**`installation`** — keep Main's aggregation and receipt-awareness.
+- **Resolve divergence 6 before archive**: check the design's removal path. If removal is receipt-driven file deletion (as the permanent spec strongly implies), drop the remove-gating clause and the "Removing a facet does not bypass adapter compatibility" scenario, and rename the requirement back toward install/add mutation gating. If removal invokes adapter contract methods, keep Main and note the rationale.
+- Add the adversary's positive-path scenario ("Compatible selected adapters install normally").
+
+## Blocking items
+
+1. **Removal gating (divergence 6)** — Main currently blocks facet *removal* on adapter incompatibility, in tension with the permanent installation spec's always-available, receipt-driven removal. Must be settled against the design before this change is archived.
+2. **Undefined `broken` classification (divergence 9)** — used normatively in two capability files but defined nowhere; either define it or remove it.
+
+Everything else is additive polish; Main is the stronger base overall.

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/tasks-review.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/reviews/tasks-review.md
@@ -1,0 +1,72 @@
+# Comparison Review: `tasks`
+
+**Main**: `openspec/changes/add-adapter-api-version-negotiation/tasks.md`
+**Adversary**: `openspec/changes/add-adapter-api-version-negotiation/adversarial/artifacts/tasks.md`
+
+Both versions were derived from the same reconciled proposal, design, and specs. The adversarial version was authored blind to the main version.
+
+## Grading bar
+
+Scoped to the tasks artifact type:
+
+1. **Artifact mechanics** — exact preamble, Step Types legend, `- [ ] X.Y` checkbox format, Research/Implementation block pattern, VIPER hard rules (Explore→Propose before Implement; Verify after every Implement batch).
+2. **Atomic + testable** — each task independently completable and verifiable in one session.
+3. **Dependency ordering** — SDK before engine consumers, resolution/verification before placement, inspection before gates, docs last.
+4. **Coverage** — every reconciled spec scenario and design decision (including Decision 7 docs and the migration plan) reaches at least one task.
+5. **Actionability** — explores scoped for parallel subagents; tasks name concrete seams so the executor doesn't re-derive the design.
+
+## Mechanics
+
+Both versions are fully compliant: identical preamble, identical legend, correct checkbox format, Research/Implementation splits, and no VIPER rule violations (every Research group ends in Propose; every Implementation group ends in Verify; Main's 18.1–18.2 Implements are followed by Verifies; Adversary's flat block 17 uses Implement→Verify, which is legal without a Propose). No mechanical gate favors either side.
+
+## Coverage comparison
+
+Block-by-block correspondence (Main ↔ Adversary):
+
+| Area | Main | Adversary |
+|---|---|---|
+| SDK constant + stamping | 1–2 (combined with prepack) | 1–2 |
+| First-party prepack metadata | inside 1–2 | 3–4 (separate block) |
+| Classifier + verifier | 3–4 | 5–6 |
+| Specifier + npm resolution | 5–6 | 7–8 |
+| Managed layout + atomic activation | 7–8 | 9–10 |
+| Inspection + fail-closed loading | 9–10 | 11–12 (combined with gates) |
+| Adapter install/list/remove commands | 11–12 | 13–14 (CLI rendering only) |
+| Build + facet-operation gates | 13–14 | inside 11–12 |
+| Documentation + rollout | 15–16 | 15–16 + 17.1 |
+| Final coverage audit | 17–18 | 17.2 only |
+
+Substantive divergences:
+
+1. **Integrated coverage audit (Main 17–18; no Adversary equivalent).** Main ends with an explicit audit of the finished implementation against every reconciled scenario, a duplication audit (API literals, field names, alias maps, engine-side message strings), `bun format`, strict OpenSpec validation, and representative end-to-end flows across npm/Git/local × managed/unmanaged × compatible/incompatible. The Adversary has only a final `bun check` plus one legacy-bundle smoke check (17.2). **Main is clearly stronger.** For a change this wide, a closing audit block is the difference between "tasks all checked" and "change actually satisfies the specs."
+
+2. **Test-fixture migration (Main 9.1/10.5; absent in Adversary).** Main recognizes that existing engine/CLI tests fabricate flat `adapter.js` bundles and will break under the managed layout, and budgets explicit exploration and migration work. The Adversary never mentions fixtures. **Main is stronger** — this is a real, sizable implementation cost that would otherwise surface as unplanned work mid-block.
+
+3. **Install-service plumbing detail (Main 11–12 vs Adversary's distribution).** Main gives the adapter install service its own block, including converting bundler/verification/placement/cleanup exception boundaries into typed failures *without losing temporary-resource cleanup* (12.2), postpack source-manifest restoration (2.4), and stale-lock-owner handling (8.2). The Adversary covers the same flow but spreads it across blocks 6, 9–10, and 13–14 and omits temp-cleanup preservation, postpack restoration, and stale-lock handling. **Main is stronger** on these operational details.
+
+4. **Rollout (Main 15.3 + 16.5 vs Adversary 17.1).** Main treats release ordering (SDK → first-party `0.0` releases → compatibility-aware CLI) as a proposed plan plus an implemented checklist; the Adversary has a single "release-ordering note" task. **Main is stronger** — the migration plan is a first-class design section and deserves more than a note.
+
+5. **Concrete grounding (Adversary throughout; Main abstract).** The Adversary names actual paths in nearly every Explore and Implement: `packages/engine/src/adapters/verify.ts`, `sources/adapter/specifier.ts`/`npm.ts`, `first-party.ts`, `packages/protocol/src/sources/version-spec.ts`, `install/run-install.ts`, `build/pipeline.ts`, and each of the eight affected doc files individually. Main describes the same seams generically ("adapter source parsing", "the affected adapter CLI ... documentation"). **Adversary is stronger.** Grounded paths make Explore steps immediately dispatchable to parallel subagents and prevent the executor from re-discovering what the planner already knew. The paths are stable enough over this change's lifetime that drift risk is negligible.
+
+6. **Explore scoping for parallelism.** The tasks rules require explores scoped to independent topics. Main's 13.2 is a monolithic seven-topic explore ("add/remove/install adapter discovery, zero-adapter picker behavior, `runInstall` no-mutation exits, Git/local facet builds, drift removal, materialization, and all failure renderers") and 11.1 bundles five topics. The Adversary's explores are mostly one-seam-per-step with paths (its widest, 11.1, is still a single consumer sweep of one function). **Adversary is stronger** on explore granularity.
+
+7. **Spec-scenario test coverage — each side misses items the other has.**
+   - Missing from Main: an explicit test that **explicit `latest` selects highest-compatible and ignores the dist-tag** (Adversary 8.5); an explicit test that a **build with no adapters installed still proceeds with unknown-adapter warnings** (Adversary 12.5, from the modified load-at-runtime requirement); an explicit **exact-request metadata optimization must preserve identical validation/failure data** proposal item (Adversary 7.5, from design Risks).
+   - Missing from Adversary: **prerelease exclusion** and **integrity-failure** tests in resolution (Main 6.6); **unique-generation import freshness** test (Main 10.6 — Adversary proposes the mechanism in 11.4 but never tests it); **concurrent-replacement** tests (Main 8.6); first-party adapter definition tests staying unchanged (Main 2.3).
+   - Net: **Main's test enumeration is broader overall**, but the three Main gaps are genuine reconciled-spec scenarios, not nice-to-haves.
+
+8. **Block organization.** Main combines SDK+prepack (rule-compliant: closely related groups SHOULD combine) where the Adversary splits them; the Adversary combines loading+gates where Main splits them into inspection (9–10), commands (11–12), and gates (13–14). Main's finer split of the largest area of work is the better trade — those three areas have distinct consumers and can be verified independently — while the Adversary's SDK/prepack split is harmless but slightly less rule-aligned. **Main is stronger on structure overall.**
+
+## Merge recommendation
+
+Use **Main as the base** — its block structure, fixture-migration work, install-service detail, rollout treatment, and closing coverage-audit block are the stronger skeleton. Fold in from the Adversary:
+
+1. **Per-block: add concrete file paths** to Main's Explore steps (and Implement steps where a single file is the seam), using the Adversary's path inventory: blocks 1 (`packages/adapter/src/{types,define-adapter,index}.ts`), 3 (`packages/engine/src/adapters/verify.ts`, `install-service.ts` fallback), 5 (`sources/adapter/{specifier,npm}.ts`, `adapters/first-party.ts`, `packages/protocol/src/sources/version-spec.ts`), 7 (`adapters/placement.ts`, common atomic-write helpers), 9 (`adapters/loader.ts`), 13 (`install/run-install.ts`, `build/pipeline.ts`), 15 (the eight individual doc paths from design Decision 7).
+2. **Block 6 (Main): add two test items** to 6.6 — explicit `latest` ignores the dist-tag and selects highest compatible; and (if the exact-request metadata optimization is implemented) identical validation and failure data versus the packument path. Source: Adversary 8.5/7.5.
+3. **Block 14 (Main): add one test item** — a build with no installed adapters proceeds and emits unknown-adapter warnings for manifest adapter metadata. Source: Adversary 12.5.
+4. **Block 13 (Main): split 13.2** into two or three scoped explores (facet-command discovery + picker; `runInstall` no-mutation exits + Git/local facet builds; materialization + failure renderers) so they can run as parallel subagents. Optionally split 11.1 the same way.
+5. Do **not** adopt the Adversary's separate first-party-metadata block, its merged loading+gates block, or its thin block 17 — Main's equivalents are stronger.
+
+## Blocking items
+
+None that must be settled before archiving the change. The closest are the two missing reconciled-spec scenario tests in Main (merge items 2–3); they should be folded in at reconciliation so the task list, not executor memory, carries them.

--- a/openspec/changes/add-adapter-api-version-negotiation/adversarial/state.json
+++ b/openspec/changes/add-adapter-api-version-negotiation/adversarial/state.json
@@ -1,0 +1,58 @@
+{
+  "change": "add-adapter-api-version-negotiation",
+  "schema": "spec-driven",
+  "entries": {
+    "proposal": {
+      "artifactId": "proposal",
+      "mainPaths": ["proposal.md"],
+      "adversarialPaths": ["adversarial/artifacts/proposal.md"],
+      "reviewPath": "adversarial/reviews/proposal-review.md",
+      "dependencies": [],
+      "status": "reconciled",
+      "authoredAt": "2026-07-21T22:38:45Z",
+      "comparedAt": "2026-07-21T22:39:58Z",
+      "reconciledAt": "2026-07-21T22:43:59Z",
+      "notes": "Adopted exact-equality semantics, no-compatible-release diagnostics, the BREAKING marker, and adapter-list compatibility output; retained the main strategic Why and explicit Git/local handling instead of the incident-led framing."
+    },
+    "design": {
+      "artifactId": "design",
+      "mainPaths": ["design.md"],
+      "adversarialPaths": ["adversarial/artifacts/design.md"],
+      "reviewPath": "adversarial/reviews/design-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-07-21T23:20:00Z",
+      "comparedAt": "2026-07-21T23:34:00Z",
+      "reconciledAt": "2026-07-21T23:13:24Z",
+      "notes": "Adopted the full-packument rationale and clarified npm package-integrity provenance; rejected placed-bundle hashing, installedAt, and a Context file inventory as unconsumed or unnecessary scope."
+    },
+    "specs": {
+      "artifactId": "specs",
+      "mainPaths": ["specs/adapter__management/spec.md", "specs/adapter__sdk/spec.md", "specs/installation/spec.md"],
+      "adversarialPaths": [
+        "adversarial/artifacts/specs/adapter__management/spec.md",
+        "adversarial/artifacts/specs/adapter__sdk/spec.md",
+        "adversarial/artifacts/specs/installation/spec.md"
+      ],
+      "reviewPath": "adversarial/reviews/specs-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-07-22T00:25:00Z",
+      "comparedAt": "2026-07-22T00:31:00Z",
+      "reconciledAt": "2026-07-22T00:27:05Z",
+      "notes": "Adopted package-version independence, split atomic replacement from provenance, added corrected Git/local provenance, defined broken installations, and added the compatible-operation path; retained facet-removal compatibility gating because deletion invokes adapter methods while remaining cache- and network-independent."
+    },
+    "tasks": {
+      "artifactId": "tasks",
+      "mainPaths": ["tasks.md"],
+      "adversarialPaths": ["adversarial/artifacts/tasks.md"],
+      "reviewPath": "adversarial/reviews/tasks-review.md",
+      "dependencies": ["specs", "design"],
+      "status": "reconciled",
+      "authoredAt": "2026-07-22T00:52:00Z",
+      "comparedAt": "2026-07-22T01:02:00Z",
+      "reconciledAt": "2026-07-22T00:49:32Z",
+      "notes": "Retained the main VIPER structure, fixture migration, install-service detail, rollout, and integrated audit; adopted selective path grounding, split broad install-service and consumer-gate explores, and added explicit latest/dist-tag, conditional exact-metadata equivalence, and no-adapters build coverage."
+    }
+  }
+}

--- a/openspec/changes/add-adapter-api-version-negotiation/design.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/design.md
@@ -1,0 +1,203 @@
+## Context
+
+Adapter bundles cross two durable boundaries: npm publication and `$FACET_DIR/adapters/` persistence. Today neither boundary carries a machine-readable adapter API identifier. `@agent-facets/adapter` exposes one unversioned `Adapter` shape, `defineAdapter()` returns that shape unchanged, npm installs resolve only the `/latest` document, installation writes one `adapter.js` directly over the live file, and runtime loading imports every discovered bundle without reusing installation verification. A stale or future bundle can therefore reach an adapter method before the CLI detects a call-contract mismatch.
+
+The implementation spans the published Adapter SDK, first-party adapter packages, engine source resolution and placement, build and facet-install consumers, and CLI diagnostics. The design MUST preserve these constraints:
+
+- The current positional method contract is adapter API `0.0`; its method signatures SHALL remain unchanged.
+- Adapter API identifiers SHALL be exact contract tokens, not semantic-version compatibility ranges, and SHALL remain independent of CLI, SDK-package, adapter-package, and facet versions.
+- The SDK SHALL remain a leaf package; npm selection, filesystem state, and CLI rendering SHALL remain in engine/CLI layers.
+- Expected parse, resolution, verification, placement, and compatibility failures SHALL be represented by discriminated result values rather than escaping as exceptions.
+- First-party and third-party adapters SHALL use the same metadata, verification, and loading path.
+- Existing undeclared releases and installed bundles SHALL be incompatible with the new CLI; no permanent legacy-compatible state will be introduced.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish one canonical SDK-owned API `0.0` declaration and stamp it into every runtime adapter returned by `defineAdapter()`.
+- Select the highest npm package version that satisfies both the user's package-version request and the CLI's exact adapter-API support set.
+- Verify compatibility before activating a candidate bundle, whenever an installed bundle is loaded, and before any adapter method or facet materialization write can occur.
+- Activate a verified replacement atomically while retaining source, resolved-package, API, and integrity provenance.
+- Return structured failures that support actionable CLI errors and compatibility-aware `facet adapter list` output.
+- Publish replacement first-party releases and align all affected user-facing documentation.
+
+**Non-Goals:**
+
+- This change SHALL NOT introduce adapter API `0.1` or alter the positional `0.0` method contract.
+- This change SHALL NOT infer compatibility from CLI, SDK-package, or adapter-package semantic versions.
+- This change SHALL NOT manipulate npm dist-tags, retain multiple active adapter versions, or auto-upgrade adapters during `facet install`.
+- This change SHALL NOT add general npm-semver syntax. Adapter package selectors SHALL use the existing Facet grammar: exact `1.2.3`, major wildcard `1.*`, minor wildcard `1.2.*`, `*`, or `latest`.
+- This change SHALL NOT add compatibility negotiation to facet archives or the facet registry protocol.
+
+## Decisions
+
+### 1. The SDK owns the canonical runtime declaration
+
+`packages/adapter/` SHALL expose a canonical `ADAPTER_API_VERSION` constant with value `0.0`. The public runtime `Adapter` type SHALL contain a required, readonly `apiVersion` field whose value is stamped by `defineAdapter()`. The factory's input type SHALL exclude that field, so an author cannot provide a conflicting value in the definition object. First-party and third-party source code will continue to call `defineAdapter({...})` without repeating `0.0`.
+
+An adapter API identifier SHALL use the canonical two-component decimal form `MAJOR.MINOR` with no sign, suffix, build metadata, or leading zeroes except the number zero itself. The engine SHALL distinguish missing, malformed, well-formed-but-unsupported, and supported declarations. Well-formed identifiers SHALL be compared only by exact string equality; numeric ordering SHALL have no compatibility meaning.
+
+The engine SHALL define its support set from the SDK constant rather than duplicating the `0.0` literal. The initial support set is exactly `{ ADAPTER_API_VERSION }`. The canonical SDK version and the CLI support set remain separate concepts: a later change MAY make a CLI support multiple exact APIs without changing how the SDK selects the API stamped into newly built adapters.
+
+**Alternative rejected:** inferring the adapter API from the SDK package version. Adapter packages bundle the SDK, npm manifests can omit the build-time SDK dependency, and SDK semver also covers non-contract changes; inference would couple independent version domains.
+
+**Alternative rejected:** asking authors to set `apiVersion` in `defineAdapter()`. That creates two author-maintained declarations and permits source/runtime drift that the factory can prevent by construction.
+
+### 2. npm package metadata uses a dedicated pre-download field
+
+Published adapter package manifests SHALL advertise the contract through the top-level package field:
+
+```json
+{
+  "facetAdapterApiVersion": "0.0"
+}
+```
+
+The SDK SHALL export the metadata-field name alongside the canonical version so engine resolution and first-party release tooling do not duplicate string literals. First-party package manifests SHALL receive this field during the existing prepack transformation, derived from `ADAPTER_API_VERSION`; packed-tarball tests SHALL prove the field is present. Third-party publishers MUST declare the field in their published `package.json`, because npm metadata is required before their runtime bundle can be downloaded.
+
+The npm declaration is a selection hint, not proof. The runtime declaration stamped into the loaded bundle SHALL remain authoritative. A missing or malformed runtime declaration, an unsupported runtime API, or disagreement between npm metadata and runtime export SHALL be a terminal verification failure. Compatibility failures SHALL NOT trigger the current “prebuilt failed, rebundle from source” fallback; fallback MAY continue only for loadability or bundling failures that do not contradict a declared contract.
+
+**Alternative rejected:** inspecting dependency ranges or bundled source to infer the SDK version. Published adapters can inline the SDK and remove development dependencies, making either signal absent or misleading.
+
+### 3. npm specifiers become a tagged package/version request
+
+The adapter specifier parser SHALL preserve source intent with non-overlapping variants rather than optional version fields:
+
+- npm package with an implicit selector (bare package or first-party alias);
+- npm package with an exact version;
+- npm package with an explicit Facet-style wildcard/`latest` selector;
+- Git source; or
+- local source.
+
+Scoped npm names SHALL be split at the version delimiter after the package name, so `@scope/name` remains a bare package while `@scope/name@1.*` carries a selector. The existing Facet `VersionSpec` grammar and satisfaction predicate SHALL be reused as the single source of truth; caret, tilde, comparator, OR, hyphen, prerelease, and `x` ranges SHALL return structured parse failures with the supported forms. Explicit `latest` means “highest compatible published version” and SHALL NOT force use of npm's `latest` dist-tag.
+
+The first-party adapter catalog SHALL become the source of truth for alias-to-package mapping as well as picker content; the parser SHALL derive aliases from it instead of maintaining a second literal map.
+
+For non-exact npm requests, the resolver SHALL fetch the full package document, parse stable `MAJOR.MINOR.PATCH` entries, constrain them by the requested package selector, discard entries whose `facetAdapterApiVersion` is missing, malformed, or unsupported, and choose the highest remaining semantic package version. For an exact request, only that package version SHALL be considered; incompatibility SHALL fail instead of substituting another release. The resolved success value SHALL carry the exact package version, declared adapter API, tarball URL, and the registry's SRI or shasum anchor so download and provenance use the same selected record.
+
+The resolver MUST request npm's full packument rather than the abbreviated `application/vnd.npm.install-v1+json` representation, because the abbreviated representation can omit custom per-version fields such as `facetAdapterApiVersion`.
+
+When no compatible candidate exists, the failure SHALL carry the package, requested selector, CLI support set, and the newest considered release with its missing, malformed, or unsupported declaration. npm `latest` SHALL continue advancing normally and SHALL not participate in compatibility policy.
+
+Git and local sources cannot be version-selected. They SHALL proceed directly to runtime verification and MUST declare a supported runtime API.
+
+### 4. One verifier owns runtime shape and compatibility classification
+
+`verifyAdapter` SHALL return a discriminated `VerifyAdapterResult` rather than throw for import, export-shape, name, API declaration, support-set, or metadata/runtime mismatch failures. Its success arm SHALL return a verified adapter and its supported API identifier. The verifier SHALL validate, in order:
+
+1. the bundle can be imported;
+2. it has a default object export;
+3. the runtime API declaration is present and syntactically valid;
+4. the declaration is in the CLI support set;
+5. any expected npm API equals the runtime declaration; and
+6. the `0.0` object has the required name and method shape.
+
+This ordering classifies a contract mismatch before any adapter method is invoked. Importing an ESM bundle necessarily runs its top-level initialization; preventing arbitrary module initialization is outside this change, but no adapter contract method SHALL run until verification succeeds.
+
+A shared pure compatibility classifier SHALL produce one failure union used by npm selection, candidate verification, installed loading, build preflight, and facet-install preflight. The union SHALL encode missing, malformed, unsupported, and metadata/runtime-mismatch states as separate variants, each carrying the adapter/package identity, the found declaration when one exists, and the supported API set. CLI renderers SHALL map these values to prose; engine code SHALL NOT construct user-facing message strings.
+
+### 5. Managed installations use an atomic active-generation receipt
+
+Managed adapters SHALL use this engine-owned layout:
+
+```text
+$FACET_DIR/adapters/<name>/
+├── installation.json
+└── generations/
+    └── <generation-id>/
+        └── adapter.js
+```
+
+`installation.json` is the atomic activation record. It SHALL contain a schema version, the active generation identifier, the verified adapter API, and a tagged source record:
+
+- npm: original specifier, resolved package name/version, and the exact SRI or shasum used to verify the tarball;
+- Git: original specifier, URL, and optional requested ref; or
+- local: original specifier and resolved source path.
+
+Package integrity is npm source provenance: an npm receipt SHALL retain the registry SRI or shasum that authenticated the selected package, including when extracted source is subsequently rebundled before placement. Git and local sources have no npm package-integrity field. This change SHALL NOT add a placed-bundle content hash because it defines no load-time byte-integrity contract that would consume one; runtime API verification remains authoritative for compatibility. A broader installed-bundle tamper-detection policy requires a separate threat model and change.
+
+Source-specific fields SHALL live only on their tagged variant so impossible npm/Git/local combinations cannot be constructed. The generation identifier SHALL be validated as a single safe path segment, and every derived path SHALL be containment-checked before reading or deleting files.
+
+Replacement SHALL proceed as follows:
+
+1. resolve, download/build, and verify a candidate in temporary storage;
+2. acquire a per-adapter replacement lock after the runtime name is known;
+3. copy the verified bundle into a new unique generation on the same filesystem;
+4. verify the generation from its final staged path;
+5. atomically replace `installation.json` with a receipt pointing to the new generation; and
+6. remove the previous generation and legacy direct bundle after activation.
+
+Before step 5, the existing receipt and active generation remain untouched. Therefore any resolution, build, verification, staging, or receipt-write failure SHALL leave the existing installation active and byte-for-byte unchanged. A cleanup failure after the atomic receipt switch SHALL be reported as a warning, not as a failed installation that claims the old version remains active. Later placement/removal MAY clean inactive generations left by a crash.
+
+Exactly one receipt generation is active. Transient staging and crash leftovers are not selectable installed versions and SHALL be ignored by loaders and listing.
+
+An adapter manually copied to the historical direct path `<name>/adapter.js` has no managed provenance. The inspector SHALL classify it as an unmanaged installation and verify its runtime declaration directly. A newly copied `0.0` bundle MAY load; an existing undeclared bundle SHALL fail as missing its API. Reinstalling through the CLI converts the directory to the managed generation layout.
+
+**Alternative rejected:** overwriting `adapter.js` and `installation.json` independently. Two renames cannot atomically switch the pair, and a failure between writes can associate a new bundle with stale provenance.
+
+**Alternative rejected:** renaming one staged directory over a populated live directory. Portable filesystems do not provide a reliable replace-nonempty-directory operation, and a two-directory swap creates crash windows. An atomic receipt pointer makes activation a single-file rename.
+
+### 6. Inspection is shared; consumers fail closed
+
+Installed-adapter inspection SHALL be the single path used by loading and `facet adapter list`. Each directory SHALL produce one tagged outcome:
+
+- compatible, with a verified adapter and supported API;
+- incompatible, with a structured compatibility failure and repair source; or
+- broken, with a structured receipt/import/shape failure.
+
+For managed installations, inspection SHALL validate `installation.json`, reject an unsupported recorded API before import, import the uniquely named active generation, and compare the runtime declaration with the receipt. Unique generation paths also prevent dynamic-import caching from returning a bundle that was replaced earlier in the same process. For unmanaged direct bundles, inspection SHALL import and verify the bundle without inventing provenance.
+
+`loadInstalledAdapters` SHALL return a result value. If any installed adapter is incompatible or broken, loading SHALL fail with all collected failures instead of warning and silently skipping it. This prevents an incompatible-but-present adapter from being misreported as “no adapters installed” or as an unknown metadata schema.
+
+The command gates SHALL be:
+
+- `facet build` and publish-build SHALL stop before `runBuildPipeline` when inspection fails.
+- `facet add`, `facet remove`, and `facet install` SHALL stop before invoking `runInstall` when inspection fails; they SHALL NOT launch the zero-adapter picker for this state.
+- `runBuildPipeline` and `runInstall` SHALL retain a defense-in-depth API preflight before any adapter method. Build failure data SHALL distinguish adapter incompatibility from content validation. `RunInstallFailure` SHALL add an `ADAPTER_INCOMPATIBLE` variant and route it through the existing no-mutation path before the per-facet loop, which also precedes Git/local facet builds that invoke adapter metadata methods.
+- Materialization MAY retain an in-loop compatibility assertion as an invariant check, but it SHALL NOT be the primary gate.
+- `facet adapter remove` SHALL continue to remove the whole adapter directory without loading it.
+
+`facet adapter list` SHALL inspect every entry and display its API as `0.0`, `missing`, or `malformed`, plus `supported`, `unsupported`, or `broken` compatibility status. Listing SHALL remain available when entries are incompatible so it can guide recovery.
+
+Compatibility failures SHALL carry a repair discriminator. Managed installations use the recorded original specifier to render `facet adapter install <specifier>`. Unmanaged first-party names use the canonical alias. Other unmanaged entries use the directory/runtime name as the best available specifier and explicitly report that original source provenance is unavailable.
+
+### 7. Documentation follows the observable contract
+
+The implementation SHALL update:
+
+- `docs/cli/adapters/install.mdx` for package selectors, highest-compatible resolution, incompatibility failures, atomic replacement, and the managed layout;
+- `docs/cli/adapters/list.mdx` for API and compatibility status output;
+- `docs/guides/custom-adapters.mdx` for SDK stamping, `facetAdapterApiVersion`, publishing, and rebuilding/reinstalling adapters;
+- `docs/guides/troubleshooting.mdx` for missing, malformed, unsupported, and metadata/runtime-mismatch recovery;
+- `docs/specification/install.mdx` and `docs/specification/commit.mdx` for the compatibility gate before the per-facet loop and materialization;
+- `docs/specification/build.mdx` for failure on an incompatible installed adapter before metadata validation;
+- `docs/cli/env.mdx` for the receipt/generation layout under `$FACET_DIR/adapters/`; and
+- `scripts/README.md` for first-party API metadata injection during prepack.
+
+The root `README.md` only describes the zero-adapter picker; that statement remains accurate and requires no change. Its package-table omissions and broken links are unrelated existing documentation defects and SHALL remain outside this change.
+
+## Risks / Trade-offs
+
+- **[Full npm package documents are larger than `/latest` responses]** → The resolver SHALL parse only version, API field, and dist metadata needed for candidates; an exact request MAY use exact-version metadata as an optimization if it preserves identical validation and failure data.
+- **[Mirrors or publishers can omit custom metadata]** → Missing metadata SHALL make that release ineligible before download. Documentation and first-party packed-manifest tests SHALL make the requirement visible and deterministic.
+- **[Package metadata can drift from bundled runtime code]** → Runtime verification SHALL be authoritative and SHALL reject mismatches before activation.
+- **[All existing managed and manually installed bundles are undeclared]** → New first-party releases SHALL be published before the compatibility-aware CLI, and diagnostics SHALL provide a reinstall command. No automatic migration will guess compatibility.
+- **[A crash after activation can leave inactive generations]** → The receipt identifies the sole active generation; loaders ignore all others, and later placement/removal SHALL clean safe inactive generations.
+- **[Concurrent installs could race generation cleanup]** → Replacement SHALL be serialized per adapter; cleanup SHALL never delete the generation named by the current receipt.
+- **[The constrained package-range grammar differs from npm's caret/tilde conventions]** → Parsing SHALL fail with supported alternatives, and command documentation SHALL show exact and wildcard examples.
+- **[Runtime verification imports third-party module initialization]** → Managed receipts allow known unsupported APIs to fail before import, but final runtime authority still requires import. Sandboxing module initialization is a separate security concern.
+- **[Rolling back to an older CLI after managed-layout activation hides adapters from that CLI]** → The project is forward-only; rollback instructions SHALL require reinstalling an adapter release understood by the older CLI rather than maintaining two layouts as active.
+
+## Migration Plan
+
+1. Add and publish the SDK `0.0` runtime declaration and release-tool metadata injection. Packed first-party adapter artifacts MUST contain both the npm field and the SDK-stamped runtime export.
+2. Publish new `0.0`-declaring releases of Claude Code, OpenCode, and Codex adapters while preserving normal npm `latest` advancement. Their method contract remains unchanged, so existing CLIs continue to consume them as before.
+3. Release the compatibility-aware CLI only after those releases are available. A plain first-party install can then always select a compatible candidate.
+4. On first use, existing direct bundles are inspected as unmanaged. Because today's bundles have no runtime API, build and facet-install commands fail before adapter methods or project writes and direct the user to `facet adapter install <specifier>`.
+5. A successful reinstall stages a managed generation, atomically activates its receipt, then removes the old direct bundle. Project manifests, facet lockfiles, receipts, and materialized assets are not migrated or rewritten.
+6. If the new CLI release is rolled back, the older CLI can require an adapter reinstall because it only recognizes the direct `adapter.js` layout. No compatibility promise is made for already-published older CLIs.
+
+## Open Questions
+
+None. The package-selector decision is resolved: adapter npm requests SHALL use the existing Facet exact/wildcard/`latest` grammar rather than full npm-semver ranges.

--- a/openspec/changes/add-adapter-api-version-negotiation/proposal.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The CLI currently downloads an npm adapter's `latest` release and loads installed bundles as the current TypeScript `Adapter` type without checking whether their runtime call contract is compatible. The adapter contract itself has no machine-readable version, so neither package resolution nor runtime loading can distinguish a compatible bundle from one built for a different call shape. The project is forward-only and cannot make already-published CLIs compatibility-aware, so this change establishes a complete versioned boundary now instead of assigning permanent compatibility semantics to an undeclared legacy state.
+
+## What Changes
+
+- Designate the current positional adapter method contract as adapter API `0.0`. Adapter API versions SHALL be discrete contract identifiers compared for exact equality, SHALL NOT be interpreted as semantic-version ranges, and SHALL be independent of CLI, adapter-package, and Adapter SDK package versions.
+- Version the Adapter SDK boundary. The SDK SHALL expose `0.0` as its canonical API version, and `defineAdapter()` SHALL stamp that version onto every returned runtime adapter without requiring adapter authors to repeat it in their definitions.
+- Make compatibility explicit on both sides. This CLI SHALL support exactly adapter API `0.0`; an adapter with a missing, malformed, or different API declaration SHALL be incompatible rather than treated as a legacy-compatible bundle.
+- Require npm adapter releases to expose their adapter API version in package metadata so compatibility can be determined before download. New first-party adapter releases SHALL declare API `0.0` in package metadata and through their SDK-produced runtime exports.
+- Replace npm `/latest` resolution with selection from package-version metadata. A plain npm or first-party install SHALL choose the highest package version whose declared adapter API is supported by the CLI. An explicit package range SHALL constrain compatible selection, while an explicit exact package version SHALL fail when that release is incompatible rather than silently substituting another release. When no package version in the requested set declares a supported adapter API, resolution SHALL fail with structured data identifying the newest considered release, its declared or missing adapter API, and the CLI's supported APIs.
+- Preserve normal npm publishing semantics: the npm `latest` tag SHALL continue to identify the latest published adapter release. Compatibility selection SHALL be the CLI's responsibility and SHALL NOT depend on moving, pinning, or withholding that tag.
+- Verify API compatibility before placing a downloaded bundle and before returning an installed bundle to build or installation workflows. A bundle with a missing, malformed, or unsupported adapter API SHALL fail with structured data before any adapter method is invoked.
+- Treat npm metadata as a selection aid and the loaded bundle's runtime declaration as the final compatibility check. Missing runtime declarations and conflicts between package metadata and the runtime export SHALL fail verification rather than silently selecting a call shape.
+- Stage and verify a candidate bundle before replacing an installed bundle. Replacement SHALL be atomic, and any verification or placement failure SHALL leave the existing installed bundle unchanged.
+- Retain installation provenance needed to identify and replace an incompatible adapter: source specifier, resolved npm package/version when applicable, adapter API version, and package integrity.
+- Return actionable diagnostics that identify the adapter, its declared or missing API, the APIs supported by the CLI, and the compatible-install command. When a selected installed adapter is incompatible, facet installation SHALL fail before any materialization writes. `facet adapter list` SHALL surface each installed adapter's declared or missing adapter API and whether it is supported by the current CLI.
+- Update `docs/cli/adapters/install.mdx`, `docs/guides/custom-adapters.mdx`, `docs/guides/troubleshooting.mdx`, and `docs/specification/install.mdx`, which do not yet document compatibility-aware adapter selection, incompatible-adapter diagnostics, or the compatibility gate before materialization.
+
+- **BREAKING:** This change does not alter the positional method signatures assigned to API `0.0`, but undeclared adapters SHALL become incompatible. Existing installed bundles SHALL require replacement with a version-declaring release, and existing unversioned npm releases SHALL not be compatible candidates for this CLI.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `adapter__sdk`: the current positional adapter contract SHALL become API `0.0`, and the SDK factory SHALL stamp the canonical API version onto every runtime adapter.
+- `adapter__management`: npm installs SHALL select the highest CLI-compatible adapter package; installed bundles SHALL be compatibility-checked before use; verified replacements SHALL be atomic; installation provenance and incompatibility failures SHALL be available to the user-facing workflow; and adapter listing SHALL surface each installed adapter's API compatibility.
+- `installation`: facet installation SHALL reject an unsupported selected adapter with structured, actionable diagnostics before any materialization writes occur.
+
+## Impact
+
+- The Adapter SDK under `packages/adapter/` will define the canonical API `0.0` identifier, include it in the runtime adapter type, and stamp it from `defineAdapter()`.
+- First-party adapter packages under `packages/adapters/` will publish new releases declaring API `0.0` in npm metadata and runtime exports.
+- Adapter source parsing and npm package resolution under `packages/engine/src/sources/adapter/` will become package-version- and adapter-API-aware instead of requesting only `/latest`.
+- Adapter verification, placement, loading, and installation services under `packages/engine/src/adapters/` will classify compatibility, retain installation provenance, and atomically replace only verified bundles.
+- Facet installation orchestration and CLI adapter-install, facet-install, adapter-list, and runtime-loading output will reject or surface incompatible selected adapters before materialization and expose structured compatibility information and diagnostics.
+- npm registry metadata becomes an input to compatible version selection; Git and local adapters cannot be version-selected and MUST pass runtime compatibility verification as supplied.
+- Existing unversioned installed bundles and npm releases will require replacement with newly versioned adapter releases.
+- Adapter installation and authoring documentation will explain API declarations, compatible resolution, migration from undeclared bundles, and pre-materialization failure behavior.
+
+## Non-goals
+
+- This change SHALL NOT alter the positional adapter method signatures designated as API `0.0` or introduce any later adapter API contract.
+- This change SHALL NOT alter, pin, or delay npm's `latest` dist-tag and SHALL NOT attempt to protect CLI releases that predate compatibility-aware resolution.
+- This change SHALL NOT install or retain multiple adapter versions side by side.
+- This change SHALL NOT automatically upgrade an incompatible installed adapter during `facet install`; it SHALL fail before materialization and direct the user to install a compatible release.
+- This change SHALL NOT couple adapter API compatibility to facet archive versions, facet package versions, or the Adapter SDK package's own semantic version.

--- a/openspec/changes/add-adapter-api-version-negotiation/specs/adapter__management/spec.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/specs/adapter__management/spec.md
@@ -1,0 +1,214 @@
+## ADDED Requirements
+
+### Requirement: npm adapter installs select the highest compatible package version
+
+The system SHALL accept npm adapter package selectors in the exact `MAJOR.MINOR.PATCH`, major-wildcard `MAJOR.*`, minor-wildcard `MAJOR.MINOR.*`, bare wildcard `*`, and `latest` forms. A bare package name or first-party alias SHALL act as an implicit unconstrained selector. For a non-exact request, the system SHALL select the highest stable package version that satisfies the selector and declares an adapter API supported by the current CLI. For an exact request, the system SHALL consider only that package version and SHALL NOT silently substitute another release.
+
+The npm `latest` distribution tag SHALL continue to advance according to normal publishing policy. Compatibility selection SHALL NOT require moving, pinning, or withholding that tag.
+
+#### Scenario: Bare package skips a newer incompatible release
+
+- **WHEN** a user installs an npm adapter by bare package name
+- **AND** the newest package release declares an unsupported adapter API
+- **AND** an older stable release declares an API supported by the CLI
+- **THEN** the system SHALL install the highest stable release that declares a supported API
+
+#### Scenario: Wildcard constrains compatible selection
+
+- **WHEN** a user installs an npm adapter with a supported wildcard selector
+- **THEN** the system SHALL select the highest stable package version that both satisfies the wildcard and declares a supported adapter API
+
+#### Scenario: Exact incompatible release is not substituted
+
+- **WHEN** a user requests an exact npm adapter package version whose declared adapter API is missing, malformed, or unsupported
+- **THEN** installation SHALL fail for that exact release
+- **AND** the system SHALL NOT install another package version instead
+
+#### Scenario: Unsupported range syntax is rejected
+
+- **WHEN** a user supplies a caret, tilde, comparator, OR, hyphen, prerelease, or `x`-style npm adapter selector
+- **THEN** the system SHALL reject the selector
+- **AND** the error SHALL identify the accepted exact, wildcard, and `latest` forms
+
+#### Scenario: No compatible release is available
+
+- **WHEN** no package version satisfying the user's selector declares an adapter API supported by the CLI
+- **THEN** installation SHALL fail before downloading an adapter bundle
+- **AND** the failure SHALL identify the package and requested selector
+- **AND** the failure SHALL identify the CLI's supported APIs
+- **AND** the failure SHALL identify the newest considered release and its missing, malformed, or unsupported declaration
+
+### Requirement: Published npm adapters declare their API before download
+
+An npm adapter release MUST publish its adapter API identifier in the top-level `facetAdapterApiVersion` package field. The package declaration SHALL be used to select a candidate before download, but the loaded adapter's runtime declaration SHALL remain authoritative. A package/runtime disagreement SHALL fail verification and SHALL NOT be treated as a reason to select a different call contract.
+
+#### Scenario: Compatible package declaration permits candidacy
+
+- **WHEN** an npm adapter release publishes a well-formed `facetAdapterApiVersion` supported by the CLI
+- **AND** its package version satisfies the user's selector
+- **THEN** that release SHALL be eligible for compatible version selection
+
+#### Scenario: Missing package declaration is ineligible
+
+- **WHEN** an npm adapter release omits `facetAdapterApiVersion`
+- **THEN** that release SHALL NOT be eligible for compatibility-aware selection
+
+#### Scenario: Package and runtime declarations disagree
+
+- **WHEN** a selected npm release declares one supported adapter API in package metadata
+- **AND** its loaded runtime adapter declares a different API
+- **THEN** verification SHALL fail before the adapter is activated
+- **AND** no adapter contract method SHALL be invoked
+
+### Requirement: Adapter replacement is atomic
+
+The system SHALL completely verify a candidate adapter before making it active. Replacing an adapter SHALL switch from the previous verified installation to the new verified installation atomically. Any failure before activation SHALL leave the previous installation active and unchanged.
+
+#### Scenario: Verified replacement becomes active
+
+- **WHEN** a user replaces an installed adapter with a candidate that passes all verification
+- **THEN** the new adapter SHALL become the sole active installation for that adapter name
+- **AND** subsequent loads SHALL use the new adapter
+
+#### Scenario: Failed replacement preserves the previous adapter
+
+- **WHEN** a user attempts to replace an installed adapter
+- **AND** candidate resolution, download, bundling, verification, staging, or activation fails
+- **THEN** the previous adapter SHALL remain active
+- **AND** the previous installation SHALL remain unchanged
+
+### Requirement: Managed adapter installations retain repair provenance
+
+A managed installation SHALL retain its original source specifier, verified adapter API, and source-specific provenance sufficient to identify the installed source and render a repair command. npm provenance SHALL include the resolved package name and version and the registry integrity used to authenticate that package. Git provenance SHALL include the repository URL and optional requested ref. Local provenance SHALL include the resolved source path. Git and local provenance SHALL NOT claim an npm package version or npm registry integrity.
+
+#### Scenario: Managed npm installation provides its repair source
+
+- **WHEN** a managed npm adapter is later found incompatible or broken
+- **THEN** its retained provenance SHALL include the original install specifier, resolved package name and version, verified adapter API, and registry integrity
+- **AND** the CLI SHALL be able to present `facet adapter install <specifier>` as the repair command
+
+#### Scenario: Git or local installation retains source-specific provenance
+
+- **WHEN** a user installs an adapter from Git or a local path
+- **THEN** the retained provenance SHALL include the original specifier and verified adapter API
+- **AND** Git provenance SHALL include the repository URL and optional requested ref
+- **AND** local provenance SHALL include the resolved source path
+- **AND** the provenance SHALL NOT include an npm package version or npm registry integrity
+
+### Requirement: Compatibility failures provide actionable diagnostics
+
+When an adapter cannot be selected, verified, or loaded because its API declaration is missing, malformed, unsupported, or inconsistent with package metadata, the system SHALL return structured failure data. User-facing diagnostics SHALL identify the affected adapter or package, the found declaration when one exists, the adapter APIs supported by the CLI, and an available compatible-install command. Compatibility failures SHALL NOT be reported as “no adapters installed” or as an unknown facet metadata schema.
+
+#### Scenario: Unsupported installed adapter reports recovery
+
+- **WHEN** an installed adapter declares an API not supported by the CLI
+- **THEN** the command SHALL fail with a diagnostic identifying the adapter and its declared API
+- **AND** the diagnostic SHALL list the APIs supported by the CLI
+- **AND** the diagnostic SHALL provide the best available compatible-install command
+
+#### Scenario: Multiple installed failures are reported together
+
+- **WHEN** more than one installed adapter is incompatible or broken
+- **THEN** loading SHALL fail with all collected adapter failures
+- **AND** each compatibility failure SHALL retain its own repair information
+
+## MODIFIED Requirements
+
+### Requirement: Adapter installation verifies the bundle before placement
+
+The system SHALL verify that a produced adapter bundle is valid and compatible before placing or activating it. Verification SHALL check that the bundle exports a valid adapter object with a present, well-formed runtime API declaration supported by the current CLI. For an npm candidate, verification SHALL also require the runtime declaration to equal the package declaration used for selection. A compatibility failure SHALL NOT trigger a source-rebundling fallback and SHALL NOT replace an existing adapter.
+
+#### Scenario: Valid bundle passes verification
+
+- **WHEN** the system bundles an adapter that correctly exports an adapter object with an API supported by the CLI
+- **THEN** verification SHALL succeed
+- **AND** the bundle SHALL be placed in the adapter directory
+
+#### Scenario: Invalid bundle fails verification
+
+- **WHEN** the system bundles an adapter that does not export a valid adapter object
+- **THEN** verification SHALL fail
+- **AND** the system SHALL report which validation checks failed
+- **AND** the bundle SHALL NOT be placed in the adapter directory
+
+#### Scenario: Runtime API declaration is missing or malformed
+
+- **WHEN** a candidate bundle has no runtime adapter API declaration or has a malformed declaration
+- **THEN** verification SHALL fail with the corresponding compatibility classification
+- **AND** the candidate SHALL NOT become active
+
+#### Scenario: Runtime API declaration is unsupported
+
+- **WHEN** a candidate bundle declares a well-formed adapter API that the CLI does not support
+- **THEN** verification SHALL fail before any adapter contract method is invoked
+- **AND** the candidate SHALL NOT become active
+
+#### Scenario: Git or local candidate is checked as supplied
+
+- **WHEN** a user installs an adapter from Git or a local path
+- **THEN** the produced runtime bundle MUST declare an adapter API supported by the CLI
+- **AND** an incompatible declaration SHALL fail rather than trigger package-version substitution
+
+### Requirement: Adapter identity is determined by the adapter itself
+
+The system SHALL determine an adapter's name from the adapter object's own name field after bundling and verification. This name SHALL be used as the directory name under the adapter installation directory. When that name matches an existing installation, the system SHALL replace the existing adapter only after the candidate has passed verification.
+
+#### Scenario: Adapter names itself
+
+- **WHEN** the system installs an adapter from any source
+- **AND** the adapter object declares its name
+- **THEN** the bundle SHALL be placed at the path corresponding to that adapter name
+
+#### Scenario: Adapter name conflict replaces atomically
+
+- **WHEN** the system installs a verified adapter whose name matches an already-installed adapter
+- **THEN** the system SHALL atomically activate the new adapter as the replacement
+- **AND** a failure before activation SHALL leave the existing adapter unchanged
+
+### Requirement: Users can list installed adapters
+
+The system SHALL provide a command to list all adapters currently installed in the adapter directory. The listing SHALL inspect every entry and display its declared adapter API as an exact identifier, `missing`, or `malformed`, together with a `supported`, `unsupported`, or `broken` compatibility status. An entry SHALL be classified as `broken` when its installation metadata is invalid, its bundle cannot be loaded, or its export is not a valid adapter object. A missing, malformed, or unsupported API declaration alone SHALL be classified as API incompatibility rather than `broken`. Listing SHALL remain available when one or more entries are incompatible or broken so the user can identify what needs repair.
+
+#### Scenario: List with compatible installed adapters
+
+- **WHEN** a user runs the list command
+- **AND** compatible adapters are installed
+- **THEN** the system SHALL display the name, declared API, and supported status of each adapter
+
+#### Scenario: List with incompatible or broken adapters
+
+- **WHEN** a user runs the list command
+- **AND** an installed entry has a missing, malformed, or unsupported API declaration, invalid installation metadata, an unloadable bundle, or an invalid export
+- **THEN** the system SHALL display that entry, its declared API when available, and its compatibility status
+- **AND** the command SHALL remain available for recovery
+
+#### Scenario: List with no installed adapters
+
+- **WHEN** a user runs the list command
+- **AND** no adapters are installed
+- **THEN** the system SHALL indicate that no adapters are installed
+
+### Requirement: The system loads installed adapter bundles at runtime
+
+The system SHALL inspect installed adapter bundles before returning them for use. A compatible installation SHALL provide a verified adapter whose runtime API is supported by the current CLI. If any installed entry is incompatible or broken, loading SHALL fail with all collected failures instead of silently skipping entries. No adapter contract method SHALL be invoked for an entry before its compatibility has been established.
+
+#### Scenario: Load compatible installed adapters for a build
+
+- **WHEN** the system runs a build command
+- **AND** every installed adapter is valid and declares a supported API
+- **THEN** the system SHALL load each verified adapter
+- **AND** pass the loaded adapter objects to the build pipeline
+
+#### Scenario: Incompatible installed adapter blocks a build
+
+- **WHEN** the system runs a build command
+- **AND** an installed adapter has a missing, malformed, or unsupported API declaration
+- **THEN** the build SHALL fail with an actionable adapter compatibility diagnostic
+- **AND** no adapter contract method SHALL be invoked
+
+#### Scenario: No adapters installed during build
+
+- **WHEN** the system runs a build command
+- **AND** no adapters are installed
+- **THEN** the build SHALL proceed
+- **AND** any adapter metadata in the manifest SHALL produce warnings for unknown adapters

--- a/openspec/changes/add-adapter-api-version-negotiation/specs/adapter__sdk/spec.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/specs/adapter__sdk/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Adapter authors can define an adapter using the SDK
+
+An adapter author SHALL be able to create an adapter by importing the SDK and calling a factory function with a definition object. The factory SHALL validate the definition shape and return an adapter object. The definition SHALL accept a name, a function to build per-asset adapter metadata (validating and enriching with defaults), and asset install/read/delete methods.
+
+The SDK SHALL expose `0.0` as the canonical adapter API identifier for the current positional method contract. Every adapter returned by the factory SHALL carry that identifier in a required, readonly `apiVersion` field. The factory definition SHALL NOT require or accept an author-supplied API identifier, so adapter authors cannot create a conflicting declaration and do not repeat the SDK-owned value.
+
+#### Scenario: Author creates a valid adapter
+
+- **WHEN** an author calls the factory function with a complete definition
+- **THEN** the factory SHALL return a valid adapter object with all provided properties and methods
+- **AND** the returned adapter SHALL declare the canonical adapter API `0.0`
+
+#### Scenario: Author provides an invalid definition
+
+- **WHEN** an author calls the factory function with a definition missing required fields
+- **THEN** the factory SHALL throw an error describing which fields are missing
+
+#### Scenario: Author does not declare the API version
+
+- **WHEN** an author creates an adapter with the SDK factory
+- **THEN** the definition SHALL NOT require the author to provide an API identifier
+- **AND** the returned adapter SHALL carry the SDK's canonical API identifier
+
+#### Scenario: Consumer reads the canonical API identifier
+
+- **WHEN** an adapter publisher or compatibility-aware consumer imports the SDK's canonical adapter API identifier
+- **THEN** the exported value SHALL be `0.0`
+
+## ADDED Requirements
+
+### Requirement: Adapter API compatibility uses exact contract identifiers
+
+An adapter API identifier SHALL use the canonical `MAJOR.MINOR` decimal form without signs, suffixes, build metadata, or leading zeroes other than zero itself. Compatibility-aware consumers SHALL distinguish missing, malformed, unsupported, and supported identifiers. They SHALL determine compatibility by exact identifier equality and SHALL NOT infer compatibility from CLI versions, SDK package versions, adapter package versions, or semantic-version ordering.
+
+#### Scenario: Exact supported identifier is compatible
+
+- **WHEN** an adapter declares API `0.0`
+- **AND** the consumer supports API `0.0`
+- **THEN** the adapter API SHALL be classified as supported
+
+#### Scenario: Different well-formed identifier is unsupported
+
+- **WHEN** an adapter declares a well-formed API identifier that is not in the consumer's support set
+- **THEN** the adapter API SHALL be classified as unsupported
+- **AND** numeric proximity to a supported identifier SHALL NOT make it compatible
+
+#### Scenario: Invalid identifier is malformed
+
+- **WHEN** an adapter declares an identifier with a patch component, suffix, build metadata, sign, or disallowed leading zero
+- **THEN** the adapter API SHALL be classified as malformed
+
+#### Scenario: API identifier is independent of package versions
+
+- **WHEN** the CLI, an adapter package, or the Adapter SDK package changes semantic version without changing the positional adapter call contract
+- **THEN** the adapter API identifier SHALL remain `0.0`
+- **AND** the package-version change SHALL NOT imply a different adapter API compatibility result

--- a/openspec/changes/add-adapter-api-version-negotiation/specs/installation/spec.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/specs/installation/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Facet operations require compatible selected adapters before mutation
+
+Before adding, removing, or installing facets, the system SHALL verify that every selected installed adapter declares an API supported by the current CLI. If a selected adapter is missing its declaration, has a malformed or unsupported declaration, conflicts with its recorded package declaration, or cannot be loaded as a valid adapter, the operation SHALL fail before invoking any adapter contract method or writing project or materialized state. The failure SHALL identify every incompatible selected adapter and provide the best available compatible-install command. The system SHALL NOT automatically upgrade or replace an incompatible adapter during a facet operation.
+
+Facet removal SHALL remain independent of cached facet content and network access, but it SHALL still require compatible selected adapters because deleting materialized assets invokes each selected adapter's contract.
+
+#### Scenario: Adding a facet with an incompatible selected adapter changes nothing
+
+- **WHEN** a user adds a facet
+- **AND** a selected installed adapter does not declare an API supported by the CLI
+- **THEN** the operation SHALL fail before any facet is materialized
+- **AND** no adapter contract method SHALL be invoked
+- **AND** the project manifest, lockfile, install receipt, and materialized assets SHALL remain unchanged
+- **AND** the error SHALL direct the user to install a compatible adapter
+
+#### Scenario: Installing with several incompatible adapters reports all of them
+
+- **WHEN** a user installs the project's declared facets
+- **AND** more than one selected installed adapter is incompatible or cannot be loaded as a valid adapter
+- **THEN** the operation SHALL fail before any materialization write
+- **AND** the failure SHALL identify every incompatible selected adapter and every selected adapter that cannot be loaded
+- **AND** each compatibility failure SHALL include its best available repair command
+
+#### Scenario: Removing a facet does not bypass adapter compatibility
+
+- **WHEN** a user removes a facet
+- **AND** a selected installed adapter is incompatible or cannot be loaded as a valid adapter
+- **THEN** the operation SHALL fail before deleting any materialized asset
+- **AND** the project manifest, lockfile, install receipt, and materialized assets SHALL remain unchanged
+
+#### Scenario: Compatible selected adapters allow facet operations to proceed
+
+- **WHEN** a user adds or installs a facet
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** the operation SHALL proceed through the applicable fetch, integrity verification, materialization, and project-state update requirements
+
+#### Scenario: Facet operation does not auto-upgrade an incompatible adapter
+
+- **WHEN** a facet operation detects an incompatible selected adapter
+- **THEN** the system SHALL NOT download or activate a replacement adapter automatically
+- **AND** the failure SHALL direct the user to an explicit adapter install command

--- a/openspec/changes/add-adapter-api-version-negotiation/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/tasks.md
@@ -1,0 +1,158 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. SDK Contract and Published Metadata — Research
+
+- [ ] 1.1 Explore: Inspect `packages/adapter/src/types.ts`, `packages/adapter/src/define-adapter.ts`, `packages/adapter/src/index.ts`, and `packages/adapter/src/__tests__/` to map the runtime adapter type, factory, public exports, and unit-test surfaces.
+- [ ] 1.2 Explore: Inspect `packages/adapters/{claude-code,codex,opencode}/` call sites, package builds, and tests to identify compile-time and packed-runtime coverage for the stamped API declaration.
+- [ ] 1.3 Explore: Inspect `scripts/prepack.ts`, `scripts/postpack.ts`, `scripts/lib/prepack.ts`, `scripts/lib/prepack.test.ts`, and `scripts/release/` to identify a literal-free metadata-injection seam and packed-manifest test strategy.
+- [ ] 1.4 Propose: Present the complete SDK and release-tooling approach, including the single source of truth for the API value and metadata field name.
+
+## 2. SDK Contract and Published Metadata — Implementation
+
+- [ ] 2.1 Implement: Add and export the canonical adapter API and package-metadata field-name constants from `@agent-facets/adapter`.
+- [ ] 2.2 Implement: Add the readonly runtime API field, define an author-input type that excludes it, and make the SDK factory stamp the canonical value without changing the positional method contract.
+- [ ] 2.3 Implement: Update SDK and first-party adapter tests to prove stamping, author-input exclusion, and unchanged first-party definitions.
+- [ ] 2.4 Implement: Extend prepack tooling to inject `facetAdapterApiVersion` into first-party adapter manifests from the SDK constants while leaving unrelated packages untouched and restoring source manifests after packing.
+- [ ] 2.5 Implement: Add pure prepack tests and packed-tarball coverage proving every first-party adapter publishes the canonical package field and runtime declaration.
+- [ ] 2.6 Verify: Run the Adapter SDK, first-party adapter, and prepack test suites and verify representative packed manifests.
+
+## 3. Compatibility Classification and Runtime Verification — Research
+
+- [ ] 3.1 Explore: Inspect `packages/engine/src/adapters/verify.ts`, `packages/engine/src/adapters/bundler.ts`, and `packages/engine/src/adapters/install-service.ts` to enumerate current verification, prebuilt-isolation, rebundling-fallback, and dynamic-import failure boundaries.
+- [ ] 3.2 Explore: Inspect result-union and rendering precedents in `packages/protocol/src/integrity/types.ts`, `packages/engine/src/install/lockfile-io.ts`, `packages/engine/src/install/types.ts`, and `packages/cli/src/util/adapter-install-errors.ts` for carrying compatibility failures without thrown expected errors.
+- [ ] 3.3 Propose: Present the shared compatibility classifier, support-set representation, verified-adapter type, and ordered `VerifyAdapterResult` contract used by all downstream consumers.
+
+## 4. Compatibility Classification and Runtime Verification — Implementation
+
+- [ ] 4.1 Implement: Add canonical adapter API syntax validation, the CLI support set derived from the SDK constant, and the shared pure compatibility failure union.
+- [ ] 4.2 Implement: Convert adapter verification to an ordered discriminated result covering import, default export, declaration syntax, support, expected-metadata equality, name, and API `0.0` method shape.
+- [ ] 4.3 Implement: Preserve prebuilt-to-source fallback only for eligible loadability or bundling failures and make compatibility contradictions terminal.
+- [ ] 4.4 Implement: Update engine exports and callers to consume verified adapters and exhaustively handle verification results.
+- [ ] 4.5 Implement: Add tests for every compatibility classification, metadata/runtime disagreement, method non-invocation, fallback eligibility, and supported success path.
+- [ ] 4.6 Verify: Run targeted verifier, bundler, and type-check suites.
+
+## 5. Adapter Specifiers and npm Compatible Resolution — Research
+
+- [ ] 5.1 Explore: Inspect `packages/engine/src/sources/adapter/specifier.ts`, `packages/engine/src/adapters/first-party.ts`, `packages/engine/src/sources/facet/parse-version.ts`, and `packages/protocol/src/sources/version-spec.ts` for scoped-name handling, alias duplication, selector parsing, and satisfaction rules.
+- [ ] 5.2 Explore: Inspect `packages/engine/src/sources/adapter/npm.ts` and its fake-registry and hardening tests to map full-packument metadata, integrity verification, extraction, and provenance flow.
+- [ ] 5.3 Propose: Present tagged source request/result types and structured parse, no-compatible-release, metadata, network, integrity, and extraction failures.
+
+## 6. Adapter Specifiers and npm Compatible Resolution — Implementation
+
+- [ ] 6.1 Implement: Make the first-party adapter catalog the single source of truth for both picker entries and alias-to-package resolution.
+- [ ] 6.2 Implement: Add tagged npm implicit, exact, wildcard/`latest`, Git, and local specifier variants with correct scoped-package splitting and reused Facet selector grammar.
+- [ ] 6.3 Implement: Return structured parse failures for unsupported npm selector forms while preserving existing Git and local source behavior.
+- [ ] 6.4 Implement: Replace npm `/latest` lookup with full-packument parsing that filters stable versions by selector and supported API, handles exact requests without substitution, and reports the newest considered incompatible release.
+- [ ] 6.5 Implement: Carry the selected package version, declared API, tarball URL, and exact SRI or shasum through download, integrity verification, extraction, and installation provenance.
+- [ ] 6.6 Implement: Add parser and fake-registry tests for scoped names, aliases, all supported selectors—including explicit `latest` selecting the highest compatible release independently of npm's `latest` dist-tag—rejected ranges, compatible selection, exact incompatibility, missing/malformed metadata, prerelease exclusion, and integrity failures; if exact-version metadata optimization is implemented, prove its validation and failure data match the full-packument path.
+- [ ] 6.7 Verify: Run targeted adapter-source and npm hardening suites.
+
+## 7. Managed Installation and Atomic Activation — Research
+
+- [ ] 7.1 Explore: Inspect `packages/engine/src/adapters/placement.ts`, `packages/engine/src/facet-dir.ts`, `packages/common/src/atomic-write.ts`, and `packages/engine/src/install/lockfile-guard.ts` for placement, directory derivation, atomic writes, advisory locking, and safe-path precedents.
+- [ ] 7.2 Explore: Inspect adapter placement tests and engine/CLI fixtures that fabricate flat installed bundles to define managed, unmanaged, staging, crash-leftover, failure-injection, and cleanup behavior.
+- [ ] 7.3 Propose: Present the versioned installation receipt schema, source-tagged provenance, generation naming and containment rules, per-adapter lock lifecycle, and atomic activation sequence.
+
+## 8. Managed Installation and Atomic Activation — Implementation
+
+- [ ] 8.1 Implement: Add validated installation receipt types and I/O for npm, Git, and local provenance without representable cross-source field combinations.
+- [ ] 8.2 Implement: Add safe unique generation paths, containment checks, and a per-adapter replacement lock with stale-owner handling.
+- [ ] 8.3 Implement: Replace direct bundle overwrite with stage, final-path verification, atomic receipt activation, and post-activation cleanup while preserving the prior installation on every pre-activation failure.
+- [ ] 8.4 Implement: Support unmanaged historical `<name>/adapter.js` entries and convert them to the managed layout only after a successful reinstall.
+- [ ] 8.5 Implement: Update adapter removal and directory enumeration to delete complete installations, ignore staging/crash leftovers, and never remove the generation named by the active receipt.
+- [ ] 8.6 Implement: Add tests for each provenance variant, invalid receipts and paths, atomic success, injected failures at every stage, cleanup warnings, stale leftovers, concurrent replacements, and legacy conversion.
+- [ ] 8.7 Verify: Run targeted placement, receipt, lock, and removal suites.
+
+## 9. Installed Inspection and Fail-Closed Loading — Research
+
+- [ ] 9.1 Explore: Inspect `packages/engine/src/adapters/loader.ts`, `packages/cli/src/commands/adapter/index.ts`, and tests that fabricate flat installed bundles to map warn-and-skip loading, list behavior, import caching, and fixture migration.
+- [ ] 9.2 Explore: Inspect `packages/engine/src/adapters/first-party.ts` and unmanaged-name consumers to define provenance-aware repair aliases without inventing unavailable source information.
+- [ ] 9.3 Propose: Present shared managed/unmanaged inspection outcomes, broken-installation failures, repair discriminators, aggregate load results, and fixture migration.
+
+## 10. Installed Inspection and Fail-Closed Loading — Implementation
+
+- [ ] 10.1 Implement: Add one installed-adapter inspector that validates managed receipts, rejects recorded unsupported APIs before import, verifies active runtime declarations, and verifies unmanaged bundles directly.
+- [ ] 10.2 Implement: Classify every directory as compatible, incompatible, or broken with structured failure and repair data, ignoring non-active generations and staging leftovers.
+- [ ] 10.3 Implement: Convert installed loading to a result that returns verified adapters only when every entry succeeds and otherwise aggregates all failures without warning-and-skip behavior.
+- [ ] 10.4 Implement: Expose inspection-backed list data containing adapter name, declared or missing/malformed API, supported/unsupported/broken status, and repair source.
+- [ ] 10.5 Implement: Migrate flat-bundle test fixtures where managed provenance is required while retaining explicit unmanaged compatibility tests.
+- [ ] 10.6 Implement: Add tests for managed and unmanaged success, missing/malformed/unsupported declarations, receipt/runtime mismatch, invalid receipt/import/export failures, aggregate failures, and unique-generation import freshness.
+- [ ] 10.7 Verify: Run targeted inspector, loader, listing-data, and integration suites.
+
+## 11. Adapter Install and Management Commands — Research
+
+- [ ] 11.1 Explore: Inspect `packages/engine/src/adapters/install-service.ts` for stage reporting, source cleanup, prebuilt fallback, and provenance flow.
+- [ ] 11.2 Explore: Inspect `packages/engine/src/adapters/bundler.ts` and its tests for thrown exception boundaries, temporary resources, and cleanup guarantees.
+- [ ] 11.3 Explore: Inspect `packages/cli/src/commands/adapter/`, `packages/cli/src/util/adapter-install-errors.ts`, and adapter command tests for install, picker, list, remove, and result-rendering behavior.
+- [ ] 11.4 Propose: Present the end-to-end install-service result flow and CLI presentation for parse, no-compatible-release, download, verification, activation, cleanup-warning, and recovery outcomes.
+
+## 12. Adapter Install and Management Commands — Implementation
+
+- [ ] 12.1 Implement: Rework the adapter install service to carry tagged source provenance through resolve, download/build, verification, lock acquisition, and atomic activation using structured results.
+- [ ] 12.2 Implement: Convert expected bundler, verification, placement, and cleanup boundaries into typed failures or warnings without losing temporary-resource cleanup.
+- [ ] 12.3 Implement: Render actionable compatibility and no-compatible-release diagnostics exclusively in the CLI, including found API, supported APIs, and the best available reinstall command.
+- [ ] 12.4 Implement: Update `facet adapter list` to render inspection-backed API and compatibility status while remaining usable for incompatible and broken entries.
+- [ ] 12.5 Implement: Preserve load-free whole-directory behavior for `facet adapter remove` and update picker/install behavior to consume the new list and load results.
+- [ ] 12.6 Implement: Update adapter command unit and end-to-end tests for selectors, managed install/list/remove, replacement preservation, migration, diagnostics, and cleanup warnings.
+- [ ] 12.7 Verify: Run targeted adapter command and CLI end-to-end suites.
+
+## 13. Build and Facet-Operation Compatibility Gates — Research
+
+- [ ] 13.1 Explore: Inspect `packages/cli/src/commands/build.ts`, `packages/cli/src/commands/publish/run-build-view.ts`, and `packages/engine/src/build/pipeline.ts` for build loading, failure rendering, and the first adapter method invocation.
+- [ ] 13.2 Explore: Inspect `packages/cli/src/commands/shared/ensure-adapters.ts` and the add, remove, and install command entry points for adapter discovery and zero-adapter-picker behavior.
+- [ ] 13.3 Explore: Inspect `packages/engine/src/install/run-install.ts` and Git/local facet resolvers for no-mutation exits, per-facet-loop ordering, and nested build invocations.
+- [ ] 13.4 Explore: Inspect drift removal, materialization, and CLI/TUI failure renderers for adapter method calls and exhaustive compatibility handling.
+- [ ] 13.5 Propose: Present command-level fail-closed inspection and defense-in-depth build/install preflights that share compatibility data and preserve exhaustive result handling.
+
+## 14. Build and Facet-Operation Compatibility Gates — Implementation
+
+- [ ] 14.1 Implement: Gate build and publish-build commands on installed inspection before starting the pipeline, and add a distinct build incompatibility failure before metadata validation.
+- [ ] 14.2 Implement: Add an `ADAPTER_INCOMPATIBLE` install failure variant and route defense-in-depth preflight failures through the no-mutation path before the per-facet loop and any Git/local facet build.
+- [ ] 14.3 Implement: Update add, remove, and install command discovery to report incompatible/broken entries without launching the zero-adapter picker or invoking adapter methods.
+- [ ] 14.4 Implement: Retain materialization compatibility checks only as invariant defense and preserve receipt-driven removal without cache or network access after the compatibility gate passes.
+- [ ] 14.5 Implement: Add exhaustive CLI/TUI rendering for build and install compatibility failures and all collected repair commands.
+- [ ] 14.6 Implement: Add tests proving incompatible adapters block build, publish-build, add, remove, and install before methods or writes; multiple failures aggregate; compatible adapters preserve the normal path; a build with no installed adapters proceeds with unknown-adapter warnings for manifest metadata; and `facet adapter remove` remains available.
+- [ ] 14.7 Verify: Run targeted build, publish, add, remove, install, TUI, and type-check suites.
+
+## 15. Documentation and Rollout — Research
+
+- [ ] 15.1 Explore: Audit `docs/cli/adapters/install.mdx`, `docs/cli/adapters/list.mdx`, `docs/guides/custom-adapters.mdx`, `docs/guides/troubleshooting.mdx`, `docs/specification/install.mdx`, `docs/specification/commit.mdx`, `docs/specification/build.mdx`, `docs/cli/env.mdx`, and `scripts/README.md` against the implemented behavior.
+- [ ] 15.2 Explore: Recheck the root `README.md`, `scripts/release/`, and affected package manifests for zero-adapter-picker accuracy and SDK → first-party adapters → CLI rollout constraints.
+- [ ] 15.3 Propose: Present the complete documentation update and SDK, first-party adapter, and compatibility-aware CLI rollout plan without manipulating npm dist-tags.
+
+## 16. Documentation and Rollout — Implementation
+
+- [ ] 16.1 Implement: Update adapter install/list documentation for selector syntax, highest-compatible resolution, incompatibility errors, atomic replacement, managed layout, and recovery.
+- [ ] 16.2 Implement: Update custom-adapter and troubleshooting guides for SDK stamping, `facetAdapterApiVersion`, publishing, rebuilding/reinstalling, and every compatibility classification.
+- [ ] 16.3 Implement: Update install, commit, and build specifications documentation for compatibility gates before adapter methods and materialization.
+- [ ] 16.4 Implement: Update environment and scripts documentation for the receipt/generation layout and first-party prepack metadata injection.
+- [ ] 16.5 Implement: Add the rollout checklist requiring the SDK and new `0.0` first-party adapter releases before the compatibility-aware CLI release while preserving normal npm `latest` advancement.
+- [ ] 16.6 Verify: Run documentation link/content checks and verify all command and layout examples against the implementation.
+
+## 17. Integrated Coverage Audit — Research
+
+- [ ] 17.1 Explore: Audit the completed implementation and tests against every reconciled SDK, adapter-management, and installation scenario and every design failure boundary.
+- [ ] 17.2 Explore: Inspect for duplicated API literals, metadata field names, alias maps, compatibility classifiers, or user-facing engine messages that violate the single-source-of-truth design.
+- [ ] 17.3 Propose: Present the final gap-closing changes and a verification matrix covering unit, integration, end-to-end, packed-artifact, documentation, and OpenSpec validation.
+
+## 18. Integrated Coverage Audit — Implementation
+
+- [ ] 18.1 Implement: Apply the approved gap-closing tests or corrections found by the coverage and duplication audit.
+- [ ] 18.2 Implement: Run `bun format` and apply any remaining non-formatting corrections required before final verification.
+- [ ] 18.3 Verify: Run the complete `bun check` pipeline and stop on any lint, type, unit, or end-to-end failure.
+- [ ] 18.4 Verify: Run strict OpenSpec validation and check the implementation and documentation against every reconciled requirement and migration constraint.
+- [ ] 18.5 Verify: Run automated representative npm, Git, local, managed, unmanaged, compatible, incompatible, replacement-failure, list, build, and facet-operation flows end to end.


### PR DESCRIPTION
### Why

Adapter bundles cross two durable boundaries — npm publication and `$FACET_DIR/adapters/` persistence — but neither carries a machine-readable adapter API identifier. The CLI resolves npm adapters by fetching `/latest` unconditionally and loads installed bundles without checking whether their runtime call contract matches what the CLI expects. A stale or future bundle can reach an adapter method before any mismatch is detected. With a breaking contract revision already staged, this boundary must become versioned before any incompatible release ships.

### Details

This change introduces the full specification, design, and implementation task plan for adapter API version negotiation. The current positional adapter method contract is designated adapter API `0.0`.

**SDK layer:** `@agent-facets/adapter` gains a canonical `ADAPTER_API_VERSION = "0.0"` constant and a metadata field-name constant. `defineAdapter()` stamps `apiVersion` onto every returned adapter; the factory input type excludes the field so authors cannot supply a conflicting value. First-party adapter manifests receive `facetAdapterApiVersion` during the existing prepack transformation, derived from the SDK constant, with packed-tarball tests proving both the npm field and the runtime declaration are present.

**Resolution:** npm adapter installs replace the `/latest` fetch with a full-packument lookup (the abbreviated packument strips custom per-version fields). The resolver filters stable releases by the user's selector and the CLI's supported API set, picks the highest compatible version, and fails with structured data when none qualifies. Exact version pins fail rather than substitute. The existing Facet `VersionSpec` grammar (exact, major/minor wildcard, `*`, `latest`) is reused; npm-style caret/tilde/comparator ranges return structured parse failures.

**Verification:** `verifyAdapter` is converted from throwing to a discriminated result. Checks run in order — import, default export, declaration syntax, support-set membership, metadata/runtime agreement, name and method shape — so a contract mismatch is classified before any adapter method is invoked. Compatibility failures never trigger the prebuilt-to-source rebundling fallback.

**Managed installation layout:** Adapters move from a direct `<name>/adapter.js` overwrite to a generation-based layout with an `installation.json` receipt pointer. Activation is a single atomic receipt rename, eliminating the crash window of a two-directory swap. The receipt carries tagged source provenance (npm: resolved package/version + registry SRI; Git: URL + ref; local: resolved path). Unique generation paths also prevent dynamic-import caching from returning a replaced bundle within the same process.

**Loading and gates:** `loadInstalledAdapters` becomes fail-closed: if any installed adapter is incompatible or broken, loading fails with all collected failures rather than warning and skipping. Build, publish-build, add, remove, and install commands gate on inspection before invoking any adapter method or writing project state. `runBuildPipeline` and `runInstall` retain defense-in-depth preflights. `facet adapter list` surfaces declared API (`0.0`, `missing`, or `malformed`) and compatibility status (`supported`, `unsupported`, `broken`) and remains available when entries are incompatible.

**Breaking behavior:** Every existing installed bundle and every already-published adapter release is undeclared and therefore incompatible with the new CLI. Diagnostics identify the adapter, its missing or declared API, the supported set, and the exact reinstall command. The migration order is: SDK release → first-party `0.0` adapter releases (method contract unchanged, so existing CLIs keep working) → compatibility-aware CLI release.

The adversarial artifacts in this PR represent a blind second-author pass over the same proposal, design, specs, and tasks, followed by structured comparison reviews. Reconciliation adopted: the full-packument rationale, exact-equality comparison semantics, no-compatible-release diagnostics, the `BREAKING` marker, adapter-list compatibility output, the package-version independence scenario, split atomic-replacement and provenance requirements, Git/local provenance scenarios, a definition of `broken` installations, and selective file-path grounding in task explores.

### Verification

CI covers type-checking, unit tests, and end-to-end flows. The task plan includes packed-tarball tests for first-party adapter manifests, fake-registry tests for every resolution scenario, injected-failure tests at every placement stage, and representative end-to-end flows across npm/Git/local × managed/unmanaged × compatible/incompatible paths. A final integrated coverage audit step checks the implementation against every reconciled spec scenario and scans for duplicated API literals or user-facing strings in engine code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and specification only—no production code paths change until the linked implementation tasks land. The planned breaking adapter reinstall and stricter install gates are high impact when implemented, not in this diff.
> 
> **Overview**
> This PR adds the **add-adapter-api-version-negotiation** OpenSpec change: proposal, design, capability specs, VIPER task plan, and an adversarial pass with comparison reviews—not runtime code yet.
> 
> **Contract:** The current positional adapter surface becomes **adapter API `0.0`**, compared by **exact string equality** (not semver ranges), independent of CLI/SDK/adapter package versions. **`defineAdapter()`** is specified to stamp **`apiVersion`** from a canonical SDK constant; authors must not supply it. npm packages must publish **`facetAdapterApiVersion`** for pre-download selection; the **runtime export stays authoritative**, and metadata/runtime mismatch fails verification.
> 
> **Install & resolve:** npm installs move off unconditional **`/latest`** to **full-packument**, **highest stable compatible** selection using the existing Facet selector grammar (exact/wildcard/`latest`; caret/tilde-style ranges rejected). **Exact pins fail** instead of substituting; **no compatible release** returns structured diagnostics. Git/local paths skip version selection but still pass the same runtime gate.
> 
> **On disk & safety:** Managed layout with **`installation.json`** + versioned **generations**, **atomic activation**, tagged provenance (npm registry integrity vs Git/local fields), **fail-closed** installed loading with aggregated errors, and command gates so **build/add/remove/install** stop before adapter methods or materialization writes. **`facet adapter list`** must show API and supported/unsupported/broken status.
> 
> **Breaking & rollout:** Undeclared existing bundles/releases are intentionally incompatible; migration order is SDK → first-party `0.0` adapter publishes → compatibility-aware CLI. Docs and an integrated audit task list are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3dd6161b0ab95c300e60cfe38db8fc68f150aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a versioned adapter API contract, initially set to `0.0`.
  * Added compatibility-aware adapter selection, verification, and installation.
  * Added compatibility status and diagnostics for installed adapters.
  * Added atomic adapter updates with provenance tracking.
  * Added pre-operation checks to prevent incompatible adapters from modifying project state.
* **Documentation**
  * Documented adapter API requirements, compatibility behavior, migration, and rollout guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->