### PR TITLE
Add managed adapter installation with atomic activation, fail-closed loading, and inspection-backed `adapter list`

### DIFF
--- a/openspec/changes/add-adapter-api-version-negotiation/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/tasks.md
@@ -63,52 +63,52 @@
 
 ## 7. Managed Installation and Atomic Activation — Research
 
-- [ ] 7.1 Explore: Inspect `packages/engine/src/adapters/placement.ts`, `packages/engine/src/facet-dir.ts`, `packages/common/src/atomic-write.ts`, and `packages/engine/src/install/lockfile-guard.ts` for placement, directory derivation, atomic writes, advisory locking, and safe-path precedents.
-- [ ] 7.2 Explore: Inspect adapter placement tests and engine/CLI fixtures that fabricate flat installed bundles to define managed, unmanaged, staging, crash-leftover, failure-injection, and cleanup behavior.
-- [ ] 7.3 Propose: Present the versioned installation receipt schema, source-tagged provenance, generation naming and containment rules, per-adapter lock lifecycle, and atomic activation sequence.
+- [x] 7.1 Explore: Inspect `packages/engine/src/adapters/placement.ts`, `packages/engine/src/facet-dir.ts`, `packages/common/src/atomic-write.ts`, and `packages/engine/src/install/lockfile-guard.ts` for placement, directory derivation, atomic writes, advisory locking, and safe-path precedents.
+- [x] 7.2 Explore: Inspect adapter placement tests and engine/CLI fixtures that fabricate flat installed bundles to define managed, unmanaged, staging, crash-leftover, failure-injection, and cleanup behavior.
+- [x] 7.3 Propose: Present the versioned installation receipt schema, source-tagged provenance, generation naming and containment rules, per-adapter lock lifecycle, and atomic activation sequence.
 
 ## 8. Managed Installation and Atomic Activation — Implementation
 
-- [ ] 8.1 Implement: Add validated installation receipt types and I/O for npm, Git, and local provenance without representable cross-source field combinations.
-- [ ] 8.2 Implement: Add safe unique generation paths, containment checks, and a per-adapter replacement lock with stale-owner handling.
-- [ ] 8.3 Implement: Replace direct bundle overwrite with stage, final-path verification, atomic receipt activation, and post-activation cleanup while preserving the prior installation on every pre-activation failure.
-- [ ] 8.4 Implement: Support unmanaged historical `<name>/adapter.js` entries and convert them to the managed layout only after a successful reinstall.
-- [ ] 8.5 Implement: Update adapter removal and directory enumeration to delete complete installations, ignore staging/crash leftovers, and never remove the generation named by the active receipt.
-- [ ] 8.6 Implement: Add tests for each provenance variant, invalid receipts and paths, atomic success, injected failures at every stage, cleanup warnings, stale leftovers, concurrent replacements, and legacy conversion.
-- [ ] 8.7 Verify: Run targeted placement, receipt, lock, and removal suites.
+- [x] 8.1 Implement: Add validated installation receipt types and I/O for npm, Git, and local provenance without representable cross-source field combinations.
+- [x] 8.2 Implement: Add safe unique generation paths, containment checks, and a per-adapter replacement lock with stale-owner handling.
+- [x] 8.3 Implement: Replace direct bundle overwrite with stage, final-path verification, atomic receipt activation, and post-activation cleanup while preserving the prior installation on every pre-activation failure.
+- [x] 8.4 Implement: Support unmanaged historical `<name>/adapter.js` entries and convert them to the managed layout only after a successful reinstall.
+- [x] 8.5 Implement: Update adapter removal and directory enumeration to delete complete installations, ignore staging/crash leftovers, and never remove the generation named by the active receipt.
+- [x] 8.6 Implement: Add tests for each provenance variant, invalid receipts and paths, atomic success, injected failures at every stage, cleanup warnings, stale leftovers, concurrent replacements, and legacy conversion.
+- [x] 8.7 Verify: Run targeted placement, receipt, lock, and removal suites.
 
 ## 9. Installed Inspection and Fail-Closed Loading — Research
 
-- [ ] 9.1 Explore: Inspect `packages/engine/src/adapters/loader.ts`, `packages/cli/src/commands/adapter/index.ts`, and tests that fabricate flat installed bundles to map warn-and-skip loading, list behavior, import caching, and fixture migration.
-- [ ] 9.2 Explore: Inspect `packages/engine/src/adapters/first-party.ts` and unmanaged-name consumers to define provenance-aware repair aliases without inventing unavailable source information.
-- [ ] 9.3 Propose: Present shared managed/unmanaged inspection outcomes, broken-installation failures, repair discriminators, aggregate load results, and fixture migration.
+- [x] 9.1 Explore: Inspect `packages/engine/src/adapters/loader.ts`, `packages/cli/src/commands/adapter/index.ts`, and tests that fabricate flat installed bundles to map warn-and-skip loading, list behavior, import caching, and fixture migration.
+- [x] 9.2 Explore: Inspect `packages/engine/src/adapters/first-party.ts` and unmanaged-name consumers to define provenance-aware repair aliases without inventing unavailable source information.
+- [x] 9.3 Propose: Present shared managed/unmanaged inspection outcomes, broken-installation failures, repair discriminators, aggregate load results, and fixture migration.
 
 ## 10. Installed Inspection and Fail-Closed Loading — Implementation
 
-- [ ] 10.1 Implement: Add one installed-adapter inspector that validates managed receipts, rejects recorded unsupported APIs before import, verifies active runtime declarations, and verifies unmanaged bundles directly.
-- [ ] 10.2 Implement: Classify every directory as compatible, incompatible, or broken with structured failure and repair data, ignoring non-active generations and staging leftovers.
-- [ ] 10.3 Implement: Convert installed loading to a result that returns verified adapters only when every entry succeeds and otherwise aggregates all failures without warning-and-skip behavior.
-- [ ] 10.4 Implement: Expose inspection-backed list data containing adapter name, declared or missing/malformed API, supported/unsupported/broken status, and repair source.
-- [ ] 10.5 Implement: Migrate flat-bundle test fixtures where managed provenance is required while retaining explicit unmanaged compatibility tests.
-- [ ] 10.6 Implement: Add tests for managed and unmanaged success, missing/malformed/unsupported declarations, receipt/runtime mismatch, invalid receipt/import/export failures, aggregate failures, and unique-generation import freshness.
-- [ ] 10.7 Verify: Run targeted inspector, loader, listing-data, and integration suites.
+- [x] 10.1 Implement: Add one installed-adapter inspector that validates managed receipts, rejects recorded unsupported APIs before import, verifies active runtime declarations, and verifies unmanaged bundles directly.
+- [x] 10.2 Implement: Classify every directory as compatible, incompatible, or broken with structured failure and repair data, ignoring non-active generations and staging leftovers.
+- [x] 10.3 Implement: Convert installed loading to a result that returns verified adapters only when every entry succeeds and otherwise aggregates all failures without warning-and-skip behavior.
+- [x] 10.4 Implement: Expose inspection-backed list data containing adapter name, declared or missing/malformed API, supported/unsupported/broken status, and repair source.
+- [x] 10.5 Implement: Migrate flat-bundle test fixtures where managed provenance is required while retaining explicit unmanaged compatibility tests.
+- [x] 10.6 Implement: Add tests for managed and unmanaged success, missing/malformed/unsupported declarations, receipt/runtime mismatch, invalid receipt/import/export failures, aggregate failures, and unique-generation import freshness.
+- [x] 10.7 Verify: Run targeted inspector, loader, listing-data, and integration suites.
 
 ## 11. Adapter Install and Management Commands — Research
 
-- [ ] 11.1 Explore: Inspect `packages/engine/src/adapters/install-service.ts` for stage reporting, source cleanup, prebuilt fallback, and provenance flow.
-- [ ] 11.2 Explore: Inspect `packages/engine/src/adapters/bundler.ts` and its tests for thrown exception boundaries, temporary resources, and cleanup guarantees.
-- [ ] 11.3 Explore: Inspect `packages/cli/src/commands/adapter/`, `packages/cli/src/util/adapter-install-errors.ts`, and adapter command tests for install, picker, list, remove, and result-rendering behavior.
-- [ ] 11.4 Propose: Present the end-to-end install-service result flow and CLI presentation for parse, no-compatible-release, download, verification, activation, cleanup-warning, and recovery outcomes.
+- [x] 11.1 Explore: Inspect `packages/engine/src/adapters/install-service.ts` for stage reporting, source cleanup, prebuilt fallback, and provenance flow.
+- [x] 11.2 Explore: Inspect `packages/engine/src/adapters/bundler.ts` and its tests for thrown exception boundaries, temporary resources, and cleanup guarantees.
+- [x] 11.3 Explore: Inspect `packages/cli/src/commands/adapter/`, `packages/cli/src/util/adapter-install-errors.ts`, and adapter command tests for install, picker, list, remove, and result-rendering behavior.
+- [x] 11.4 Propose: Present the end-to-end install-service result flow and CLI presentation for parse, no-compatible-release, download, verification, activation, cleanup-warning, and recovery outcomes.
 
 ## 12. Adapter Install and Management Commands — Implementation
 
-- [ ] 12.1 Implement: Rework the adapter install service to carry tagged source provenance through resolve, download/build, verification, lock acquisition, and atomic activation using structured results.
-- [ ] 12.2 Implement: Convert expected bundler, verification, placement, and cleanup boundaries into typed failures or warnings without losing temporary-resource cleanup.
-- [ ] 12.3 Implement: Render actionable compatibility and no-compatible-release diagnostics exclusively in the CLI, including found API, supported APIs, and the best available reinstall command.
-- [ ] 12.4 Implement: Update `facet adapter list` to render inspection-backed API and compatibility status while remaining usable for incompatible and broken entries.
-- [ ] 12.5 Implement: Preserve load-free whole-directory behavior for `facet adapter remove` and update picker/install behavior to consume the new list and load results.
-- [ ] 12.6 Implement: Update adapter command unit and end-to-end tests for selectors, managed install/list/remove, replacement preservation, migration, diagnostics, and cleanup warnings.
-- [ ] 12.7 Verify: Run targeted adapter command and CLI end-to-end suites.
+- [x] 12.1 Implement: Rework the adapter install service to carry tagged source provenance through resolve, download/build, verification, lock acquisition, and atomic activation using structured results.
+- [x] 12.2 Implement: Convert expected bundler, verification, placement, and cleanup boundaries into typed failures or warnings without losing temporary-resource cleanup.
+- [x] 12.3 Implement: Render actionable compatibility and no-compatible-release diagnostics exclusively in the CLI, including found API, supported APIs, and the best available reinstall command.
+- [x] 12.4 Implement: Update `facet adapter list` to render inspection-backed API and compatibility status while remaining usable for incompatible and broken entries.
+- [x] 12.5 Implement: Preserve load-free whole-directory behavior for `facet adapter remove` and update picker/install behavior to consume the new list and load results.
+- [x] 12.6 Implement: Update adapter command unit and end-to-end tests for selectors, managed install/list/remove, replacement preservation, migration, diagnostics, and cleanup warnings.
+- [x] 12.7 Verify: Run targeted adapter command and CLI end-to-end suites.
 
 ## 13. Build and Facet-Operation Compatibility Gates — Research
 

--- a/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
@@ -247,6 +247,18 @@ function adaptersIn(facetDir: string): string {
   return join(facetDir, 'adapters')
 }
 
+/**
+ * Resolve the active managed bundle for an installed adapter by reading
+ * its `installation.json` receipt. Managed installs place bundles at
+ * `<name>/generations/<activeGeneration>/adapter.js`; the flat
+ * `<name>/adapter.js` layout is legacy/unmanaged.
+ */
+async function activeManagedBundle(facetDir: string, name: string): Promise<string> {
+  const receiptPath = join(adaptersIn(facetDir), name, 'installation.json')
+  const receipt = (await Bun.file(receiptPath).json()) as { activeGeneration: string }
+  return join(adaptersIn(facetDir), name, 'generations', receipt.activeGeneration, 'adapter.js')
+}
+
 beforeAll(async () => {
   // Verify the compiled binary exists — if it doesn't, the test suite can't
   // run. The turbo config declares test depends on build, but surface a
@@ -269,8 +281,8 @@ describe('facet adapter install — fast path from extracted npm tarball', () =>
       expect(result.stdout).toContain('using prebuilt bundle for')
       expect(result.stdout).toContain('Adapter "opencode" installed successfully.')
 
-      // Adapter should be placed at <facetDir>/adapters/opencode/adapter.js
-      const installedBundle = join(adaptersIn(facetDir), 'opencode', 'adapter.js')
+      // Adapter should be activated via a managed receipt + generation
+      const installedBundle = await activeManagedBundle(facetDir, 'opencode')
       const stats = await stat(installedBundle)
       expect(stats.isFile()).toBe(true)
 
@@ -300,7 +312,7 @@ describe('facet adapter install — slow path from unbuilt local source', () => 
       expect(result.stdout).not.toContain('Using prebuilt bundle...')
       expect(result.stdout).toContain('Adapter "my-unbuilt-adapter" installed successfully.')
 
-      const installedBundle = join(adaptersIn(facetDir), 'my-unbuilt-adapter', 'adapter.js')
+      const installedBundle = await activeManagedBundle(facetDir, 'my-unbuilt-adapter')
       const stats = await stat(installedBundle)
       expect(stats.isFile()).toBe(true)
       expect(stats.size).toBeGreaterThan(0)
@@ -364,7 +376,7 @@ describe('facet adapter install — slow-path fallback after broken prebuilt', (
       const prebuiltLogCount = (result.stdout.match(/using prebuilt bundle for/g) ?? []).length
       expect(prebuiltLogCount).toBe(1)
 
-      const installedBundle = join(adaptersIn(facetDir), 'my-fallback-adapter', 'adapter.js')
+      const installedBundle = await activeManagedBundle(facetDir, 'my-fallback-adapter')
       const stats = await stat(installedBundle)
       expect(stats.isFile()).toBe(true)
       expect(stats.size).toBeGreaterThan(0)
@@ -405,7 +417,7 @@ describe('facet adapter install — externalized prebuilt (PR #142 P1 regression
       // NOT the original dist/index.mjs. We assert by comparing sizes:
       // the rebundled file inlines `fixture-runtime-dep` so it must be
       // strictly larger than the 2-line stub in dist/index.mjs.
-      const installedBundle = join(adaptersIn(facetDir), 'my-externalized-adapter', 'adapter.js')
+      const installedBundle = await activeManagedBundle(facetDir, 'my-externalized-adapter')
       const installedStats = await stat(installedBundle)
       const sourceStats = await stat(join(adapterDir, 'dist/index.mjs'))
       expect(installedStats.size).toBeGreaterThan(sourceStats.size)
@@ -510,6 +522,78 @@ describe('facet adapter install + list + remove — round trip', () => {
   })
 })
 
+describe('facet adapter install — managed replacement', () => {
+  test('reinstalling keeps exactly one active generation and updates the receipt', async () => {
+    const extractedDir = await packOpencode()
+    const facetDir = await makeFacetDir()
+    const env = { FACET_DIR: facetDir }
+    try {
+      const first = await runCli(['adapter', 'install', extractedDir], env)
+      expect(first.exitCode).toBe(0)
+      const firstBundle = await activeManagedBundle(facetDir, 'opencode')
+
+      const second = await runCli(['adapter', 'install', extractedDir], env)
+      expect(second.exitCode).toBe(0)
+      const secondBundle = await activeManagedBundle(facetDir, 'opencode')
+
+      // A fresh generation was activated and the old one was cleaned up.
+      expect(secondBundle).not.toBe(firstBundle)
+      const generations = await readdir(join(adaptersIn(facetDir), 'opencode', 'generations'))
+      expect(generations).toHaveLength(1)
+      await expect(stat(firstBundle)).rejects.toThrow()
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter list — inspection-backed output', () => {
+  test('renders API and compatibility status for a compatible install', async () => {
+    const extractedDir = await packOpencode()
+    const facetDir = await makeFacetDir()
+    try {
+      const installResult = await runCli(['adapter', 'install', extractedDir], { FACET_DIR: facetDir })
+      expect(installResult.exitCode).toBe(0)
+
+      const listResult = await runCli(['adapter', 'list'], { FACET_DIR: facetDir })
+      expect(listResult.exitCode).toBe(0)
+      expect(listResult.stdout).toContain('opencode')
+      expect(listResult.stdout).toContain('api 0.0')
+      expect(listResult.stdout).toContain('supported')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+
+  test('remains usable with an incompatible (undeclared) entry and shows recovery', async () => {
+    const facetDir = await makeFacetDir()
+    try {
+      // Fabricate an unmanaged legacy bundle with no API declaration.
+      const legacyDir = join(adaptersIn(facetDir), 'legacy-tool')
+      await mkdir(legacyDir, { recursive: true })
+      await writeFile(
+        join(legacyDir, 'adapter.js'),
+        `export default {
+  name: 'legacy-tool',
+  buildAssetMetadata: () => ({ ok: true, data: {} }),
+  installAsset: async () => undefined,
+  readAsset: async () => ({ content: '' }),
+  deleteAsset: async () => undefined,
+}`,
+      )
+
+      const listResult = await runCli(['adapter', 'list'], { FACET_DIR: facetDir })
+      expect(listResult.exitCode).toBe(0)
+      expect(listResult.stdout).toContain('legacy-tool')
+      expect(listResult.stdout).toContain('api missing')
+      expect(listResult.stdout).toContain('unsupported')
+      expect(listResult.stdout).toContain('facet adapter install legacy-tool')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('FACET_DIR redirect', () => {
   test('install writes to the env-var dir, leaving ~/.facet/adapters untouched', async () => {
     const extractedDir = await packOpencode()
@@ -524,7 +608,7 @@ describe('FACET_DIR redirect', () => {
 
       expect(result.exitCode).toBe(0)
 
-      const installedBundle = join(adaptersIn(facetDir), 'opencode', 'adapter.js')
+      const installedBundle = await activeManagedBundle(facetDir, 'opencode')
       const stats = await stat(installedBundle)
       expect(stats.isFile()).toBe(true)
     } finally {

--- a/packages/cli/src/__tests__/adapter-integration.test.ts
+++ b/packages/cli/src/__tests__/adapter-integration.test.ts
@@ -97,7 +97,10 @@ describe('adapter install-load-build integration', () => {
       await placeAdapter(verified.name, bundlePath, adapterBaseDir)
 
       // Step 4: Load the adapter back via loadInstalledAdapters with the temp base dir
-      const loaded = await loadInstalledAdapters(adapterBaseDir)
+      // (an unmanaged flat placement — the compatible-unmanaged path)
+      const loadResult = await loadInstalledAdapters(adapterBaseDir)
+      if (!loadResult.ok) expect.unreachable()
+      const loaded = loadResult.adapters
       expect(loaded).toHaveLength(1)
       expect(loaded[0]?.name).toBe('integ-test-adapter')
 
@@ -147,7 +150,9 @@ describe('adapter install-load-build integration', () => {
       const verifyResult = await verifyAdapter(bundlePath)
       if (!verifyResult.ok) expect.unreachable()
       await placeAdapter(verifyResult.verified.adapter.name, bundlePath, adapterBaseDir)
-      const loaded = await loadInstalledAdapters(adapterBaseDir)
+      const loadResult = await loadInstalledAdapters(adapterBaseDir)
+      if (!loadResult.ok) expect.unreachable()
+      const loaded = loadResult.adapters
 
       // Manifest has invalid metadata for the adapter (custom must be a string, not a number)
       await Bun.write(join(facetDir, 'skills/example/SKILL.md'), '# Example skill')

--- a/packages/cli/src/__tests__/create-build.e2e.test.ts
+++ b/packages/cli/src/__tests__/create-build.e2e.test.ts
@@ -34,10 +34,16 @@ if (!existsSync(CLI_PATH)) {
 }
 
 async function runCli(...args: string[]) {
+  // Hermetic FACET_DIR: `facet build` fail-closed-loads installed
+  // adapters, so inheriting the developer's real ~/.facet (which may
+  // hold legacy incompatible bundles) would leak machine state into
+  // these tests. An empty temp dir means "no adapters installed", and
+  // builds proceed with unknown-adapter warnings.
+  const facetDir = await mkdtemp(join(tmpdir(), 'facets-create-build-facet-dir-'))
   const proc = Bun.spawn([CLI_PATH, ...args], {
     stdout: 'pipe',
     stderr: 'pipe',
-    env: { ...process.env, NO_COLOR: '1' },
+    env: { ...process.env, NO_COLOR: '1', FACET_DIR: facetDir },
   })
   const stdout = await new Response(proc.stdout).text()
   const stderr = await new Response(proc.stderr).text()

--- a/packages/cli/src/commands/adapter/index.ts
+++ b/packages/cli/src/commands/adapter/index.ts
@@ -1,6 +1,11 @@
-import { installAdapter, listInstalledAdapters, removeAdapter } from '@agent-facets/engine'
+import {
+  type InstalledAdapterInspection,
+  inspectInstalledAdapters,
+  installAdapter,
+  removeAdapter,
+} from '@agent-facets/engine'
 import type { Command } from '../../commands.ts'
-import { describeAdapterInstallFailure } from '../../util/adapter-install-errors.ts'
+import { describeAdapterInstallFailure, repairCommand } from '../../util/adapter-install-errors.ts'
 import { writeCliError } from '../../util/errors.ts'
 import { pickAndInstallAdapters } from './pick-and-install.ts'
 
@@ -78,6 +83,9 @@ async function handleInstall(args: string[]): Promise<number> {
     return 1
   }
   console.log(`Adapter "${result.adapter.name}" installed successfully.`)
+  for (const warning of result.warnings) {
+    console.error(`warning: could not clean up ${warning.path} (${warning.cause})`)
+  }
   return 0
 }
 
@@ -100,19 +108,65 @@ async function handleInstallPicker(): Promise<number> {
   return 1
 }
 
-async function handleList(): Promise<number> {
-  const names = await listInstalledAdapters()
+/** The API column for one inspected entry: exact id, missing, malformed, or unknown. */
+function apiColumn(inspection: InstalledAdapterInspection): string {
+  switch (inspection.kind) {
+    case 'compatible':
+      return `api ${inspection.verified.apiVersion}`
+    case 'incompatible':
+      switch (inspection.failure.kind) {
+        case 'api-missing':
+          return 'api missing'
+        case 'api-malformed':
+          return `api malformed ("${inspection.failure.found}")`
+        case 'api-unsupported':
+          return `api ${inspection.failure.found}`
+        case 'api-metadata-mismatch':
+          return `api ${inspection.failure.runtimeDeclared}`
+      }
+      break
+    case 'broken':
+      return inspection.declaredApi !== undefined ? `api ${inspection.declaredApi}` : 'api unknown'
+  }
+}
 
-  if (names.length === 0) {
+/** The status column plus recovery hint for one inspected entry. */
+function statusColumn(inspection: InstalledAdapterInspection): string {
+  switch (inspection.kind) {
+    case 'compatible':
+      return 'supported'
+    case 'incompatible':
+      return `unsupported — reinstall: ${repairCommand(inspection.repair)}`
+    case 'broken': {
+      const why =
+        inspection.reason.kind === 'invalid-receipt'
+          ? 'invalid installation record'
+          : inspection.reason.kind === 'missing-active-generation'
+            ? 'missing active bundle'
+            : 'bundle failed to load'
+      return `broken (${why}) — reinstall: ${repairCommand(inspection.repair)}`
+    }
+  }
+}
+
+async function handleList(): Promise<number> {
+  const inspections = await inspectInstalledAdapters()
+
+  if (inspections.length === 0) {
     console.log('No adapters installed.')
     console.log('')
     console.log('Install one with: facet adapter install <specifier>')
     return 0
   }
 
+  const nameWidth = Math.max(...inspections.map((inspection) => inspection.name.length))
+  const apiWidth = Math.max(...inspections.map((inspection) => apiColumn(inspection).length))
+
   console.log('Installed adapters:')
-  for (const name of names) {
-    console.log(`  ${name}`)
+  for (const inspection of inspections) {
+    const name = inspection.name.padEnd(nameWidth)
+    const api = apiColumn(inspection).padEnd(apiWidth)
+    console.log(`  ${name}  ${api}  ${statusColumn(inspection)}`)
   }
   return 0
 }

--- a/packages/cli/src/commands/adapter/pick-and-install.ts
+++ b/packages/cli/src/commands/adapter/pick-and-install.ts
@@ -8,7 +8,7 @@ import {
 } from '@agent-facets/engine'
 import { render } from 'ink'
 import { createElement } from 'react'
-import { describeAdapterInstallFailure } from '../../util/adapter-install-errors.ts'
+import { describeAdapterInstallFailure, describeInstalledAdapterFailure } from '../../util/adapter-install-errors.ts'
 import { writeCliError } from '../../util/errors.ts'
 import { InstallPicker } from './install-picker.tsx'
 
@@ -93,6 +93,13 @@ export async function pickAndInstallAdapters(): Promise<PickAndInstallResult> {
   }
 
   // Re-load adapters from disk so callers see the freshly-installed ones.
-  const adapters = await loadInstalledAdapters()
-  return { ok: true, adapters }
+  // Fail closed if any installed entry is incompatible or broken.
+  const loaded = await loadInstalledAdapters()
+  if (!loaded.ok) {
+    for (const failure of loaded.failures) {
+      writeCliError(describeInstalledAdapterFailure(failure))
+    }
+    return { ok: false, reason: 'install-failed' }
+  }
+  return { ok: true, adapters: loaded.adapters }
 }

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import { captureStderr } from '../../../__tests__/helpers/capture-std.ts'
 import { withTTY } from '../../../__tests__/helpers/with-tty.ts'
 import { addCommand } from '../index.ts'
@@ -44,6 +45,7 @@ function path(type, name) {
 
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,6 +9,8 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../commands.ts'
 import { BuildView } from '../tui/views/build/build-view.tsx'
+import { describeInstalledAdapterFailure } from '../util/adapter-install-errors.ts'
+import { writeCliError } from '../util/errors.ts'
 import { resolveTargetDir } from './resolve-dir.ts'
 
 /** Version tag for the machine-readable `--json` output document. */
@@ -46,12 +48,17 @@ export const buildCommand: Command = {
     const verify = flags.verify === true
     const json = flags.json === true
 
-    // Load installed adapters so their metadata schemas can validate the manifest.
-    // In JSON mode adapter-load warnings would corrupt the JSON document on stdout,
-    // so route them to stderr (which they already use) and keep stdout clean.
-    const adapters = await loadInstalledAdapters(undefined, {
-      onWarn: (line) => console.error(line),
-    })
+    // Load installed adapters so their metadata schemas can validate the
+    // manifest. Loading fails closed: any incompatible or broken installed
+    // adapter stops the build before the pipeline starts.
+    const loaded = await loadInstalledAdapters()
+    if (!loaded.ok) {
+      for (const failure of loaded.failures) {
+        writeCliError(describeInstalledAdapterFailure(failure))
+      }
+      return 1
+    }
+    const adapters = loaded.adapters
 
     // --verify or --json take the plain (non-Ink) path: run the pipeline
     // directly, and only write output when not verifying.

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import { captureStderr } from '../../../__tests__/helpers/capture-std.ts'
 import { withTTY } from '../../../__tests__/helpers/with-tty.ts'
 import { installCommand } from '../index.ts'
@@ -50,6 +51,7 @@ function path(type, name) {
 
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) {

--- a/packages/cli/src/commands/publish/run-build-view.ts
+++ b/packages/cli/src/commands/publish/run-build-view.ts
@@ -2,6 +2,8 @@ import { loadInstalledAdapters } from '@agent-facets/engine'
 import { render } from 'ink'
 import { createElement } from 'react'
 import { BuildView } from '../../tui/views/build/build-view.tsx'
+import { describeInstalledAdapterFailure } from '../../util/adapter-install-errors.ts'
+import { writeCliError } from '../../util/errors.ts'
 
 /**
  * Mount `<BuildView>` for the publish command's build/rebuild branch
@@ -22,9 +24,16 @@ import { BuildView } from '../../tui/views/build/build-view.tsx'
  * just propagates the exit code.
  */
 export async function runBuildViewAndCapture(projectRoot: string): Promise<{ ok: boolean }> {
-  const adapters = await loadInstalledAdapters(undefined, {
-    onWarn: (line) => console.error(line),
-  })
+  // Fail closed before mounting the view: incompatible or broken
+  // installed adapters block the publish build entirely.
+  const loaded = await loadInstalledAdapters()
+  if (!loaded.ok) {
+    for (const failure of loaded.failures) {
+      writeCliError(describeInstalledAdapterFailure(failure))
+    }
+    return { ok: false }
+  }
+  const adapters = loaded.adapters
   const state: { failed: boolean } = { failed: false }
   const instance = render(
     createElement(BuildView, {

--- a/packages/cli/src/commands/shared/ensure-adapters.ts
+++ b/packages/cli/src/commands/shared/ensure-adapters.ts
@@ -1,5 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import { loadInstalledAdapters } from '@agent-facets/engine'
+import { describeInstalledAdapterFailure } from '../../util/adapter-install-errors.ts'
 import { writeCliError } from '../../util/errors.ts'
 import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
 
@@ -15,7 +16,17 @@ import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
  * is identical for all of them.
  */
 export async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
-  const adapters = await loadInstalledAdapters()
+  // Fail closed: incompatible or broken installed adapters block the
+  // operation entirely — they must NOT fall through to the zero-adapter
+  // picker, which would misreport them as "no adapters installed".
+  const loaded = await loadInstalledAdapters()
+  if (!loaded.ok) {
+    for (const failure of loaded.failures) {
+      writeCliError(describeInstalledAdapterFailure(failure))
+    }
+    return null
+  }
+  const adapters = loaded.adapters
   const installable = adapters.filter((a) => a.supportsInstall === true)
   if (installable.length > 0) return installable
 

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -2,7 +2,11 @@ import type {
   AdapterCompatibilityFailure,
   AdapterInstallFailure,
   ApiDeclarationClassification,
+  BundleFailure,
+  InstalledAdapterFailure,
   NpmVersionRequest,
+  PlaceAdapterFailure,
+  RepairSource,
   VerifyAdapterFailure,
 } from '@agent-facets/engine'
 
@@ -23,19 +27,63 @@ export function describeAdapterInstallFailure(failure: AdapterInstallFailure): {
     case 'download-failed':
       return describeDownloadFailure(failure.specifier, failure.source)
     case 'bundle-failed':
-      return {
-        what: `failed to bundle adapter "${failure.specifier}"`,
-        detail: failure.cause,
-        fix: 'verify the adapter package builds with `bun build`; ensure all imports resolve',
-      }
+      return describeBundleFailure(failure.specifier, failure.failure)
     case 'verify-failed':
       return describeVerifyFailure(failure.specifier, failure.failure)
     case 'place-failed':
+      return describePlaceFailure(failure.adapter, failure.failure)
+  }
+}
+
+/** Render the repair command for an installed-adapter failure. */
+export function repairCommand(repair: RepairSource): string {
+  switch (repair.kind) {
+    case 'managed':
+      return `facet adapter install ${repair.specifier}`
+    case 'first-party-alias':
+      return `facet adapter install ${repair.alias}`
+    case 'unmanaged-name':
+      return `facet adapter install ${repair.name}`
+  }
+}
+
+/**
+ * Sole rendering point for installed-adapter inspection failures
+ * (incompatible or broken entries surfaced by fail-closed loading and
+ * command preflights). Engine returns structured data; adding a variant
+ * forces this switch to update.
+ */
+export function describeInstalledAdapterFailure(failure: InstalledAdapterFailure): {
+  what: string
+  detail: string
+  fix: string
+} {
+  const repairNote =
+    failure.repair.kind === 'unmanaged-name' ? ' (original install source unavailable; using the adapter name)' : ''
+  const fix = `reinstall a compatible release: ${repairCommand(failure.repair)}${repairNote}`
+
+  if (failure.kind === 'incompatible') {
+    const base = describeCompatibilityFailure(failure.failure)
+    return { what: base.what, detail: base.detail, fix }
+  }
+
+  switch (failure.reason.kind) {
+    case 'invalid-receipt':
       return {
-        what: `failed to place adapter "${failure.adapter}"`,
-        detail: failure.cause,
-        fix: 'check filesystem permissions on ~/.facet/adapters/',
+        what: `installed adapter "${failure.name}" has an invalid installation record`,
+        detail: failure.reason.detail,
+        fix,
       }
+    case 'missing-active-generation':
+      return {
+        what: `installed adapter "${failure.name}" is missing its active bundle`,
+        detail: `generation "${failure.reason.generation}" does not contain adapter.js`,
+        fix,
+      }
+    case 'load-failed': {
+      const base = describeVerifyFailure(failure.name, failure.reason.failure)
+      return { what: base.what, detail: base.detail, fix }
+    }
   }
 }
 
@@ -55,6 +103,78 @@ function describeSpecifierFailure(
         what: `invalid version selector "${failure.selector}" for "${failure.packageName}"`,
         detail: failure.error.what,
         fix: failure.error.fix,
+      }
+  }
+}
+
+function describeBundleFailure(
+  specifier: string,
+  failure: BundleFailure,
+): { what: string; detail: string; fix: string } {
+  switch (failure.kind) {
+    case 'no-package-json':
+      return {
+        what: `adapter source for "${specifier}" has no package.json`,
+        detail: `looked in ${failure.sourceDir}`,
+        fix: 'point the specifier at an adapter package root',
+      }
+    case 'no-entry-point':
+      return {
+        what: `cannot determine an entry point for adapter "${specifier}"`,
+        detail: `tried:\n  - ${failure.tried.join('\n  - ')}`,
+        fix: 'set "exports" or "main" in package.json, or ship a prebuilt dist/index.mjs',
+      }
+    case 'install-failed':
+      return {
+        what: `failed to install dependencies for adapter "${specifier}"`,
+        detail: failure.stderr,
+        fix: 'verify the adapter package installs with `bun install`',
+      }
+    case 'build-failed':
+      return {
+        what: `failed to bundle adapter "${specifier}"`,
+        detail: failure.errors.join('\n'),
+        fix: 'verify the adapter package builds with `bun build`; ensure all imports resolve',
+      }
+    case 'no-output':
+      return {
+        what: `bundling adapter "${specifier}" produced no output`,
+        detail: `Bun.build() succeeded but emitted nothing for ${failure.sourceDir}`,
+        fix: 'this is unexpected; please file a bug',
+      }
+  }
+}
+
+function describePlaceFailure(
+  adapter: string,
+  failure: PlaceAdapterFailure,
+): { what: string; detail: string; fix: string } {
+  switch (failure.kind) {
+    case 'lock-held':
+      return {
+        what: `another install is replacing adapter "${adapter}"`,
+        detail: `replacement lock held by pid ${failure.heldByPid} (${failure.lockPath})`,
+        fix: 'wait for the other install to finish and retry',
+      }
+    case 'stage-failed':
+      return {
+        what: `failed to stage adapter "${adapter}"`,
+        detail: failure.cause,
+        fix: 'check filesystem permissions and free space under ~/.facet/adapters/',
+      }
+    case 'verify-failed':
+      return describeVerifyFailure(adapter, failure.failure)
+    case 'name-mismatch':
+      return {
+        what: `staged adapter for "${adapter}" identifies as "${failure.runtimeName}"`,
+        detail: 'the staged bundle changed identity between verification and activation',
+        fix: 'retry the install; report this if it persists',
+      }
+    case 'receipt-write-failed':
+      return {
+        what: `failed to activate adapter "${adapter}"`,
+        detail: failure.cause,
+        fix: 'check filesystem permissions on ~/.facet/adapters/; the previous installation remains active',
       }
   }
 }

--- a/packages/engine/src/adapters/__tests__/bundler.test.ts
+++ b/packages/engine/src/adapters/__tests__/bundler.test.ts
@@ -34,7 +34,9 @@ describe('resolveEntryPoint', () => {
   test('exports as a string pointing at a prebuilt .mjs', async () => {
     const dir = await makeFixture({ name: 'a', exports: './dist/index.mjs' }, { 'dist/index.mjs': 'export default {}' })
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
       expect(resolved.kind).toBe('prebuilt')
     } finally {
@@ -48,7 +50,9 @@ describe('resolveEntryPoint', () => {
       { 'dist/index.mjs': 'export default {}' },
     )
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
       expect(resolved.kind).toBe('prebuilt')
     } finally {
@@ -65,7 +69,9 @@ describe('resolveEntryPoint', () => {
       { 'dist/index.mjs': 'export default {}' },
     )
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
       expect(resolved.kind).toBe('prebuilt')
     } finally {
@@ -79,7 +85,9 @@ describe('resolveEntryPoint', () => {
       { 'src/index.ts': 'export default {}' },
     )
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'src/index.ts'))
       expect(resolved.kind).toBe('source')
     } finally {
@@ -90,7 +98,9 @@ describe('resolveEntryPoint', () => {
   test('main field only, pointing at prebuilt .mjs', async () => {
     const dir = await makeFixture({ name: 'a', main: './dist/index.mjs' }, { 'dist/index.mjs': 'export default {}' })
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
       expect(resolved.kind).toBe('prebuilt')
     } finally {
@@ -101,7 +111,9 @@ describe('resolveEntryPoint', () => {
   test('disk fallback to dist/index.mjs when no exports/main', async () => {
     const dir = await makeFixture({ name: 'a' }, { 'dist/index.mjs': 'export default {}' })
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
       expect(resolved.kind).toBe('prebuilt')
     } finally {
@@ -112,7 +124,9 @@ describe('resolveEntryPoint', () => {
   test('disk fallback to dist/index.js when dist/index.mjs missing', async () => {
     const dir = await makeFixture({ name: 'a' }, { 'dist/index.js': 'export default {}' })
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.js'))
       expect(resolved.kind).toBe('prebuilt')
     } finally {
@@ -123,7 +137,9 @@ describe('resolveEntryPoint', () => {
   test('disk fallback to src/index.ts is classified as source', async () => {
     const dir = await makeFixture({ name: 'a' }, { 'src/index.ts': 'export default {}' })
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'src/index.ts'))
       expect(resolved.kind).toBe('source')
     } finally {
@@ -139,7 +155,9 @@ describe('resolveEntryPoint', () => {
       { 'src/index.ts': 'export default {}' },
     )
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'src/index.ts'))
       expect(resolved.kind).toBe('source')
     } finally {
@@ -147,21 +165,26 @@ describe('resolveEntryPoint', () => {
     }
   })
 
-  test('throws when no entry point can be found, listing what was tried', async () => {
+  test('fails with no-entry-point when nothing resolves, listing what was tried', async () => {
     const dir = await makeFixture({ name: 'a', exports: './does-not-exist.mjs', main: './also-missing.js' })
     try {
-      await expect(resolveEntryPoint(dir)).rejects.toThrow(
-        /Cannot determine entry point.*does-not-exist.mjs.*also-missing.js.*dist\/index.mjs/s,
-      )
+      const result = await resolveEntryPoint(dir)
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'no-entry-point') expect.unreachable()
+      expect(result.failure.tried.join('\n')).toContain('does-not-exist.mjs')
+      expect(result.failure.tried.join('\n')).toContain('also-missing.js')
+      expect(result.failure.tried.join('\n')).toContain('dist/index.mjs')
     } finally {
       await cleanup(dir)
     }
   })
 
-  test('throws when package.json is missing', async () => {
+  test('fails with no-package-json when package.json is missing', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'facet-bundler-test-'))
     try {
-      await expect(resolveEntryPoint(dir)).rejects.toThrow(/No package.json found/)
+      const result = await resolveEntryPoint(dir)
+      if (result.ok) expect.unreachable()
+      expect(result.failure.kind).toBe('no-package-json')
     } finally {
       await cleanup(dir)
     }
@@ -180,7 +203,9 @@ describe('resolveEntryPoint', () => {
       },
     )
     try {
-      const resolved = await resolveEntryPoint(dir)
+      const result = await resolveEntryPoint(dir)
+      if (!result.ok) expect.unreachable()
+      const resolved = result.entry
       expect(resolved.path).toBe(join(dir, 'dist/index.mjs'))
     } finally {
       await cleanup(dir)
@@ -188,18 +213,6 @@ describe('resolveEntryPoint', () => {
   })
 })
 
-/**
- * Tests for the BundleResult.cleanup contract introduced in PR #142
- * follow-up: every bundler entry point returns `{ bundlePath, cleanup }`,
- * and callers MUST be able to invoke `cleanup()` safely (whether or not
- * a temp dir was created).
- *
- * The slow-path `rebundleAdapter` cleanup is exercised end-to-end by the
- * adapter-install-cli test suite (which checks that `facet-adapter-build-*`
- * dirs don't accumulate in tmpdir across installs). Here we cover the fast
- * path: it must return a no-op cleanup that doesn't throw and doesn't
- * delete anything in the source tree.
- */
 /**
  * Slow-path ordering: the build runs BEFORE any `bun install`. A source
  * tree whose dependencies are already satisfied (an installed workspace,
@@ -227,6 +240,7 @@ describe('rebundleAdapter — build-first, install only on failure', () => {
     )
     try {
       const result = await bundleAdapter(dir)
+      if (!result.ok) expect.unreachable()
       try {
         const stats = await stat(result.bundlePath)
         expect(stats.isFile()).toBe(true)
@@ -262,6 +276,7 @@ describe('rebundleAdapter — build-first, install only on failure', () => {
     )
     try {
       const result = await bundleAdapter(dir)
+      if (!result.ok) expect.unreachable()
       try {
         const stats = await stat(result.bundlePath)
         expect(stats.isFile()).toBe(true)
@@ -281,6 +296,18 @@ describe('rebundleAdapter — build-first, install only on failure', () => {
   })
 })
 
+/**
+ * Tests for the BundleResult.cleanup contract introduced in PR #142
+ * follow-up: every bundler entry point returns `{ bundlePath, cleanup }`,
+ * and callers MUST be able to invoke `cleanup()` safely (whether or not
+ * a temp dir was created).
+ *
+ * The slow-path `rebundleAdapter` cleanup is exercised end-to-end by the
+ * adapter-install-cli test suite (which checks that `facet-adapter-build-*`
+ * dirs don't accumulate in tmpdir across installs). Here we cover the fast
+ * path: it must return a no-op cleanup that doesn't throw and doesn't
+ * delete anything in the source tree.
+ */
 describe('bundleAdapter — fast path returns a safe no-op cleanup', () => {
   test('cleanup is callable and resolves without throwing', async () => {
     const dir = await makeFixture(
@@ -289,6 +316,7 @@ describe('bundleAdapter — fast path returns a safe no-op cleanup', () => {
     )
     try {
       const result = await bundleAdapter(dir)
+      if (!result.ok) expect.unreachable()
       // Fast path: bundlePath should point AT the source tree's prebuilt
       expect(result.bundlePath).toBe(join(dir, 'dist/index.mjs'))
       // Cleanup must not throw
@@ -309,6 +337,7 @@ describe('bundleAdapter — fast path returns a safe no-op cleanup', () => {
     )
     try {
       const result = await bundleAdapter(dir)
+      if (!result.ok) expect.unreachable()
       await result.cleanup()
       await expect(result.cleanup()).resolves.toBeUndefined()
       await expect(result.cleanup()).resolves.toBeUndefined()

--- a/packages/engine/src/adapters/__tests__/inspect.test.ts
+++ b/packages/engine/src/adapters/__tests__/inspect.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+import { inspectInstalledAdapter, inspectInstalledAdapters } from '../inspect.ts'
+import { GENERATIONS_DIR_NAME, INSTALLATION_RECEIPT_NAME, type InstallationSource } from '../installation.ts'
+import { loadInstalledAdapters } from '../loader.ts'
+import { placeAdapter, placeAdapterManaged } from '../placement.ts'
+
+let facetDir: string
+let baseDir: string
+let workDir: string
+let originalFacetDir: string | undefined
+
+beforeEach(async () => {
+  facetDir = await mkdtemp(join(tmpdir(), 'facet-inspect-'))
+  baseDir = join(facetDir, 'adapters')
+  workDir = await mkdtemp(join(tmpdir(), 'facet-inspect-work-'))
+  originalFacetDir = process.env.FACET_DIR
+  process.env.FACET_DIR = facetDir
+})
+
+afterEach(async () => {
+  if (originalFacetDir === undefined) {
+    delete process.env.FACET_DIR
+  } else {
+    process.env.FACET_DIR = originalFacetDir
+  }
+  await rm(facetDir, { recursive: true, force: true }).catch(() => {})
+  await rm(workDir, { recursive: true, force: true }).catch(() => {})
+})
+
+let bundleCounter = 0
+async function makeBundle(
+  name: string,
+  opts: { apiVersion?: string | null; marker?: string; sideEffectFile?: string } = {},
+): Promise<string> {
+  const api = opts.apiVersion === null ? '' : `apiVersion: '${opts.apiVersion ?? ADAPTER_API_VERSION}',`
+  const sideEffect = opts.sideEffectFile ? `await Bun.write('${opts.sideEffectFile}', 'imported')\n` : ''
+  const path = join(workDir, `bundle-${++bundleCounter}.mjs`)
+  await Bun.write(
+    path,
+    `${sideEffect}export const marker = '${opts.marker ?? 'default'}'
+export default {
+  name: '${name}',
+  ${api}
+  buildAssetMetadata: () => ({ ok: true, data: { marker: '${opts.marker ?? 'default'}' } }),
+  installAsset: async () => undefined,
+  readAsset: async () => ({ content: '' }),
+  deleteAsset: async () => undefined,
+}
+`,
+  )
+  return path
+}
+
+const source: InstallationSource = {
+  kind: 'npm',
+  specifier: 'my-adapter@1.0.0',
+  packageName: 'my-adapter',
+  version: '1.0.0',
+  integrity: { kind: 'sri', value: 'sha512-test' },
+}
+
+async function installManaged(name: string, bundle: string, apiVersion = ADAPTER_API_VERSION): Promise<string> {
+  const result = await placeAdapterManaged(name, bundle, { apiVersion, source }, baseDir)
+  if (!result.ok) throw new Error(`test bug: managed install failed (${result.failure.kind})`)
+  return result.receipt.activeGeneration
+}
+
+describe('inspectInstalledAdapter — managed', () => {
+  test('valid managed installation is compatible with managed repair', async () => {
+    await installManaged('my-adapter', await makeBundle('my-adapter'))
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'compatible') expect.unreachable()
+    expect(inspection.managed).toBe(true)
+    expect(inspection.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+    expect(inspection.repair).toEqual({ kind: 'managed', specifier: 'my-adapter@1.0.0' })
+  })
+
+  test('recorded unsupported API is incompatible without importing the bundle', async () => {
+    await installManaged('my-adapter', await makeBundle('my-adapter'))
+    // Rewrite the receipt to claim an unsupported API, and give the
+    // active generation a bundle that records a side effect on import.
+    const sideEffectFile = join(workDir, 'was-imported.txt')
+    const receiptPath = join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME)
+    const receipt = await Bun.file(receiptPath).json()
+    const genBundle = join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, receipt.activeGeneration, 'adapter.js')
+    await Bun.write(genBundle, await Bun.file(await makeBundle('my-adapter', { sideEffectFile })).text())
+    receipt.apiVersion = '9.9'
+    await Bun.write(receiptPath, JSON.stringify(receipt))
+
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'incompatible') expect.unreachable()
+    expect(inspection.failure).toEqual({
+      kind: 'api-unsupported',
+      adapter: 'my-adapter',
+      found: '9.9',
+      supported: [ADAPTER_API_VERSION],
+    })
+    // The bundle was never imported.
+    expect(await Bun.file(sideEffectFile).exists()).toBe(false)
+  })
+
+  test('receipt/runtime disagreement is incompatible', async () => {
+    // Fabricate the managed layout directly (never imported before) so
+    // the runtime declaration genuinely differs from the receipt's.
+    // With a single supported API the disagreement classifies as
+    // api-unsupported (support check precedes metadata equality).
+    const genDir = join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, 'gen-fixture-drift')
+    await mkdir(genDir, { recursive: true })
+    await Bun.write(
+      join(genDir, 'adapter.js'),
+      await Bun.file(await makeBundle('my-adapter', { apiVersion: '0.1' })).text(),
+    )
+    await Bun.write(
+      join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME),
+      JSON.stringify({
+        schemaVersion: 1,
+        activeGeneration: 'gen-fixture-drift',
+        apiVersion: ADAPTER_API_VERSION,
+        source,
+      }),
+    )
+
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'incompatible') expect.unreachable()
+    expect(inspection.failure.kind).toBe('api-unsupported')
+  })
+
+  test('invalid receipt classifies as broken and keeps a repair source', async () => {
+    await installManaged('my-adapter', await makeBundle('my-adapter'))
+    await Bun.write(join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME), '{not json')
+
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'broken') expect.unreachable()
+    if (inspection.reason.kind !== 'invalid-receipt') expect.unreachable()
+    expect(inspection.repair).toEqual({ kind: 'unmanaged-name', name: 'my-adapter' })
+  })
+
+  test('missing active generation classifies as broken with the declared API', async () => {
+    const generation = await installManaged('my-adapter', await makeBundle('my-adapter'))
+    await rm(join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, generation), { recursive: true, force: true })
+
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'broken') expect.unreachable()
+    expect(inspection.reason).toEqual({ kind: 'missing-active-generation', generation })
+    expect(inspection.declaredApi).toBe(ADAPTER_API_VERSION)
+  })
+
+  test('unloadable active bundle classifies as broken (load-failed)', async () => {
+    // Fabricated directly at a never-imported path so the dynamic-import
+    // cache can't mask the unloadable bytes.
+    const genDir = join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, 'gen-fixture-unloadable')
+    await mkdir(genDir, { recursive: true })
+    await Bun.write(join(genDir, 'adapter.js'), `import missing from 'no-such-package-xyz'\nexport default missing`)
+    await Bun.write(
+      join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME),
+      JSON.stringify({
+        schemaVersion: 1,
+        activeGeneration: 'gen-fixture-unloadable',
+        apiVersion: ADAPTER_API_VERSION,
+        source,
+      }),
+    )
+
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'broken') expect.unreachable()
+    if (inspection.reason.kind !== 'load-failed') expect.unreachable()
+    expect(inspection.reason.failure.kind).toBe('import-failed')
+  })
+})
+
+describe('inspectInstalledAdapter — unmanaged', () => {
+  test('declared unmanaged bundle is compatible with best-effort repair', async () => {
+    await placeAdapter('custom-thing', await makeBundle('custom-thing'), baseDir)
+    const inspection = await inspectInstalledAdapter('custom-thing', baseDir)
+    if (inspection.kind !== 'compatible') expect.unreachable()
+    expect(inspection.managed).toBe(false)
+    expect(inspection.repair).toEqual({ kind: 'unmanaged-name', name: 'custom-thing' })
+  })
+
+  test('unmanaged first-party name repairs via its catalog alias', async () => {
+    await placeAdapter('opencode', await makeBundle('opencode', { apiVersion: null }), baseDir)
+    const inspection = await inspectInstalledAdapter('opencode', baseDir)
+    if (inspection.kind !== 'incompatible') expect.unreachable()
+    expect(inspection.failure.kind).toBe('api-missing')
+    expect(inspection.repair).toEqual({ kind: 'first-party-alias', alias: 'opencode' })
+  })
+
+  test('undeclared unmanaged bundle is incompatible (api-missing), not broken', async () => {
+    await placeAdapter('legacy', await makeBundle('legacy', { apiVersion: null }), baseDir)
+    const inspection = await inspectInstalledAdapter('legacy', baseDir)
+    if (inspection.kind !== 'incompatible') expect.unreachable()
+    expect(inspection.failure).toEqual({ kind: 'api-missing', adapter: 'legacy', supported: [ADAPTER_API_VERSION] })
+  })
+
+  test('malformed unmanaged declaration is incompatible (api-malformed)', async () => {
+    await placeAdapter('malformed', await makeBundle('malformed', { apiVersion: '0.0.1' }), baseDir)
+    const inspection = await inspectInstalledAdapter('malformed', baseDir)
+    if (inspection.kind !== 'incompatible') expect.unreachable()
+    expect(inspection.failure.kind).toBe('api-malformed')
+  })
+
+  test('invalid unmanaged export is broken', async () => {
+    const dir = join(baseDir, 'not-an-adapter')
+    await mkdir(dir, { recursive: true })
+    await Bun.write(join(dir, 'adapter.js'), 'export const nope = 1')
+    const inspection = await inspectInstalledAdapter('not-an-adapter', baseDir)
+    if (inspection.kind !== 'broken') expect.unreachable()
+    if (inspection.reason.kind !== 'load-failed') expect.unreachable()
+    expect(inspection.reason.failure.kind).toBe('no-default-export')
+  })
+})
+
+describe('loadInstalledAdapters — fail-closed aggregation', () => {
+  test('all-compatible installations load successfully', async () => {
+    await installManaged('alpha', await makeBundle('alpha'))
+    await placeAdapter('beta', await makeBundle('beta'), baseDir)
+
+    const result = await loadInstalledAdapters(baseDir)
+    if (!result.ok) expect.unreachable()
+    expect(result.adapters.map((adapter) => adapter.name)).toEqual(['alpha', 'beta'])
+  })
+
+  test('a single incompatible entry fails the whole load with all failures collected', async () => {
+    await installManaged('good', await makeBundle('good'))
+    await placeAdapter('legacy', await makeBundle('legacy', { apiVersion: null }), baseDir)
+    const brokenDir = join(baseDir, 'shattered')
+    await mkdir(brokenDir, { recursive: true })
+    await Bun.write(join(brokenDir, 'adapter.js'), 'export const nope = 1')
+
+    const result = await loadInstalledAdapters(baseDir)
+    if (result.ok) expect.unreachable()
+    expect(result.failures.map((failure) => [failure.name, failure.kind])).toEqual([
+      ['legacy', 'incompatible'],
+      ['shattered', 'broken'],
+    ])
+  })
+
+  test('empty base dir loads zero adapters successfully', async () => {
+    const result = await loadInstalledAdapters(baseDir)
+    if (!result.ok) expect.unreachable()
+    expect(result.adapters).toEqual([])
+  })
+
+  test('unique generation paths keep replaced adapters fresh within one process', async () => {
+    await installManaged('fresh', await makeBundle('fresh', { marker: 'one' }))
+    const first = await loadInstalledAdapters(baseDir)
+    if (!first.ok) expect.unreachable()
+    const firstMeta = first.adapters[0]?.buildAssetMetadata({})
+    if (!firstMeta?.ok) expect.unreachable()
+    expect(firstMeta.data.marker).toBe('one')
+
+    await installManaged('fresh', await makeBundle('fresh', { marker: 'two' }))
+    const second = await loadInstalledAdapters(baseDir)
+    if (!second.ok) expect.unreachable()
+    const secondMeta = second.adapters[0]?.buildAssetMetadata({})
+    if (!secondMeta?.ok) expect.unreachable()
+    // A flat overwrite would hit the dynamic-import cache and still
+    // return 'one'; unique generation paths guarantee freshness.
+    expect(secondMeta.data.marker).toBe('two')
+  })
+})
+
+describe('inspectInstalledAdapters — enumeration', () => {
+  test('returns sorted inspections and ignores staging leftovers', async () => {
+    await installManaged('bravo', await makeBundle('bravo'))
+    await placeAdapter('alpha', await makeBundle('alpha'), baseDir)
+    const leftover = join(baseDir, 'ghost', GENERATIONS_DIR_NAME, 'gen-crash')
+    await mkdir(leftover, { recursive: true })
+
+    const inspections = await inspectInstalledAdapters(baseDir)
+    expect(inspections.map((inspection) => inspection.name)).toEqual(['alpha', 'bravo'])
+  })
+})

--- a/packages/engine/src/adapters/__tests__/installation.test.ts
+++ b/packages/engine/src/adapters/__tests__/installation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { generationDir, isSafeGenerationId, newGenerationId, validateReceipt } from '../installation.ts'
+
+const validNpmReceipt = {
+  schemaVersion: 1,
+  activeGeneration: 'gen-1-abc',
+  apiVersion: '0.0',
+  source: {
+    kind: 'npm',
+    specifier: 'opencode',
+    packageName: '@agent-facets/adapter-opencode',
+    version: '1.2.3',
+    integrity: { kind: 'sri', value: 'sha512-abc' },
+  },
+}
+
+describe('validateReceipt — valid receipts', () => {
+  test('npm provenance round-trips', () => {
+    const result = validateReceipt(validNpmReceipt)
+    if (!result.ok) expect.unreachable()
+    expect(result.receipt).toEqual(validNpmReceipt as never)
+  })
+
+  test('git provenance round-trips with optional ref', () => {
+    const receipt = {
+      schemaVersion: 1,
+      activeGeneration: 'gen-2-def',
+      apiVersion: '0.0',
+      source: { kind: 'git', specifier: 'git+https://x/y.git#v1', url: 'https://x/y.git', ref: 'v1' },
+    }
+    const result = validateReceipt(receipt)
+    if (!result.ok) expect.unreachable()
+    expect(result.receipt).toEqual(receipt as never)
+  })
+
+  test('git provenance round-trips without ref', () => {
+    const receipt = {
+      schemaVersion: 1,
+      activeGeneration: 'gen-2-def',
+      apiVersion: '0.0',
+      source: { kind: 'git', specifier: 'git+https://x/y.git', url: 'https://x/y.git' },
+    }
+    const result = validateReceipt(receipt)
+    if (!result.ok) expect.unreachable()
+    expect(result.receipt.source).toEqual({ kind: 'git', specifier: 'git+https://x/y.git', url: 'https://x/y.git' })
+  })
+
+  test('local provenance round-trips', () => {
+    const receipt = {
+      schemaVersion: 1,
+      activeGeneration: 'gen-3',
+      apiVersion: '0.0',
+      source: { kind: 'local', specifier: './adapters/mine', sourcePath: '/abs/adapters/mine' },
+    }
+    const result = validateReceipt(receipt)
+    if (!result.ok) expect.unreachable()
+    expect(result.receipt.source.kind).toBe('local')
+  })
+})
+
+describe('validateReceipt — invalid receipts', () => {
+  test.each([
+    ['not an object', 42],
+    ['null', null],
+    ['wrong schemaVersion', { ...validNpmReceipt, schemaVersion: 2 }],
+    ['missing schemaVersion', { ...validNpmReceipt, schemaVersion: undefined }],
+    ['unsafe generation id (traversal)', { ...validNpmReceipt, activeGeneration: '../escape' }],
+    ['unsafe generation id (separator)', { ...validNpmReceipt, activeGeneration: 'a/b' }],
+    ['unsafe generation id (hidden)', { ...validNpmReceipt, activeGeneration: '.hidden' }],
+    ['unsafe generation id (empty)', { ...validNpmReceipt, activeGeneration: '' }],
+    ['missing apiVersion', { ...validNpmReceipt, apiVersion: undefined }],
+    ['missing source', { ...validNpmReceipt, source: undefined }],
+    ['unknown source kind', { ...validNpmReceipt, source: { kind: 'ftp', specifier: 'x' } }],
+    [
+      'npm source without integrity',
+      {
+        ...validNpmReceipt,
+        source: { kind: 'npm', specifier: 'x', packageName: 'x', version: '1.0.0' },
+      },
+    ],
+    [
+      'npm source with malformed integrity kind',
+      {
+        ...validNpmReceipt,
+        source: {
+          kind: 'npm',
+          specifier: 'x',
+          packageName: 'x',
+          version: '1.0.0',
+          integrity: { kind: 'md5', value: 'x' },
+        },
+      },
+    ],
+    ['git source without url', { ...validNpmReceipt, source: { kind: 'git', specifier: 'x' } }],
+    [
+      'git source with non-string ref',
+      { ...validNpmReceipt, source: { kind: 'git', specifier: 'x', url: 'https://x', ref: 42 } },
+    ],
+    ['local source without sourcePath', { ...validNpmReceipt, source: { kind: 'local', specifier: 'x' } }],
+    ['source without specifier', { ...validNpmReceipt, source: { kind: 'local', sourcePath: '/x' } }],
+  ])('rejects %s', (_label, receipt) => {
+    const result = validateReceipt(receipt)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('invalid')
+  })
+})
+
+describe('generation ids', () => {
+  test('newGenerationId mints safe unique ids', () => {
+    const a = newGenerationId()
+    const b = newGenerationId()
+    expect(isSafeGenerationId(a)).toBe(true)
+    expect(isSafeGenerationId(b)).toBe(true)
+    expect(a).not.toBe(b)
+  })
+
+  test.each(['gen-1', 'a', 'A.b_c-d', '0'])('accepts safe id %s', (id) => {
+    expect(isSafeGenerationId(id)).toBe(true)
+  })
+
+  test.each(['', '.', '..', '.hidden', 'a/b', 'a\\b', '../x', '-flag'])('rejects unsafe id %j', (id) => {
+    expect(isSafeGenerationId(id)).toBe(false)
+  })
+
+  test('generationDir resolves contained paths', () => {
+    expect(generationDir('/base/adapters/x', 'gen-1')).toBe(join('/base/adapters/x', 'generations', 'gen-1'))
+  })
+
+  test('generationDir returns null for unsafe ids', () => {
+    expect(generationDir('/base/adapters/x', '../../escape')).toBeNull()
+    expect(generationDir('/base/adapters/x', 'a/b')).toBeNull()
+  })
+})

--- a/packages/engine/src/adapters/__tests__/locate-and-verify.test.ts
+++ b/packages/engine/src/adapters/__tests__/locate-and-verify.test.ts
@@ -73,8 +73,9 @@ describe('locateAndVerifyAdapter — fallback eligibility', () => {
     try {
       const result = await locateAndVerifyAdapter(dir)
       if (result.ok) expect.unreachable()
-      if (result.failure.kind !== 'incompatible') expect.unreachable()
-      expect(result.failure.failure).toEqual({
+      if (result.failure.kind !== 'verify') expect.unreachable()
+      if (result.failure.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure.failure).toEqual({
         kind: 'api-unsupported',
         adapter: 'future-adapter',
         found: '9.9',
@@ -100,12 +101,13 @@ describe('locateAndVerifyAdapter — fallback eligibility', () => {
     try {
       const result = await locateAndVerifyAdapter(dir)
       if (result.ok) expect.unreachable()
-      if (result.failure.kind !== 'incompatible') expect.unreachable()
-      expect(result.failure.failure.kind).toBe('api-missing')
+      if (result.failure.kind !== 'verify') expect.unreachable()
+      const verifyFailure = result.failure.failure
+      if (verifyFailure.kind !== 'incompatible') expect.unreachable()
+      expect(verifyFailure.failure.kind).toBe('api-missing')
       // The failure identifies the original prebuilt path, not a
       // transient isolation copy.
-      if (result.failure.failure.kind !== 'api-missing') expect.unreachable()
-      expect(result.failure.bundlePath).toBe(join(dir, 'dist/index.mjs'))
+      expect(verifyFailure.bundlePath).toBe(join(dir, 'dist/index.mjs'))
     } finally {
       await rm(dir, { recursive: true, force: true }).catch(() => {})
     }

--- a/packages/engine/src/adapters/__tests__/placement-managed.test.ts
+++ b/packages/engine/src/adapters/__tests__/placement-managed.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { chmod, mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+import { acquireAdapterLock } from '../../install/lockfile-guard.ts'
+import {
+  GENERATIONS_DIR_NAME,
+  INSTALLATION_RECEIPT_NAME,
+  type InstallationSource,
+  readInstallationReceipt,
+} from '../installation.ts'
+import { listInstalledAdapters, placeAdapter, placeAdapterManaged, removeAdapter } from '../placement.ts'
+
+/**
+ * Managed placement tests: atomic activation, failure injection at every
+ * stage (proving the previous installation survives untouched), cleanup
+ * warnings, stale leftovers, concurrent replacement, legacy conversion,
+ * and the new removal/enumeration semantics.
+ */
+
+let facetDir: string
+let baseDir: string
+let workDir: string
+let originalFacetDir: string | undefined
+
+beforeEach(async () => {
+  facetDir = await mkdtemp(join(tmpdir(), 'facet-place-managed-'))
+  baseDir = join(facetDir, 'adapters')
+  workDir = await mkdtemp(join(tmpdir(), 'facet-place-work-'))
+  originalFacetDir = process.env.FACET_DIR
+  // Locks live under $FACET_DIR/locks — redirect them per test.
+  process.env.FACET_DIR = facetDir
+})
+
+afterEach(async () => {
+  if (originalFacetDir === undefined) {
+    delete process.env.FACET_DIR
+  } else {
+    process.env.FACET_DIR = originalFacetDir
+  }
+  await rm(facetDir, { recursive: true, force: true }).catch(() => {})
+  await rm(workDir, { recursive: true, force: true }).catch(() => {})
+})
+
+let bundleCounter = 0
+/** Write a dependency-free verifiable bundle; unique file per call. */
+async function makeBundle(name: string, opts: { apiVersion?: string; marker?: string } = {}): Promise<string> {
+  const api = opts.apiVersion ?? ADAPTER_API_VERSION
+  const path = join(workDir, `bundle-${++bundleCounter}.mjs`)
+  await Bun.write(
+    path,
+    `export const marker = '${opts.marker ?? 'default'}'
+export default {
+  name: '${name}',
+  apiVersion: '${api}',
+  buildAssetMetadata: () => ({ ok: true, data: {} }),
+  installAsset: async () => undefined,
+  readAsset: async () => ({ content: '' }),
+  deleteAsset: async () => undefined,
+}
+`,
+  )
+  return path
+}
+
+const npmSource: InstallationSource = {
+  kind: 'npm',
+  specifier: 'my-adapter',
+  packageName: 'my-adapter',
+  version: '1.0.0',
+  integrity: { kind: 'sri', value: 'sha512-test' },
+}
+
+async function generationNames(name: string): Promise<string[]> {
+  try {
+    return (await readdir(join(baseDir, name, GENERATIONS_DIR_NAME))).sort()
+  } catch {
+    return []
+  }
+}
+
+describe('placeAdapterManaged — success paths', () => {
+  test('fresh install writes an active generation and receipt', async () => {
+    const bundle = await makeBundle('my-adapter')
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      bundle,
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!result.ok) expect.unreachable()
+    expect(result.warnings).toEqual([])
+    expect(result.receipt.apiVersion).toBe(ADAPTER_API_VERSION)
+    expect(result.receipt.source).toEqual(npmSource)
+
+    const read = await readInstallationReceipt(join(baseDir, 'my-adapter'))
+    if (!read.ok) expect.unreachable()
+    expect(read.receipt).toEqual(result.receipt)
+
+    const generations = await generationNames('my-adapter')
+    expect(generations).toEqual([result.receipt.activeGeneration])
+    expect(
+      await Bun.file(
+        join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, result.receipt.activeGeneration, 'adapter.js'),
+      ).exists(),
+    ).toBe(true)
+  })
+
+  test('replacement activates a new generation and removes the old one', async () => {
+    const first = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter', { marker: 'one' }),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!first.ok) expect.unreachable()
+
+    const second = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter', { marker: 'two' }),
+      { apiVersion: ADAPTER_API_VERSION, source: { ...npmSource, version: '2.0.0' } },
+      baseDir,
+    )
+    if (!second.ok) expect.unreachable()
+    expect(second.receipt.activeGeneration).not.toBe(first.receipt.activeGeneration)
+    expect(await generationNames('my-adapter')).toEqual([second.receipt.activeGeneration])
+
+    const read = await readInstallationReceipt(join(baseDir, 'my-adapter'))
+    if (!read.ok) expect.unreachable()
+    if (read.receipt.source.kind !== 'npm') expect.unreachable()
+    expect(read.receipt.source.version).toBe('2.0.0')
+  })
+
+  test('successful install converts a legacy flat bundle to managed', async () => {
+    await placeAdapter('my-adapter', await makeBundle('my-adapter', { marker: 'legacy' }), baseDir)
+    const legacyPath = join(baseDir, 'my-adapter', 'adapter.js')
+    expect(await Bun.file(legacyPath).exists()).toBe(true)
+
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter', { marker: 'managed' }),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!result.ok) expect.unreachable()
+    expect(await Bun.file(legacyPath).exists()).toBe(false)
+    const read = await readInstallationReceipt(join(baseDir, 'my-adapter'))
+    expect(read.ok).toBe(true)
+  })
+
+  test('successful install cleans stale crash leftovers', async () => {
+    // A crash between staging and activation leaves an orphaned generation.
+    const leftover = join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, 'gen-crash-leftover')
+    await mkdir(leftover, { recursive: true })
+    await Bun.write(join(leftover, 'adapter.js'), '// stale')
+
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter'),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!result.ok) expect.unreachable()
+    expect(await generationNames('my-adapter')).toEqual([result.receipt.activeGeneration])
+  })
+})
+
+describe('placeAdapterManaged — failure injection', () => {
+  /** Install a good managed version, returning its receipt for later comparison. */
+  async function installGood(): Promise<{ activeGeneration: string; receiptText: string }> {
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter', { marker: 'good' }),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!result.ok) expect.unreachable()
+    const receiptText = await Bun.file(join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME)).text()
+    return { activeGeneration: result.receipt.activeGeneration, receiptText }
+  }
+
+  async function expectUntouched(previous: { activeGeneration: string; receiptText: string }): Promise<void> {
+    expect(await Bun.file(join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME)).text()).toBe(previous.receiptText)
+    expect(await generationNames('my-adapter')).toEqual([previous.activeGeneration])
+  }
+
+  test('stage failure (missing bundle) leaves the previous installation untouched', async () => {
+    const previous = await installGood()
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      join(workDir, 'does-not-exist.mjs'),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (result.ok) expect.unreachable()
+    expect(result.failure.kind).toBe('stage-failed')
+    await expectUntouched(previous)
+  })
+
+  test('verification failure at the staged path leaves the previous installation untouched', async () => {
+    const previous = await installGood()
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter', { apiVersion: '9.9' }),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (result.ok) expect.unreachable()
+    if (result.failure.kind !== 'verify-failed') expect.unreachable()
+    expect(result.failure.failure.kind).toBe('incompatible')
+    await expectUntouched(previous)
+  })
+
+  test('metadata/runtime disagreement at the staged path is terminal', async () => {
+    const previous = await installGood()
+    // Runtime declares the supported API but provenance claims 0.1 —
+    // the staged re-verification must reject the contradiction.
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter'),
+      { apiVersion: '0.1', source: npmSource },
+      baseDir,
+    )
+    if (result.ok) expect.unreachable()
+    if (result.failure.kind !== 'verify-failed') expect.unreachable()
+    expect(result.failure.failure.kind).toBe('incompatible')
+    await expectUntouched(previous)
+  })
+
+  test('runtime name mismatch leaves the previous installation untouched', async () => {
+    const previous = await installGood()
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('other-name'),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (result.ok) expect.unreachable()
+    if (result.failure.kind !== 'name-mismatch') expect.unreachable()
+    expect(result.failure.runtimeName).toBe('other-name')
+    await expectUntouched(previous)
+  })
+
+  test('receipt-write failure leaves the previous installation untouched', async () => {
+    const previous = await installGood()
+    // atomicWriteFileSync writes to `<receipt>.tmp` first; making that
+    // path a directory forces the write to fail after staging.
+    await mkdir(join(baseDir, 'my-adapter', `${INSTALLATION_RECEIPT_NAME}.tmp`), { recursive: true })
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter', { marker: 'unactivatable' }),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    await rm(join(baseDir, 'my-adapter', `${INSTALLATION_RECEIPT_NAME}.tmp`), { recursive: true, force: true })
+    if (result.ok) expect.unreachable()
+    expect(result.failure.kind).toBe('receipt-write-failed')
+    await expectUntouched(previous)
+  })
+
+  test('concurrent replacement is refused while the adapter lock is held', async () => {
+    const lock = acquireAdapterLock('my-adapter')
+    if (!lock.ok) expect.unreachable()
+    try {
+      const result = await placeAdapterManaged(
+        'my-adapter',
+        await makeBundle('my-adapter'),
+        { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+        baseDir,
+      )
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'lock-held') expect.unreachable()
+      expect(result.failure.heldByPid).toBe(process.pid)
+    } finally {
+      await lock.lock.release()
+    }
+  })
+
+  test('undeletable old generation degrades to a cleanup warning, not a failure', async () => {
+    const previous = await installGood()
+    const oldGenDir = join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, previous.activeGeneration)
+    // Remove write permission so the old generation's contents can't be unlinked.
+    await chmod(oldGenDir, 0o555)
+    try {
+      const result = await placeAdapterManaged(
+        'my-adapter',
+        await makeBundle('my-adapter', { marker: 'new' }),
+        { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+        baseDir,
+      )
+      if (!result.ok) expect.unreachable()
+      expect(result.warnings.length).toBeGreaterThan(0)
+      expect(result.warnings[0]?.kind).toBe('cleanup-failed')
+      // Activation still succeeded: the receipt points at the new generation.
+      const read = await readInstallationReceipt(join(baseDir, 'my-adapter'))
+      if (!read.ok) expect.unreachable()
+      expect(read.receipt.activeGeneration).not.toBe(previous.activeGeneration)
+    } finally {
+      await chmod(oldGenDir, 0o755).catch(() => {})
+    }
+  })
+})
+
+describe('removal and enumeration semantics', () => {
+  test('removeAdapter deletes a managed installation without loading it', async () => {
+    const result = await placeAdapterManaged(
+      'my-adapter',
+      await makeBundle('my-adapter'),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!result.ok) expect.unreachable()
+    expect(await removeAdapter('my-adapter', baseDir)).toBe(true)
+    expect(await Bun.file(join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME)).exists()).toBe(false)
+  })
+
+  test('removeAdapter deletes a legacy flat installation', async () => {
+    await placeAdapter('legacy-adapter', await makeBundle('legacy-adapter'), baseDir)
+    expect(await removeAdapter('legacy-adapter', baseDir)).toBe(true)
+  })
+
+  test('removeAdapter ignores a staging-leftover-only directory', async () => {
+    const leftover = join(baseDir, 'ghost', GENERATIONS_DIR_NAME, 'gen-crash')
+    await mkdir(leftover, { recursive: true })
+    await Bun.write(join(leftover, 'adapter.js'), '// stale')
+    expect(await removeAdapter('ghost', baseDir)).toBe(false)
+    expect(await Bun.file(join(leftover, 'adapter.js')).exists()).toBe(true)
+  })
+
+  test('removeAdapter returns false for a nonexistent adapter', async () => {
+    expect(await removeAdapter('nope', baseDir)).toBe(false)
+  })
+
+  test('listInstalledAdapters lists managed and legacy entries, ignoring leftovers', async () => {
+    const placed = await placeAdapterManaged(
+      'managed-one',
+      await makeBundle('managed-one'),
+      { apiVersion: ADAPTER_API_VERSION, source: npmSource },
+      baseDir,
+    )
+    if (!placed.ok) expect.unreachable()
+    await placeAdapter('legacy-one', await makeBundle('legacy-one'), baseDir)
+    const leftover = join(baseDir, 'ghost', GENERATIONS_DIR_NAME, 'gen-crash')
+    await mkdir(leftover, { recursive: true })
+
+    expect(await listInstalledAdapters(baseDir)).toEqual(['legacy-one', 'managed-one'])
+  })
+})

--- a/packages/engine/src/adapters/bundler.ts
+++ b/packages/engine/src/adapters/bundler.ts
@@ -3,19 +3,37 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 /**
+ * Discriminated failure for bundle production. Expected failure modes
+ * are values, not thrown errors:
+ *
+ *   - `no-package-json` — `sourceDir` has no package.json.
+ *   - `no-entry-point` — no entry could be resolved; `tried` lists
+ *     every location that was checked.
+ *   - `install-failed` — `bun install` failed in the source tree.
+ *   - `build-failed` — the build reported errors.
+ *   - `no-output` — the build succeeded but produced no output file.
+ */
+export type BundleFailure =
+  | { kind: 'no-package-json'; sourceDir: string }
+  | { kind: 'no-entry-point'; sourceDir: string; tried: string[] }
+  | { kind: 'install-failed'; sourceDir: string; stderr: string }
+  | { kind: 'build-failed'; sourceDir: string; errors: string[] }
+  | { kind: 'no-output'; sourceDir: string }
+
+/**
  * The result of building (or locating) an adapter bundle. Includes the
  * absolute path to the bundle and a `cleanup` function that removes any
  * temp directory the build created. Callers MUST invoke `cleanup()` after
  * they're done consuming `bundlePath` (typically in a `finally` block).
+ * Failure arms have already cleaned up their own temp resources.
  *
  * The fast path returns a no-op `cleanup` since `bundlePath` points at
  * a file inside the source tree (or inside the source-tree temp dir,
  * which has its own cleanup lifecycle).
  */
-export type BundleResult = {
-  bundlePath: string
-  cleanup: () => Promise<void>
-}
+export type BundleResult =
+  | { ok: true; bundlePath: string; cleanup: () => Promise<void> }
+  | { ok: false; failure: BundleFailure }
 
 /** A no-op cleanup, used when the fast path needs no temp dir. */
 const noopCleanup = async (): Promise<void> => {}
@@ -31,26 +49,26 @@ const noopCleanup = async (): Promise<void> => {}
  * When the fast path is not available (e.g. a third-party adapter with no
  * prebuilt dist, a local source tree during development, a git install
  * without committed build output), the slow path kicks in: bundle the
- * resolved entry point with `Bun.build()`, installing dependencies first
- * only if the optimistic build fails (see `rebundleAdapter`).
+ * resolved entry point, installing dependencies first only if the
+ * optimistic build fails (see `rebundleAdapter`).
  *
  * @param sourceDir - Path to the adapter source (must contain package.json)
- * @returns A `BundleResult` with the bundle path and a cleanup function.
  */
 export async function bundleAdapter(sourceDir: string): Promise<BundleResult> {
   const resolved = await resolveEntryPoint(sourceDir)
+  if (!resolved.ok) return resolved
 
   // Fast path: adapter ships a prebuilt bundle. Return it directly — no
   // install, no build. Verify step will dynamically import() it to confirm
   // it loads without missing externals; if that fails, the caller will fall
   // back to the slow path via `rebundleAdapter`.
-  if (resolved.kind === 'prebuilt') {
-    return { bundlePath: resolved.path, cleanup: noopCleanup }
+  if (resolved.entry.kind === 'prebuilt') {
+    return { ok: true, bundlePath: resolved.entry.path, cleanup: noopCleanup }
   }
 
-  // Slow path: source tree (e.g. unbuilt local adapter). Bundle with
-  // Bun.build(), installing dependencies only if needed.
-  return rebundleAdapter(sourceDir, resolved.path)
+  // Slow path: source tree (e.g. unbuilt local adapter). Bundle, installing
+  // dependencies only if needed.
+  return rebundleAdapter(sourceDir, resolved.entry.path)
 }
 
 /**
@@ -78,7 +96,8 @@ export async function bundleAdapter(sourceDir: string): Promise<BundleResult> {
  * build artifacts behind. Returns the bundle path along with a `cleanup`
  * function that removes the temp directory; callers MUST invoke `cleanup()`
  * after consuming the bundle (typically in a `finally` block) so we don't
- * accumulate `facet-adapter-build-*` dirs in the OS temp directory.
+ * accumulate `facet-adapter-build-*` dirs in the OS temp directory. Every
+ * failure arm removes its own temp directory before returning.
  *
  * Exported separately so callers can also invoke it as a retry fallback
  * when the fast path's prebuilt bundle fails to load (e.g. missing
@@ -88,39 +107,49 @@ export async function rebundleAdapter(sourceDir: string, entryPoint: string): Pr
   // Optimistic pass: dependencies may already be on disk.
   const first = await tryBuild(sourceDir, entryPoint)
   if (first.ok) {
-    return { bundlePath: first.bundlePath, cleanup: first.cleanup }
+    return { ok: true, bundlePath: first.bundlePath, cleanup: first.cleanup }
   }
 
   // Fallback: install dependencies, then retry the build exactly once.
-  installDependencies(sourceDir)
+  const installed = installDependencies(sourceDir)
+  if (!installed.ok) {
+    return { ok: false, failure: installed.failure }
+  }
   const second = await tryBuild(sourceDir, entryPoint)
   if (second.ok) {
-    return { bundlePath: second.bundlePath, cleanup: second.cleanup }
+    return { ok: true, bundlePath: second.bundlePath, cleanup: second.cleanup }
   }
-  throw new Error(`Failed to bundle adapter from "${sourceDir}":\n${second.errors}`)
+  return { ok: false, failure: second.failure }
 }
 
 /**
  * Install dependencies in `sourceDir` with `bun install` — frozen
  * lockfile first, then a plain retry (covers sources shipped without a
- * lockfile). Throws when both attempts fail.
+ * lockfile).
  */
-function installDependencies(sourceDir: string): void {
+function installDependencies(
+  sourceDir: string,
+): { ok: true } | { ok: false; failure: Extract<BundleFailure, { kind: 'install-failed' }> } {
   const installResult = Bun.spawnSync(['bun', 'install', '--frozen-lockfile'], {
     cwd: sourceDir,
     stdout: 'pipe',
     stderr: 'pipe',
   })
-  if (installResult.exitCode === 0) return
+  if (installResult.exitCode === 0) return { ok: true }
 
+  // If frozen-lockfile fails (no lockfile), try without it
   const retryResult = Bun.spawnSync(['bun', 'install'], {
     cwd: sourceDir,
     stdout: 'pipe',
     stderr: 'pipe',
   })
   if (retryResult.exitCode !== 0) {
-    throw new Error(`Failed to install dependencies in "${sourceDir}": ${retryResult.stderr.toString().trim()}`)
+    return {
+      ok: false,
+      failure: { kind: 'install-failed', sourceDir, stderr: retryResult.stderr.toString().trim() },
+    }
   }
+  return { ok: true }
 }
 
 /**
@@ -138,7 +167,10 @@ function installDependencies(sourceDir: string): void {
 async function tryBuild(
   sourceDir: string,
   entryPoint: string,
-): Promise<{ ok: true; bundlePath: string; cleanup: () => Promise<void> } | { ok: false; errors: string }> {
+): Promise<
+  | { ok: true; bundlePath: string; cleanup: () => Promise<void> }
+  | { ok: false; failure: Extract<BundleFailure, { kind: 'build-failed' | 'no-output' }> }
+> {
   // Write outside of `sourceDir` so local installs from a user's source
   // tree don't leave build artifacts behind.
   const outdir = await mkdtemp(join(tmpdir(), 'facet-adapter-build-'))
@@ -158,12 +190,15 @@ async function tryBuild(
 
   if (result.exitCode !== 0) {
     await cleanup()
-    return { ok: false, errors: result.stderr.toString().trim() }
+    return {
+      ok: false,
+      failure: { kind: 'build-failed', sourceDir, errors: [result.stderr.toString().trim()] },
+    }
   }
 
   if (!(await Bun.file(bundlePath).exists())) {
     await cleanup()
-    return { ok: false, errors: `bun build produced no output for "${sourceDir}"` }
+    return { ok: false, failure: { kind: 'no-output', sourceDir } }
   }
 
   return { ok: true, bundlePath, cleanup }
@@ -179,6 +214,11 @@ export type ResolvedEntryPoint = {
   path: string
   kind: 'prebuilt' | 'source'
 }
+
+/** Result of `resolveEntryPoint`. */
+export type ResolveEntryPointResult =
+  | { ok: true; entry: ResolvedEntryPoint }
+  | { ok: false; failure: Extract<BundleFailure, { kind: 'no-package-json' | 'no-entry-point' }> }
 
 /** Classify a resolved path by its file extension. */
 function classify(path: string): 'prebuilt' | 'source' {
@@ -196,16 +236,16 @@ function classify(path: string): 'prebuilt' | 'source' {
  *   5. Disk fallback: `dist/index.mjs`.
  *   6. Disk fallback: `dist/index.js`.
  *   7. Disk fallback: `src/index.ts` (unbuilt local source).
- *   8. Throws, listing every location that was tried.
+ *   8. `no-entry-point` failure listing every location that was tried.
  *
  * Exported for direct unit testing.
  */
-export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntryPoint> {
+export async function resolveEntryPoint(sourceDir: string): Promise<ResolveEntryPointResult> {
   const pkgJsonPath = join(sourceDir, 'package.json')
   const pkgFile = Bun.file(pkgJsonPath)
 
   if (!(await pkgFile.exists())) {
-    throw new Error(`No package.json found in "${sourceDir}"`)
+    return { ok: false, failure: { kind: 'no-package-json', sourceDir } }
   }
 
   const pkg = (await pkgFile.json()) as {
@@ -220,7 +260,7 @@ export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntr
     const absolute = join(sourceDir, pkg.exports)
     tried.push(`exports: "${pkg.exports}"`)
     if (await Bun.file(absolute).exists()) {
-      return { path: absolute, kind: classify(absolute) }
+      return { ok: true, entry: { path: absolute, kind: classify(absolute) } }
     }
   }
 
@@ -230,7 +270,7 @@ export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntr
     const absolute = join(sourceDir, relative)
     tried.push(`exports["."]: "${relative}"`)
     if (await Bun.file(absolute).exists()) {
-      return { path: absolute, kind: classify(absolute) }
+      return { ok: true, entry: { path: absolute, kind: classify(absolute) } }
     }
   }
 
@@ -246,7 +286,7 @@ export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntr
     const absolute = join(sourceDir, relative)
     tried.push(`exports["."].import: "${relative}"`)
     if (await Bun.file(absolute).exists()) {
-      return { path: absolute, kind: classify(absolute) }
+      return { ok: true, entry: { path: absolute, kind: classify(absolute) } }
     }
   }
 
@@ -255,7 +295,7 @@ export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntr
     const absolute = join(sourceDir, pkg.main)
     tried.push(`main: "${pkg.main}"`)
     if (await Bun.file(absolute).exists()) {
-      return { path: absolute, kind: classify(absolute) }
+      return { ok: true, entry: { path: absolute, kind: classify(absolute) } }
     }
   }
 
@@ -265,13 +305,9 @@ export async function resolveEntryPoint(sourceDir: string): Promise<ResolvedEntr
     const absolute = join(sourceDir, relative)
     tried.push(`disk: "${relative}"`)
     if (await Bun.file(absolute).exists()) {
-      return { path: absolute, kind: classify(absolute) }
+      return { ok: true, entry: { path: absolute, kind: classify(absolute) } }
     }
   }
 
-  throw new Error(
-    `Cannot determine entry point for adapter in "${sourceDir}". ` +
-      `Tried:\n  - ${tried.join('\n  - ')}\n` +
-      `Set "exports" or "main" in package.json, or ship a prebuilt dist/index.mjs.`,
-  )
+  return { ok: false, failure: { kind: 'no-entry-point', sourceDir, tried } }
 }

--- a/packages/engine/src/adapters/inspect.ts
+++ b/packages/engine/src/adapters/inspect.ts
@@ -1,0 +1,191 @@
+import {
+  type AdapterCompatibilityFailure,
+  classifyApiDeclaration,
+  SUPPORTED_ADAPTER_APIS,
+} from './api-compatibility.ts'
+import { FIRST_PARTY_ADAPTERS } from './first-party.ts'
+import { generationBundlePath, generationDir, readInstallationReceipt } from './installation.ts'
+import { getAdapterBundlePath, getAdapterDir, listInstalledAdapters } from './placement.ts'
+import { type VerifiedAdapter, type VerifyAdapterFailure, verifyAdapter } from './verify.ts'
+
+/**
+ * Shared installed-adapter inspection — the single path used by runtime
+ * loading and `facet adapter list`. Every installation directory
+ * produces exactly one tagged outcome; consumers fail closed on
+ * anything that is not `compatible`.
+ */
+
+/**
+ * How the user can repair or replace this installation.
+ *
+ *   - `managed` — the receipt retains the original install specifier.
+ *   - `first-party-alias` — unmanaged, but the directory name is a
+ *     first-party catalog alias, which is itself a valid specifier.
+ *   - `unmanaged-name` — unmanaged and unknown; the name is the best
+ *     available specifier and original source provenance is unavailable.
+ */
+export type RepairSource =
+  | { kind: 'managed'; specifier: string }
+  | { kind: 'first-party-alias'; alias: string }
+  | { kind: 'unmanaged-name'; name: string }
+
+/** Why an installation is broken (as opposed to API-incompatible). */
+export type BrokenReason =
+  | { kind: 'invalid-receipt'; detail: string }
+  | { kind: 'missing-active-generation'; generation: string }
+  | { kind: 'load-failed'; failure: VerifyAdapterFailure }
+
+/**
+ * One tagged outcome per installation directory:
+ *
+ *   - `compatible` — verified adapter with a supported runtime API.
+ *   - `incompatible` — structurally sound, but its API declaration is
+ *     missing, malformed, unsupported, or contradicts the receipt.
+ *   - `broken` — invalid installation metadata, unresolvable active
+ *     generation, unloadable bundle, or invalid adapter export.
+ *     `declaredApi` carries the receipt's recorded API when one exists.
+ */
+export type InstalledAdapterInspection =
+  | { kind: 'compatible'; name: string; managed: boolean; verified: VerifiedAdapter; repair: RepairSource }
+  | { kind: 'incompatible'; name: string; managed: boolean; failure: AdapterCompatibilityFailure; repair: RepairSource }
+  | {
+      kind: 'broken'
+      name: string
+      managed: boolean
+      reason: BrokenReason
+      declaredApi?: string
+      repair: RepairSource
+    }
+
+/** Best available repair source for an entry without a usable receipt. */
+function unmanagedRepair(name: string): RepairSource {
+  const isFirstParty = FIRST_PARTY_ADAPTERS.some((adapter) => adapter.name === name)
+  return isFirstParty ? { kind: 'first-party-alias', alias: name } : { kind: 'unmanaged-name', name }
+}
+
+/**
+ * Inspect every installed adapter directory under `baseDir`, in sorted
+ * name order. Staging/crash leftovers are not installations and are
+ * already excluded by enumeration.
+ */
+export async function inspectInstalledAdapters(baseDir?: string): Promise<InstalledAdapterInspection[]> {
+  const names = await listInstalledAdapters(baseDir)
+  const inspections: InstalledAdapterInspection[] = []
+  for (const name of names) {
+    inspections.push(await inspectInstalledAdapter(name, baseDir))
+  }
+  return inspections
+}
+
+/** Inspect one installed adapter directory. */
+export async function inspectInstalledAdapter(name: string, baseDir?: string): Promise<InstalledAdapterInspection> {
+  const adapterDir = getAdapterDir(name, baseDir)
+  const receipt = await readInstallationReceipt(adapterDir)
+
+  if (receipt.ok) {
+    return inspectManaged(name, adapterDir, receipt.receipt)
+  }
+  if (receipt.reason === 'invalid') {
+    return {
+      kind: 'broken',
+      name,
+      managed: true,
+      reason: { kind: 'invalid-receipt', detail: receipt.detail },
+      repair: unmanagedRepair(name),
+    }
+  }
+
+  // No receipt: unmanaged historical `<name>/adapter.js` layout.
+  return inspectUnmanaged(name, baseDir)
+}
+
+async function inspectManaged(
+  name: string,
+  adapterDir: string,
+  receipt: { activeGeneration: string; apiVersion: string; source: { specifier: string } },
+): Promise<InstalledAdapterInspection> {
+  const repair: RepairSource = { kind: 'managed', specifier: receipt.source.specifier }
+
+  // Reject a recorded unsupported API before importing anything — a
+  // known-incompatible install must not run module initialization.
+  const recorded = classifyApiDeclaration(receipt.apiVersion)
+  if (recorded.kind !== 'supported') {
+    return {
+      kind: 'incompatible',
+      name,
+      managed: true,
+      failure: compatibilityFailureFromClassification(name, recorded),
+      repair,
+    }
+  }
+
+  const genDir = generationDir(adapterDir, receipt.activeGeneration)
+  if (genDir === null) {
+    // Unreachable for a validated receipt; classify honestly anyway.
+    return {
+      kind: 'broken',
+      name,
+      managed: true,
+      reason: { kind: 'invalid-receipt', detail: 'active generation failed containment' },
+      declaredApi: receipt.apiVersion,
+      repair,
+    }
+  }
+  const bundlePath = generationBundlePath(genDir)
+  if (!(await Bun.file(bundlePath).exists())) {
+    return {
+      kind: 'broken',
+      name,
+      managed: true,
+      reason: { kind: 'missing-active-generation', generation: receipt.activeGeneration },
+      declaredApi: receipt.apiVersion,
+      repair,
+    }
+  }
+
+  // The receipt's API is the expected declaration; a runtime
+  // disagreement classifies as api-metadata-mismatch.
+  const verified = await verifyAdapter(bundlePath, { expectedApiVersion: receipt.apiVersion })
+  if (verified.ok) {
+    return { kind: 'compatible', name, managed: true, verified: verified.verified, repair }
+  }
+  if (verified.failure.kind === 'incompatible') {
+    return { kind: 'incompatible', name, managed: true, failure: verified.failure.failure, repair }
+  }
+  return {
+    kind: 'broken',
+    name,
+    managed: true,
+    reason: { kind: 'load-failed', failure: verified.failure },
+    declaredApi: receipt.apiVersion,
+    repair,
+  }
+}
+
+async function inspectUnmanaged(name: string, baseDir?: string): Promise<InstalledAdapterInspection> {
+  const repair = unmanagedRepair(name)
+  const bundlePath = getAdapterBundlePath(name, baseDir)
+
+  const verified = await verifyAdapter(bundlePath)
+  if (verified.ok) {
+    return { kind: 'compatible', name, managed: false, verified: verified.verified, repair }
+  }
+  if (verified.failure.kind === 'incompatible') {
+    return { kind: 'incompatible', name, managed: false, failure: verified.failure.failure, repair }
+  }
+  return { kind: 'broken', name, managed: false, reason: { kind: 'load-failed', failure: verified.failure }, repair }
+}
+
+function compatibilityFailureFromClassification(
+  adapter: string,
+  classification: Exclude<ReturnType<typeof classifyApiDeclaration>, { kind: 'supported' }>,
+): AdapterCompatibilityFailure {
+  switch (classification.kind) {
+    case 'missing':
+      return { kind: 'api-missing', adapter, supported: SUPPORTED_ADAPTER_APIS }
+    case 'malformed':
+      return { kind: 'api-malformed', adapter, found: classification.found, supported: SUPPORTED_ADAPTER_APIS }
+    case 'unsupported':
+      return { kind: 'api-unsupported', adapter, found: classification.api, supported: SUPPORTED_ADAPTER_APIS }
+  }
+}

--- a/packages/engine/src/adapters/install-service.ts
+++ b/packages/engine/src/adapters/install-service.ts
@@ -12,8 +12,9 @@ import {
   resolveNpmAdapter,
 } from '../sources/adapter/npm.ts'
 import { type ParseAdapterSpecifierResult, parseAdapterSpecifier } from '../sources/adapter/specifier.ts'
-import { rebundleAdapter, resolveEntryPoint } from './bundler.ts'
-import { placeAdapter } from './placement.ts'
+import { type BundleFailure, rebundleAdapter, resolveEntryPoint } from './bundler.ts'
+import type { InstallationReceipt, InstallationSource } from './installation.ts'
+import { type PlaceAdapterFailure, type PlacementWarning, placeAdapterManaged } from './placement.ts'
 import { type VerifiedAdapter, type VerifyAdapterFailure, verifyAdapter } from './verify.ts'
 
 /**
@@ -50,13 +51,13 @@ export interface AdapterInstallOptions {
  *     local-path resolution failed. The `source` discriminator carries
  *     the resolver-specific reason (for npm: compatible-release
  *     resolution failures and tarball download/integrity failures).
- *   - `bundle-failed` / `place-failed` — bundler load or placement
- *     threw. These two still wrap thrown errors today; the fix here is
- *     to surface them as structured failures to the caller instead of
- *     letting them escape the boundary.
+ *   - `bundle-failed` — entry resolution, dependency install, or
+ *     bundling failed. Carries the structured `BundleFailure`.
  *   - `verify-failed` — the produced bundle failed verification. Carries
  *     the full structured `VerifyAdapterFailure` (including adapter API
  *     compatibility classifications) for the CLI to render.
+ *   - `place-failed` — managed placement failed (lock, staging,
+ *     staged-path verification, or receipt activation).
  */
 export type AdapterInstallFailure =
   | { kind: 'specifier-invalid'; specifier: string; failure: Extract<ParseAdapterSpecifierResult, { ok: false }> }
@@ -71,16 +72,19 @@ export type AdapterInstallFailure =
         | { kind: 'git'; failure: Extract<CloneAdapterGitResult, { ok: false }> }
         | { kind: 'local'; failure: Extract<ResolveLocalAdapterResult, { ok: false }> }
     }
-  | { kind: 'bundle-failed'; specifier: string; cause: string }
+  | { kind: 'bundle-failed'; specifier: string; failure: BundleFailure }
   | { kind: 'verify-failed'; specifier: string; failure: VerifyAdapterFailure }
-  | { kind: 'place-failed'; specifier: string; adapter: string; cause: string }
+  | { kind: 'place-failed'; specifier: string; adapter: string; failure: PlaceAdapterFailure }
 
 /**
  * Result of `installAdapter`. Discriminated by `ok`. On success the
- * caller gets the loaded `Adapter` instance; on failure, a structured
- * `AdapterInstallFailure` for the CLI to render.
+ * caller gets the loaded `Adapter` instance, the activated installation
+ * receipt, and any post-activation cleanup warnings; on failure, a
+ * structured `AdapterInstallFailure` for the CLI to render.
  */
-export type AdapterInstallResult = { ok: true; adapter: Adapter } | { ok: false; failure: AdapterInstallFailure }
+export type AdapterInstallResult =
+  | { ok: true; adapter: Adapter; receipt: InstallationReceipt; warnings: PlacementWarning[] }
+  | { ok: false; failure: AdapterInstallFailure }
 
 export async function installAdapter(
   specifier: string,
@@ -97,6 +101,8 @@ export async function installAdapter(
   let bundleCleanup: (() => Promise<void>) | undefined
   /** The npm package declaration used for selection, when installing from npm. */
   let expectedApiVersion: string | undefined
+  /** Receipt provenance, minus the verified API (known after verification). */
+  let source: InstallationSource | undefined
 
   try {
     opts.onProgress?.('resolving', specifier)
@@ -120,6 +126,13 @@ export async function installAdapter(
         }
         sourceDir = dl.path
         expectedApiVersion = resolution.release.apiVersion
+        source = {
+          kind: 'npm',
+          specifier,
+          packageName: resolution.release.packageName,
+          version: resolution.release.version,
+          integrity: dl.usedIntegrity,
+        }
         break
       }
       case 'git': {
@@ -132,6 +145,12 @@ export async function installAdapter(
           }
         }
         sourceDir = clone.path
+        source = {
+          kind: 'git',
+          specifier,
+          url: resolved.url,
+          ...(resolved.commitish !== undefined ? { ref: resolved.commitish } : {}),
+        }
         break
       }
       case 'local': {
@@ -144,24 +163,21 @@ export async function installAdapter(
         }
         sourceDir = local.path
         needsCleanup = false // Don't delete user's local directory
+        source = { kind: 'local', specifier, sourcePath: local.path }
         break
       }
     }
 
     opts.onProgress?.('bundling')
-    let located: LocateAndVerifyResult
-    try {
-      located = await locateAndVerifyAdapter(sourceDir, { onLog: opts.onLog, expectedApiVersion })
-    } catch (err) {
-      // bundler internals (`rebundleAdapter`, `resolveEntryPoint`) still
-      // throw today — converting them is a later step. Catch at this
-      // boundary so the `installAdapter` contract stays result-typed
-      // even though its dependencies haven't been converted yet.
-      const cause = err instanceof Error ? err.message : String(err)
-      return { ok: false, failure: { kind: 'bundle-failed', specifier, cause } }
-    }
+    const located = await locateAndVerifyAdapter(sourceDir, { onLog: opts.onLog, expectedApiVersion })
     if (!located.ok) {
-      return { ok: false, failure: { kind: 'verify-failed', specifier, failure: located.failure } }
+      return {
+        ok: false,
+        failure:
+          located.failure.kind === 'bundle'
+            ? { kind: 'bundle-failed', specifier, failure: located.failure.failure }
+            : { kind: 'verify-failed', specifier, failure: located.failure.failure },
+      }
     }
     bundleCleanup = located.cleanup
     const adapter = located.verified.adapter
@@ -171,17 +187,18 @@ export async function installAdapter(
     // stage tick just exists for progress symmetry on the picker.
 
     opts.onProgress?.('placing', adapter.name)
-    try {
-      await placeAdapter(adapter.name, located.bundlePath)
-    } catch (err) {
-      const cause = err instanceof Error ? err.message : String(err)
+    const placed = await placeAdapterManaged(adapter.name, located.bundlePath, {
+      apiVersion: located.verified.apiVersion,
+      source,
+    })
+    if (!placed.ok) {
       return {
         ok: false,
-        failure: { kind: 'place-failed', specifier, adapter: adapter.name, cause },
+        failure: { kind: 'place-failed', specifier, adapter: adapter.name, failure: placed.failure },
       }
     }
 
-    return { ok: true, adapter }
+    return { ok: true, adapter, receipt: placed.receipt, warnings: placed.warnings }
   } finally {
     if (bundleCleanup) await bundleCleanup()
     if (needsCleanup && sourceDir) {
@@ -196,11 +213,15 @@ const noopCleanup = async (): Promise<void> => {}
  * Result of `locateAndVerifyAdapter`. On success, `bundlePath` is the
  * verified bundle ready for placement and `cleanup` removes any build
  * temp directory (callers MUST invoke it). On failure the function has
- * already cleaned up its own temp resources.
+ * already cleaned up its own temp resources; the tagged failure
+ * distinguishes bundle-production failures from verification failures.
  */
 export type LocateAndVerifyResult =
   | { ok: true; bundlePath: string; verified: VerifiedAdapter; cleanup: () => Promise<void> }
-  | { ok: false; failure: VerifyAdapterFailure }
+  | {
+      ok: false
+      failure: { kind: 'bundle'; failure: BundleFailure } | { kind: 'verify'; failure: VerifyAdapterFailure }
+    }
 
 /**
  * Locates a usable adapter bundle from `sourceDir` and verifies it loads
@@ -229,40 +250,47 @@ export async function locateAndVerifyAdapter(
   opts: { onLog?: OnLog; expectedApiVersion?: string } = {},
 ): Promise<LocateAndVerifyResult> {
   const resolved = await resolveEntryPoint(sourceDir)
+  if (!resolved.ok) {
+    return { ok: false, failure: { kind: 'bundle', failure: resolved.failure } }
+  }
   const verifyOpts = { expectedApiVersion: opts.expectedApiVersion }
 
-  if (resolved.kind === 'prebuilt') {
+  if (resolved.entry.kind === 'prebuilt') {
+    const prebuiltPath = resolved.entry.path
     opts.onLog?.(() => `[verbose]   using prebuilt bundle for ${basename(sourceDir)}`)
-    const verifyResult = await verifyPrebuiltInIsolation(resolved.path, verifyOpts)
+    const verifyResult = await verifyPrebuiltInIsolation(prebuiltPath, verifyOpts)
     if (verifyResult.ok) {
-      return { ok: true, bundlePath: resolved.path, verified: verifyResult.verified, cleanup: noopCleanup }
+      return { ok: true, bundlePath: prebuiltPath, verified: verifyResult.verified, cleanup: noopCleanup }
     }
     const prebuiltFailure = verifyResult.failure
     if (prebuiltFailure.kind !== 'import-failed') {
       // Terminal: the prebuilt bundle loaded but contradicts the
       // contract (or isn't an adapter). No rebundling fallback.
-      return { ok: false, failure: prebuiltFailure }
+      return { ok: false, failure: { kind: 'verify', failure: prebuiltFailure } }
     }
     opts.onLog?.(
       () =>
         `[verbose]   prebuilt bundle for ${basename(sourceDir)} did not load cleanly (${prebuiltFailure.cause}); rebundling from source`,
     )
-    const sourceEntry = await resolveSourceEntry(sourceDir, resolved.path)
+    const sourceEntry = await resolveSourceEntry(sourceDir, prebuiltPath)
     return verifyBuilt(await rebundleAdapter(sourceDir, sourceEntry), verifyOpts)
   }
 
-  return verifyBuilt(await rebundleAdapter(sourceDir, resolved.path), verifyOpts)
+  return verifyBuilt(await rebundleAdapter(sourceDir, resolved.entry.path), verifyOpts)
 }
 
 /** Verify a freshly rebundled adapter; on failure, clean up its temp dir. */
 async function verifyBuilt(
-  built: { bundlePath: string; cleanup: () => Promise<void> },
+  built: Awaited<ReturnType<typeof rebundleAdapter>>,
   verifyOpts: { expectedApiVersion?: string },
 ): Promise<LocateAndVerifyResult> {
+  if (!built.ok) {
+    return { ok: false, failure: { kind: 'bundle', failure: built.failure } }
+  }
   const result = await verifyAdapter(built.bundlePath, verifyOpts)
   if (!result.ok) {
     await built.cleanup()
-    return { ok: false, failure: result.failure }
+    return { ok: false, failure: { kind: 'verify', failure: result.failure } }
   }
   return { ok: true, bundlePath: built.bundlePath, verified: result.verified, cleanup: built.cleanup }
 }

--- a/packages/engine/src/adapters/installation.ts
+++ b/packages/engine/src/adapters/installation.ts
@@ -1,0 +1,228 @@
+import { join, relative, resolve, sep } from 'node:path'
+import { atomicWriteFileSync } from '@agent-facets/common'
+import { jsonFileText } from '../json-file-text.ts'
+
+/**
+ * Managed adapter installation receipts.
+ *
+ * A managed adapter directory looks like:
+ *
+ *   $FACET_DIR/adapters/<name>/
+ *   ├── installation.json          ← atomic activation record (this module)
+ *   └── generations/<generation-id>/adapter.js
+ *
+ * `installation.json` is the single pointer that decides which generation
+ * is active. Replacing it with `atomicWriteFileSync` (tmp + same-dir
+ * rename) IS the activation switch — everything staged before that
+ * rename is invisible to loaders.
+ */
+
+export const INSTALLATION_RECEIPT_NAME = 'installation.json'
+export const GENERATIONS_DIR_NAME = 'generations'
+export const INSTALLATION_SCHEMA_VERSION = 1
+
+/**
+ * Tagged source provenance. Source-specific fields live only on their
+ * variant so impossible npm/git/local combinations cannot be
+ * constructed. `specifier` is always the original user input — the
+ * repair command renders `facet adapter install <specifier>`.
+ */
+export type InstallationSource =
+  | {
+      kind: 'npm'
+      specifier: string
+      packageName: string
+      /** Exact resolved package version (M.N.P). */
+      version: string
+      /** The registry integrity anchor that authenticated the tarball. */
+      integrity: { kind: 'sri' | 'shasum'; value: string }
+    }
+  | { kind: 'git'; specifier: string; url: string; ref?: string }
+  | { kind: 'local'; specifier: string; sourcePath: string }
+
+export interface InstallationReceipt {
+  schemaVersion: typeof INSTALLATION_SCHEMA_VERSION
+  /** The sole active generation id — a validated safe path segment. */
+  activeGeneration: string
+  /** The verified runtime adapter API at activation time. */
+  apiVersion: string
+  source: InstallationSource
+}
+
+/**
+ * A generation id must be one safe path segment: alphanumeric start,
+ * then alphanumerics, dots, underscores, or hyphens. This shape cannot
+ * contain a separator, be empty, or start with a dot — so `..`,
+ * absolute paths, and hidden entries are unrepresentable.
+ */
+const GENERATION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/** True iff `id` is a safe single-segment generation id. */
+export function isSafeGenerationId(id: string): boolean {
+  return GENERATION_ID_RE.test(id) && !id.includes('..')
+}
+
+/** Mint a fresh, unique generation id (time-ordered plus random suffix). */
+export function newGenerationId(): string {
+  const random = Math.random().toString(16).slice(2, 10).padEnd(8, '0')
+  return `gen-${Date.now()}-${random}`
+}
+
+/**
+ * Resolve the directory of a generation, containment-checked against
+ * the adapter directory. Returns null when the id is unsafe or the
+ * derived path escapes — callers treat that as an invalid receipt, not
+ * a path to read or delete.
+ */
+export function generationDir(adapterDir: string, generationId: string): string | null {
+  if (!isSafeGenerationId(generationId)) return null
+  const dir = resolve(adapterDir, GENERATIONS_DIR_NAME, generationId)
+  const rel = relative(resolve(adapterDir), dir)
+  if (rel.startsWith('..') || rel.split(sep).some((segment) => segment === '..')) return null
+  return dir
+}
+
+/** Path of the active bundle inside a generation directory. */
+export function generationBundlePath(genDir: string): string {
+  return join(genDir, 'adapter.js')
+}
+
+export type ReadReceiptResult =
+  | { ok: true; receipt: InstallationReceipt }
+  | { ok: false; reason: 'not-found' }
+  | { ok: false; reason: 'invalid'; detail: string }
+
+/**
+ * Read and validate `installation.json` from an adapter directory.
+ * Never throws for expected failures; malformed JSON, unknown shapes,
+ * unknown source kinds, and unsafe generation ids all classify as
+ * `invalid` with a human-readable detail (rendered by the CLI).
+ */
+export async function readInstallationReceipt(adapterDir: string): Promise<ReadReceiptResult> {
+  const path = join(adapterDir, INSTALLATION_RECEIPT_NAME)
+  const file = Bun.file(path)
+  if (!(await file.exists())) {
+    return { ok: false, reason: 'not-found' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await file.text())
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      detail: `malformed JSON: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  return validateReceipt(parsed)
+}
+
+/** Pure receipt validation, exported for direct unit testing. */
+export function validateReceipt(parsed: unknown): ReadReceiptResult {
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { ok: false, reason: 'invalid', detail: 'receipt is not an object' }
+  }
+  const record = parsed as Record<string, unknown>
+
+  if (record.schemaVersion !== INSTALLATION_SCHEMA_VERSION) {
+    return { ok: false, reason: 'invalid', detail: `unsupported schemaVersion ${String(record.schemaVersion)}` }
+  }
+  if (typeof record.activeGeneration !== 'string' || !isSafeGenerationId(record.activeGeneration)) {
+    return { ok: false, reason: 'invalid', detail: 'activeGeneration is not a safe path segment' }
+  }
+  if (typeof record.apiVersion !== 'string' || record.apiVersion.length === 0) {
+    return { ok: false, reason: 'invalid', detail: 'apiVersion is missing' }
+  }
+
+  const source = validateSource(record.source)
+  if (!source.ok) return source
+
+  return {
+    ok: true,
+    receipt: {
+      schemaVersion: INSTALLATION_SCHEMA_VERSION,
+      activeGeneration: record.activeGeneration,
+      apiVersion: record.apiVersion,
+      source: source.source,
+    },
+  }
+}
+
+function validateSource(
+  value: unknown,
+): { ok: true; source: InstallationSource } | { ok: false; reason: 'invalid'; detail: string } {
+  if (typeof value !== 'object' || value === null) {
+    return { ok: false, reason: 'invalid', detail: 'source is not an object' }
+  }
+  const record = value as Record<string, unknown>
+  if (typeof record.specifier !== 'string' || record.specifier.length === 0) {
+    return { ok: false, reason: 'invalid', detail: 'source.specifier is missing' }
+  }
+
+  switch (record.kind) {
+    case 'npm': {
+      if (typeof record.packageName !== 'string' || record.packageName.length === 0) {
+        return { ok: false, reason: 'invalid', detail: 'npm source.packageName is missing' }
+      }
+      if (typeof record.version !== 'string' || record.version.length === 0) {
+        return { ok: false, reason: 'invalid', detail: 'npm source.version is missing' }
+      }
+      const integrity = record.integrity as Record<string, unknown> | null | undefined
+      if (
+        typeof integrity !== 'object' ||
+        integrity === null ||
+        (integrity.kind !== 'sri' && integrity.kind !== 'shasum') ||
+        typeof integrity.value !== 'string' ||
+        integrity.value.length === 0
+      ) {
+        return { ok: false, reason: 'invalid', detail: 'npm source.integrity is missing or malformed' }
+      }
+      return {
+        ok: true,
+        source: {
+          kind: 'npm',
+          specifier: record.specifier,
+          packageName: record.packageName,
+          version: record.version,
+          integrity: { kind: integrity.kind, value: integrity.value },
+        },
+      }
+    }
+    case 'git': {
+      if (typeof record.url !== 'string' || record.url.length === 0) {
+        return { ok: false, reason: 'invalid', detail: 'git source.url is missing' }
+      }
+      if (record.ref !== undefined && typeof record.ref !== 'string') {
+        return { ok: false, reason: 'invalid', detail: 'git source.ref is not a string' }
+      }
+      return {
+        ok: true,
+        source: {
+          kind: 'git',
+          specifier: record.specifier,
+          url: record.url,
+          ...(record.ref !== undefined ? { ref: record.ref } : {}),
+        },
+      }
+    }
+    case 'local': {
+      if (typeof record.sourcePath !== 'string' || record.sourcePath.length === 0) {
+        return { ok: false, reason: 'invalid', detail: 'local source.sourcePath is missing' }
+      }
+      return { ok: true, source: { kind: 'local', specifier: record.specifier, sourcePath: record.sourcePath } }
+    }
+    default:
+      return { ok: false, reason: 'invalid', detail: `unknown source.kind ${String(record.kind)}` }
+  }
+}
+
+/**
+ * Atomically write `installation.json` — this is the activation switch.
+ * The tmp file lives in the same directory, so the rename is atomic on
+ * every POSIX filesystem.
+ */
+export function writeInstallationReceipt(adapterDir: string, receipt: InstallationReceipt): void {
+  atomicWriteFileSync(join(adapterDir, INSTALLATION_RECEIPT_NAME), jsonFileText(receipt))
+}

--- a/packages/engine/src/adapters/loader.ts
+++ b/packages/engine/src/adapters/loader.ts
@@ -1,41 +1,43 @@
 import type { Adapter } from '@agent-facets/adapter'
-import { getAdapterBundlePath, listInstalledAdapters } from './placement.ts'
+import { type InstalledAdapterInspection, inspectInstalledAdapters } from './inspect.ts'
+
+/** An installed entry that cannot be used: incompatible or broken. */
+export type InstalledAdapterFailure = Extract<InstalledAdapterInspection, { kind: 'incompatible' | 'broken' }>
 
 /**
- * Loads all installed adapters by scanning the adapter base directory
- * and dynamically importing each `adapter.js` bundle.
- *
- * @param baseDir - Base directory for installed adapters (defaults to `$FACET_DIR/adapters`,
- *   where `FACET_DIR` defaults to `~/.facet`)
- * @param opts.onWarn - Optional callback for warnings about adapters that
- *   couldn't be loaded (e.g. invalid export, dynamic import failure). The
- *   CLI passes a callback that writes to stderr; tests can pass a no-op
- *   or array collector. When omitted, warnings are silently swallowed
- *   (preferable to a hardcoded `console.error` because callers may want
- *   to route warnings through their own logging infrastructure).
+ * Result of `loadInstalledAdapters`. Loading fails closed: if any
+ * installed adapter is incompatible or broken, the failure arm carries
+ * ALL collected failures and no adapters are returned. This prevents an
+ * incompatible-but-present adapter from being misreported as "no
+ * adapters installed" or as unknown facet metadata.
  */
-export async function loadInstalledAdapters(
-  baseDir?: string,
-  opts: { onWarn?: (line: string) => void } = {},
-): Promise<Adapter[]> {
-  const names = await listInstalledAdapters(baseDir)
-  const adapters: Adapter[] = []
+export type LoadAdaptersResult = { ok: true; adapters: Adapter[] } | { ok: false; failures: InstalledAdapterFailure[] }
 
-  for (const name of names) {
-    const bundlePath = getAdapterBundlePath(name, baseDir)
-    try {
-      const module = (await import(bundlePath)) as { default?: Adapter }
-      if (module.default) {
-        adapters.push(module.default)
-      } else {
-        opts.onWarn?.(`Warning: Installed adapter "${name}" has an invalid export, skipping.`)
-      }
-    } catch (err) {
-      opts.onWarn?.(
-        `Warning: Failed to load installed adapter "${name}": ${err instanceof Error ? err.message : String(err)}`,
-      )
+/**
+ * Loads all installed adapters through shared inspection. Managed
+ * installations are validated against their receipts (recorded
+ * unsupported APIs fail before import); unmanaged legacy bundles are
+ * verified directly. No adapter contract method is invoked before its
+ * compatibility has been established.
+ *
+ * @param baseDir - Base directory for installed adapters (defaults to
+ *   `$FACET_DIR/adapters`, where `FACET_DIR` defaults to `~/.facet`)
+ */
+export async function loadInstalledAdapters(baseDir?: string): Promise<LoadAdaptersResult> {
+  const inspections = await inspectInstalledAdapters(baseDir)
+
+  const failures: InstalledAdapterFailure[] = []
+  const adapters: Adapter[] = []
+  for (const inspection of inspections) {
+    if (inspection.kind === 'compatible') {
+      adapters.push(inspection.verified.adapter)
+    } else {
+      failures.push(inspection)
     }
   }
 
-  return adapters
+  if (failures.length > 0) {
+    return { ok: false, failures }
+  }
+  return { ok: true, adapters }
 }

--- a/packages/engine/src/adapters/placement.ts
+++ b/packages/engine/src/adapters/placement.ts
@@ -1,8 +1,21 @@
-import { mkdir, rm } from 'node:fs/promises'
+import { cp, mkdir, readdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { facetAdaptersDir } from '../facet-dir.ts'
+import { acquireAdapterLock } from '../install/lockfile-guard.ts'
+import {
+  GENERATIONS_DIR_NAME,
+  generationBundlePath,
+  generationDir,
+  INSTALLATION_RECEIPT_NAME,
+  INSTALLATION_SCHEMA_VERSION,
+  type InstallationReceipt,
+  type InstallationSource,
+  newGenerationId,
+  writeInstallationReceipt,
+} from './installation.ts'
+import { type VerifyAdapterFailure, verifyAdapter } from './verify.ts'
 
-/** The filename for the bundled adapter file */
+/** The filename for the bundled adapter file (legacy direct layout). */
 const ADAPTER_BUNDLE_FILENAME = 'adapter.js'
 
 /**
@@ -54,7 +67,11 @@ export function getAdapterBundlePath(name: string, baseDir: string = resolveAdap
 }
 
 /**
- * Places a built adapter.js file into the installed adapters directory.
+ * Places a built adapter.js file into the legacy flat layout
+ * (`<base>/<name>/adapter.js`) WITHOUT a receipt.
+ *
+ * Production installs use `placeAdapterManaged`. This helper remains for
+ * tests that fabricate unmanaged historical installations.
  *
  * @param name - The adapter name (used as the directory name)
  * @param bundlePath - Absolute path to the built adapter.js file
@@ -74,8 +91,185 @@ export async function placeAdapter(
   await Bun.write(destPath, content)
 }
 
+/** Non-fatal issue after successful activation (old-state cleanup). */
+export type PlacementWarning = { kind: 'cleanup-failed'; path: string; cause: string }
+
 /**
- * Removes an installed adapter by deleting its directory.
+ * Discriminated failure for `placeAdapterManaged`. Every failure leaves
+ * the previous installation (receipt, active generation, legacy bundle)
+ * byte-for-byte unchanged.
+ */
+export type PlaceAdapterFailure =
+  | { kind: 'lock-held'; adapter: string; heldByPid: number; lockPath: string }
+  | { kind: 'stage-failed'; adapter: string; cause: string }
+  | { kind: 'verify-failed'; adapter: string; failure: VerifyAdapterFailure }
+  | { kind: 'name-mismatch'; adapter: string; runtimeName: string }
+  | { kind: 'receipt-write-failed'; adapter: string; cause: string }
+
+export type PlaceAdapterResult =
+  | { ok: true; receipt: InstallationReceipt; warnings: PlacementWarning[] }
+  | { ok: false; failure: PlaceAdapterFailure }
+
+/** Provenance recorded in the receipt at activation. */
+export interface PlacementProvenance {
+  /** The verified runtime adapter API of the candidate. */
+  apiVersion: string
+  source: InstallationSource
+}
+
+/**
+ * Install a verified candidate bundle as the active managed installation
+ * for `name`, atomically.
+ *
+ * Sequence (design decision 5):
+ *   1. acquire the per-adapter replacement lock;
+ *   2. copy the bundle into a fresh unique generation directory on the
+ *      same filesystem as the receipt;
+ *   3. re-verify the bundle at its final staged path (runtime API must
+ *      equal `provenance.apiVersion`; runtime name must equal `name`);
+ *   4. atomically replace `installation.json` — the activation switch;
+ *   5. best-effort cleanup of non-active generations and the legacy
+ *      direct bundle (failures are warnings, never install failures).
+ *
+ * Any failure before step 4 removes the staged generation and leaves
+ * the previous installation untouched and active.
+ */
+export async function placeAdapterManaged(
+  name: string,
+  bundlePath: string,
+  provenance: PlacementProvenance,
+  baseDir: string = resolveAdapterBaseDir(),
+): Promise<PlaceAdapterResult> {
+  const adapterDir = getAdapterDir(name, baseDir)
+
+  const lockResult = acquireAdapterLock(name)
+  if (!lockResult.ok) {
+    return {
+      ok: false,
+      failure: { kind: 'lock-held', adapter: name, heldByPid: lockResult.heldByPid, lockPath: lockResult.path },
+    }
+  }
+
+  const generationId = newGenerationId()
+  // Non-null by construction: newGenerationId always mints a safe segment.
+  const genDir = generationDir(adapterDir, generationId)
+  if (genDir === null) {
+    await lockResult.lock.release()
+    return { ok: false, failure: { kind: 'stage-failed', adapter: name, cause: 'generated id failed containment' } }
+  }
+
+  const removeStaged = async (): Promise<void> => {
+    await rm(genDir, { recursive: true, force: true }).catch(() => {})
+  }
+
+  try {
+    // 2. Stage the bundle into its final generation directory.
+    const stagedBundle = generationBundlePath(genDir)
+    try {
+      await mkdir(genDir, { recursive: true })
+      await cp(bundlePath, stagedBundle)
+    } catch (err) {
+      await removeStaged()
+      return {
+        ok: false,
+        failure: { kind: 'stage-failed', adapter: name, cause: err instanceof Error ? err.message : String(err) },
+      }
+    }
+
+    // 3. Verify the exact bytes that will be activated, at their final path.
+    const verified = await verifyAdapter(stagedBundle, { expectedApiVersion: provenance.apiVersion })
+    if (!verified.ok) {
+      await removeStaged()
+      return { ok: false, failure: { kind: 'verify-failed', adapter: name, failure: verified.failure } }
+    }
+    if (verified.verified.adapter.name !== name) {
+      await removeStaged()
+      return {
+        ok: false,
+        failure: { kind: 'name-mismatch', adapter: name, runtimeName: verified.verified.adapter.name },
+      }
+    }
+
+    // 4. Atomic activation: replace the receipt in one rename.
+    const receipt: InstallationReceipt = {
+      schemaVersion: INSTALLATION_SCHEMA_VERSION,
+      activeGeneration: generationId,
+      apiVersion: verified.verified.apiVersion,
+      source: provenance.source,
+    }
+    try {
+      writeInstallationReceipt(adapterDir, receipt)
+    } catch (err) {
+      await removeStaged()
+      return {
+        ok: false,
+        failure: {
+          kind: 'receipt-write-failed',
+          adapter: name,
+          cause: err instanceof Error ? err.message : String(err),
+        },
+      }
+    }
+
+    // 5. Post-activation cleanup — warnings only.
+    const warnings: PlacementWarning[] = []
+    const generationsDir = join(adapterDir, GENERATIONS_DIR_NAME)
+    let staleGenerations: string[] = []
+    try {
+      staleGenerations = (await readdir(generationsDir, { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory() && entry.name !== generationId)
+        .map((entry) => entry.name)
+    } catch {
+      // generations dir unreadable — nothing to clean.
+    }
+    for (const stale of staleGenerations) {
+      const stalePath = join(generationsDir, stale)
+      try {
+        await rm(stalePath, { recursive: true, force: true })
+      } catch (err) {
+        warnings.push({
+          kind: 'cleanup-failed',
+          path: stalePath,
+          cause: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
+    const legacyBundle = getAdapterBundlePath(name, baseDir)
+    if (await Bun.file(legacyBundle).exists()) {
+      try {
+        await rm(legacyBundle, { force: true })
+      } catch (err) {
+        warnings.push({
+          kind: 'cleanup-failed',
+          path: legacyBundle,
+          cause: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
+    return { ok: true, receipt, warnings }
+  } finally {
+    await lockResult.lock.release()
+  }
+}
+
+/**
+ * True when a directory holds an adapter installation: a managed
+ * receipt (valid or not — an invalid receipt is still an installation
+ * the user must be able to remove and see listed as broken) or a legacy
+ * direct bundle. Directories containing only staging/crash leftovers
+ * (e.g. an orphaned `generations/` tree) do not qualify.
+ */
+async function isInstallationDir(adapterDir: string): Promise<boolean> {
+  if (await Bun.file(join(adapterDir, INSTALLATION_RECEIPT_NAME)).exists()) return true
+  return Bun.file(join(adapterDir, ADAPTER_BUNDLE_FILENAME)).exists()
+}
+
+/**
+ * Removes an installed adapter by deleting its whole directory —
+ * without loading or verifying it, so incompatible and broken
+ * installations remain removable.
  *
  * @param name - The adapter name to remove
  * @param baseDir - Base directory for installed adapters (defaults to the
@@ -84,9 +278,7 @@ export async function placeAdapter(
  */
 export async function removeAdapter(name: string, baseDir: string = resolveAdapterBaseDir()): Promise<boolean> {
   const adapterDir = getAdapterDir(name, baseDir)
-  const exists = await Bun.file(join(adapterDir, ADAPTER_BUNDLE_FILENAME)).exists()
-
-  if (!exists) {
+  if (!(await isInstallationDir(adapterDir))) {
     return false
   }
 
@@ -95,24 +287,21 @@ export async function removeAdapter(name: string, baseDir: string = resolveAdapt
 }
 
 /**
- * Lists the names of all installed adapters by scanning the base directory.
+ * Lists the names of all installed adapters by scanning the base
+ * directory. An entry qualifies when it holds a managed receipt or a
+ * legacy direct bundle; staging/crash leftovers are ignored.
  *
  * @param baseDir - Base directory for installed adapters (defaults to the
  *   resolved base dir, which honors `FACET_DIR`).
  */
 export async function listInstalledAdapters(baseDir: string = resolveAdapterBaseDir()): Promise<string[]> {
   try {
-    const { readdir } = await import('node:fs/promises')
     const entries = await readdir(baseDir, { withFileTypes: true })
     const names: string[] = []
 
     for (const entry of entries) {
-      if (entry.isDirectory()) {
-        // Verify it has an adapter.js file
-        const bundlePath = join(baseDir, entry.name, ADAPTER_BUNDLE_FILENAME)
-        if (await Bun.file(bundlePath).exists()) {
-          names.push(entry.name)
-        }
+      if (entry.isDirectory() && (await isInstallationDir(join(baseDir, entry.name)))) {
+        names.push(entry.name)
       }
     }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,10 +6,16 @@
 // adapter machinery
 export type { AdapterCompatibilityFailure, ApiDeclarationClassification } from './adapters/api-compatibility.ts'
 export { classifyApiDeclaration, isWellFormedAdapterApi, SUPPORTED_ADAPTER_APIS } from './adapters/api-compatibility.ts'
-export type { BundleResult, ResolvedEntryPoint } from './adapters/bundler.ts'
+export type { BundleFailure, BundleResult, ResolvedEntryPoint, ResolveEntryPointResult } from './adapters/bundler.ts'
 export { bundleAdapter, rebundleAdapter, resolveEntryPoint } from './adapters/bundler.ts'
 export type { FirstPartyAdapter } from './adapters/first-party.ts'
 export { FIRST_PARTY_ADAPTERS } from './adapters/first-party.ts'
+export type {
+  BrokenReason,
+  InstalledAdapterInspection,
+  RepairSource,
+} from './adapters/inspect.ts'
+export { inspectInstalledAdapter, inspectInstalledAdapters } from './adapters/inspect.ts'
 export type {
   AdapterInstallFailure,
   AdapterInstallOptions,
@@ -18,13 +24,31 @@ export type {
   LocateAndVerifyResult,
 } from './adapters/install-service.ts'
 export { installAdapter, locateAndVerifyAdapter } from './adapters/install-service.ts'
+export type {
+  InstallationReceipt,
+  InstallationSource,
+  ReadReceiptResult,
+} from './adapters/installation.ts'
+export {
+  INSTALLATION_RECEIPT_NAME,
+  isSafeGenerationId,
+  readInstallationReceipt,
+} from './adapters/installation.ts'
+export type { InstalledAdapterFailure, LoadAdaptersResult } from './adapters/loader.ts'
 export { loadInstalledAdapters } from './adapters/loader.ts'
+export type {
+  PlaceAdapterFailure,
+  PlaceAdapterResult,
+  PlacementProvenance,
+  PlacementWarning,
+} from './adapters/placement.ts'
 export {
   getAdapterBaseDir,
   getAdapterBundlePath,
   getAdapterDir,
   listInstalledAdapters,
   placeAdapter,
+  placeAdapterManaged,
   removeAdapter,
 } from './adapters/placement.ts'
 export type { VerifiedAdapter, VerifyAdapterFailure, VerifyAdapterResult } from './adapters/verify.ts'

--- a/packages/engine/src/install/__tests__/run-add.test.ts
+++ b/packages/engine/src/install/__tests__/run-add.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 
 /**
  * Tests for the `facet add` orchestrator (`runAdd`).
@@ -93,6 +94,7 @@ import { join } from 'node:path'
 function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
@@ -117,7 +119,9 @@ function writeFacets(facets: Record<string, string>): string {
 async function add(specifier: string) {
   const parsed = parseFacetSource(specifier)
   if (!parsed.ok) throw new Error(`test bug: unparseable specifier ${specifier}`)
-  const adapters = await loadInstalledAdapters()
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters
   return runAdd({
     projectRoot,
     sources: [{ specifier, source: parsed.value }],

--- a/packages/engine/src/install/__tests__/run-install.chain.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.chain.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import type { BuildManifest, LockfileFacet } from '@agent-facets/protocol'
 import { LOCKFILE_VERSION } from '@agent-facets/protocol'
 import type { Addition } from '../types.ts'
@@ -145,6 +146,7 @@ import { join } from 'node:path'
 function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
@@ -191,7 +193,9 @@ function registryAddition(specifier: string): Addition {
 }
 
 async function install(opts: { additions?: Addition[]; frozen?: boolean } = {}) {
-  const adapters = await loadInstalledAdapters()
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters
   return runInstall({
     projectRoot,
     adapters: adapters.filter((a) => a.supportsInstall === true),

--- a/packages/engine/src/install/__tests__/run-install.receipt.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.receipt.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import type { BuildManifest } from '@agent-facets/protocol'
 import type { Receipt } from '../receipt.ts'
 import type { Addition, StageEvent } from '../types.ts'
@@ -101,6 +102,7 @@ import { join } from 'node:path'
 function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
@@ -125,7 +127,9 @@ async function install(
     onStage?: (event: StageEvent) => void
   } = {},
 ) {
-  const adapters = await loadInstalledAdapters()
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters
   return runInstall({
     projectRoot,
     adapters: adapters.filter((a) => a.supportsInstall === true),

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import type { BuildManifest } from '@agent-facets/protocol'
 
 /**
@@ -135,6 +136,7 @@ import { join } from 'node:path'
 function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
@@ -187,12 +189,16 @@ function readLock(): {
 }
 
 async function install() {
-  const adapters = await loadInstalledAdapters()
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters
   return runInstall({ projectRoot, adapters: adapters.filter((a) => a.supportsInstall === true) })
 }
 
 async function installFrozen() {
-  const adapters = await loadInstalledAdapters()
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters
   return runInstall({
     projectRoot,
     adapters: adapters.filter((a) => a.supportsInstall === true),
@@ -232,7 +238,9 @@ afterEach(() => {
 describe('runInstall — DELTA_CONFLICT (#23)', () => {
   test('a delta with the same facet in additions and removals fails before any mutation', async () => {
     writeFacets({ cowsay: '0.1.0' })
-    const adapters = await loadInstalledAdapters()
+    const loadResult = await loadInstalledAdapters()
+    if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+    const adapters = loadResult.adapters
     const result = await runInstall({
       projectRoot,
       adapters: adapters.filter((a) => a.supportsInstall === true),

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 
 /**
  * Tests for the `facet remove` orchestrator (`runRemove`).
@@ -92,6 +93,7 @@ import { join } from 'node:path'
 function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
 export default {
   name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(scope, type, name, content, metadata) { await installAssetFile({ file: path(type, name) }, content, metadata) },
@@ -120,7 +122,9 @@ async function installFacet(name: string, version: string): Promise<void> {
   registryFixtureDir = buildFixture(fakeHome, name, version)
   const parsed = parseFacetSource(`${name}@${version}`)
   if (!parsed.ok) throw new Error(`test bug: unparseable specifier ${name}@${version}`)
-  const adapters = (await loadInstalledAdapters()).filter((a) => a.supportsInstall === true)
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters.filter((a) => a.supportsInstall === true)
   const result = await runAdd({
     projectRoot,
     sources: [{ specifier: `${name}@${version}`, source: parsed.value }],
@@ -130,7 +134,9 @@ async function installFacet(name: string, version: string): Promise<void> {
 }
 
 async function remove(names: string[]) {
-  const adapters = (await loadInstalledAdapters()).filter((a) => a.supportsInstall === true)
+  const loadResult = await loadInstalledAdapters()
+  if (!loadResult.ok) throw new Error('test bug: installed fixture adapters failed to load')
+  const adapters = loadResult.adapters.filter((a) => a.supportsInstall === true)
   return runRemove({ projectRoot, names, adapters })
 }
 

--- a/packages/engine/src/install/lockfile-guard.ts
+++ b/packages/engine/src/install/lockfile-guard.ts
@@ -71,8 +71,13 @@ export interface AcquireLockError {
 
 export type AcquireLockResult = { ok: true; lock: InstallLock } | AcquireLockError
 
-export function acquireInstallLock(projectRoot: string): AcquireLockResult {
-  const path = computeLockPath(projectRoot)
+/**
+ * Core advisory-lock primitive shared by the project install lock and
+ * the per-adapter replacement lock: `O_CREAT|O_EXCL` create with the
+ * holder's pid, ESRCH-only stale detection, unlink-then-retry that
+ * preserves the exclusive-create invariant, and an idempotent release.
+ */
+export function acquireLockFile(path: string): AcquireLockResult {
   // Ensure $FACET_DIR/locks/ exists. Lazy — first acquire creates it,
   // subsequent ones reuse it. The directory is intentionally not removed
   // on release; it persists across runs as part of the facet directory
@@ -114,6 +119,27 @@ export function acquireInstallLock(projectRoot: string): AcquireLockResult {
   }
 
   return { ok: false, heldByPid: held ?? -1, path }
+}
+
+export function acquireInstallLock(projectRoot: string): AcquireLockResult {
+  return acquireLockFile(computeLockPath(projectRoot))
+}
+
+/**
+ * Compute the lock path serializing replacement of one adapter:
+ * `$FACET_DIR/locks/adapter-<sanitized-name>-<sha16(name)>.lock`. The
+ * sanitized name is for grep-ability; the hash is the uniqueness
+ * guarantee for names that sanitize identically.
+ */
+export function computeAdapterLockPath(adapterName: string): string {
+  const base = sanitizeBasename(adapterName)
+  const hash = createHash('sha256').update(adapterName).digest('hex').slice(0, 16)
+  return join(facetLocksDir(), `adapter-${base}-${hash}.lock`)
+}
+
+/** Acquire the per-adapter replacement lock for `adapterName`. */
+export function acquireAdapterLock(adapterName: string): AcquireLockResult {
+  return acquireLockFile(computeAdapterLockPath(adapterName))
 }
 
 function makeLock(path: string): InstallLock {


### PR DESCRIPTION
### Why

Adapter installations previously used a flat `<name>/adapter.js` layout with no provenance record, making it impossible to know where an adapter came from, what API version it declared at install time, or whether a replacement had completed cleanly. Loading was warn-and-skip, meaning an incompatible or broken adapter would silently fall through rather than blocking operations that depend on it.

### Details

**Installation receipts and managed layout**

A new `installation.json` receipt is written atomically alongside each install. It records the schema version, active generation id, verified API version, and tagged source provenance (npm, git, or local — with source-specific fields that cannot be mixed). The active bundle lives at `<name>/generations/<generation-id>/adapter.js`. Replacing `installation.json` via a same-directory tmp-rename is the activation switch; everything staged before that rename is invisible to loaders.

**Atomic replacement sequence**

1. Acquire a per-adapter advisory lock (`$FACET_DIR/locks/adapter-<name>-<hash>.lock`) using the same `O_CREAT|O_EXCL` + ESRCH stale-detection primitive as the existing project install lock, now extracted into `acquireLockFile`.
2. Copy the candidate bundle into a fresh unique generation directory.
3. Re-verify the staged bundle at its final path — the runtime API must equal the provenance's declared API and the runtime name must equal the adapter name.
4. Atomically write the receipt.
5. Best-effort cleanup of non-active generations and any legacy flat bundle; failures become `PlacementWarning` values, not install failures.

Any failure before step 4 removes the staged generation and leaves the previous installation byte-for-byte unchanged.

**Fail-closed loading**

`loadInstalledAdapters` now returns a discriminated result. If any installed adapter is incompatible or broken, the failure arm collects all failures and returns no adapters. This prevents an incompatible adapter from being misreported as "no adapters installed" or from contributing unknown metadata to a build. All call sites in `build`, `publish`, `ensure-adapters`, and `pick-and-install` have been updated to handle the failure arm explicitly.

**Inspection and list**

A new `inspectInstalledAdapters` / `inspectInstalledAdapter` layer classifies every installation directory as `compatible`, `incompatible`, or `broken`, with structured failure and repair data. Managed installs are checked against their receipt before any import; a recorded unsupported API is rejected without running module initialization. `facet adapter list` now renders the API version and compatibility status for each entry, and includes a repair command for incompatible and broken entries.

**Legacy compatibility**

Unmanaged historical `<name>/adapter.js` entries are recognized by the absence of a receipt. They are inspected directly and converted to the managed layout only after a successful reinstall. `removeAdapter` and `listInstalledAdapters` now use a shared `isInstallationDir` predicate that recognizes both layouts and ignores staging/crash leftovers.

**Bundler error handling**

`resolveEntryPoint`, `bundleAdapter`, and `rebundleAdapter` now return discriminated results (`BundleFailure`) instead of throwing. The `locateAndVerifyAdapter` failure type distinguishes `bundle` failures from `verify` failures so the CLI can render actionable diagnostics for each.

**CLI diagnostics**

`describeInstalledAdapterFailure` and `repairCommand` are the sole rendering points for installed-adapter failures. `describeAdapterInstallFailure` is extended to cover the new structured `BundleFailure` and `PlaceAdapterFailure` variants. Post-activation cleanup warnings are printed to stderr after a successful install.

**Test isolation**

`create-build` e2e tests now use a hermetic `FACET_DIR` temp directory so a developer's real `~/.facet` (which may hold legacy bundles) cannot leak into CI.

### Verification

New unit test suites cover receipt validation (all provenance variants, invalid shapes, unsafe generation ids), managed placement (success, replacement, legacy conversion, stale leftover cleanup), failure injection at every pre-activation stage (proving the previous installation survives untouched), cleanup warnings, concurrent lock contention, and the `inspectInstalledAdapters` enumeration. The fail-closed loader is tested for all-compatible success, mixed incompatible/broken aggregation, and unique-generation import freshness. E2e tests verify managed receipt layout after install, managed replacement (single active generation), and inspection-backed list output for both compatible and incompatible entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core adapter install layout, atomic replacement, and fail-closed loading across build, publish, and facet commands—any inspection or receipt bug can block workflows or leave partial installs.
> 
> **Overview**
> This PR completes the **managed installation** slice of adapter API versioning: installs activate via **`installation.json`** and **`generations/<id>/adapter.js`** instead of overwriting **`<name>/adapter.js`**, with per-adapter locks, staged verify-then-activate, and legacy flat layouts converted only after a successful reinstall.
> 
> **Engine:** New receipt validation and **`placeAdapterManaged`**; **`inspectInstalledAdapters`** classifies each install as compatible / incompatible / broken with **repair** hints. **`loadInstalledAdapters`** now returns a result and **fails closed** (all failures aggregated) instead of warn-and-skip. **`bundleAdapter`** / **`resolveEntryPoint`** return **`BundleFailure`** values; **`installAdapter`** threads npm/git/local provenance through to managed placement and surfaces placement/cleanup warnings.
> 
> **CLI:** **`facet adapter list`** shows API and status plus reinstall commands; **build**, **publish** build, **`ensure-adapters`**, and the install picker abort when loading fails. Install error rendering covers bundle, placement, and installed-adapter failures. E2E tests follow the receipt layout; **create-build** e2e uses a hermetic **`FACET_DIR`**.
> 
> OpenSpec **tasks 7–12** are marked done; build/install pipeline gates (tasks 13–14) remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20c9ad0381df033536168c32b92a02e46ab5a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->