### PR TITLE
Add compatibility-aware npm adapter resolution with full-packument version selection, structured specifier failures, and integrity provenance

### DIFF
--- a/openspec/changes/add-adapter-api-version-negotiation/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/tasks.md
@@ -47,19 +47,19 @@
 
 ## 5. Adapter Specifiers and npm Compatible Resolution — Research
 
-- [ ] 5.1 Explore: Inspect `packages/engine/src/sources/adapter/specifier.ts`, `packages/engine/src/adapters/first-party.ts`, `packages/engine/src/sources/facet/parse-version.ts`, and `packages/protocol/src/sources/version-spec.ts` for scoped-name handling, alias duplication, selector parsing, and satisfaction rules.
-- [ ] 5.2 Explore: Inspect `packages/engine/src/sources/adapter/npm.ts` and its fake-registry and hardening tests to map full-packument metadata, integrity verification, extraction, and provenance flow.
-- [ ] 5.3 Propose: Present tagged source request/result types and structured parse, no-compatible-release, metadata, network, integrity, and extraction failures.
+- [x] 5.1 Explore: Inspect `packages/engine/src/sources/adapter/specifier.ts`, `packages/engine/src/adapters/first-party.ts`, `packages/engine/src/sources/facet/parse-version.ts`, and `packages/protocol/src/sources/version-spec.ts` for scoped-name handling, alias duplication, selector parsing, and satisfaction rules.
+- [x] 5.2 Explore: Inspect `packages/engine/src/sources/adapter/npm.ts` and its fake-registry and hardening tests to map full-packument metadata, integrity verification, extraction, and provenance flow.
+- [x] 5.3 Propose: Present tagged source request/result types and structured parse, no-compatible-release, metadata, network, integrity, and extraction failures.
 
 ## 6. Adapter Specifiers and npm Compatible Resolution — Implementation
 
-- [ ] 6.1 Implement: Make the first-party adapter catalog the single source of truth for both picker entries and alias-to-package resolution.
-- [ ] 6.2 Implement: Add tagged npm implicit, exact, wildcard/`latest`, Git, and local specifier variants with correct scoped-package splitting and reused Facet selector grammar.
-- [ ] 6.3 Implement: Return structured parse failures for unsupported npm selector forms while preserving existing Git and local source behavior.
-- [ ] 6.4 Implement: Replace npm `/latest` lookup with full-packument parsing that filters stable versions by selector and supported API, handles exact requests without substitution, and reports the newest considered incompatible release.
-- [ ] 6.5 Implement: Carry the selected package version, declared API, tarball URL, and exact SRI or shasum through download, integrity verification, extraction, and installation provenance.
-- [ ] 6.6 Implement: Add parser and fake-registry tests for scoped names, aliases, all supported selectors—including explicit `latest` selecting the highest compatible release independently of npm's `latest` dist-tag—rejected ranges, compatible selection, exact incompatibility, missing/malformed metadata, prerelease exclusion, and integrity failures; if exact-version metadata optimization is implemented, prove its validation and failure data match the full-packument path.
-- [ ] 6.7 Verify: Run targeted adapter-source and npm hardening suites.
+- [x] 6.1 Implement: Make the first-party adapter catalog the single source of truth for both picker entries and alias-to-package resolution.
+- [x] 6.2 Implement: Add tagged npm implicit, exact, wildcard/`latest`, Git, and local specifier variants with correct scoped-package splitting and reused Facet selector grammar.
+- [x] 6.3 Implement: Return structured parse failures for unsupported npm selector forms while preserving existing Git and local source behavior.
+- [x] 6.4 Implement: Replace npm `/latest` lookup with full-packument parsing that filters stable versions by selector and supported API, handles exact requests without substitution, and reports the newest considered incompatible release.
+- [x] 6.5 Implement: Carry the selected package version, declared API, tarball URL, and exact SRI or shasum through download, integrity verification, extraction, and installation provenance.
+- [x] 6.6 Implement: Add parser and fake-registry tests for scoped names, aliases, all supported selectors—including explicit `latest` selecting the highest compatible release independently of npm's `latest` dist-tag—rejected ranges, compatible selection, exact incompatibility, missing/malformed metadata, prerelease exclusion, and integrity failures; if exact-version metadata optimization is implemented, prove its validation and failure data match the full-packument path.
+- [x] 6.7 Verify: Run targeted adapter-source and npm hardening suites.
 
 ## 7. Managed Installation and Atomic Activation — Research
 

--- a/packages/cli/src/__tests__/adapter-specifier.test.ts
+++ b/packages/cli/src/__tests__/adapter-specifier.test.ts
@@ -6,35 +6,47 @@ describe('parseAdapterSpecifier', () => {
     const result = parseAdapterSpecifier('opencode')
     if (!result.ok) expect.unreachable()
 
-    expect(result.resolved).toEqual({ type: 'npm', packageName: '@agent-facets/adapter-opencode' })
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: '@agent-facets/adapter-opencode',
+      request: { kind: 'implicit' },
+    })
   })
 
   test('built-in name "claude-code" resolves to npm package', () => {
     const result = parseAdapterSpecifier('claude-code')
     if (!result.ok) expect.unreachable()
 
-    expect(result.resolved).toEqual({ type: 'npm', packageName: '@agent-facets/adapter-claude-code' })
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: '@agent-facets/adapter-claude-code',
+      request: { kind: 'implicit' },
+    })
   })
 
   test('built-in name "codex" resolves to npm package', () => {
     const result = parseAdapterSpecifier('codex')
     if (!result.ok) expect.unreachable()
 
-    expect(result.resolved).toEqual({ type: 'npm', packageName: '@agent-facets/adapter-codex' })
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: '@agent-facets/adapter-codex',
+      request: { kind: 'implicit' },
+    })
   })
 
   test('scoped npm package passes through', () => {
     const result = parseAdapterSpecifier('@acme/adapter-custom')
     if (!result.ok) expect.unreachable()
 
-    expect(result.resolved).toEqual({ type: 'npm', packageName: '@acme/adapter-custom' })
+    expect(result.resolved).toEqual({ type: 'npm', packageName: '@acme/adapter-custom', request: { kind: 'implicit' } })
   })
 
   test('unscoped npm package passes through', () => {
     const result = parseAdapterSpecifier('my-adapter')
     if (!result.ok) expect.unreachable()
 
-    expect(result.resolved).toEqual({ type: 'npm', packageName: 'my-adapter' })
+    expect(result.resolved).toEqual({ type: 'npm', packageName: 'my-adapter', request: { kind: 'implicit' } })
   })
 
   test('git+https URL is parsed', () => {

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -1,4 +1,10 @@
-import type { AdapterCompatibilityFailure, AdapterInstallFailure, VerifyAdapterFailure } from '@agent-facets/engine'
+import type {
+  AdapterCompatibilityFailure,
+  AdapterInstallFailure,
+  ApiDeclarationClassification,
+  NpmVersionRequest,
+  VerifyAdapterFailure,
+} from '@agent-facets/engine'
 
 /**
  * Map an `AdapterInstallFailure` to the `{ what, detail, fix }` triple
@@ -13,11 +19,7 @@ export function describeAdapterInstallFailure(failure: AdapterInstallFailure): {
 } {
   switch (failure.kind) {
     case 'specifier-invalid':
-      return {
-        what: `invalid adapter specifier "${failure.specifier}"`,
-        detail: `git URL must start with https://, http://, ssh://, or git:// — got "${failure.failure.url}"`,
-        fix: 'use a built-in adapter name, npm package, supported git URL, or local path',
-      }
+      return describeSpecifierFailure(failure.specifier, failure.failure)
     case 'download-failed':
       return describeDownloadFailure(failure.specifier, failure.source)
     case 'bundle-failed':
@@ -33,6 +35,26 @@ export function describeAdapterInstallFailure(failure: AdapterInstallFailure): {
         what: `failed to place adapter "${failure.adapter}"`,
         detail: failure.cause,
         fix: 'check filesystem permissions on ~/.facet/adapters/',
+      }
+  }
+}
+
+function describeSpecifierFailure(
+  specifier: string,
+  failure: Extract<AdapterInstallFailure, { kind: 'specifier-invalid' }>['failure'],
+): { what: string; detail: string; fix: string } {
+  switch (failure.reason) {
+    case 'invalid-git-url':
+      return {
+        what: `invalid adapter specifier "${specifier}"`,
+        detail: `git URL must start with https://, http://, ssh://, or git:// — got "${failure.url}"`,
+        fix: 'use a built-in adapter name, npm package, supported git URL, or local path',
+      }
+    case 'invalid-npm-selector':
+      return {
+        what: `invalid version selector "${failure.selector}" for "${failure.packageName}"`,
+        detail: failure.error.what,
+        fix: failure.error.fix,
       }
   }
 }
@@ -149,12 +171,14 @@ function describeNpmFailure(
         detail: failure.statusText,
         fix: failure.status === 404 ? 'verify the package name' : 'retry; this is usually transient',
       }
-    case 'no-tarball-url':
+    case 'metadata-invalid':
       return {
-        what: `npm registry returned no tarball URL for "${failure.packageName}"`,
-        detail: 'the registry response was missing dist.tarball',
+        what: `npm registry returned unusable metadata for "${failure.packageName}"`,
+        detail: failure.detail,
         fix: 'verify the package was published correctly',
       }
+    case 'no-compatible-release':
+      return describeNoCompatibleRelease(failure)
     case 'tarball-network-error':
       return {
         what: `could not download tarball for "${failure.packageName}"`,
@@ -197,6 +221,47 @@ function describeNpmFailure(
         detail: 'this is a tar-slip attempt; refusing to install',
         fix: 'do not install this package; report it to the registry',
       }
+  }
+}
+
+function describeNoCompatibleRelease(failure: {
+  packageName: string
+  request: NpmVersionRequest
+  supported: readonly string[]
+  newestConsidered?: { version: string; declared: ApiDeclarationClassification }
+}): { what: string; detail: string; fix: string } {
+  const selector = failure.request.kind === 'implicit' ? 'any version' : `selector "${failure.request.raw}"`
+  const supported = failure.supported.join(', ')
+
+  let newest: string
+  if (!failure.newestConsidered) {
+    newest = 'no published stable version satisfies the request'
+  } else {
+    const { version, declared } = failure.newestConsidered
+    switch (declared.kind) {
+      case 'missing':
+        newest = `newest considered release ${version} declares no adapter API`
+        break
+      case 'malformed':
+        newest = `newest considered release ${version} declares malformed adapter API "${declared.found}"`
+        break
+      case 'unsupported':
+        newest = `newest considered release ${version} declares unsupported adapter API ${declared.api}`
+        break
+      case 'supported':
+        // Unreachable when resolution failed, but render honestly.
+        newest = `newest considered release ${version} declares adapter API ${declared.api}`
+        break
+    }
+  }
+
+  return {
+    what: `no compatible release of "${failure.packageName}" (${selector})`,
+    detail: `this CLI supports adapter API ${supported}; ${newest}`,
+    fix:
+      failure.request.kind === 'exact'
+        ? `that exact version is incompatible; try \`facet adapter install ${failure.packageName}\` for the highest compatible release`
+        : 'the publisher must release a version declaring a supported adapter API',
   }
 }
 

--- a/packages/engine/src/adapters/install-service.ts
+++ b/packages/engine/src/adapters/install-service.ts
@@ -5,7 +5,12 @@ import type { Adapter } from '@agent-facets/adapter'
 import type { OnLog } from '../install/types.ts'
 import { type CloneAdapterGitResult, cloneAdapterGitRepository } from '../sources/adapter/git.ts'
 import { type ResolveLocalAdapterResult, resolveLocalAdapterPath } from '../sources/adapter/local.ts'
-import { type DownloadNpmResult, downloadNpmPackage } from '../sources/adapter/npm.ts'
+import {
+  type DownloadNpmResult,
+  downloadNpmRelease,
+  type ResolveNpmAdapterResult,
+  resolveNpmAdapter,
+} from '../sources/adapter/npm.ts'
 import { type ParseAdapterSpecifierResult, parseAdapterSpecifier } from '../sources/adapter/specifier.ts'
 import { rebundleAdapter, resolveEntryPoint } from './bundler.ts'
 import { placeAdapter } from './placement.ts'
@@ -41,9 +46,10 @@ export interface AdapterInstallOptions {
  *
  *   - `specifier-invalid` — `parseAdapterSpecifier` rejected the
  *     specifier (e.g. `git+ftp://…` with a disallowed scheme).
- *   - `download-failed` — npm registry / git clone / local-path
- *     resolution failed. The `source` discriminator carries the
- *     resolver-specific reason.
+ *   - `download-failed` — npm resolution/download, git clone, or
+ *     local-path resolution failed. The `source` discriminator carries
+ *     the resolver-specific reason (for npm: compatible-release
+ *     resolution failures and tarball download/integrity failures).
  *   - `bundle-failed` / `place-failed` — bundler load or placement
  *     threw. These two still wrap thrown errors today; the fix here is
  *     to surface them as structured failures to the caller instead of
@@ -58,7 +64,10 @@ export type AdapterInstallFailure =
       kind: 'download-failed'
       specifier: string
       source:
-        | { kind: 'npm'; failure: Extract<DownloadNpmResult, { ok: false }> }
+        | {
+            kind: 'npm'
+            failure: Extract<ResolveNpmAdapterResult, { ok: false }> | Extract<DownloadNpmResult, { ok: false }>
+          }
         | { kind: 'git'; failure: Extract<CloneAdapterGitResult, { ok: false }> }
         | { kind: 'local'; failure: Extract<ResolveLocalAdapterResult, { ok: false }> }
     }
@@ -86,14 +95,23 @@ export async function installAdapter(
   let sourceDir: string | undefined
   let needsCleanup = true
   let bundleCleanup: (() => Promise<void>) | undefined
+  /** The npm package declaration used for selection, when installing from npm. */
+  let expectedApiVersion: string | undefined
 
   try {
     opts.onProgress?.('resolving', specifier)
 
     switch (resolved.type) {
       case 'npm': {
-        opts.onProgress?.('downloading', resolved.packageName)
-        const dl = await downloadNpmPackage(resolved.packageName)
+        const resolution = await resolveNpmAdapter(resolved.packageName, resolved.request)
+        if (!resolution.ok) {
+          return {
+            ok: false,
+            failure: { kind: 'download-failed', specifier, source: { kind: 'npm', failure: resolution } },
+          }
+        }
+        opts.onProgress?.('downloading', `${resolved.packageName}@${resolution.release.version}`)
+        const dl = await downloadNpmRelease(resolution.release)
         if (!dl.ok) {
           return {
             ok: false,
@@ -101,6 +119,7 @@ export async function installAdapter(
           }
         }
         sourceDir = dl.path
+        expectedApiVersion = resolution.release.apiVersion
         break
       }
       case 'git': {
@@ -132,7 +151,7 @@ export async function installAdapter(
     opts.onProgress?.('bundling')
     let located: LocateAndVerifyResult
     try {
-      located = await locateAndVerifyAdapter(sourceDir, { onLog: opts.onLog })
+      located = await locateAndVerifyAdapter(sourceDir, { onLog: opts.onLog, expectedApiVersion })
     } catch (err) {
       // bundler internals (`rebundleAdapter`, `resolveEntryPoint`) still
       // throw today — converting them is a later step. Catch at this

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -235,10 +235,22 @@ export { resolveLocalAdapterPath } from './sources/adapter/local.ts'
 export type {
   AssertInsideTempDirResult,
   DownloadNpmResult,
+  NpmResolvedRelease,
+  ResolveNpmAdapterResult,
+  UsedIntegrity,
   VerifyTarballIntegrityResult,
 } from './sources/adapter/npm.ts'
-export { assertInsideTempDir, downloadNpmPackage, verifyTarballIntegrity } from './sources/adapter/npm.ts'
-export type { ParseAdapterSpecifierResult, ResolvedAdapterSpecifier } from './sources/adapter/specifier.ts'
+export {
+  assertInsideTempDir,
+  downloadNpmRelease,
+  resolveNpmAdapter,
+  verifyTarballIntegrity,
+} from './sources/adapter/npm.ts'
+export type {
+  NpmVersionRequest,
+  ParseAdapterSpecifierResult,
+  ResolvedAdapterSpecifier,
+} from './sources/adapter/specifier.ts'
 export { getBuiltinAdapterNames, parseAdapterSpecifier } from './sources/adapter/specifier.ts'
 // facet sources
 export { parseFacetSource } from './sources/facet/parse-source.ts'

--- a/packages/engine/src/sources/adapter/__tests__/npm-hardening.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/npm-hardening.test.ts
@@ -21,12 +21,20 @@ describe('verifyTarballIntegrity — SRI', () => {
     return `${algo}-${createHash(algo).update(input).digest('base64')}`
   }
 
-  test('accepts a correct sha512 integrity', () => {
-    expect(verifyTarballIntegrity('pkg', bytes, sri('sha512', bytes), undefined)).toEqual({ ok: true })
+  test('accepts a correct sha512 integrity and reports the SRI anchor', () => {
+    const anchor = sri('sha512', bytes)
+    expect(verifyTarballIntegrity('pkg', bytes, anchor, undefined)).toEqual({
+      ok: true,
+      usedIntegrity: { kind: 'sri', value: anchor },
+    })
   })
 
-  test('accepts a correct sha256 integrity', () => {
-    expect(verifyTarballIntegrity('pkg', bytes, sri('sha256', bytes), undefined)).toEqual({ ok: true })
+  test('accepts a correct sha256 integrity and reports the SRI anchor', () => {
+    const anchor = sri('sha256', bytes)
+    expect(verifyTarballIntegrity('pkg', bytes, anchor, undefined)).toEqual({
+      ok: true,
+      usedIntegrity: { kind: 'sri', value: anchor },
+    })
   })
 
   test('rejects a mismatched integrity with structured failure', () => {
@@ -44,9 +52,12 @@ describe('verifyTarballIntegrity — SRI', () => {
     expect(result.reason).toBe('integrity-unsupported-algo')
   })
 
-  test('accepts shasum fallback when SRI is absent', () => {
+  test('accepts shasum fallback when SRI is absent and reports the anchor', () => {
     const shasum = createHash('sha1').update(bytes).digest('hex')
-    expect(verifyTarballIntegrity('pkg', bytes, undefined, shasum)).toEqual({ ok: true })
+    expect(verifyTarballIntegrity('pkg', bytes, undefined, shasum)).toEqual({
+      ok: true,
+      usedIntegrity: { kind: 'shasum', value: shasum },
+    })
   })
 
   test('rejects a wrong shasum with structured failure', () => {

--- a/packages/engine/src/sources/adapter/__tests__/npm-resolve.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/npm-resolve.test.ts
@@ -1,0 +1,343 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from '@agent-facets/adapter/api-version'
+import { downloadNpmRelease, resolveNpmAdapter } from '../npm.ts'
+import type { NpmVersionRequest } from '../specifier.ts'
+
+/**
+ * Fake-registry tests for compatibility-aware npm resolution.
+ *
+ * A `Bun.serve` instance on an ephemeral port serves packuments and
+ * tarball bytes. Version entries are declared per test via the
+ * `packuments` map; tarballs are real gzipped tars produced in-memory.
+ */
+
+/** Minimal gzipped tarball containing a single `package/package.json`. */
+function makeTarball(content: string): Uint8Array {
+  const body = new TextEncoder().encode(content)
+  const name = 'package/package.json'
+  const header = new Uint8Array(512)
+  const write = (text: string, offset: number): void => {
+    for (let i = 0; i < text.length; i++) header[offset + i] = text.charCodeAt(i)
+  }
+  write(name, 0)
+  write('0000644\0', 100) // mode
+  write('0000000\0', 108) // uid
+  write('0000000\0', 116) // gid
+  write(`${body.length.toString(8).padStart(11, '0')}\0`, 124) // size
+  write('00000000000\0', 136) // mtime
+  write('        ', 148) // checksum placeholder (spaces while computing)
+  header[156] = 48 // typeflag '0'
+  write('ustar\0', 257)
+  write('00', 263)
+  let checksum = 0
+  for (const byte of header) checksum += byte
+  write(`${checksum.toString(8).padStart(6, '0')}\0 `, 148)
+
+  const padded = new Uint8Array(512 + Math.ceil(body.length / 512) * 512 + 1024)
+  padded.set(header, 0)
+  padded.set(body, 512)
+  return Bun.gzipSync(padded)
+}
+
+interface FakeVersion {
+  /** Adapter API declaration; `undefined` omits the field entirely. */
+  api?: unknown
+  /** Omit dist.integrity/shasum when false-y flags are set. */
+  noIntegrity?: boolean
+  useShasumOnly?: boolean
+  /** Corrupt the advertised integrity so downloads fail verification. */
+  corruptIntegrity?: boolean
+  /** Omit dist entirely. */
+  noDist?: boolean
+}
+
+const tarballBytes = makeTarball(JSON.stringify({ name: 'fake', version: '0.0.0' }))
+const goodSri = `sha512-${createHash('sha512').update(tarballBytes).digest('base64')}`
+const goodShasum = createHash('sha1').update(tarballBytes).digest('hex')
+
+let server: ReturnType<typeof Bun.serve>
+let baseUrl: string
+/** name → { versions, distTags } served by the fake registry. */
+const packuments = new Map<string, { versions: Record<string, FakeVersion>; distTags?: Record<string, string> }>()
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url)
+      if (url.pathname === '/tarballs/good.tgz') {
+        return new Response(tarballBytes)
+      }
+      const name = decodeURIComponent(url.pathname.slice(1))
+      const entry = packuments.get(name)
+      if (!entry) return new Response('not found', { status: 404 })
+      if (name === 'broken-json') return new Response('{not json', { headers: { 'content-type': 'application/json' } })
+      if (name === 'no-versions') return new Response(JSON.stringify({ name }))
+
+      const versions: Record<string, unknown> = {}
+      for (const [version, spec] of Object.entries(entry.versions)) {
+        const dist = spec.noDist
+          ? undefined
+          : {
+              tarball: `${baseUrl}/tarballs/good.tgz`,
+              ...(spec.noIntegrity
+                ? {}
+                : spec.useShasumOnly
+                  ? { shasum: goodShasum }
+                  : { integrity: spec.corruptIntegrity ? `sha512-${'A'.repeat(88)}` : goodSri }),
+            }
+        versions[version] = {
+          version,
+          ...(spec.api === undefined ? {} : { [ADAPTER_API_VERSION_PACKAGE_FIELD]: spec.api }),
+          ...(dist ? { dist } : {}),
+        }
+      }
+      return new Response(JSON.stringify({ name, 'dist-tags': entry.distTags ?? {}, versions }))
+    },
+  })
+  baseUrl = `http://localhost:${server.port}`
+})
+
+afterAll(() => {
+  server.stop(true)
+})
+
+const implicit: NpmVersionRequest = { kind: 'implicit' }
+const opts = () => ({ registryBaseUrl: baseUrl })
+
+describe('resolveNpmAdapter — compatible selection', () => {
+  test('bare package skips a newer incompatible release', async () => {
+    packuments.set('skip-newer', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '1.1.0': { api: ADAPTER_API_VERSION },
+        '2.0.0': { api: '9.9' },
+      },
+    })
+    const result = await resolveNpmAdapter('skip-newer', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('1.1.0')
+    expect(result.release.apiVersion).toBe(ADAPTER_API_VERSION)
+    expect(result.release.tarballUrl).toBe(`${baseUrl}/tarballs/good.tgz`)
+    expect(result.release.dist.integrity).toBe(goodSri)
+  })
+
+  test('wildcard selector constrains compatible selection', async () => {
+    packuments.set('wildcarded', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '1.2.0': { api: ADAPTER_API_VERSION },
+        '2.0.0': { api: ADAPTER_API_VERSION },
+      },
+    })
+    const result = await resolveNpmAdapter(
+      'wildcarded',
+      { kind: 'selector', spec: { kind: 'majorWildcard', major: 1 }, raw: '1.*' },
+      opts(),
+    )
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('1.2.0')
+  })
+
+  test('explicit latest selects highest compatible independently of the latest dist-tag', async () => {
+    packuments.set('tagged', {
+      distTags: { latest: '3.0.0' },
+      versions: {
+        '2.5.0': { api: ADAPTER_API_VERSION },
+        '3.0.0': { api: '9.9' },
+      },
+    })
+    const result = await resolveNpmAdapter(
+      'tagged',
+      { kind: 'selector', spec: { kind: 'latest' }, raw: 'latest' },
+      opts(),
+    )
+    if (!result.ok) expect.unreachable()
+    // dist-tags.latest points at incompatible 3.0.0; selection ignores it.
+    expect(result.release.version).toBe('2.5.0')
+  })
+
+  test('prerelease versions are excluded from consideration', async () => {
+    packuments.set('prereleased', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '2.0.0-rc.1': { api: ADAPTER_API_VERSION },
+      },
+    })
+    const result = await resolveNpmAdapter('prereleased', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('1.0.0')
+  })
+
+  test('exact request selects exactly that compatible release', async () => {
+    packuments.set('pinned', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '1.1.0': { api: ADAPTER_API_VERSION },
+      },
+    })
+    const result = await resolveNpmAdapter(
+      'pinned',
+      { kind: 'exact', major: 1, minor: 0, patch: 0, raw: '1.0.0' },
+      opts(),
+    )
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('1.0.0')
+  })
+})
+
+describe('resolveNpmAdapter — incompatibility failures', () => {
+  test('exact incompatible release fails without substitution', async () => {
+    packuments.set('exact-incompatible', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '2.0.0': { api: '9.9' },
+      },
+    })
+    const request: NpmVersionRequest = { kind: 'exact', major: 2, minor: 0, patch: 0, raw: '2.0.0' }
+    const result = await resolveNpmAdapter('exact-incompatible', request, opts())
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'no-compatible-release') expect.unreachable()
+    expect(result.request).toEqual(request)
+    expect(result.supported).toEqual([ADAPTER_API_VERSION])
+    expect(result.newestConsidered).toEqual({ version: '2.0.0', declared: { kind: 'unsupported', api: '9.9' } })
+  })
+
+  test('missing package declaration makes a release ineligible', async () => {
+    packuments.set('undeclared', {
+      versions: {
+        '1.0.0': {},
+        '0.9.0': { api: ADAPTER_API_VERSION },
+      },
+    })
+    const result = await resolveNpmAdapter('undeclared', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('0.9.0')
+  })
+
+  test('malformed package declaration makes a release ineligible', async () => {
+    packuments.set('malformed', {
+      versions: {
+        '1.0.0': { api: '0.0.1' },
+      },
+    })
+    const result = await resolveNpmAdapter('malformed', implicit, opts())
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'no-compatible-release') expect.unreachable()
+    expect(result.newestConsidered).toEqual({ version: '1.0.0', declared: { kind: 'malformed', found: '0.0.1' } })
+  })
+
+  test('no release satisfying the selector reports no newestConsidered', async () => {
+    packuments.set('sparse', {
+      versions: { '1.0.0': { api: ADAPTER_API_VERSION } },
+    })
+    const result = await resolveNpmAdapter(
+      'sparse',
+      { kind: 'selector', spec: { kind: 'majorWildcard', major: 5 }, raw: '5.*' },
+      opts(),
+    )
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'no-compatible-release') expect.unreachable()
+    expect(result.newestConsidered).toBeUndefined()
+  })
+
+  test('all-undeclared package reports the newest considered release as missing', async () => {
+    packuments.set('legacy-only', {
+      versions: {
+        '1.0.0': {},
+        '1.2.0': {},
+      },
+    })
+    const result = await resolveNpmAdapter('legacy-only', implicit, opts())
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'no-compatible-release') expect.unreachable()
+    expect(result.newestConsidered).toEqual({ version: '1.2.0', declared: { kind: 'missing' } })
+  })
+})
+
+describe('resolveNpmAdapter — metadata failures', () => {
+  test('http failure surfaces as metadata-fetch-failed', async () => {
+    const result = await resolveNpmAdapter('never-published', implicit, opts())
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'metadata-fetch-failed') expect.unreachable()
+    expect(result.status).toBe(404)
+  })
+
+  test('unparseable packument surfaces as metadata-invalid', async () => {
+    packuments.set('broken-json', { versions: {} })
+    const result = await resolveNpmAdapter('broken-json', implicit, opts())
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('metadata-invalid')
+  })
+
+  test('packument without versions surfaces as metadata-invalid', async () => {
+    packuments.set('no-versions', { versions: {} })
+    const result = await resolveNpmAdapter('no-versions', implicit, opts())
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('metadata-invalid')
+  })
+
+  test('selected release without a tarball surfaces as metadata-invalid', async () => {
+    packuments.set('distless', {
+      versions: { '1.0.0': { api: ADAPTER_API_VERSION, noDist: true } },
+    })
+    const result = await resolveNpmAdapter('distless', implicit, opts())
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'metadata-invalid') expect.unreachable()
+    expect(result.detail).toContain('1.0.0')
+  })
+
+  test('unreachable registry surfaces as metadata-network-error', async () => {
+    const result = await resolveNpmAdapter('any-package', implicit, {
+      registryBaseUrl: 'http://127.0.0.1:1',
+    })
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('metadata-network-error')
+  })
+})
+
+describe('downloadNpmRelease — integrity provenance', () => {
+  test('download verifies SRI and reports the anchor used', async () => {
+    packuments.set('sri-download', { versions: { '1.0.0': { api: ADAPTER_API_VERSION } } })
+    const resolved = await resolveNpmAdapter('sri-download', implicit, opts())
+    if (!resolved.ok) expect.unreachable()
+    const dl = await downloadNpmRelease(resolved.release)
+    if (!dl.ok) expect.unreachable()
+    expect(dl.usedIntegrity).toEqual({ kind: 'sri', value: goodSri })
+    expect(await Bun.file(`${dl.path}/package.json`).exists()).toBe(true)
+  })
+
+  test('download falls back to shasum and reports the anchor used', async () => {
+    packuments.set('shasum-download', {
+      versions: { '1.0.0': { api: ADAPTER_API_VERSION, useShasumOnly: true } },
+    })
+    const resolved = await resolveNpmAdapter('shasum-download', implicit, opts())
+    if (!resolved.ok) expect.unreachable()
+    const dl = await downloadNpmRelease(resolved.release)
+    if (!dl.ok) expect.unreachable()
+    expect(dl.usedIntegrity).toEqual({ kind: 'shasum', value: goodShasum })
+  })
+
+  test('corrupted integrity fails the download', async () => {
+    packuments.set('tampered', {
+      versions: { '1.0.0': { api: ADAPTER_API_VERSION, corruptIntegrity: true } },
+    })
+    const resolved = await resolveNpmAdapter('tampered', implicit, opts())
+    if (!resolved.ok) expect.unreachable()
+    const dl = await downloadNpmRelease(resolved.release)
+    if (dl.ok) expect.unreachable()
+    expect(dl.reason).toBe('integrity-mismatch')
+  })
+
+  test('release without integrity anchors refuses to install', async () => {
+    packuments.set('anchorless', {
+      versions: { '1.0.0': { api: ADAPTER_API_VERSION, noIntegrity: true } },
+    })
+    const resolved = await resolveNpmAdapter('anchorless', implicit, opts())
+    if (!resolved.ok) expect.unreachable()
+    const dl = await downloadNpmRelease(resolved.release)
+    if (dl.ok) expect.unreachable()
+    expect(dl.reason).toBe('integrity-missing')
+  })
+})

--- a/packages/engine/src/sources/adapter/__tests__/specifier.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/specifier.test.ts
@@ -1,31 +1,40 @@
 import { describe, expect, test } from 'bun:test'
+import { FIRST_PARTY_ADAPTERS } from '../../../adapters/first-party.ts'
 import { getBuiltinAdapterNames, parseAdapterSpecifier } from '../specifier.ts'
 
 describe('parseAdapterSpecifier — built-in aliases', () => {
-  test('opencode resolves to the npm package', () => {
-    const result = parseAdapterSpecifier('opencode')
+  test('every first-party catalog entry resolves to its npm package', () => {
+    // The catalog is the single source of truth for aliases: this test
+    // holds for any adapter added to (or removed from) the catalog.
+    expect(FIRST_PARTY_ADAPTERS.length).toBeGreaterThan(0)
+    for (const adapter of FIRST_PARTY_ADAPTERS) {
+      const result = parseAdapterSpecifier(adapter.name)
+      if (!result.ok) expect.unreachable()
+      expect(result.resolved).toEqual({
+        type: 'npm',
+        packageName: adapter.npmPackage,
+        request: { kind: 'implicit' },
+      })
+    }
+  })
+
+  test('alias composes with a version selector', () => {
+    const result = parseAdapterSpecifier('opencode@1.*')
     if (!result.ok) expect.unreachable()
     expect(result.resolved).toEqual({
       type: 'npm',
       packageName: '@agent-facets/adapter-opencode',
+      request: { kind: 'selector', spec: { kind: 'majorWildcard', major: 1 }, raw: '1.*' },
     })
   })
 
-  test('claude-code resolves to the npm package', () => {
-    const result = parseAdapterSpecifier('claude-code')
-    if (!result.ok) expect.unreachable()
-    expect(result.resolved).toEqual({
-      type: 'npm',
-      packageName: '@agent-facets/adapter-claude-code',
-    })
-  })
-
-  test('codex resolves to the npm package', () => {
-    const result = parseAdapterSpecifier('codex')
+  test('alias composes with an exact version', () => {
+    const result = parseAdapterSpecifier('codex@1.2.3')
     if (!result.ok) expect.unreachable()
     expect(result.resolved).toEqual({
       type: 'npm',
       packageName: '@agent-facets/adapter-codex',
+      request: { kind: 'exact', major: 1, minor: 2, patch: 3, raw: '1.2.3' },
     })
   })
 })
@@ -66,7 +75,7 @@ describe('parseAdapterSpecifier — git URLs', () => {
   })
 })
 
-describe('parseAdapterSpecifier — local and npm', () => {
+describe('parseAdapterSpecifier — local paths', () => {
   test('relative path', () => {
     const result = parseAdapterSpecifier('./local/adapter')
     if (!result.ok) expect.unreachable()
@@ -84,32 +93,100 @@ describe('parseAdapterSpecifier — local and npm', () => {
       path: '/abs/adapter',
     })
   })
+})
 
-  test('scoped npm package', () => {
+describe('parseAdapterSpecifier — npm packages', () => {
+  test('scoped npm package stays a bare package', () => {
     const result = parseAdapterSpecifier('@scope/my-adapter')
     if (!result.ok) expect.unreachable()
     expect(result.resolved).toEqual({
       type: 'npm',
       packageName: '@scope/my-adapter',
+      request: { kind: 'implicit' },
     })
   })
 
-  test('bare npm package', () => {
+  test('bare npm package is an implicit request', () => {
     const result = parseAdapterSpecifier('some-adapter')
     if (!result.ok) expect.unreachable()
     expect(result.resolved).toEqual({
       type: 'npm',
       packageName: 'some-adapter',
+      request: { kind: 'implicit' },
+    })
+  })
+
+  test('scoped npm package splits the selector after the package name', () => {
+    const result = parseAdapterSpecifier('@scope/my-adapter@1.2.*')
+    if (!result.ok) expect.unreachable()
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: '@scope/my-adapter',
+      request: { kind: 'selector', spec: { kind: 'minorWildcard', major: 1, minor: 2 }, raw: '1.2.*' },
+    })
+  })
+
+  test('bare npm package with exact version', () => {
+    const result = parseAdapterSpecifier('some-adapter@2.0.1')
+    if (!result.ok) expect.unreachable()
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: 'some-adapter',
+      request: { kind: 'exact', major: 2, minor: 0, patch: 1, raw: '2.0.1' },
+    })
+  })
+
+  test('bare wildcard selector', () => {
+    const result = parseAdapterSpecifier('some-adapter@*')
+    if (!result.ok) expect.unreachable()
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: 'some-adapter',
+      request: { kind: 'selector', spec: { kind: 'wildcard' }, raw: '*' },
+    })
+  })
+
+  test('explicit latest selector', () => {
+    const result = parseAdapterSpecifier('@scope/my-adapter@latest')
+    if (!result.ok) expect.unreachable()
+    expect(result.resolved).toEqual({
+      type: 'npm',
+      packageName: '@scope/my-adapter',
+      request: { kind: 'selector', spec: { kind: 'latest' }, raw: 'latest' },
     })
   })
 })
 
+describe('parseAdapterSpecifier — rejected npm selectors', () => {
+  test.each([
+    ['some-adapter@^1.0.0', 'CARET_RANGE'],
+    ['some-adapter@~1.2.0', 'TILDE_RANGE'],
+    ['some-adapter@>=1.0.0', 'COMPARATOR_RANGE'],
+    ['some-adapter@1.0.0 || 2.0.0', 'OR_RANGE'],
+    ['some-adapter@1.0.0 - 2.0.0', 'COMPARATOR_RANGE'],
+    ['some-adapter@1.x', 'X_RANGE'],
+    ['@scope/my-adapter@1.2.x', 'X_RANGE'],
+    ['some-adapter@1.2.3-rc.1', 'INVALID_VERSION'],
+    ['some-adapter@', 'EMPTY'],
+  ])('rejects %s with %s', (specifier, code) => {
+    const result = parseAdapterSpecifier(specifier)
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid-npm-selector') expect.unreachable()
+    expect(result.error.code).toBe(code as never)
+    expect(result.specifier).toBe(specifier)
+  })
+
+  test('rejected selector reports the alias-resolved package name', () => {
+    const result = parseAdapterSpecifier('opencode@^1.0.0')
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid-npm-selector') expect.unreachable()
+    expect(result.packageName).toBe('@agent-facets/adapter-opencode')
+    expect(result.selector).toBe('^1.0.0')
+  })
+})
+
 describe('getBuiltinAdapterNames', () => {
-  test('returns all three built-in adapter names', () => {
-    const names = getBuiltinAdapterNames()
-    expect(names).toContain('opencode')
-    expect(names).toContain('claude-code')
-    expect(names).toContain('codex')
-    expect(names).toHaveLength(3)
+  test('derives from the first-party catalog', () => {
+    expect(getBuiltinAdapterNames()).toEqual(FIRST_PARTY_ADAPTERS.map((adapter) => adapter.name))
   })
 })

--- a/packages/engine/src/sources/adapter/npm.ts
+++ b/packages/engine/src/sources/adapter/npm.ts
@@ -2,28 +2,278 @@ import { createHash } from 'node:crypto'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { isAbsolute, join, relative, sep } from 'node:path'
+// Subpath import keeps engine's runtime graph free of the full SDK.
+import { ADAPTER_API_VERSION_PACKAGE_FIELD } from '@agent-facets/adapter/api-version'
+import { satisfies } from '@agent-facets/protocol'
 import { parseTarGzip } from 'nanotar'
+import {
+  type ApiDeclarationClassification,
+  classifyApiDeclaration,
+  SUPPORTED_ADAPTER_APIS,
+} from '../../adapters/api-compatibility.ts'
+import type { NpmVersionRequest } from './specifier.ts'
+
+/** Default npm registry. Overridable per call for fake-registry tests. */
+const DEFAULT_REGISTRY_BASE_URL = 'https://registry.npmjs.org'
+
+export interface NpmResolveOptions {
+  /** Registry base URL (no trailing slash). Defaults to the public npm registry. */
+  registryBaseUrl?: string
+}
 
 /**
- * Discriminated result for `downloadNpmPackage`. The success arm
- * carries the path to the extracted package; each failure arm carries
- * the structured fields the CLI needs to render a precise message.
+ * The release selected by compatibility-aware resolution. Carries every
+ * field download and installation provenance need, so all stages use the
+ * same selected record.
+ */
+export interface NpmResolvedRelease {
+  packageName: string
+  /** Exact `M.N.P` package version of the selected release. */
+  version: string
+  /** The release's declared adapter API — validated and CLI-supported. */
+  apiVersion: string
+  tarballUrl: string
+  /** Registry integrity anchors for the tarball, verbatim. */
+  dist: { integrity?: string; shasum?: string }
+}
+
+/**
+ * Discriminated result for `resolveNpmAdapter`.
  *
- *   - `metadata-fetch-failed` — `GET <registry>/<name>/latest` failed
- *     at the HTTP level (network error or non-2xx status).
- *   - `no-tarball-url` — registry response lacked `dist.tarball`.
+ *   - `metadata-network-error` / `metadata-fetch-failed` — the packument
+ *     request failed at the network/HTTP level.
+ *   - `metadata-invalid` — the packument parsed but its shape is
+ *     unusable (missing `versions`, or the selected release lacks a
+ *     tarball URL).
+ *   - `no-compatible-release` — no stable release satisfying the
+ *     request declares a CLI-supported adapter API. `newestConsidered`
+ *     is the newest release that satisfied the package-version request
+ *     (when any did), with its API classification — absent when nothing
+ *     satisfied the request at all.
+ */
+export type ResolveNpmAdapterResult =
+  | { ok: true; release: NpmResolvedRelease }
+  | { ok: false; reason: 'metadata-network-error'; packageName: string; cause: string }
+  | { ok: false; reason: 'metadata-fetch-failed'; packageName: string; status: number; statusText: string }
+  | { ok: false; reason: 'metadata-invalid'; packageName: string; detail: string }
+  | {
+      ok: false
+      reason: 'no-compatible-release'
+      packageName: string
+      request: NpmVersionRequest
+      supported: readonly string[]
+      newestConsidered?: { version: string; declared: ApiDeclarationClassification }
+    }
+
+/** A stable release parsed out of the packument's `versions` map. */
+interface StableRelease {
+  version: string
+  components: { major: number; minor: number; patch: number }
+  declared: ApiDeclarationClassification
+  dist: { tarball?: string; integrity?: string; shasum?: string }
+}
+
+const STABLE_VERSION_RE = /^(\d+)\.(\d+)\.(\d+)$/
+
+/**
+ * Resolve an npm adapter request to a concrete release using the full
+ * packument (`GET <registry>/<name>`).
+ *
+ * The full document is required: the abbreviated
+ * `application/vnd.npm.install-v1+json` representation can omit custom
+ * per-version fields such as the adapter API declaration.
+ *
+ * Selection rules:
+ *   - only stable `M.N.P` versions are considered (prereleases excluded);
+ *   - the user's package-version request constrains the candidate set;
+ *   - releases whose adapter API declaration is missing, malformed, or
+ *     unsupported are ineligible;
+ *   - the highest remaining semantic version wins.
+ *
+ * An exact request considers only that release — incompatibility fails
+ * rather than substituting another version. `dist-tags` (including
+ * `latest`) are never consulted; explicit `latest` means "highest
+ * compatible published version".
+ */
+export async function resolveNpmAdapter(
+  packageName: string,
+  request: NpmVersionRequest,
+  opts: NpmResolveOptions = {},
+): Promise<ResolveNpmAdapterResult> {
+  const base = opts.registryBaseUrl ?? DEFAULT_REGISTRY_BASE_URL
+  const registryUrl = `${base}/${packageName}`
+
+  let response: Response
+  try {
+    response = await fetch(registryUrl)
+  } catch (e) {
+    return {
+      ok: false,
+      reason: 'metadata-network-error',
+      packageName,
+      cause: e instanceof Error ? e.message : String(e),
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: 'metadata-fetch-failed',
+      packageName,
+      status: response.status,
+      statusText: response.statusText,
+    }
+  }
+
+  let packument: unknown
+  try {
+    packument = await response.json()
+  } catch (e) {
+    return {
+      ok: false,
+      reason: 'metadata-invalid',
+      packageName,
+      detail: `packument is not valid JSON: ${e instanceof Error ? e.message : String(e)}`,
+    }
+  }
+
+  const versionsField = (packument as { versions?: unknown } | null)?.versions
+  if (versionsField === null || typeof versionsField !== 'object') {
+    return { ok: false, reason: 'metadata-invalid', packageName, detail: 'packument has no "versions" object' }
+  }
+
+  // Parse stable releases that satisfy the package-version request.
+  const considered: StableRelease[] = []
+  for (const [version, entry] of Object.entries(versionsField as Record<string, unknown>)) {
+    const match = STABLE_VERSION_RE.exec(version)
+    if (!match || match[1] === undefined || match[2] === undefined || match[3] === undefined) continue
+    const components = {
+      major: Number.parseInt(match[1], 10),
+      minor: Number.parseInt(match[2], 10),
+      patch: Number.parseInt(match[3], 10),
+    }
+    if (!satisfiesRequest(components, request)) continue
+
+    const record = typeof entry === 'object' && entry !== null ? (entry as Record<string, unknown>) : {}
+    const dist = typeof record.dist === 'object' && record.dist !== null ? (record.dist as Record<string, unknown>) : {}
+    considered.push({
+      version,
+      components,
+      declared: classifyApiDeclaration(record[ADAPTER_API_VERSION_PACKAGE_FIELD]),
+      dist: {
+        tarball: typeof dist.tarball === 'string' ? dist.tarball : undefined,
+        integrity: typeof dist.integrity === 'string' ? dist.integrity : undefined,
+        shasum: typeof dist.shasum === 'string' ? dist.shasum : undefined,
+      },
+    })
+  }
+
+  const newestConsidered = highestBy(considered)
+  const eligible = considered.filter((release) => release.declared.kind === 'supported')
+  const selected = highestBy(eligible)
+
+  if (!selected) {
+    return {
+      ok: false,
+      reason: 'no-compatible-release',
+      packageName,
+      request,
+      supported: SUPPORTED_ADAPTER_APIS,
+      ...(newestConsidered
+        ? { newestConsidered: { version: newestConsidered.version, declared: newestConsidered.declared } }
+        : {}),
+    }
+  }
+
+  if (!selected.dist.tarball) {
+    return {
+      ok: false,
+      reason: 'metadata-invalid',
+      packageName,
+      detail: `selected release ${selected.version} has no dist.tarball`,
+    }
+  }
+  if (selected.declared.kind !== 'supported') {
+    // Unreachable by construction (eligible filters on 'supported');
+    // kept as a type-narrowing guard rather than a non-null assertion.
+    return {
+      ok: false,
+      reason: 'metadata-invalid',
+      packageName,
+      detail: `selected release ${selected.version} lost its API classification`,
+    }
+  }
+
+  return {
+    ok: true,
+    release: {
+      packageName,
+      version: selected.version,
+      apiVersion: selected.declared.api,
+      tarballUrl: selected.dist.tarball,
+      dist: { integrity: selected.dist.integrity, shasum: selected.dist.shasum },
+    },
+  }
+}
+
+function satisfiesRequest(
+  components: { major: number; minor: number; patch: number },
+  request: NpmVersionRequest,
+): boolean {
+  switch (request.kind) {
+    case 'implicit':
+      return true
+    case 'exact':
+      return (
+        components.major === request.major && components.minor === request.minor && components.patch === request.patch
+      )
+    case 'selector':
+      return satisfies(components, request.spec)
+  }
+}
+
+/** Highest release by semantic version order; undefined for an empty list. */
+function highestBy(releases: readonly StableRelease[]): StableRelease | undefined {
+  let best: StableRelease | undefined
+  for (const release of releases) {
+    if (!best || compareComponents(release.components, best.components) > 0) {
+      best = release
+    }
+  }
+  return best
+}
+
+function compareComponents(
+  a: { major: number; minor: number; patch: number },
+  b: { major: number; minor: number; patch: number },
+): number {
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  return a.patch - b.patch
+}
+
+/**
+ * The integrity anchor that authenticated a downloaded tarball —
+ * recorded verbatim in installation provenance.
+ */
+export type UsedIntegrity = { kind: 'sri'; value: string } | { kind: 'shasum'; value: string }
+
+/**
+ * Discriminated result for `downloadNpmRelease`. The success arm
+ * carries the path to the extracted package and the integrity anchor
+ * that authenticated the bytes; each failure arm carries the structured
+ * fields the CLI needs to render a precise message.
+ *
  *   - `tarball-fetch-failed` — `GET <tarball>` failed at the HTTP level.
- *   - `integrity-mismatch` — SRI/shasum check rejected the bytes.
- *   - `integrity-missing` — registry shipped neither SRI nor shasum;
+ *   - `integrity-mismatch` — SRI check rejected the bytes.
+ *   - `integrity-shasum-mismatch` — shasum check rejected the bytes.
+ *   - `integrity-unsupported-algo` — the SRI string had no supported algorithm.
+ *   - `integrity-missing` — the release shipped neither SRI nor shasum;
  *     we refuse to install untrusted bytes.
  *   - `tar-slip` — a tarball entry's resolved path escapes the
  *     extraction directory (`..`-traversal or absolute path).
  */
 export type DownloadNpmResult =
-  | { ok: true; path: string }
-  | { ok: false; reason: 'metadata-fetch-failed'; packageName: string; status: number; statusText: string }
-  | { ok: false; reason: 'metadata-network-error'; packageName: string; cause: string }
-  | { ok: false; reason: 'no-tarball-url'; packageName: string }
+  | { ok: true; path: string; usedIntegrity: UsedIntegrity }
   | { ok: false; reason: 'tarball-fetch-failed'; packageName: string; status: number; statusText: string }
   | { ok: false; reason: 'tarball-network-error'; packageName: string; cause: string }
   | { ok: false; reason: 'integrity-mismatch'; packageName: string; algo: string; expected: string; actual: string }
@@ -33,13 +283,13 @@ export type DownloadNpmResult =
   | { ok: false; reason: 'tar-slip'; packageName: string; entryName: string }
 
 /**
- * Discriminated result for `verifyTarballIntegrity` — `{ ok: true }` on
- * pass, otherwise one of the integrity-related failure variants from
- * `DownloadNpmResult`. Exported for direct unit-testing without a fake
- * registry pipeline.
+ * Discriminated result for `verifyTarballIntegrity` — the success arm
+ * reports which anchor authenticated the bytes, otherwise one of the
+ * integrity-related failure variants from `DownloadNpmResult`. Exported
+ * for direct unit-testing without a fake registry pipeline.
  */
 export type VerifyTarballIntegrityResult =
-  | { ok: true }
+  | { ok: true; usedIntegrity: UsedIntegrity }
   | Extract<
       DownloadNpmResult,
       | { reason: 'integrity-mismatch' }
@@ -55,11 +305,10 @@ export type VerifyTarballIntegrityResult =
 export type AssertInsideTempDirResult = { ok: true } | Extract<DownloadNpmResult, { reason: 'tar-slip' }>
 
 /**
- * Download an npm package to a temp directory.
- * Uses the npm registry API to resolve the tarball URL, then fetches and extracts it.
+ * Download the resolved release's tarball to a temp directory.
  *
  * F16 hardening:
- *  - Verifies the downloaded bytes against the registry's `dist.integrity`
+ *  - Verifies the downloaded bytes against the release's `dist.integrity`
  *    SRI string (Subresource Integrity, format: `sha<N>-<base64>`). Fails
  *    loud on mismatch so a compromised mirror or in-flight tamper is
  *    detectable. Supports sha512/sha384/sha256/sha1 (npm registry ships one).
@@ -70,43 +319,12 @@ export type AssertInsideTempDirResult = { ok: true } | Extract<DownloadNpmResult
  * Returns a discriminated `DownloadNpmResult` — never throws on a
  * documented failure mode.
  */
-export async function downloadNpmPackage(packageName: string): Promise<DownloadNpmResult> {
-  // Fetch package metadata from the npm registry
-  const registryUrl = `https://registry.npmjs.org/${packageName}/latest`
-  let metaResponse: Response
-  try {
-    metaResponse = await fetch(registryUrl)
-  } catch (e) {
-    return {
-      ok: false,
-      reason: 'metadata-network-error',
-      packageName,
-      cause: e instanceof Error ? e.message : String(e),
-    }
-  }
-  if (!metaResponse.ok) {
-    return {
-      ok: false,
-      reason: 'metadata-fetch-failed',
-      packageName,
-      status: metaResponse.status,
-      statusText: metaResponse.statusText,
-    }
-  }
+export async function downloadNpmRelease(release: NpmResolvedRelease): Promise<DownloadNpmResult> {
+  const { packageName } = release
 
-  const meta = (await metaResponse.json()) as {
-    dist?: { tarball?: string; integrity?: string; shasum?: string }
-    version?: string
-  }
-  const tarballUrl = meta.dist?.tarball
-  if (!tarballUrl) {
-    return { ok: false, reason: 'no-tarball-url', packageName }
-  }
-
-  // Download the tarball
   let tarballResponse: Response
   try {
-    tarballResponse = await fetch(tarballUrl)
+    tarballResponse = await fetch(release.tarballUrl)
   } catch (e) {
     return {
       ok: false,
@@ -129,7 +347,7 @@ export async function downloadNpmPackage(packageName: string): Promise<DownloadN
 
   // Integrity check. The registry normally ships `dist.integrity` (SRI);
   // older entries ship `dist.shasum` (hex sha1). Either is sufficient.
-  const integrityResult = verifyTarballIntegrity(packageName, tarballBytes, meta.dist?.integrity, meta.dist?.shasum)
+  const integrityResult = verifyTarballIntegrity(packageName, tarballBytes, release.dist.integrity, release.dist.shasum)
   if (!integrityResult.ok) return integrityResult
 
   // Extract to a temp directory
@@ -149,14 +367,15 @@ export async function downloadNpmPackage(packageName: string): Promise<DownloadN
     await Bun.write(outputPath, entry.data)
   }
 
-  return { ok: true, path: tempDir }
+  return { ok: true, path: tempDir, usedIntegrity: integrityResult.usedIntegrity }
 }
 
 /**
  * Parse an SRI string (`sha512-<base64>`) and verify `bytes` hashes to the
  * expected digest. Falls back to `shasum` (hex sha1) when SRI is absent.
  * Returns a structured failure when integrity metadata is missing — we
- * refuse to install unhashed tarballs.
+ * refuse to install unhashed tarballs. On success, reports the exact
+ * anchor that authenticated the bytes.
  *
  * Exported for direct unit-testing of the integrity guard without
  * standing up a whole fake registry + tarball pipeline.
@@ -176,7 +395,7 @@ export function verifyTarballIntegrity(
       const expected = candidate.slice(dashIndex + 1)
       if (!SUPPORTED_SRI_ALGOS.has(algo)) continue
       const actual = createHash(algo).update(bytes).digest('base64')
-      if (actual === expected) return { ok: true }
+      if (actual === expected) return { ok: true, usedIntegrity: { kind: 'sri', value: candidate } }
       return { ok: false, reason: 'integrity-mismatch', packageName, algo, expected, actual }
     }
     return { ok: false, reason: 'integrity-unsupported-algo', packageName, integrity }
@@ -187,7 +406,7 @@ export function verifyTarballIntegrity(
     if (actual !== shasum) {
       return { ok: false, reason: 'integrity-shasum-mismatch', packageName, expected: shasum, actual }
     }
-    return { ok: true }
+    return { ok: true, usedIntegrity: { kind: 'shasum', value: shasum } }
   }
 
   return { ok: false, reason: 'integrity-missing', packageName }

--- a/packages/engine/src/sources/adapter/specifier.ts
+++ b/packages/engine/src/sources/adapter/specifier.ts
@@ -1,38 +1,83 @@
+import type { VersionSpec } from '@agent-facets/protocol'
+import { FIRST_PARTY_ADAPTERS } from '../../adapters/first-party.ts'
+import { parseVersionSpec } from '../facet/parse-version.ts'
+import type { ParseError } from '../facet/types.ts'
+
 /**
  * Parses an adapter install specifier into a resolved source type.
  *
  * Specifier formats:
- * - Built-in name: "opencode", "claude-code", "codex"
- * - npm package: "@scope/adapter-name" or "adapter-name"
+ * - Built-in name: "opencode", "claude-code", "codex" (from the
+ *   first-party catalog), optionally with a version selector
+ * - npm package: "@scope/adapter-name" or "adapter-name", optionally
+ *   with a version selector ("name@1.2.3", "@scope/name@1.*", "name@latest")
  * - Git URL: "git+https://...", "git+ssh://..."
  * - Local path: "./path", "../path", "/absolute/path"
  */
 
-/** Alias map for first-party adapter convenience names */
-const BUILTIN_ALIASES: Record<string, string> = {
-  opencode: '@agent-facets/adapter-opencode',
-  'claude-code': '@agent-facets/adapter-claude-code',
-  codex: '@agent-facets/adapter-codex',
-}
+/**
+ * Alias map for first-party adapter convenience names, derived from the
+ * first-party catalog — the single source of truth for both picker
+ * content and alias-to-package resolution.
+ */
+const BUILTIN_ALIASES: ReadonlyMap<string, string> = new Map(
+  FIRST_PARTY_ADAPTERS.map((adapter) => [adapter.name, adapter.npmPackage]),
+)
+
+/**
+ * The package-version request attached to an npm adapter source.
+ * Non-overlapping variants preserve the user's intent:
+ *
+ *   - `implicit` — bare package name or first-party alias; resolution
+ *     selects the highest compatible stable release.
+ *   - `exact` — a fully pinned `M.N.P`; resolution considers only that
+ *     release and never substitutes another.
+ *   - `selector` — an explicit Facet-style wildcard or `latest`
+ *     selector; resolution selects the highest compatible stable
+ *     release satisfying it. The `spec` type excludes `exact` so a
+ *     pinned version cannot masquerade as a selector.
+ *
+ * `raw` is the surface form the user typed, for display.
+ */
+export type NpmVersionRequest =
+  | { kind: 'implicit' }
+  | { kind: 'exact'; major: number; minor: number; patch: number; raw: string }
+  | {
+      kind: 'selector'
+      spec: Extract<VersionSpec, { kind: 'majorWildcard' | 'minorWildcard' | 'wildcard' | 'latest' }>
+      raw: string
+    }
 
 export type ResolvedAdapterSpecifier =
-  | { type: 'npm'; packageName: string }
+  | { type: 'npm'; packageName: string; request: NpmVersionRequest }
   | { type: 'git'; url: string; commitish?: string }
   | { type: 'local'; path: string }
 
 /**
  * Discriminated result for `parseAdapterSpecifier`. The success arm
- * carries the resolved source description; the failure arm carries
+ * carries the resolved source description; the failure arms carry
  * structured fields the CLI needs to render a precise message.
  *
  *   - `invalid-git-url` — the specifier started with `git+` but the
  *     URL after the prefix used a scheme outside the allowlist
  *     (https/http/ssh/git/file). Closes the F15 tar-slip / flag-injection
  *     hole at the boundary.
+ *   - `invalid-npm-selector` — the npm version selector after `@` is
+ *     not in the supported exact/wildcard/`latest` grammar. Carries the
+ *     structured `ParseError` from the shared Facet selector parser
+ *     (caret/tilde/comparator/OR/hyphen/x-range/prerelease/empty).
  */
 export type ParseAdapterSpecifierResult =
   | { ok: true; resolved: ResolvedAdapterSpecifier }
   | { ok: false; reason: 'invalid-git-url'; specifier: string; url: string }
+  | {
+      ok: false
+      reason: 'invalid-npm-selector'
+      specifier: string
+      packageName: string
+      selector: string
+      error: ParseError
+    }
 
 // F15 — same scheme allowlist as the facet-side parseFacetSource. Anything
 // not in this set (notably leading `-` or nonsense schemes) is rejected
@@ -47,12 +92,6 @@ const GIT_URL_SCHEME_RE = /^(https?|ssh|git|file):\/\//
  * Errors are values: callers pattern-match on `result.reason`.
  */
 export function parseAdapterSpecifier(specifier: string): ParseAdapterSpecifierResult {
-  // Check built-in aliases first
-  const alias = BUILTIN_ALIASES[specifier]
-  if (alias) {
-    return { ok: true, resolved: { type: 'npm', packageName: alias } }
-  }
-
   // Git URLs: git+https://, git+ssh://
   if (specifier.startsWith('git+')) {
     const raw = specifier.slice(4) // strip "git+" prefix
@@ -73,11 +112,43 @@ export function parseAdapterSpecifier(specifier: string): ParseAdapterSpecifierR
     return { ok: true, resolved: { type: 'local', path: specifier } }
   }
 
-  // Everything else is an npm package specifier
-  return { ok: true, resolved: { type: 'npm', packageName: specifier } }
+  // npm package (bare name, alias, or either with a version selector)
+  const { name, selector } = splitNpmSpecifier(specifier)
+  const packageName = BUILTIN_ALIASES.get(name) ?? name
+
+  if (selector === undefined) {
+    return { ok: true, resolved: { type: 'npm', packageName, request: { kind: 'implicit' } } }
+  }
+
+  const parsed = parseVersionSpec(selector)
+  if (!parsed.ok) {
+    return { ok: false, reason: 'invalid-npm-selector', specifier, packageName, selector, error: parsed.error }
+  }
+  const spec = parsed.value
+  const request: NpmVersionRequest =
+    spec.kind === 'exact'
+      ? { kind: 'exact', major: spec.major, minor: spec.minor, patch: spec.patch, raw: selector }
+      : { kind: 'selector', spec, raw: selector }
+  return { ok: true, resolved: { type: 'npm', packageName, request } }
 }
 
-/** Returns the list of known built-in adapter names */
+/**
+ * Split an npm specifier into package name and optional version
+ * selector. Scoped names keep their leading `@`: the version delimiter
+ * is an `@` that appears after the package name — for `@scope/name`
+ * forms, after the first `/`; otherwise any `@` past position 0.
+ */
+function splitNpmSpecifier(specifier: string): { name: string; selector?: string } {
+  const searchFrom = specifier.startsWith('@') ? specifier.indexOf('/') + 1 : 1
+  // A leading '@' with no '/' can't carry a selector delimiter we
+  // recognize; treat the whole string as the package name.
+  if (searchFrom === 0) return { name: specifier }
+  const atIndex = specifier.indexOf('@', Math.max(searchFrom, 1))
+  if (atIndex === -1) return { name: specifier }
+  return { name: specifier.slice(0, atIndex), selector: specifier.slice(atIndex + 1) }
+}
+
+/** Returns the list of known built-in adapter names (from the first-party catalog). */
 export function getBuiltinAdapterNames(): string[] {
-  return Object.keys(BUILTIN_ALIASES)
+  return [...BUILTIN_ALIASES.keys()]
 }


### PR DESCRIPTION
### Why

Adapter installation previously resolved npm packages by hitting the `/latest` dist-tag endpoint, which meant the CLI had no way to filter releases by declared adapter API compatibility. This implements compatibility-aware resolution: the full packument is fetched, stable releases are filtered by the user's version request and by whether they declare a supported adapter API, and the highest qualifying release wins.

### Details

**Resolution split into two stages**

`downloadNpmPackage` is replaced by two functions: `resolveNpmAdapter` (selects a compatible release from the packument) and `downloadNpmRelease` (downloads and verifies the tarball for an already-selected release). The install service calls them in sequence, threading the resolved release through so the selected version, declared API, tarball URL, and integrity anchors are all carried together into download, verification, extraction, and installation provenance.

**Selection rules**

- Only stable `M.N.P` versions are considered; prereleases are excluded.
- The user's version request constrains the candidate set before compatibility filtering.
- Releases whose adapter API declaration is missing, malformed, or unsupported are ineligible.
- The highest remaining semantic version wins.
- Exact requests consider only that one release and never substitute another.
- `dist-tags` (including `latest`) are never consulted; an explicit `latest` selector means "highest compatible published version."

**Version request types on the specifier**

`NpmVersionRequest` is added to `ResolvedAdapterSpecifier` with three variants: `implicit` (bare name, no selector), `exact` (fully pinned `M.N.P`), and `selector` (wildcard or `latest`). The specifier parser now splits scoped and unscoped package names from their `@`-delimited selector, reuses the existing Facet `parseVersionSpec` grammar, and returns a structured `invalid-npm-selector` failure for unsupported forms (caret, tilde, comparator, OR, hyphen, x-range, prerelease, empty).

**First-party catalog as single source of truth**

`BUILTIN_ALIASES` is derived from `FIRST_PARTY_ADAPTERS` rather than being a separate hardcoded map, so picker entries and alias-to-package resolution stay in sync automatically.

**Integrity provenance**

`verifyTarballIntegrity` now returns `{ ok: true; usedIntegrity: UsedIntegrity }` on success, where `UsedIntegrity` is `{ kind: 'sri' | 'shasum'; value: string }`. `downloadNpmRelease` surfaces this on its success arm so the exact anchor that authenticated the bytes is available for installation provenance.

**Error messages**

`describeAdapterInstallFailure` is extended to handle `invalid-npm-selector` (with the structured `ParseError` from the parser) and `no-compatible-release` (with the request kind, supported API list, and the newest considered release's API classification). The old `no-tarball-url` case is replaced by `metadata-invalid`.

### Verification

New fake-registry test suite (`npm-resolve.test.ts`) covers: compatible selection skipping newer incompatible releases, wildcard selector constraining selection, explicit `latest` ignoring the dist-tag, prerelease exclusion, exact pinning, exact incompatibility without substitution, missing/malformed API declarations, no release satisfying the selector, HTTP and network metadata failures, unparseable packuments, missing `dist`, SRI download with provenance reporting, shasum fallback with provenance reporting, corrupted integrity rejection, and missing integrity anchor rejection. Existing hardening tests are updated to assert the `usedIntegrity` field on success.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the npm adapter install and resolution path (registry metadata, version selection, and verification inputs), which is user-facing and security-sensitive around tarball integrity, though behavior is heavily covered by new tests and structured failures.
> 
> **Overview**
> Replaces npm adapter installs that used **`/latest`** with **full-packument resolution** and a separate tarball download: **`resolveNpmAdapter`** picks a stable release that matches the user’s version request and declares a **CLI-supported adapter API**; **`downloadNpmRelease`** fetches and verifies that release only.
> 
> **Specifier and catalog changes:** npm resolutions now carry **`NpmVersionRequest`** (`implicit`, exact `M.N.P`, or Facet-style wildcards/`latest`). Built-in aliases come from **`FIRST_PARTY_ADAPTERS`**; scoped `@scope/pkg@selector` splitting and **`invalid-npm-selector`** errors reuse the facet version parser. Unsupported selectors (caret, ranges, etc.) fail structurally.
> 
> **Install pipeline:** `installAdapter` resolves then downloads, passes **`expectedApiVersion`** into verification, and surfaces resolution failures (including **`no-compatible-release`** with newest considered release) through existing download-failure wiring.
> 
> **Integrity:** successful tarball verification returns **`usedIntegrity`** (SRI or shasum) for provenance; CLI messaging adds **`metadata-invalid`**, **`no-compatible-release`**, and npm selector errors.
> 
> OpenSpec tasks for adapter specifier/npm resolution (sections 5–6) are marked complete; broad **`npm-resolve`** fake-registry tests cover selection, dist-tag independence, exact-pin failure, and integrity paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c582e1d429f789c8d6d1d4b7ca2a42787210b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->