### PR TITLE
Add adapter API version negotiation: SDK stamping, compatibility classification, and prepack injection

### DIFF
--- a/openspec/changes/add-adapter-api-version-negotiation/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/tasks.md
@@ -16,34 +16,34 @@
 
 ## 1. SDK Contract and Published Metadata — Research
 
-- [ ] 1.1 Explore: Inspect `packages/adapter/src/types.ts`, `packages/adapter/src/define-adapter.ts`, `packages/adapter/src/index.ts`, and `packages/adapter/src/__tests__/` to map the runtime adapter type, factory, public exports, and unit-test surfaces.
-- [ ] 1.2 Explore: Inspect `packages/adapters/{claude-code,codex,opencode}/` call sites, package builds, and tests to identify compile-time and packed-runtime coverage for the stamped API declaration.
-- [ ] 1.3 Explore: Inspect `scripts/prepack.ts`, `scripts/postpack.ts`, `scripts/lib/prepack.ts`, `scripts/lib/prepack.test.ts`, and `scripts/release/` to identify a literal-free metadata-injection seam and packed-manifest test strategy.
-- [ ] 1.4 Propose: Present the complete SDK and release-tooling approach, including the single source of truth for the API value and metadata field name.
+- [x] 1.1 Explore: Inspect `packages/adapter/src/types.ts`, `packages/adapter/src/define-adapter.ts`, `packages/adapter/src/index.ts`, and `packages/adapter/src/__tests__/` to map the runtime adapter type, factory, public exports, and unit-test surfaces.
+- [x] 1.2 Explore: Inspect `packages/adapters/{claude-code,codex,opencode}/` call sites, package builds, and tests to identify compile-time and packed-runtime coverage for the stamped API declaration.
+- [x] 1.3 Explore: Inspect `scripts/prepack.ts`, `scripts/postpack.ts`, `scripts/lib/prepack.ts`, `scripts/lib/prepack.test.ts`, and `scripts/release/` to identify a literal-free metadata-injection seam and packed-manifest test strategy.
+- [x] 1.4 Propose: Present the complete SDK and release-tooling approach, including the single source of truth for the API value and metadata field name.
 
 ## 2. SDK Contract and Published Metadata — Implementation
 
-- [ ] 2.1 Implement: Add and export the canonical adapter API and package-metadata field-name constants from `@agent-facets/adapter`.
-- [ ] 2.2 Implement: Add the readonly runtime API field, define an author-input type that excludes it, and make the SDK factory stamp the canonical value without changing the positional method contract.
-- [ ] 2.3 Implement: Update SDK and first-party adapter tests to prove stamping, author-input exclusion, and unchanged first-party definitions.
-- [ ] 2.4 Implement: Extend prepack tooling to inject `facetAdapterApiVersion` into first-party adapter manifests from the SDK constants while leaving unrelated packages untouched and restoring source manifests after packing.
-- [ ] 2.5 Implement: Add pure prepack tests and packed-tarball coverage proving every first-party adapter publishes the canonical package field and runtime declaration.
-- [ ] 2.6 Verify: Run the Adapter SDK, first-party adapter, and prepack test suites and verify representative packed manifests.
+- [x] 2.1 Implement: Add and export the canonical adapter API and package-metadata field-name constants from `@agent-facets/adapter`.
+- [x] 2.2 Implement: Add the readonly runtime API field, define an author-input type that excludes it, and make the SDK factory stamp the canonical value without changing the positional method contract.
+- [x] 2.3 Implement: Update SDK and first-party adapter tests to prove stamping, author-input exclusion, and unchanged first-party definitions.
+- [x] 2.4 Implement: Extend prepack tooling to inject `facetAdapterApiVersion` into first-party adapter manifests from the SDK constants while leaving unrelated packages untouched and restoring source manifests after packing.
+- [x] 2.5 Implement: Add pure prepack tests and packed-tarball coverage proving every first-party adapter publishes the canonical package field and runtime declaration.
+- [x] 2.6 Verify: Run the Adapter SDK, first-party adapter, and prepack test suites and verify representative packed manifests.
 
 ## 3. Compatibility Classification and Runtime Verification — Research
 
-- [ ] 3.1 Explore: Inspect `packages/engine/src/adapters/verify.ts`, `packages/engine/src/adapters/bundler.ts`, and `packages/engine/src/adapters/install-service.ts` to enumerate current verification, prebuilt-isolation, rebundling-fallback, and dynamic-import failure boundaries.
-- [ ] 3.2 Explore: Inspect result-union and rendering precedents in `packages/protocol/src/integrity/types.ts`, `packages/engine/src/install/lockfile-io.ts`, `packages/engine/src/install/types.ts`, and `packages/cli/src/util/adapter-install-errors.ts` for carrying compatibility failures without thrown expected errors.
-- [ ] 3.3 Propose: Present the shared compatibility classifier, support-set representation, verified-adapter type, and ordered `VerifyAdapterResult` contract used by all downstream consumers.
+- [x] 3.1 Explore: Inspect `packages/engine/src/adapters/verify.ts`, `packages/engine/src/adapters/bundler.ts`, and `packages/engine/src/adapters/install-service.ts` to enumerate current verification, prebuilt-isolation, rebundling-fallback, and dynamic-import failure boundaries.
+- [x] 3.2 Explore: Inspect result-union and rendering precedents in `packages/protocol/src/integrity/types.ts`, `packages/engine/src/install/lockfile-io.ts`, `packages/engine/src/install/types.ts`, and `packages/cli/src/util/adapter-install-errors.ts` for carrying compatibility failures without thrown expected errors.
+- [x] 3.3 Propose: Present the shared compatibility classifier, support-set representation, verified-adapter type, and ordered `VerifyAdapterResult` contract used by all downstream consumers.
 
 ## 4. Compatibility Classification and Runtime Verification — Implementation
 
-- [ ] 4.1 Implement: Add canonical adapter API syntax validation, the CLI support set derived from the SDK constant, and the shared pure compatibility failure union.
-- [ ] 4.2 Implement: Convert adapter verification to an ordered discriminated result covering import, default export, declaration syntax, support, expected-metadata equality, name, and API `0.0` method shape.
-- [ ] 4.3 Implement: Preserve prebuilt-to-source fallback only for eligible loadability or bundling failures and make compatibility contradictions terminal.
-- [ ] 4.4 Implement: Update engine exports and callers to consume verified adapters and exhaustively handle verification results.
-- [ ] 4.5 Implement: Add tests for every compatibility classification, metadata/runtime disagreement, method non-invocation, fallback eligibility, and supported success path.
-- [ ] 4.6 Verify: Run targeted verifier, bundler, and type-check suites.
+- [x] 4.1 Implement: Add canonical adapter API syntax validation, the CLI support set derived from the SDK constant, and the shared pure compatibility failure union.
+- [x] 4.2 Implement: Convert adapter verification to an ordered discriminated result covering import, default export, declaration syntax, support, expected-metadata equality, name, and API `0.0` method shape.
+- [x] 4.3 Implement: Preserve prebuilt-to-source fallback only for eligible loadability or bundling failures and make compatibility contradictions terminal.
+- [x] 4.4 Implement: Update engine exports and callers to consume verified adapters and exhaustively handle verification results.
+- [x] 4.5 Implement: Add tests for every compatibility classification, metadata/runtime disagreement, method non-invocation, fallback eligibility, and supported success path.
+- [x] 4.6 Verify: Run targeted verifier, bundler, and type-check suites.
 
 ## 5. Adapter Specifiers and npm Compatible Resolution — Research
 

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -11,7 +11,8 @@
     "dist"
   ],
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./api-version": "./src/api-version.ts"
   },
   "scripts": {
     "build": "tsdown",
@@ -35,6 +36,10 @@
       ".": {
         "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts"
+      },
+      "./api-version": {
+        "import": "./dist/api-version.mjs",
+        "types": "./dist/api-version.d.mts"
       }
     }
   }

--- a/packages/adapter/src/__tests__/index.test.ts
+++ b/packages/adapter/src/__tests__/index.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from 'bun:test'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from '../api-version.ts'
 import { defineAdapter } from '../define-adapter.ts'
-import type { Adapter } from '../types.ts'
+import type { AdapterDefinition } from '../types.ts'
 
 /**
  * A minimal valid adapter definition for tests that need a base object.
  * Overrides any individual field by spreading this then assigning.
  */
-function validDefinition(): Adapter {
+function validDefinition(): AdapterDefinition {
   return {
     name: 'test-adapter',
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
@@ -49,6 +50,39 @@ describe('defineAdapter — required field validation', () => {
     // biome-ignore lint/suspicious/noExplicitAny: intentional type hole for runtime validation test
     const def = { ...validDefinition(), buildAssetMetadata: 'not-a-function' as any }
     expect(() => defineAdapter(def)).toThrow(/"buildAssetMetadata" is required/)
+  })
+})
+
+describe('canonical adapter API constants', () => {
+  // The one place tests anchor the spec literals — everywhere else compares
+  // against the exported constants.
+  test('ADAPTER_API_VERSION is 0.0', () => {
+    expect(ADAPTER_API_VERSION).toBe('0.0')
+  })
+
+  test('ADAPTER_API_VERSION_PACKAGE_FIELD is facetAdapterApiVersion', () => {
+    expect(ADAPTER_API_VERSION_PACKAGE_FIELD).toBe('facetAdapterApiVersion')
+  })
+})
+
+describe('defineAdapter — API version stamping', () => {
+  test('stamps the canonical API version onto the returned adapter', () => {
+    const adapter = defineAdapter(validDefinition())
+    expect(adapter.apiVersion).toBe(ADAPTER_API_VERSION)
+  })
+
+  test('the definition type excludes apiVersion', () => {
+    // @ts-expect-error — apiVersion is SDK-owned; authors cannot supply it
+    const definition: Parameters<typeof defineAdapter>[0] = { ...validDefinition(), apiVersion: '9.9' }
+    // Runtime still stamps the canonical value even when the type is bypassed
+    expect(defineAdapter(definition).apiVersion).toBe(ADAPTER_API_VERSION)
+  })
+
+  test('a conflicting runtime apiVersion smuggled past the types is overwritten', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional type hole to prove the stamp wins at runtime
+    const definition = { ...validDefinition(), apiVersion: '1.0' } as any
+    const adapter = defineAdapter(definition)
+    expect(adapter.apiVersion).toBe(ADAPTER_API_VERSION)
   })
 })
 
@@ -107,13 +141,13 @@ describe('defineAdapter — returned adapter shape', () => {
 })
 
 describe('defineAdapter — stub fallbacks for missing asset methods', () => {
-  function buildMinimal(overrides: Partial<Adapter> = {}): Adapter {
+  function buildMinimal(overrides: Partial<AdapterDefinition> = {}): AdapterDefinition {
     const minimal = {
       name: 'stubbed-adapter',
       buildAssetMetadata: (data: unknown) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       ...overrides,
     }
-    // biome-ignore lint/suspicious/noExplicitAny: intentionally construct a partial Adapter to test stub fallbacks
+    // biome-ignore lint/suspicious/noExplicitAny: intentionally construct a partial definition to test stub fallbacks
     return minimal as any
   }
 

--- a/packages/adapter/src/api-version.ts
+++ b/packages/adapter/src/api-version.ts
@@ -1,0 +1,28 @@
+/**
+ * Canonical adapter API contract identifiers.
+ *
+ * The adapter API version is a discrete contract token compared for exact
+ * equality — it is NOT a semantic-version range and is independent of the
+ * CLI version, this SDK package's version, and adapter package versions.
+ *
+ * This module is the single source of truth for both the API value and the
+ * package-metadata field name. Engine compatibility checks and first-party
+ * release tooling import these constants instead of repeating the literals.
+ */
+
+/**
+ * The adapter API contract identifier this SDK stamps into every adapter
+ * returned by `defineAdapter()`. Identifies the current positional adapter
+ * method contract.
+ */
+export const ADAPTER_API_VERSION = '0.0' as const
+
+/**
+ * The top-level `package.json` field where a published npm adapter release
+ * declares its adapter API version, so compatibility can be determined
+ * before downloading the bundle.
+ */
+export const ADAPTER_API_VERSION_PACKAGE_FIELD = 'facetAdapterApiVersion' as const
+
+/** The adapter API identifier type produced by this SDK. */
+export type AdapterApiVersion = typeof ADAPTER_API_VERSION

--- a/packages/adapter/src/define-adapter.ts
+++ b/packages/adapter/src/define-adapter.ts
@@ -1,10 +1,12 @@
-import type { Adapter } from './types.ts'
+import { ADAPTER_API_VERSION } from './api-version.ts'
+import type { Adapter, AdapterDefinition } from './types.ts'
 
 /**
  * Create an adapter from a definition object.
  *
  * Validates the definition shape and provides stub defaults for optional
- * CRUD methods. Returns a frozen `Adapter` object.
+ * CRUD methods. Returns a frozen `Adapter` object stamped with the SDK's
+ * canonical adapter API version (`ADAPTER_API_VERSION`).
  *
  * @example
  * ```ts
@@ -18,7 +20,7 @@ import type { Adapter } from './types.ts'
  * })
  * ```
  */
-export function defineAdapter(definition: Adapter): Adapter {
+export function defineAdapter(definition: AdapterDefinition): Adapter {
   // Validate required fields
   if (!definition.name || typeof definition.name !== 'string') {
     throw new Error('defineAdapter: "name" is required and must be a non-empty string')
@@ -30,6 +32,10 @@ export function defineAdapter(definition: Adapter): Adapter {
 
   const adapter: Adapter = {
     name: definition.name,
+
+    // SDK-owned: always the canonical value, even if a non-TypeScript
+    // caller sneaks an `apiVersion` past the input type.
+    apiVersion: ADAPTER_API_VERSION,
 
     supportsInstall: definition.supportsInstall,
 

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,3 +1,5 @@
+export type { AdapterApiVersion } from './api-version.ts'
+export { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from './api-version.ts'
 export type { AssetPath } from './asset-fs.ts'
 export {
   assembleAssetContent,
@@ -10,6 +12,7 @@ export {
 export { defineAdapter } from './define-adapter.ts'
 export type {
   Adapter,
+  AdapterDefinition,
   AdapterMetadata,
   AssetType,
   Scope,

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -1,4 +1,5 @@
 import type { AssetType, Scope, Validated, ValidationError } from '@agent-facets/common'
+import type { AdapterApiVersion } from './api-version.ts'
 
 /**
  * Opaque record type for adapter-specific asset metadata.
@@ -16,6 +17,15 @@ export type AdapterMetadata = Record<string, unknown>
 export interface Adapter {
   /** Unique adapter name (e.g., "opencode", "claude-code", "codex") */
   readonly name: string
+
+  /**
+   * The adapter API contract identifier this adapter implements.
+   *
+   * Stamped by `defineAdapter()` from the SDK's canonical
+   * `ADAPTER_API_VERSION` — adapter authors do not (and cannot) supply
+   * it; the factory's input type (`AdapterDefinition`) excludes it.
+   */
+  readonly apiVersion: AdapterApiVersion
 
   /**
    * When true, this adapter exposes real filesystem I/O (installAsset,
@@ -57,6 +67,15 @@ export interface Adapter {
    */
   deleteAsset(scope: Scope, assetType: AssetType, name: string): Promise<string | undefined>
 }
+
+/**
+ * The author-facing definition accepted by `defineAdapter()`.
+ *
+ * Identical to `Adapter` except the SDK-owned `apiVersion` field is
+ * excluded — the factory stamps the canonical value, so an author cannot
+ * declare a conflicting API identifier.
+ */
+export type AdapterDefinition = Omit<Adapter, 'apiVersion'>
 
 // Re-export common types for convenience — SDK consumers don't need to install common
 export type { AssetType, Scope, Validated, ValidationError }

--- a/packages/adapter/tsdown.config.ts
+++ b/packages/adapter/tsdown.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // `api-version.ts` is a separate, dependency-free entry so compatibility-
+  // aware consumers can import the canonical constants without loading the
+  // full SDK module graph.
+  entry: ['src/index.ts', 'src/api-version.ts'],
   format: ['esm'],
   dts: {
     eager: true,

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -18,7 +18,8 @@
     "prepack": "bun ../../../scripts/prepack.ts",
     "postpack": "bun ../../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
+    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts"
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/adapters/claude-code/src/__tests__/adapter.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/adapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
 import adapter from '../index.ts'
 
 describe('claude-code adapter — identity', () => {
@@ -11,6 +12,10 @@ describe('claude-code adapter — identity', () => {
 
   test('declares install support', () => {
     expect(adapter.supportsInstall).toBe(true)
+  })
+
+  test('declares the canonical adapter API version', () => {
+    expect(adapter.apiVersion).toBe(ADAPTER_API_VERSION)
   })
 })
 

--- a/packages/adapters/claude-code/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/dist.e2e.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Packed-runtime coverage: the built `dist/index.mjs` (the exact artifact
+ * published to npm and loaded by the CLI at install time) must carry the
+ * SDK-stamped canonical adapter API version. Requires `bun run build`
+ * first — wired via the `test:e2e` script.
+ */
+import { expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import sourceAdapter from '../index.ts'
+
+test('built dist bundle declares the canonical adapter API version', async () => {
+  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
+    default?: { name?: string; apiVersion?: string }
+  }
+  expect(module.default?.name).toBe(sourceAdapter.name)
+  expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
+})

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -18,7 +18,8 @@
     "prepack": "bun ../../../scripts/prepack.ts",
     "postpack": "bun ../../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
+    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts"
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/adapters/codex/src/__tests__/adapter.test.ts
+++ b/packages/adapters/codex/src/__tests__/adapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
 import adapter from '../index.ts'
 
 // ---------------------------------------------------------------------------
@@ -15,6 +16,10 @@ describe('codex adapter — identity', () => {
 
   test('declares install support', () => {
     expect(adapter.supportsInstall).toBe(true)
+  })
+
+  test('declares the canonical adapter API version', () => {
+    expect(adapter.apiVersion).toBe(ADAPTER_API_VERSION)
   })
 })
 

--- a/packages/adapters/codex/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/codex/src/__tests__/dist.e2e.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Packed-runtime coverage: the built `dist/index.mjs` (the exact artifact
+ * published to npm and loaded by the CLI at install time) must carry the
+ * SDK-stamped canonical adapter API version. Requires `bun run build`
+ * first — wired via the `test:e2e` script.
+ */
+import { expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import sourceAdapter from '../index.ts'
+
+test('built dist bundle declares the canonical adapter API version', async () => {
+  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
+    default?: { name?: string; apiVersion?: string }
+  }
+  expect(module.default?.name).toBe(sourceAdapter.name)
+  expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
+})

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -18,7 +18,8 @@
     "prepack": "bun ../../../scripts/prepack.ts",
     "postpack": "bun ../../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
+    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts"
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/adapters/opencode/src/__tests__/adapter.test.ts
+++ b/packages/adapters/opencode/src/__tests__/adapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
 import adapter from '../index.ts'
 
 describe('opencode adapter — identity', () => {
@@ -11,6 +12,10 @@ describe('opencode adapter — identity', () => {
 
   test('declares install support', () => {
     expect(adapter.supportsInstall).toBe(true)
+  })
+
+  test('declares the canonical adapter API version', () => {
+    expect(adapter.apiVersion).toBe(ADAPTER_API_VERSION)
   })
 })
 

--- a/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Packed-runtime coverage: the built `dist/index.mjs` (the exact artifact
+ * published to npm and loaded by the CLI at install time) must carry the
+ * SDK-stamped canonical adapter API version. Requires `bun run build`
+ * first — wired via the `test:e2e` script.
+ */
+import { expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import sourceAdapter from '../index.ts'
+
+test('built dist bundle declares the canonical adapter API version', async () => {
+  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
+    default?: { name?: string; apiVersion?: string }
+  }
+  expect(module.default?.name).toBe(sourceAdapter.name)
+  expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
+})

--- a/packages/cli/src/__tests__/adapter-integration.test.ts
+++ b/packages/cli/src/__tests__/adapter-integration.test.ts
@@ -88,7 +88,9 @@ describe('adapter install-load-build integration', () => {
       const bundlePath = await buildTestAdapter(adapterSourceDir, 'integ-test-adapter')
 
       // Step 2: Verify the bundle exports a valid Adapter (exercises the verify module)
-      const verified = await verifyAdapter(bundlePath)
+      const verifyResult = await verifyAdapter(bundlePath)
+      if (!verifyResult.ok) expect.unreachable()
+      const verified = verifyResult.verified.adapter
       expect(verified.name).toBe('integ-test-adapter')
 
       // Step 3: Place the bundle into the temp base directory
@@ -142,8 +144,9 @@ describe('adapter install-load-build integration', () => {
 
     try {
       const bundlePath = await buildTestAdapter(adapterSourceDir, 'integ-test-adapter')
-      const verified = await verifyAdapter(bundlePath)
-      await placeAdapter(verified.name, bundlePath, adapterBaseDir)
+      const verifyResult = await verifyAdapter(bundlePath)
+      if (!verifyResult.ok) expect.unreachable()
+      await placeAdapter(verifyResult.verified.adapter.name, bundlePath, adapterBaseDir)
       const loaded = await loadInstalledAdapters(adapterBaseDir)
 
       // Manifest has invalid metadata for the adapter (custom must be a string, not a number)

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -1,4 +1,4 @@
-import type { AdapterInstallFailure } from '@agent-facets/engine'
+import type { AdapterCompatibilityFailure, AdapterInstallFailure, VerifyAdapterFailure } from '@agent-facets/engine'
 
 /**
  * Map an `AdapterInstallFailure` to the `{ what, detail, fix }` triple
@@ -27,16 +27,85 @@ export function describeAdapterInstallFailure(failure: AdapterInstallFailure): {
         fix: 'verify the adapter package builds with `bun build`; ensure all imports resolve',
       }
     case 'verify-failed':
-      return {
-        what: `failed to verify adapter "${failure.specifier}"`,
-        detail: failure.cause,
-        fix: 'the bundled adapter did not export a valid Adapter; check the SDK version',
-      }
+      return describeVerifyFailure(failure.specifier, failure.failure)
     case 'place-failed':
       return {
         what: `failed to place adapter "${failure.adapter}"`,
         detail: failure.cause,
         fix: 'check filesystem permissions on ~/.facet/adapters/',
+      }
+  }
+}
+
+function describeVerifyFailure(
+  specifier: string,
+  failure: VerifyAdapterFailure,
+): { what: string; detail: string; fix: string } {
+  switch (failure.kind) {
+    case 'import-failed':
+      return {
+        what: `failed to load adapter bundle for "${specifier}"`,
+        detail: failure.cause,
+        fix: 'verify the adapter package builds with `bun build`; ensure all imports resolve',
+      }
+    case 'no-default-export':
+      return {
+        what: `adapter "${specifier}" has no default export`,
+        detail: `the bundle at ${failure.bundlePath} must export default from defineAdapter()`,
+        fix: 'rebuild the adapter so its entry point default-exports the defineAdapter() result',
+      }
+    case 'incompatible':
+      return describeCompatibilityFailure(failure.failure)
+    case 'invalid-name':
+      return {
+        what: `adapter "${specifier}" has an invalid or missing name`,
+        detail: `the bundle at ${failure.bundlePath} must declare a non-empty string name`,
+        fix: 'set a non-empty "name" in the defineAdapter() definition and rebuild',
+      }
+    case 'invalid-shape':
+      return {
+        what: `adapter "${failure.adapter}" does not implement the adapter contract`,
+        detail: failure.detail,
+        fix: 'rebuild the adapter with the @agent-facets/adapter SDK factory (defineAdapter)',
+      }
+  }
+}
+
+/**
+ * Sole rendering point for the shared adapter-API compatibility failure
+ * union. Engine returns structured data; adding a variant forces this
+ * switch to update.
+ */
+export function describeCompatibilityFailure(failure: AdapterCompatibilityFailure): {
+  what: string
+  detail: string
+  fix: string
+} {
+  const supported = failure.supported.join(', ')
+  switch (failure.kind) {
+    case 'api-missing':
+      return {
+        what: `adapter "${failure.adapter}" does not declare an adapter API version`,
+        detail: `this CLI supports adapter API ${supported}; undeclared adapters are incompatible`,
+        fix: `install a release built with a current @agent-facets/adapter SDK: facet adapter install ${failure.adapter}`,
+      }
+    case 'api-malformed':
+      return {
+        what: `adapter "${failure.adapter}" declares a malformed adapter API version`,
+        detail: `found "${failure.found}"; this CLI supports adapter API ${supported}`,
+        fix: `install a release with a valid API declaration: facet adapter install ${failure.adapter}`,
+      }
+    case 'api-unsupported':
+      return {
+        what: `adapter "${failure.adapter}" declares unsupported adapter API ${failure.found}`,
+        detail: `this CLI supports adapter API ${supported}`,
+        fix: `install a compatible release: facet adapter install ${failure.adapter}`,
+      }
+    case 'api-metadata-mismatch':
+      return {
+        what: `adapter "${failure.adapter}" package metadata disagrees with its runtime API declaration`,
+        detail: `package declares ${failure.packageDeclared}, runtime declares ${failure.runtimeDeclared}; supported: ${supported}`,
+        fix: 'this release is inconsistently published; report it to the adapter author and install a different version',
       }
   }
 }

--- a/packages/engine/src/__tests__/materialize.test.ts
+++ b/packages/engine/src/__tests__/materialize.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
-import { deleteAssetFile, installAssetFile, readAssetFile } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION, deleteAssetFile, installAssetFile, readAssetFile } from '@agent-facets/adapter'
 import type { ResolvedFacetManifest } from '@agent-facets/protocol'
 import { InstallJournal } from '../install/journal.ts'
 import { computeAssetList, materialize } from '../install/materialize.ts'
@@ -29,6 +29,7 @@ function buildRecordingAdapter(name: string): {
   const calls: Array<{ name: string; metadata: unknown }> = []
   const adapter: Adapter = {
     name,
+    apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(_scope, type, n, content, metadata) {
@@ -85,6 +86,7 @@ function buildSdkAdapter(name: string): {
   })
   const adapter: Adapter = {
     name,
+    apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(_scope, type, n, content, metadata) {

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
-import { deleteAssetFile, installAssetFile, readAssetFile } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION, deleteAssetFile, installAssetFile, readAssetFile } from '@agent-facets/adapter'
 import type { BuildManifest, Lockfile } from '@agent-facets/protocol'
 import { computeContentHash } from '@agent-facets/protocol'
 import { type CacheIdentity, cachePath, cachePutVerified, computeDirIntegrity } from '../cache/index.ts'
@@ -37,6 +37,7 @@ function buildFakeAdapter(name: string): Adapter {
   const path = (type: string, n: string) => ({ file: join(baseDir, `${type}s`, `${n}.md`) })
   const adapter: Adapter = {
     name,
+    apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
     buildAssetMetadata: (data) => ({
       ok: true,
@@ -72,6 +73,7 @@ function buildNestedFakeAdapter(name: string): Adapter {
   })
   return {
     name,
+    apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(_scope, type, n, content, metadata) {
@@ -95,6 +97,7 @@ function buildBrokenAdapter(name: string, throwOnCall: number): Adapter {
   const baseDir = join(projectRoot, `.${name}`)
   return {
     name,
+    apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(_scope, type, n, content) {
@@ -128,6 +131,7 @@ function buildBrokenAdapter(name: string, throwOnCall: number): Adapter {
 function buildBadReadAdapter(name: string): Adapter {
   return {
     name,
+    apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset() {

--- a/packages/engine/src/adapters/__tests__/api-compatibility.test.ts
+++ b/packages/engine/src/adapters/__tests__/api-compatibility.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { classifyApiDeclaration, isWellFormedAdapterApi, SUPPORTED_ADAPTER_APIS } from '../api-compatibility.ts'
+
+describe('SUPPORTED_ADAPTER_APIS', () => {
+  test('is exactly the SDK canonical version', () => {
+    expect(SUPPORTED_ADAPTER_APIS).toEqual([ADAPTER_API_VERSION])
+  })
+})
+
+describe('isWellFormedAdapterApi', () => {
+  test.each(['0.0', '0.1', '1.0', '10.25', '999.999'])('accepts canonical MAJOR.MINOR %s', (value) => {
+    expect(isWellFormedAdapterApi(value)).toBe(true)
+  })
+
+  test.each([
+    '0.0.1', // patch component
+    '0', // no minor
+    '0.', // dangling separator
+    '.0', // missing major
+    '+0.0', // sign
+    '-0.0', // sign
+    '0.-1', // signed minor
+    '00.1', // leading zero
+    '0.00', // leading zero
+    '01.2', // leading zero
+    '0.0-beta', // suffix
+    '0.0+build', // build metadata
+    'v0.0', // prefix
+    ' 0.0', // whitespace
+    '0.0 ', // whitespace
+    '0 .0', // inner whitespace
+    '', // empty
+    'latest', // tag
+  ])('rejects malformed %j', (value) => {
+    expect(isWellFormedAdapterApi(value)).toBe(false)
+  })
+})
+
+describe('classifyApiDeclaration', () => {
+  test('classifies the supported canonical version as supported', () => {
+    expect(classifyApiDeclaration(ADAPTER_API_VERSION)).toEqual({ kind: 'supported', api: ADAPTER_API_VERSION })
+  })
+
+  test.each(['9.9', '1.0', '0.1'])('classifies well-formed but unknown %s as unsupported', (value) => {
+    expect(classifyApiDeclaration(value)).toEqual({ kind: 'unsupported', api: value })
+  })
+
+  test('numeric proximity to a supported identifier does not make it supported', () => {
+    // '0.1' is numerically adjacent to '0.0' but is a different contract.
+    const result = classifyApiDeclaration('0.1')
+    expect(result.kind).toBe('unsupported')
+  })
+
+  test.each(['0.0.1', '+0.0', '00.1', '0.0-beta', ''])('classifies invalid string %j as malformed', (value) => {
+    expect(classifyApiDeclaration(value)).toEqual({ kind: 'malformed', found: value })
+  })
+
+  // Each case wrapped in an argument list so array values aren't spread.
+  test.each([[42], [true], [{}], [[]]])('classifies non-string %j as malformed', (value) => {
+    const result = classifyApiDeclaration(value)
+    expect(result.kind).toBe('malformed')
+  })
+
+  test('classifies undefined as missing', () => {
+    expect(classifyApiDeclaration(undefined)).toEqual({ kind: 'missing' })
+  })
+
+  test('classifies null as missing', () => {
+    expect(classifyApiDeclaration(null)).toEqual({ kind: 'missing' })
+  })
+})

--- a/packages/engine/src/adapters/__tests__/bundler.test.ts
+++ b/packages/engine/src/adapters/__tests__/bundler.test.ts
@@ -200,6 +200,87 @@ describe('resolveEntryPoint', () => {
  * path: it must return a no-op cleanup that doesn't throw and doesn't
  * delete anything in the source tree.
  */
+/**
+ * Slow-path ordering: the build runs BEFORE any `bun install`. A source
+ * tree whose dependencies are already satisfied (an installed workspace,
+ * a zero-dep adapter) must bundle without spawning a package manager —
+ * an unconditional install would re-enter the enclosing workspace's
+ * lifecycle scripts (the repo's own postinstall → adapter install →
+ * bun install recursion). The fallback install must still fire for a
+ * standalone source dir with uninstalled dependencies.
+ *
+ * Both fixtures carry a root `postinstall` script that writes a marker
+ * file, so "did an install run?" is directly observable.
+ */
+describe('rebundleAdapter — build-first, install only on failure', () => {
+  test('source with satisfied deps bundles without running bun install', async () => {
+    const dir = await makeFixture(
+      {
+        name: 'no-install-needed',
+        exports: { '.': './src/index.ts' },
+        scripts: { postinstall: 'bun marker.ts' },
+      },
+      {
+        'src/index.ts': 'export default { name: "no-install-needed" }',
+        'marker.ts': `await Bun.write('install-ran.marker', '1')`,
+      },
+    )
+    try {
+      const result = await bundleAdapter(dir)
+      try {
+        const stats = await stat(result.bundlePath)
+        expect(stats.isFile()).toBe(true)
+        // No package manager ran: the fixture's postinstall never fired.
+        await expect(stat(join(dir, 'install-ran.marker'))).rejects.toThrow()
+      } finally {
+        await result.cleanup()
+      }
+    } finally {
+      await cleanup(dir)
+    }
+  })
+
+  test('source with missing deps installs them and succeeds on retry', async () => {
+    const dir = await makeFixture(
+      {
+        name: 'needs-install',
+        exports: { '.': './src/index.ts' },
+        scripts: { postinstall: 'bun marker.ts' },
+        // file: dependency — installable offline.
+        dependencies: { 'tiny-dep': 'file:./vendor/tiny-dep' },
+      },
+      {
+        'src/index.ts': `import { greeting } from 'tiny-dep'\nexport default { name: greeting }`,
+        'marker.ts': `await Bun.write('install-ran.marker', '1')`,
+        'vendor/tiny-dep/package.json': JSON.stringify({
+          name: 'tiny-dep',
+          version: '1.0.0',
+          main: 'index.js',
+        }),
+        'vendor/tiny-dep/index.js': 'export const greeting = "from-tiny-dep"',
+      },
+    )
+    try {
+      const result = await bundleAdapter(dir)
+      try {
+        const stats = await stat(result.bundlePath)
+        expect(stats.isFile()).toBe(true)
+        // The fallback install DID run (first build failed on the
+        // unresolved import, install linked the file: dep, retry passed).
+        const marker = await stat(join(dir, 'install-ran.marker'))
+        expect(marker.isFile()).toBe(true)
+        // The bundle is self-contained: the dep got inlined.
+        const bundled = await Bun.file(result.bundlePath).text()
+        expect(bundled).toContain('from-tiny-dep')
+      } finally {
+        await result.cleanup()
+      }
+    } finally {
+      await cleanup(dir)
+    }
+  })
+})
+
 describe('bundleAdapter — fast path returns a safe no-op cleanup', () => {
   test('cleanup is callable and resolves without throwing', async () => {
     const dir = await makeFixture(

--- a/packages/engine/src/adapters/__tests__/locate-and-verify.test.ts
+++ b/packages/engine/src/adapters/__tests__/locate-and-verify.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { locateAndVerifyAdapter } from '../install-service.ts'
+
+/**
+ * Fallback-eligibility tests for `locateAndVerifyAdapter`.
+ *
+ * Only an `import-failed` prebuilt bundle may fall back to
+ * rebundling-from-source. A compatibility contradiction in a prebuilt
+ * bundle is terminal — proven here by giving each fixture a source tree
+ * that WOULD produce a valid adapter if the fallback ran.
+ */
+
+/** A dependency-free adapter module source that verifies successfully. */
+function validAdapterModule(name: string): string {
+  return `export default {
+  name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
+  buildAssetMetadata: () => ({ ok: true, data: {} }),
+  installAsset: async () => undefined,
+  readAsset: async () => ({ content: '' }),
+  deleteAsset: async () => undefined,
+}
+`
+}
+
+async function makeFixture(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'facet-locate-verify-test-'))
+  for (const [relative, content] of Object.entries(files)) {
+    const absolute = join(dir, relative)
+    await mkdir(dirname(absolute), { recursive: true })
+    await Bun.write(absolute, content)
+  }
+  return dir
+}
+
+describe('locateAndVerifyAdapter — fallback eligibility', () => {
+  test('prebuilt bundle that fails to import falls back to rebundling from source', async () => {
+    const dir = await makeFixture({
+      'package.json': JSON.stringify({ name: 'fixture-adapter', exports: './dist/index.mjs' }),
+      // Unresolvable external import → dynamic import() throws → fallback eligible.
+      'dist/index.mjs': `import missing from 'this-package-does-not-exist-xyz'\nexport default missing`,
+      'src/index.ts': validAdapterModule('fallback-adapter'),
+    })
+    try {
+      const result = await locateAndVerifyAdapter(dir)
+      if (!result.ok) expect.unreachable()
+      expect(result.verified.adapter.name).toBe('fallback-adapter')
+      expect(result.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+      await result.cleanup()
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  }, 30000)
+
+  test('prebuilt bundle with an unsupported API is terminal — no rebundle', async () => {
+    const dir = await makeFixture({
+      'package.json': JSON.stringify({ name: 'fixture-adapter', exports: './dist/index.mjs' }),
+      'dist/index.mjs': `export default {
+  name: 'future-adapter',
+  apiVersion: '9.9',
+  buildAssetMetadata: () => ({ ok: true, data: {} }),
+  installAsset: async () => undefined,
+  readAsset: async () => ({ content: '' }),
+  deleteAsset: async () => undefined,
+}`,
+      // Would verify successfully if the (forbidden) fallback ran.
+      'src/index.ts': validAdapterModule('future-adapter'),
+    })
+    try {
+      const result = await locateAndVerifyAdapter(dir)
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure).toEqual({
+        kind: 'api-unsupported',
+        adapter: 'future-adapter',
+        found: '9.9',
+        supported: [ADAPTER_API_VERSION],
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('prebuilt bundle with a missing API declaration is terminal — no rebundle', async () => {
+    const dir = await makeFixture({
+      'package.json': JSON.stringify({ name: 'fixture-adapter', exports: './dist/index.mjs' }),
+      'dist/index.mjs': `export default {
+  name: 'legacy-adapter',
+  buildAssetMetadata: () => ({ ok: true, data: {} }),
+  installAsset: async () => undefined,
+  readAsset: async () => ({ content: '' }),
+  deleteAsset: async () => undefined,
+}`,
+      'src/index.ts': validAdapterModule('legacy-adapter'),
+    })
+    try {
+      const result = await locateAndVerifyAdapter(dir)
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure.kind).toBe('api-missing')
+      // The failure identifies the original prebuilt path, not a
+      // transient isolation copy.
+      if (result.failure.failure.kind !== 'api-missing') expect.unreachable()
+      expect(result.failure.bundlePath).toBe(join(dir, 'dist/index.mjs'))
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('valid prebuilt bundle verifies on the fast path', async () => {
+    const dir = await makeFixture({
+      'package.json': JSON.stringify({ name: 'fixture-adapter', exports: './dist/index.mjs' }),
+      'dist/index.mjs': validAdapterModule('prebuilt-adapter'),
+    })
+    try {
+      const result = await locateAndVerifyAdapter(dir)
+      if (!result.ok) expect.unreachable()
+      expect(result.verified.adapter.name).toBe('prebuilt-adapter')
+      // Fast path returns the in-tree bundle path with a no-op cleanup.
+      expect(result.bundlePath).toBe(join(dir, 'dist/index.mjs'))
+      await result.cleanup()
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+})

--- a/packages/engine/src/adapters/__tests__/verify.test.ts
+++ b/packages/engine/src/adapters/__tests__/verify.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { verifyAdapter } from '../verify.ts'
+
+/**
+ * Verifier tests operate on real bundle files: each fixture writes an
+ * `.mjs` module into a fresh temp dir and lets `verifyAdapter` import it.
+ * Every adapter fixture's contract methods THROW when invoked — proving
+ * that verification classifies bundles without ever calling an adapter
+ * contract method.
+ */
+
+const THROWING_METHODS = `
+  buildAssetMetadata() { throw new Error('contract method invoked during verification') },
+  async installAsset() { throw new Error('contract method invoked during verification') },
+  async readAsset() { throw new Error('contract method invoked during verification') },
+  async deleteAsset() { throw new Error('contract method invoked during verification') },
+`
+
+/** Write `source` as an .mjs bundle in a fresh temp dir; run `fn` on its path. */
+async function withBundle(source: string, fn: (bundlePath: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'facet-verify-test-'))
+  try {
+    const bundlePath = join(dir, 'adapter.mjs')
+    await Bun.write(bundlePath, source)
+    await fn(bundlePath)
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+function adapterSource(fields: string): string {
+  return `export default {\n${fields}\n${THROWING_METHODS}\n}`
+}
+
+describe('verifyAdapter — ordered checks', () => {
+  test('1: unimportable bundle fails with import-failed', async () => {
+    await withBundle(`import missing from 'this-package-does-not-exist-xyz'\nexport default missing`, async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      expect(result.failure.kind).toBe('import-failed')
+    })
+  })
+
+  test('2: module without a default export fails with no-default-export', async () => {
+    await withBundle(`export const notAnAdapter = 1`, async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      expect(result.failure.kind).toBe('no-default-export')
+    })
+  })
+
+  test('2: non-object default export fails with no-default-export', async () => {
+    await withBundle(`export default 42`, async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      expect(result.failure.kind).toBe('no-default-export')
+    })
+  })
+
+  test('3: missing runtime declaration fails as api-missing', async () => {
+    await withBundle(adapterSource(`  name: 'undeclared',`), async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure).toEqual({
+        kind: 'api-missing',
+        adapter: 'undeclared',
+        supported: [ADAPTER_API_VERSION],
+      })
+    })
+  })
+
+  test('3: malformed runtime declaration fails as api-malformed', async () => {
+    await withBundle(adapterSource(`  name: 'malformed', apiVersion: '0.0.1',`), async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure).toEqual({
+        kind: 'api-malformed',
+        adapter: 'malformed',
+        found: '0.0.1',
+        supported: [ADAPTER_API_VERSION],
+      })
+    })
+  })
+
+  test('4: well-formed unsupported declaration fails as api-unsupported', async () => {
+    await withBundle(adapterSource(`  name: 'future', apiVersion: '9.9',`), async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure).toEqual({
+        kind: 'api-unsupported',
+        adapter: 'future',
+        found: '9.9',
+        supported: [ADAPTER_API_VERSION],
+      })
+    })
+  })
+
+  test('4 precedes 5: unsupported runtime declaration wins over metadata equality', async () => {
+    // Even when npm metadata agrees with the runtime declaration, an
+    // unsupported API is classified as unsupported, not as a mismatch.
+    await withBundle(adapterSource(`  name: 'future', apiVersion: '9.9',`), async (path) => {
+      const result = await verifyAdapter(path, { expectedApiVersion: '9.9' })
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure.kind).toBe('api-unsupported')
+    })
+  })
+
+  test('5: package/runtime disagreement fails as api-metadata-mismatch', async () => {
+    await withBundle(adapterSource(`  name: 'split-brain', apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
+      const result = await verifyAdapter(path, { expectedApiVersion: '0.1' })
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure).toEqual({
+        kind: 'api-metadata-mismatch',
+        adapter: 'split-brain',
+        packageDeclared: '0.1',
+        runtimeDeclared: ADAPTER_API_VERSION,
+        supported: [ADAPTER_API_VERSION],
+      })
+    })
+  })
+
+  test('6: missing name fails with invalid-name', async () => {
+    await withBundle(adapterSource(`  apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      expect(result.failure.kind).toBe('invalid-name')
+    })
+  })
+
+  test('6: missing contract method fails with invalid-shape', async () => {
+    await withBundle(
+      `export default { name: 'incomplete', apiVersion: '${ADAPTER_API_VERSION}', buildAssetMetadata() {}, async installAsset() {}, async readAsset() {} }`,
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (result.ok) expect.unreachable()
+        if (result.failure.kind !== 'invalid-shape') expect.unreachable()
+        expect(result.failure.adapter).toBe('incomplete')
+        expect(result.failure.detail).toContain('deleteAsset')
+      },
+    )
+  })
+
+  test('supported bundle verifies without invoking any contract method', async () => {
+    await withBundle(adapterSource(`  name: 'good', apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
+      const result = await verifyAdapter(path)
+      // Every contract method in the fixture throws on invocation, so a
+      // success result proves none were called.
+      if (!result.ok) expect.unreachable()
+      expect(result.verified.adapter.name).toBe('good')
+      expect(result.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+    })
+  })
+
+  test('supported bundle with matching npm metadata verifies', async () => {
+    await withBundle(adapterSource(`  name: 'good', apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
+      const result = await verifyAdapter(path, { expectedApiVersion: ADAPTER_API_VERSION })
+      if (!result.ok) expect.unreachable()
+      expect(result.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+    })
+  })
+
+  test('incompatible bundle with throwing methods never invokes them', async () => {
+    // The fixture's methods throw; classification must happen before any
+    // method access could matter. Reaching a structured failure (rather
+    // than an escaped throw) proves non-invocation on the failure path.
+    await withBundle(adapterSource(`  name: 'future', apiVersion: '9.9',`), async (path) => {
+      const result = await verifyAdapter(path)
+      if (result.ok) expect.unreachable()
+      expect(result.failure.kind).toBe('incompatible')
+    })
+  })
+})

--- a/packages/engine/src/adapters/api-compatibility.ts
+++ b/packages/engine/src/adapters/api-compatibility.ts
@@ -1,0 +1,86 @@
+// Subpath import: `api-version` is a dependency-free module, so engine's
+// runtime graph stays free of the full SDK (yaml, asset-fs, common). This
+// also avoids a bun:test-runner cache collision between runtime-loaded SDK
+// sources and in-process `Bun.build` runs over the same files.
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+
+/**
+ * Pure adapter-API compatibility primitives.
+ *
+ * Adapter API versions are discrete contract identifiers compared for
+ * exact equality — never semantic-version ranges. This module owns the
+ * CLI's support set, the canonical syntax rule, and the shared failure
+ * union consumed by npm selection, candidate verification, installed
+ * loading, and build/install preflights. No I/O, no user-facing prose —
+ * CLI renderers map these values to messages.
+ */
+
+/**
+ * The exact adapter APIs this CLI supports. Derived from the SDK's
+ * canonical constant — the `0.0` literal lives only in the SDK. A later
+ * change MAY add further exact identifiers without changing how the SDK
+ * stamps newly built adapters.
+ */
+export const SUPPORTED_ADAPTER_APIS: readonly string[] = [ADAPTER_API_VERSION]
+
+/**
+ * Canonical adapter API syntax: `MAJOR.MINOR` in decimal with no sign,
+ * suffix, build metadata, patch component, or leading zeroes other than
+ * the number zero itself.
+ */
+const ADAPTER_API_SYNTAX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+/** True iff `value` is a syntactically valid adapter API identifier. */
+export function isWellFormedAdapterApi(value: string): boolean {
+  return ADAPTER_API_SYNTAX.test(value)
+}
+
+/**
+ * Classification of a declared adapter API value — from a runtime
+ * `apiVersion` export or a package-metadata field. `undefined` and
+ * `null` classify as missing; any non-string or syntactically invalid
+ * string classifies as malformed.
+ */
+export type ApiDeclarationClassification =
+  | { kind: 'supported'; api: string }
+  | { kind: 'unsupported'; api: string }
+  | { kind: 'malformed'; found: string }
+  | { kind: 'missing' }
+
+/**
+ * Classify a declared adapter API value against the CLI support set.
+ * Pure; shared by npm release filtering and runtime verification so both
+ * sides apply identical rules.
+ */
+export function classifyApiDeclaration(declared: unknown): ApiDeclarationClassification {
+  if (declared === undefined || declared === null) {
+    return { kind: 'missing' }
+  }
+  if (typeof declared !== 'string' || !isWellFormedAdapterApi(declared)) {
+    return { kind: 'malformed', found: typeof declared === 'string' ? declared : String(declared) }
+  }
+  if (!SUPPORTED_ADAPTER_APIS.includes(declared)) {
+    return { kind: 'unsupported', api: declared }
+  }
+  return { kind: 'supported', api: declared }
+}
+
+/**
+ * The shared compatibility failure union.
+ *
+ * `adapter` is the best-known identity at the failure site: the runtime
+ * adapter name when the bundle exposes one, otherwise the npm package
+ * name or bundle path. Every variant carries the CLI support set so
+ * renderers never reach back into this module for it.
+ */
+export type AdapterCompatibilityFailure =
+  | { kind: 'api-missing'; adapter: string; supported: readonly string[] }
+  | { kind: 'api-malformed'; adapter: string; found: string; supported: readonly string[] }
+  | { kind: 'api-unsupported'; adapter: string; found: string; supported: readonly string[] }
+  | {
+      kind: 'api-metadata-mismatch'
+      adapter: string
+      packageDeclared: string
+      runtimeDeclared: string
+      supported: readonly string[]
+    }

--- a/packages/engine/src/adapters/bundler.ts
+++ b/packages/engine/src/adapters/bundler.ts
@@ -30,9 +30,9 @@ const noopCleanup = async (): Promise<void> => {}
  *
  * When the fast path is not available (e.g. a third-party adapter with no
  * prebuilt dist, a local source tree during development, a git install
- * without committed build output), the slow path kicks in: run `bun install`
- * in the source directory and re-bundle the resolved entry point with
- * `Bun.build()`.
+ * without committed build output), the slow path kicks in: bundle the
+ * resolved entry point with `Bun.build()`, installing dependencies first
+ * only if the optimistic build fails (see `rebundleAdapter`).
  *
  * @param sourceDir - Path to the adapter source (must contain package.json)
  * @returns A `BundleResult` with the bundle path and a cleanup function.
@@ -48,14 +48,30 @@ export async function bundleAdapter(sourceDir: string): Promise<BundleResult> {
     return { bundlePath: resolved.path, cleanup: noopCleanup }
   }
 
-  // Slow path: source tree (e.g. unbuilt local adapter). Run `bun install`
-  // and re-bundle with Bun.build().
+  // Slow path: source tree (e.g. unbuilt local adapter). Bundle with
+  // Bun.build(), installing dependencies only if needed.
   return rebundleAdapter(sourceDir, resolved.path)
 }
 
 /**
- * Slow path: install dependencies in `sourceDir` and bundle `entryPoint`
- * into a self-contained .js file.
+ * Slow path: bundle `entryPoint` into a self-contained .js file,
+ * installing dependencies in `sourceDir` only when the optimistic
+ * build fails.
+ *
+ * The build runs FIRST, against whatever dependencies are already on
+ * disk. When the source sits inside an installed workspace — the
+ * monorepo's own adapters during the root postinstall, or any dev
+ * checkout — its dependencies are already present, and the build
+ * succeeds without spawning a package manager. This ordering is
+ * load-bearing: an unconditional `bun install` here resolves the
+ * enclosing workspace root and re-runs its lifecycle scripts, so the
+ * repo's own `postinstall → facet adapter install ./packages/adapters/…
+ * → bun install → postinstall` chain would recurse indefinitely.
+ *
+ * Only when that first build fails (typically a standalone source dir
+ * whose dependencies were never installed — a git clone, an extracted
+ * tarball) does the fallback run `bun install` (frozen first, then
+ * plain) and retry the build exactly once.
  *
  * The bundle output is written to a fresh `mkdtemp` directory (NOT inside
  * `sourceDir`), so local installs from a user's source tree don't leave
@@ -69,61 +85,88 @@ export async function bundleAdapter(sourceDir: string): Promise<BundleResult> {
  * externals, truncated file).
  */
 export async function rebundleAdapter(sourceDir: string, entryPoint: string): Promise<BundleResult> {
-  // Step 1: Install dependencies
+  // Optimistic pass: dependencies may already be on disk.
+  const first = await tryBuild(sourceDir, entryPoint)
+  if (first.ok) {
+    return { bundlePath: first.bundlePath, cleanup: first.cleanup }
+  }
+
+  // Fallback: install dependencies, then retry the build exactly once.
+  installDependencies(sourceDir)
+  const second = await tryBuild(sourceDir, entryPoint)
+  if (second.ok) {
+    return { bundlePath: second.bundlePath, cleanup: second.cleanup }
+  }
+  throw new Error(`Failed to bundle adapter from "${sourceDir}":\n${second.errors}`)
+}
+
+/**
+ * Install dependencies in `sourceDir` with `bun install` — frozen
+ * lockfile first, then a plain retry (covers sources shipped without a
+ * lockfile). Throws when both attempts fail.
+ */
+function installDependencies(sourceDir: string): void {
   const installResult = Bun.spawnSync(['bun', 'install', '--frozen-lockfile'], {
     cwd: sourceDir,
     stdout: 'pipe',
     stderr: 'pipe',
   })
+  if (installResult.exitCode === 0) return
 
-  // If frozen-lockfile fails (no lockfile), try without it
-  if (installResult.exitCode !== 0) {
-    const retryResult = Bun.spawnSync(['bun', 'install'], {
-      cwd: sourceDir,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
-    if (retryResult.exitCode !== 0) {
-      throw new Error(`Failed to install dependencies in "${sourceDir}": ${retryResult.stderr.toString().trim()}`)
-    }
+  const retryResult = Bun.spawnSync(['bun', 'install'], {
+    cwd: sourceDir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (retryResult.exitCode !== 0) {
+    throw new Error(`Failed to install dependencies in "${sourceDir}": ${retryResult.stderr.toString().trim()}`)
   }
+}
 
-  // Step 2: Bundle with Bun.build() into a fresh temp directory. Writing
-  // outside of `sourceDir` keeps local installs from polluting the user's
-  // source tree.
+/**
+ * One build attempt into a fresh temp outdir. Failure arms remove their
+ * own outdir.
+ *
+ * The build runs as a `bun build` SUBPROCESS rather than an in-process
+ * `Bun.build()` call: Bun caches failed module resolution per process,
+ * so an optimistic in-process attempt that failed before `bun install`
+ * would keep failing after it even though node_modules now exists. A
+ * subprocess starts with a cold resolver, making the attempt-install-
+ * retry sequence actually observable. (`bun` on PATH is already a slow-
+ * path requirement — the dependency install spawns it too.)
+ */
+async function tryBuild(
+  sourceDir: string,
+  entryPoint: string,
+): Promise<{ ok: true; bundlePath: string; cleanup: () => Promise<void> } | { ok: false; errors: string }> {
+  // Write outside of `sourceDir` so local installs from a user's source
+  // tree don't leave build artifacts behind.
   const outdir = await mkdtemp(join(tmpdir(), 'facet-adapter-build-'))
   const cleanup = async (): Promise<void> => {
     await rm(outdir, { recursive: true, force: true }).catch(() => {})
   }
+  const bundlePath = join(outdir, 'bundle.js')
 
-  let buildResult: Awaited<ReturnType<typeof Bun.build>>
-  try {
-    buildResult = await Bun.build({
-      entrypoints: [entryPoint],
-      outdir,
-      target: 'bun',
-      format: 'esm',
-    })
-  } catch (err) {
-    // If Bun.build itself throws (rare — usually it returns a result with
-    // success: false), make sure we don't leak the outdir.
+  const result = Bun.spawnSync(
+    ['bun', 'build', entryPoint, '--outfile', bundlePath, '--target', 'bun', '--format', 'esm'],
+    {
+      cwd: sourceDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  if (result.exitCode !== 0) {
     await cleanup()
-    throw err
+    return { ok: false, errors: result.stderr.toString().trim() }
   }
 
-  if (!buildResult.success) {
+  if (!(await Bun.file(bundlePath).exists())) {
     await cleanup()
-    const errors = buildResult.logs.map((l) => l.message).join('\n')
-    throw new Error(`Failed to bundle adapter from "${sourceDir}":\n${errors}`)
+    return { ok: false, errors: `bun build produced no output for "${sourceDir}"` }
   }
 
-  const outputFile = buildResult.outputs[0]
-  if (!outputFile) {
-    await cleanup()
-    throw new Error(`Bun.build() produced no output for "${sourceDir}"`)
-  }
-
-  return { bundlePath: outputFile.path, cleanup }
+  return { ok: true, bundlePath, cleanup }
 }
 
 /**

--- a/packages/engine/src/adapters/install-service.ts
+++ b/packages/engine/src/adapters/install-service.ts
@@ -9,7 +9,7 @@ import { type DownloadNpmResult, downloadNpmPackage } from '../sources/adapter/n
 import { type ParseAdapterSpecifierResult, parseAdapterSpecifier } from '../sources/adapter/specifier.ts'
 import { rebundleAdapter, resolveEntryPoint } from './bundler.ts'
 import { placeAdapter } from './placement.ts'
-import { verifyAdapter } from './verify.ts'
+import { type VerifiedAdapter, type VerifyAdapterFailure, verifyAdapter } from './verify.ts'
 
 /**
  * Picker-safe adapter install pipeline (Adjustment Q).
@@ -44,11 +44,13 @@ export interface AdapterInstallOptions {
  *   - `download-failed` — npm registry / git clone / local-path
  *     resolution failed. The `source` discriminator carries the
  *     resolver-specific reason.
- *   - `bundle-failed` / `verify-failed` / `place-failed` — bundler
- *     load, verification, or placement threw. These three still wrap
- *     thrown errors today (their internals weren't part of the #3
- *     scope); the fix here is to surface them as structured failures
- *     to the caller instead of letting them escape the boundary.
+ *   - `bundle-failed` / `place-failed` — bundler load or placement
+ *     threw. These two still wrap thrown errors today; the fix here is
+ *     to surface them as structured failures to the caller instead of
+ *     letting them escape the boundary.
+ *   - `verify-failed` — the produced bundle failed verification. Carries
+ *     the full structured `VerifyAdapterFailure` (including adapter API
+ *     compatibility classifications) for the CLI to render.
  */
 export type AdapterInstallFailure =
   | { kind: 'specifier-invalid'; specifier: string; failure: Extract<ParseAdapterSpecifierResult, { ok: false }> }
@@ -61,7 +63,7 @@ export type AdapterInstallFailure =
         | { kind: 'local'; failure: Extract<ResolveLocalAdapterResult, { ok: false }> }
     }
   | { kind: 'bundle-failed'; specifier: string; cause: string }
-  | { kind: 'verify-failed'; specifier: string; cause: string }
+  | { kind: 'verify-failed'; specifier: string; failure: VerifyAdapterFailure }
   | { kind: 'place-failed'; specifier: string; adapter: string; cause: string }
 
 /**
@@ -128,36 +130,39 @@ export async function installAdapter(
     }
 
     opts.onProgress?.('bundling')
-    let located: { bundlePath: string; adapter: Adapter; cleanup: () => Promise<void> }
+    let located: LocateAndVerifyResult
     try {
       located = await locateAndVerifyAdapter(sourceDir, { onLog: opts.onLog })
     } catch (err) {
-      // bundler internals (`rebundleAdapter`, `verifyAdapter`,
-      // `resolveEntryPoint`) still throw today — converting them is
-      // out of scope for #3. Catch at this boundary so the
-      // `installAdapter` contract stays result-typed even though its
-      // dependencies haven't been converted yet.
+      // bundler internals (`rebundleAdapter`, `resolveEntryPoint`) still
+      // throw today — converting them is a later step. Catch at this
+      // boundary so the `installAdapter` contract stays result-typed
+      // even though its dependencies haven't been converted yet.
       const cause = err instanceof Error ? err.message : String(err)
       return { ok: false, failure: { kind: 'bundle-failed', specifier, cause } }
     }
+    if (!located.ok) {
+      return { ok: false, failure: { kind: 'verify-failed', specifier, failure: located.failure } }
+    }
     bundleCleanup = located.cleanup
+    const adapter = located.verified.adapter
 
-    opts.onProgress?.('verifying', located.adapter.name)
+    opts.onProgress?.('verifying', adapter.name)
     // verification already happened inside locateAndVerifyAdapter; this
     // stage tick just exists for progress symmetry on the picker.
 
-    opts.onProgress?.('placing', located.adapter.name)
+    opts.onProgress?.('placing', adapter.name)
     try {
-      await placeAdapter(located.adapter.name, located.bundlePath)
+      await placeAdapter(adapter.name, located.bundlePath)
     } catch (err) {
       const cause = err instanceof Error ? err.message : String(err)
       return {
         ok: false,
-        failure: { kind: 'place-failed', specifier, adapter: located.adapter.name, cause },
+        failure: { kind: 'place-failed', specifier, adapter: adapter.name, cause },
       }
     }
 
-    return { ok: true, adapter: located.adapter }
+    return { ok: true, adapter }
   } finally {
     if (bundleCleanup) await bundleCleanup()
     if (needsCleanup && sourceDir) {
@@ -169,13 +174,28 @@ export async function installAdapter(
 const noopCleanup = async (): Promise<void> => {}
 
 /**
- * Locates a usable adapter bundle from `sourceDir` and verifies it loads.
+ * Result of `locateAndVerifyAdapter`. On success, `bundlePath` is the
+ * verified bundle ready for placement and `cleanup` removes any build
+ * temp directory (callers MUST invoke it). On failure the function has
+ * already cleaned up its own temp resources.
+ */
+export type LocateAndVerifyResult =
+  | { ok: true; bundlePath: string; verified: VerifiedAdapter; cleanup: () => Promise<void> }
+  | { ok: false; failure: VerifyAdapterFailure }
+
+/**
+ * Locates a usable adapter bundle from `sourceDir` and verifies it loads
+ * and is API-compatible.
  *
  * Tries the fast path first (prebuilt `dist/index.mjs` or whatever the
  * package's `exports`/`main` points at). If the fast-path bundle fails to
- * load — typically because it still has unresolved external imports — falls
- * back to the slow path: `bun install` + `Bun.build()` on the resolved
- * entry point.
+ * *import* — typically because it still has unresolved external imports —
+ * falls back to the slow path: `bun install` + `Bun.build()` on the
+ * resolved entry point. Only `import-failed` is fallback-eligible: a
+ * compatibility contradiction (missing/malformed/unsupported API,
+ * metadata mismatch) or an invalid adapter shape is terminal, because
+ * rebundling the same source cannot fix a declared contract and must
+ * never silently select a different call shape.
  *
  * Fast-path verification is performed by copying the candidate bundle into
  * a freshly-created temp directory and importing it from there. This is
@@ -187,42 +207,61 @@ const noopCleanup = async (): Promise<void> => {}
  */
 export async function locateAndVerifyAdapter(
   sourceDir: string,
-  opts: { onLog?: OnLog } = {},
-): Promise<{ bundlePath: string; adapter: Adapter; cleanup: () => Promise<void> }> {
+  opts: { onLog?: OnLog; expectedApiVersion?: string } = {},
+): Promise<LocateAndVerifyResult> {
   const resolved = await resolveEntryPoint(sourceDir)
+  const verifyOpts = { expectedApiVersion: opts.expectedApiVersion }
 
   if (resolved.kind === 'prebuilt') {
     opts.onLog?.(() => `[verbose]   using prebuilt bundle for ${basename(sourceDir)}`)
-    const verifyResult = await verifyPrebuiltInIsolation(resolved.path)
+    const verifyResult = await verifyPrebuiltInIsolation(resolved.path, verifyOpts)
     if (verifyResult.ok) {
-      return { bundlePath: resolved.path, adapter: verifyResult.adapter, cleanup: noopCleanup }
+      return { ok: true, bundlePath: resolved.path, verified: verifyResult.verified, cleanup: noopCleanup }
+    }
+    const prebuiltFailure = verifyResult.failure
+    if (prebuiltFailure.kind !== 'import-failed') {
+      // Terminal: the prebuilt bundle loaded but contradicts the
+      // contract (or isn't an adapter). No rebundling fallback.
+      return { ok: false, failure: prebuiltFailure }
     }
     opts.onLog?.(
       () =>
-        `[verbose]   prebuilt bundle for ${basename(sourceDir)} did not load cleanly (${verifyResult.message}); rebundling from source`,
+        `[verbose]   prebuilt bundle for ${basename(sourceDir)} did not load cleanly (${prebuiltFailure.cause}); rebundling from source`,
     )
     const sourceEntry = await resolveSourceEntry(sourceDir, resolved.path)
-    const built = await rebundleAdapter(sourceDir, sourceEntry)
-    const adapter = await verifyAdapter(built.bundlePath)
-    return { bundlePath: built.bundlePath, adapter, cleanup: built.cleanup }
+    return verifyBuilt(await rebundleAdapter(sourceDir, sourceEntry), verifyOpts)
   }
 
-  const built = await rebundleAdapter(sourceDir, resolved.path)
-  const adapter = await verifyAdapter(built.bundlePath)
-  return { bundlePath: built.bundlePath, adapter, cleanup: built.cleanup }
+  return verifyBuilt(await rebundleAdapter(sourceDir, resolved.path), verifyOpts)
+}
+
+/** Verify a freshly rebundled adapter; on failure, clean up its temp dir. */
+async function verifyBuilt(
+  built: { bundlePath: string; cleanup: () => Promise<void> },
+  verifyOpts: { expectedApiVersion?: string },
+): Promise<LocateAndVerifyResult> {
+  const result = await verifyAdapter(built.bundlePath, verifyOpts)
+  if (!result.ok) {
+    await built.cleanup()
+    return { ok: false, failure: result.failure }
+  }
+  return { ok: true, bundlePath: built.bundlePath, verified: result.verified, cleanup: built.cleanup }
 }
 
 async function verifyPrebuiltInIsolation(
   prebuiltPath: string,
-): Promise<{ ok: true; adapter: Adapter } | { ok: false; message: string }> {
+  verifyOpts: { expectedApiVersion?: string },
+): Promise<{ ok: true; verified: VerifiedAdapter } | { ok: false; failure: VerifyAdapterFailure }> {
   const isolationDir = await mkdtemp(join(tmpdir(), 'facet-adapter-verify-'))
   try {
     const isolatedPath = join(isolationDir, basename(prebuiltPath))
     await cp(prebuiltPath, isolatedPath)
-    const adapter = await verifyAdapter(isolatedPath)
-    return { ok: true, adapter }
-  } catch (err) {
-    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+    const result = await verifyAdapter(isolatedPath, verifyOpts)
+    if (!result.ok) {
+      // Report the original prebuilt path, not the transient isolation copy.
+      return { ok: false, failure: { ...result.failure, bundlePath: prebuiltPath } }
+    }
+    return { ok: true, verified: result.verified }
   } finally {
     await rm(isolationDir, { recursive: true, force: true }).catch(() => {})
   }

--- a/packages/engine/src/adapters/verify.ts
+++ b/packages/engine/src/adapters/verify.ts
@@ -1,37 +1,164 @@
 import type { Adapter } from '@agent-facets/adapter'
+import {
+  type AdapterCompatibilityFailure,
+  classifyApiDeclaration,
+  SUPPORTED_ADAPTER_APIS,
+} from './api-compatibility.ts'
 
 /**
- * Verifies that a built adapter.js file exports a valid Adapter object.
- * Dynamically imports the file and checks its shape.
+ * A bundle that passed every verification check. `apiVersion` is the
+ * exact supported API the runtime bundle declared — carried separately
+ * so consumers (receipts, listings) don't re-derive it from the adapter.
+ */
+export interface VerifiedAdapter {
+  adapter: Adapter
+  apiVersion: string
+}
+
+/**
+ * Discriminated verification failure, ordered by the check sequence:
+ *
+ *   1. `import-failed` — the bundle could not be dynamically imported.
+ *   2. `no-default-export` — the module has no default object export.
+ *   3./4./5. `incompatible` — the runtime API declaration is missing,
+ *      malformed, unsupported, or disagrees with the npm package
+ *      declaration used for selection.
+ *   6. `invalid-name` / `invalid-shape` — the API `0.0` object is
+ *      missing its name or a required method.
+ *
+ * A compatibility contradiction is classified before any adapter
+ * contract method could be invoked; verification never calls one.
+ */
+export type VerifyAdapterFailure =
+  | { kind: 'import-failed'; bundlePath: string; cause: string }
+  | { kind: 'no-default-export'; bundlePath: string }
+  | { kind: 'incompatible'; bundlePath: string; failure: AdapterCompatibilityFailure }
+  | { kind: 'invalid-name'; bundlePath: string }
+  | { kind: 'invalid-shape'; adapter: string; bundlePath: string; detail: string }
+
+/** Result of `verifyAdapter`. Discriminated by `ok`; never throws for expected failures. */
+export type VerifyAdapterResult = { ok: true; verified: VerifiedAdapter } | { ok: false; failure: VerifyAdapterFailure }
+
+/** The API `0.0` contract methods every adapter object must expose. */
+const REQUIRED_METHODS = ['buildAssetMetadata', 'installAsset', 'readAsset', 'deleteAsset'] as const
+
+/**
+ * Verifies that a built adapter.js file exports a valid, compatible
+ * Adapter object. Dynamically imports the file and checks, in order:
+ * importability, default export, runtime API declaration syntax, CLI
+ * support, optional npm-metadata equality, then the `0.0` name and
+ * method shape.
+ *
+ * Importing an ESM bundle necessarily runs its top-level initialization;
+ * no adapter *contract method* is invoked here.
  *
  * @param bundlePath - Absolute path to the built adapter.js file
- * @returns The loaded Adapter object
+ * @param opts.expectedApiVersion - The npm package declaration used to
+ *   select this candidate, when installing from npm. Verification fails
+ *   with `api-metadata-mismatch` when the runtime declaration differs.
  */
-export async function verifyAdapter(bundlePath: string): Promise<Adapter> {
+export async function verifyAdapter(
+  bundlePath: string,
+  opts: { expectedApiVersion?: string } = {},
+): Promise<VerifyAdapterResult> {
+  // 1. Importability
   let module: Record<string, unknown>
-
   try {
     module = (await import(bundlePath)) as Record<string, unknown>
   } catch (err) {
-    throw new Error(`Failed to load adapter from "${bundlePath}": ${err instanceof Error ? err.message : String(err)}`)
+    return {
+      ok: false,
+      failure: { kind: 'import-failed', bundlePath, cause: err instanceof Error ? err.message : String(err) },
+    }
   }
 
-  // Check for default export
-  const adapter = module.default as Adapter | undefined
-  if (!adapter) {
-    throw new Error(
-      `Adapter at "${bundlePath}" does not have a default export. Adapter packages must export default from defineAdapter().`,
-    )
+  // 2. Default object export
+  const candidate = module.default
+  if (typeof candidate !== 'object' || candidate === null) {
+    return { ok: false, failure: { kind: 'no-default-export', bundlePath } }
+  }
+  const adapter = candidate as Record<string, unknown>
+  const identity = typeof adapter.name === 'string' && adapter.name ? adapter.name : bundlePath
+
+  // 3./4. Runtime API declaration: present, well-formed, supported
+  const classified = classifyApiDeclaration(adapter.apiVersion)
+  switch (classified.kind) {
+    case 'missing':
+      return {
+        ok: false,
+        failure: {
+          kind: 'incompatible',
+          bundlePath,
+          failure: { kind: 'api-missing', adapter: identity, supported: SUPPORTED_ADAPTER_APIS },
+        },
+      }
+    case 'malformed':
+      return {
+        ok: false,
+        failure: {
+          kind: 'incompatible',
+          bundlePath,
+          failure: {
+            kind: 'api-malformed',
+            adapter: identity,
+            found: classified.found,
+            supported: SUPPORTED_ADAPTER_APIS,
+          },
+        },
+      }
+    case 'unsupported':
+      return {
+        ok: false,
+        failure: {
+          kind: 'incompatible',
+          bundlePath,
+          failure: {
+            kind: 'api-unsupported',
+            adapter: identity,
+            found: classified.api,
+            supported: SUPPORTED_ADAPTER_APIS,
+          },
+        },
+      }
+    case 'supported':
+      break
   }
 
-  // Validate the Adapter shape
+  // 5. npm package declaration must equal the runtime declaration
+  if (opts.expectedApiVersion !== undefined && opts.expectedApiVersion !== classified.api) {
+    return {
+      ok: false,
+      failure: {
+        kind: 'incompatible',
+        bundlePath,
+        failure: {
+          kind: 'api-metadata-mismatch',
+          adapter: identity,
+          packageDeclared: opts.expectedApiVersion,
+          runtimeDeclared: classified.api,
+          supported: SUPPORTED_ADAPTER_APIS,
+        },
+      },
+    }
+  }
+
+  // 6. API `0.0` name and method shape
   if (typeof adapter.name !== 'string' || !adapter.name) {
-    throw new Error(`Adapter at "${bundlePath}" has an invalid or missing "name" field.`)
+    return { ok: false, failure: { kind: 'invalid-name', bundlePath } }
+  }
+  for (const method of REQUIRED_METHODS) {
+    if (typeof adapter[method] !== 'function') {
+      return {
+        ok: false,
+        failure: {
+          kind: 'invalid-shape',
+          adapter: adapter.name,
+          bundlePath,
+          detail: `"${method}" is not a function`,
+        },
+      }
+    }
   }
 
-  if (typeof adapter.buildAssetMetadata !== 'function') {
-    throw new Error(`Adapter "${adapter.name}" has an invalid "buildAssetMetadata" field.`)
-  }
-
-  return adapter
+  return { ok: true, verified: { adapter: candidate as Adapter, apiVersion: classified.api } }
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,6 +4,8 @@
 // of this file as a litmus test for the engine's package boundary.
 
 // adapter machinery
+export type { AdapterCompatibilityFailure, ApiDeclarationClassification } from './adapters/api-compatibility.ts'
+export { classifyApiDeclaration, isWellFormedAdapterApi, SUPPORTED_ADAPTER_APIS } from './adapters/api-compatibility.ts'
 export type { BundleResult, ResolvedEntryPoint } from './adapters/bundler.ts'
 export { bundleAdapter, rebundleAdapter, resolveEntryPoint } from './adapters/bundler.ts'
 export type { FirstPartyAdapter } from './adapters/first-party.ts'
@@ -13,6 +15,7 @@ export type {
   AdapterInstallOptions,
   AdapterInstallResult,
   AdapterInstallStage,
+  LocateAndVerifyResult,
 } from './adapters/install-service.ts'
 export { installAdapter, locateAndVerifyAdapter } from './adapters/install-service.ts'
 export { loadInstalledAdapters } from './adapters/loader.ts'
@@ -24,6 +27,7 @@ export {
   placeAdapter,
   removeAdapter,
 } from './adapters/placement.ts'
+export type { VerifiedAdapter, VerifyAdapterFailure, VerifyAdapterResult } from './adapters/verify.ts'
 export { verifyAdapter } from './adapters/verify.ts'
 // build (engine-side: gzip compression — protocol provides the deterministic
 // tar layout and integrity hash; engine compresses for delivery)

--- a/scripts/lib/prepack.test.ts
+++ b/scripts/lib/prepack.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import {
   applyPublishConfig,
   createDiskResolver,
+  injectAdapterApiVersion,
   rewriteWorkspaceDeps,
   stripDevDependencies,
   type VersionResolver,
@@ -585,6 +586,67 @@ describe('createDiskResolver', () => {
     await withFakeWorkspace(async (rootDir) => {
       const resolver = createDiskResolver(rootDir)
       expect(await resolver('@fake/nonexistent')).toBeNull()
+    })
+  })
+})
+
+describe('injectAdapterApiVersion', () => {
+  test('adds the field with the given value and reports modified', () => {
+    const pkg = { name: '@my/adapter-x', version: '1.0.0' }
+    const { pkg: result, modified } = injectAdapterApiVersion(pkg, { fieldName: 'someApiField', version: '0.0' })
+
+    expect(modified).toBe(true)
+    expect(result.someApiField).toBe('0.0')
+  })
+
+  test('does not mutate the input manifest', () => {
+    const pkg = { name: '@my/adapter-x', version: '1.0.0' }
+    injectAdapterApiVersion(pkg, { fieldName: 'someApiField', version: '0.0' })
+
+    expect('someApiField' in pkg).toBe(false)
+  })
+
+  test('reports unmodified when the field already has the same value', () => {
+    const pkg = { name: '@my/adapter-x', someApiField: '0.0' }
+    const { pkg: result, modified } = injectAdapterApiVersion(pkg, { fieldName: 'someApiField', version: '0.0' })
+
+    expect(modified).toBe(false)
+    expect(result).toBe(pkg)
+  })
+
+  test('overwrites a stale value and reports modified', () => {
+    const pkg = { name: '@my/adapter-x', someApiField: 'stale' }
+    const { pkg: result, modified } = injectAdapterApiVersion(pkg, { fieldName: 'someApiField', version: '0.0' })
+
+    expect(modified).toBe(true)
+    expect(result.someApiField).toBe('0.0')
+  })
+
+  test('composes with the full prepack transform chain', async () => {
+    const pkg = {
+      name: '@my/adapter-x',
+      version: '2.0.0',
+      dependencies: { '@my/core': 'workspace:*' },
+      devDependencies: { '@my/helper': 'workspace:*' },
+      publishConfig: { exports: { '.': './dist/index.mjs' } },
+    }
+
+    const { pkg: afterDeps } = await rewriteWorkspaceDeps(pkg, mockResolver({ '@my/core': '0.5.0' }))
+    const { pkg: afterPublish } = applyPublishConfig(afterDeps)
+    const { pkg: afterStrip } = stripDevDependencies(afterPublish)
+    const { pkg: result, modified } = injectAdapterApiVersion(afterStrip, {
+      fieldName: 'someApiField',
+      version: '0.0',
+    })
+
+    expect(modified).toBe(true)
+    expect(result).toEqual({
+      name: '@my/adapter-x',
+      version: '2.0.0',
+      dependencies: { '@my/core': '0.5.0' },
+      exports: { '.': './dist/index.mjs' },
+      publishConfig: { exports: { '.': './dist/index.mjs' } },
+      someApiField: '0.0',
     })
   })
 })

--- a/scripts/lib/prepack.ts
+++ b/scripts/lib/prepack.ts
@@ -175,6 +175,32 @@ export function stripDevDependencies(pkg: Record<string, unknown>): {
 }
 
 /**
+ * Set an adapter API metadata field on a package manifest.
+ *
+ * Used at pack time to inject the top-level adapter API declaration
+ * (field name and value both come from `@agent-facets/adapter`'s
+ * canonical constants — this helper deliberately takes them as inputs so
+ * it stays pure and literal-free). The caller decides which packages
+ * qualify; this function unconditionally applies the field.
+ *
+ * Returns `{ pkg, modified }`; `modified` is false only when the field is
+ * already present with the same value.
+ */
+export function injectAdapterApiVersion(
+  pkg: Record<string, unknown>,
+  opts: { fieldName: string; version: string },
+): { pkg: Record<string, unknown>; modified: boolean } {
+  if (pkg[opts.fieldName] === opts.version) {
+    return { pkg, modified: false }
+  }
+
+  // Deep-clone so we don't mutate the caller's object
+  const result = JSON.parse(JSON.stringify(pkg)) as Record<string, unknown>
+  result[opts.fieldName] = opts.version
+  return { pkg: result, modified: true }
+}
+
+/**
  * Build a `VersionResolver` that scans workspace packages on disk.
  *
  * Reads the root `package.json` at `rootDir` to discover workspace glob

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -13,6 +13,22 @@
 
 import { $ } from 'bun'
 
+/**
+ * Re-entrancy guard. Steps 2 and 3 run the in-repo CLI, which can spawn
+ * a nested `bun install` (e.g. the adapter bundler's install-and-retry
+ * fallback). A nested install resolves the workspace root and re-runs
+ * this very script; without the guard that recursion never terminates.
+ * The variable is inherited by every child process, so the nested run
+ * exits immediately and the parent's steps remain the only ones doing
+ * real work.
+ */
+const REENTRY_GUARD = 'FACETS_POSTINSTALL_ACTIVE'
+if (process.env[REENTRY_GUARD] === '1') {
+  console.log('  ↩ nested bun install — dev setup already running in a parent process, skipping')
+  process.exit(0)
+}
+process.env[REENTRY_GUARD] = '1'
+
 type Step = {
   label: string
   run: () => Promise<void>
@@ -25,7 +41,15 @@ const steps: Step[] = [
   },
   {
     label: 'opencode adapter',
-    run: () => $`bun dev adapter install opencode`.quiet().then(() => undefined),
+    // Install from the workspace source, not npm. The in-repo CLI's
+    // adapter API support set advances with the in-repo SDK, so a
+    // published adapter release may lag behind what this checkout
+    // requires (the rollout publishes adapters before the CLI, but the
+    // monorepo's own bootstrap can't depend on that ordering — it would
+    // deadlock the release CI that publishes the first compatible
+    // release). The local path bundles and verifies the same adapter
+    // source this checkout was built against.
+    run: () => $`bun dev adapter install ./packages/adapters/opencode`.quiet().then(() => undefined),
   },
   {
     label: 'facets',

--- a/scripts/prepack-adapters.test.ts
+++ b/scripts/prepack-adapters.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Packed-manifest coverage for first-party adapter packages.
+ *
+ * Proves two things about the prepack pipeline:
+ *
+ * 1. Every real first-party adapter manifest under `packages/adapters/`,
+ *    when run through the full prepack transform chain, publishes the
+ *    canonical adapter API metadata field.
+ * 2. The `scripts/prepack.ts` entry script itself qualifies exactly the
+ *    packages under `packages/adapters/` for injection — an unrelated
+ *    package's manifest is left untouched. This runs the real script
+ *    against a fabricated temp monorepo.
+ */
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from '../packages/adapter/src/api-version'
+import {
+  applyPublishConfig,
+  createDiskResolver,
+  injectAdapterApiVersion,
+  rewriteWorkspaceDeps,
+  stripDevDependencies,
+} from './lib/prepack'
+
+const repoRoot = resolve(import.meta.dir, '..')
+const adaptersDir = resolve(repoRoot, 'packages', 'adapters')
+const prepackScript = resolve(repoRoot, 'scripts', 'prepack.ts')
+
+/** Enumerate the real first-party adapter package manifests. */
+async function adapterManifestPaths(): Promise<string[]> {
+  const paths: string[] = []
+  for await (const entry of new Bun.Glob('*/package.json').scan(adaptersDir)) {
+    paths.push(resolve(adaptersDir, entry))
+  }
+  return paths.sort()
+}
+
+describe('first-party adapter packed manifests', () => {
+  test('every adapter package publishes the canonical API field after the prepack chain', async () => {
+    const manifests = await adapterManifestPaths()
+    // Guard against silently testing nothing if the layout moves.
+    expect(manifests.length).toBeGreaterThan(0)
+
+    const resolver = createDiskResolver(repoRoot)
+    for (const manifestPath of manifests) {
+      const pkg = await Bun.file(manifestPath).json()
+
+      const { pkg: afterDeps } = await rewriteWorkspaceDeps(pkg, resolver)
+      const { pkg: afterPublish } = applyPublishConfig(afterDeps)
+      const { pkg: afterStrip } = stripDevDependencies(afterPublish)
+      const { pkg: packed } = injectAdapterApiVersion(afterStrip, {
+        fieldName: ADAPTER_API_VERSION_PACKAGE_FIELD,
+        version: ADAPTER_API_VERSION,
+      })
+
+      expect(packed[ADAPTER_API_VERSION_PACKAGE_FIELD]).toBe(ADAPTER_API_VERSION)
+    }
+  })
+})
+
+describe('prepack.ts adapter qualification', () => {
+  /**
+   * Run the real prepack script from `packageDir` (inside a fake monorepo
+   * scaffolded by `withFakeMonorepo`) and return the resulting manifest.
+   */
+  async function runPrepackIn(
+    packageDir: string,
+  ): Promise<{ manifest: Record<string, unknown>; exitCode: number; stderr: string }> {
+    const proc = Bun.spawn(['bun', prepackScript], {
+      cwd: packageDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const exitCode = await proc.exited
+    const stderr = await new Response(proc.stderr).text()
+    const manifest = await Bun.file(join(packageDir, 'package.json')).json()
+    return { manifest, exitCode, stderr }
+  }
+
+  async function withFakeMonorepo(fn: (rootDir: string) => Promise<void>): Promise<void> {
+    const rootDir = await mkdtemp(join(tmpdir(), 'prepack-adapters-test-'))
+    try {
+      await Bun.write(
+        join(rootDir, 'package.json'),
+        JSON.stringify({ name: 'fake-root', private: true, workspaces: ['packages/*', 'packages/adapters/*'] }),
+      )
+      await Bun.write(
+        join(rootDir, 'packages/adapters/fake/package.json'),
+        JSON.stringify({ name: '@fake/adapter-fake', version: '1.0.0' }),
+      )
+      await Bun.write(
+        join(rootDir, 'packages/library/package.json'),
+        JSON.stringify({ name: '@fake/library', version: '1.0.0' }),
+      )
+      await fn(rootDir)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  }
+
+  test('injects the canonical API field for a package under packages/adapters/', async () => {
+    await withFakeMonorepo(async (rootDir) => {
+      const packageDir = join(rootDir, 'packages/adapters/fake')
+      const { manifest, exitCode, stderr } = await runPrepackIn(packageDir)
+
+      expect(exitCode).toBe(0)
+      expect(manifest[ADAPTER_API_VERSION_PACKAGE_FIELD]).toBe(ADAPTER_API_VERSION)
+      expect(stderr).toContain(ADAPTER_API_VERSION_PACKAGE_FIELD)
+      // A backup must exist so postpack can restore the source manifest.
+      expect(await Bun.file(join(packageDir, '.package.json.bak')).exists()).toBe(true)
+    })
+  })
+
+  test('leaves a package outside packages/adapters/ untouched', async () => {
+    await withFakeMonorepo(async (rootDir) => {
+      const packageDir = join(rootDir, 'packages/library')
+      const { manifest, exitCode } = await runPrepackIn(packageDir)
+
+      expect(exitCode).toBe(0)
+      expect(ADAPTER_API_VERSION_PACKAGE_FIELD in manifest).toBe(false)
+      // Nothing was modified, so no backup is written.
+      expect(await Bun.file(join(packageDir, '.package.json.bak')).exists()).toBe(false)
+    })
+  })
+})

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -2,7 +2,7 @@
  * Prepack entry point — run via `bun <relative-path>/scripts/prepack.ts`
  * from a package directory during `npm publish` or `changeset publish`.
  *
- * Does three things before the tarball is packed:
+ * Does four things before the tarball is packed:
  *   1. Rewrites workspace:* dependencies to concrete versions.
  *   2. Hoists whitelisted fields from `publishConfig` (exports, main,
  *      types, module, bin) to the top-level manifest — mirrors pnpm's
@@ -11,6 +11,11 @@
  *      `workspace:*` references that npm would have stripped from the
  *      tarball anyway. See `lib/prepack.ts#stripDevDependencies` for
  *      the full rationale.
+ *   4. For first-party adapter packages (anything under
+ *      `packages/adapters/`), injects the top-level adapter API metadata
+ *      field so compatibility-aware CLIs can select releases before
+ *      download. Field name and value come from the adapter SDK's
+ *      canonical constants — no literals here.
  *
  * A backup of the original `package.json` is saved so postpack.ts can
  * restore it after packing.
@@ -21,8 +26,17 @@
  * `packages/<name>/` and `packages/adapters/<name>/`).
  */
 
-import { dirname, resolve } from 'node:path'
-import { applyPublishConfig, createDiskResolver, rewriteWorkspaceDeps, stripDevDependencies } from './lib/prepack'
+import { dirname, resolve, sep } from 'node:path'
+// Relative source import (not the package name) so prepack works even when
+// node_modules is absent; api-version.ts is dependency-free by design.
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from '../packages/adapter/src/api-version'
+import {
+  applyPublishConfig,
+  createDiskResolver,
+  injectAdapterApiVersion,
+  rewriteWorkspaceDeps,
+  stripDevDependencies,
+} from './lib/prepack'
 
 const cwd = process.cwd()
 const pkgPath = resolve(cwd, 'package.json')
@@ -59,11 +73,25 @@ async function findMonorepoRoot(start: string): Promise<string> {
 const rootDir = await findMonorepoRoot(cwd)
 const resolver = createDiskResolver(rootDir)
 
+/**
+ * First-party adapter packages are exactly the workspace members under
+ * `packages/adapters/` (mirrors the root workspace glob). Only they
+ * publish the adapter API metadata field.
+ */
+const adaptersDir = resolve(rootDir, 'packages', 'adapters')
+const isFirstPartyAdapter = cwd.startsWith(adaptersDir + sep)
+
 const { pkg: afterDepRewrite, modified: depsModified } = await rewriteWorkspaceDeps(pkg, resolver)
 const { pkg: afterPublishConfig, modified: publishConfigModified } = applyPublishConfig(afterDepRewrite)
-const { pkg: rewritten, modified: devDepsStripped } = stripDevDependencies(afterPublishConfig)
+const { pkg: afterDevDepsStrip, modified: devDepsStripped } = stripDevDependencies(afterPublishConfig)
+const { pkg: rewritten, modified: apiVersionInjected } = isFirstPartyAdapter
+  ? injectAdapterApiVersion(afterDevDepsStrip, {
+      fieldName: ADAPTER_API_VERSION_PACKAGE_FIELD,
+      version: ADAPTER_API_VERSION,
+    })
+  : { pkg: afterDevDepsStrip, modified: false }
 
-const modified = depsModified || publishConfigModified || devDepsStripped
+const modified = depsModified || publishConfigModified || devDepsStripped || apiVersionInjected
 
 if (modified) {
   // Save backup of the original for postpack restore
@@ -75,6 +103,7 @@ if (modified) {
   if (depsModified) changes.push('rewrote workspace:* dependencies to concrete versions')
   if (publishConfigModified) changes.push('hoisted publishConfig fields to top-level')
   if (devDepsStripped) changes.push('stripped devDependencies')
+  if (apiVersionInjected) changes.push(`injected ${ADAPTER_API_VERSION_PACKAGE_FIELD} ${ADAPTER_API_VERSION}`)
   // Diagnostic output goes to stderr so `bun pm pack --quiet` stdout stays
   // parseable by `packAndPublish` (see scripts/lib/npm.ts#extractPackFilename).
   console.error(`prepack: ${changes.join('; ')}`)

--- a/turbo.json
+++ b/turbo.json
@@ -47,12 +47,13 @@
         ".changeset/**",
         "package.json",
         "packages/*/package.json",
-        "packages/adapters/*/package.json"
+        "packages/adapters/*/package.json",
+        "packages/adapter/src/api-version.ts"
       ],
       "outputs": ["$TURBO_ROOT$/test-results/scripts-junit.xml"]
     },
     "//#types": {
-      "inputs": ["scripts/**", "tsconfig.json"]
+      "inputs": ["scripts/**", "tsconfig.json", "packages/adapter/src/api-version.ts"]
     },
     "//#lint": {
       "inputs": [


### PR DESCRIPTION
### Why

Adapters and the CLI had no shared contract identifier, making it impossible to determine whether an installed adapter is compatible with the running CLI before downloading or loading it. This change introduces a discrete adapter API version token (`0.0`) that the SDK stamps onto every adapter at build time and that the CLI checks at verification time.

### Details

**SDK (`@agent-facets/adapter`)**

A new `api-version.ts` module is the single source of truth for two constants: `ADAPTER_API_VERSION` (`'0.0'`) and `ADAPTER_API_VERSION_PACKAGE_FIELD` (`'facetAdapterApiVersion'`). This module is exposed as a separate, dependency-free subpath export (`./api-version`) so the engine can import just the constants without pulling in the full SDK module graph.

`defineAdapter()` now accepts `AdapterDefinition` (which excludes `apiVersion`) and always stamps the canonical value onto the returned `Adapter`, overwriting any value a non-TypeScript caller might sneak past the type system. The `Adapter` interface gains a readonly `apiVersion: AdapterApiVersion` field.

**Engine — compatibility classification (`api-compatibility.ts`)**

A new pure module owns the CLI's support set (`SUPPORTED_ADAPTER_APIS`, derived from the SDK constant), the canonical `MAJOR.MINOR` syntax rule, and the shared `AdapterCompatibilityFailure` discriminated union. Both npm release filtering and runtime verification import from here so both sides apply identical rules.

**Engine — verification (`verify.ts`)**

`verifyAdapter` is converted from a throwing function to a result-typed one (`VerifyAdapterResult`). Checks run in a defined order: importability → default object export → runtime API declaration (missing / malformed / unsupported) → optional npm-metadata equality (`expectedApiVersion`) → name and method shape. Compatibility contradictions are classified before any adapter contract method could be invoked; verification never calls one.

**Engine — install service (`install-service.ts`)**

`locateAndVerifyAdapter` is converted to return `LocateAndVerifyResult`. Only an `import-failed` prebuilt bundle is eligible for the rebundling fallback — a compatibility contradiction in a prebuilt bundle is terminal, because rebundling the same source cannot fix a declared contract. `AdapterInstallFailure`'s `verify-failed` variant now carries a structured `VerifyAdapterFailure` instead of a raw string.

**CLI error rendering (`adapter-install-errors.ts`)**

`describeAdapterInstallFailure` is updated to delegate `verify-failed` to a new `describeVerifyFailure` function, which exhaustively handles every `VerifyAdapterFailure` variant. A separate exported `describeCompatibilityFailure` handles the shared `AdapterCompatibilityFailure` union and can be reused by other rendering sites.

**Prepack tooling**

A new `injectAdapterApiVersion` helper in `scripts/lib/prepack.ts` sets the `facetAdapterApiVersion` field on a manifest. `scripts/prepack.ts` applies it to any package whose `cwd` is under `packages/adapters/`, using the SDK constants directly via a relative source import (so it works without `node_modules`). The field name and value never appear as literals in the tooling.

**Test separation**

Each first-party adapter package gains a `test:e2e` script that builds the dist bundle first and then runs a `dist.e2e.test.ts` fixture that imports the built artifact and asserts `apiVersion` is present. The default `test` script excludes `*.e2e.test.ts` so unit runs stay fast.

### Verification

- `packages/adapter` unit tests assert the constant values, that `defineAdapter` stamps the canonical version, and that a conflicting value smuggled past the types is overwritten.
- `packages/engine` gains three new test files: `api-compatibility.test.ts` (syntax validation and classification), `verify.test.ts` (all six ordered checks, non-invocation of contract methods), and `locate-and-verify.test.ts` (fallback eligibility: import failure falls back, compatibility contradiction is terminal, valid prebuilt takes the fast path).
- `scripts/prepack-adapters.test.ts` proves every real first-party adapter manifest carries the canonical field after the full transform chain, and that the prepack script qualifies only `packages/adapters/` packages for injection.
- First-party adapter unit tests each assert `adapter.apiVersion === ADAPTER_API_VERSION`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes adapter install/verify and bundler/postinstall paths used on every dev bootstrap and adapter install; incorrect compatibility or rebundle logic could block installs, though coverage is extensive.
> 
> **Overview**
> This PR adds **adapter API version negotiation** for the first slice of the OpenSpec change: a shared contract id **`0.0`**, not semver.
> 
> **SDK (`@agent-facets/adapter`)** — New `api-version` constants and a separate **`./api-version`** export. `defineAdapter()` now takes **`AdapterDefinition`** (no `apiVersion`) and always stamps **`apiVersion`** on the returned **`Adapter`**. First-party adapters gain unit + **`test:e2e`** checks that built **`dist`** bundles carry the stamped version.
> 
> **Release tooling** — Prepack injects **`facetAdapterApiVersion`** into manifests under **`packages/adapters/`** from SDK constants (no duplicated literals), with tests for the transform chain and qualification rules.
> 
> **Engine** — **`api-compatibility`** centralizes syntax, the CLI support set, and **`AdapterCompatibilityFailure`**. **`verifyAdapter`** becomes a **result type** with ordered checks (import → export → API declaration → optional npm metadata match → shape) without calling contract methods. **`locateAndVerifyAdapter`** only rebundles on **`import-failed`**; API mismatches are terminal. **`rebundleAdapter`** tries **`bun build` first** and runs **`bun install`** only on failure (subprocess build to avoid resolver cache issues).
> 
> **CLI** — Install errors map structured **`verify-failed`** / compatibility variants via **`describeCompatibilityFailure`**.
> 
> **Dev bootstrap** — **`postinstall`** uses a re-entrancy guard and installs opencode from **`./packages/adapters/opencode`** so monorepo setup does not depend on published adapter ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ae9a2a4e31eb3275cdb80567bbf7592873755d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->