### PR TITLE
Gate build and install on adapter API compatibility preflight, adding `ADAPTER_INCOMPATIBLE` failure variant with exhaustive CLI/TUI rendering

### DIFF
--- a/openspec/changes/add-adapter-api-version-negotiation/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/tasks.md
@@ -112,21 +112,21 @@
 
 ## 13. Build and Facet-Operation Compatibility Gates — Research
 
-- [ ] 13.1 Explore: Inspect `packages/cli/src/commands/build.ts`, `packages/cli/src/commands/publish/run-build-view.ts`, and `packages/engine/src/build/pipeline.ts` for build loading, failure rendering, and the first adapter method invocation.
-- [ ] 13.2 Explore: Inspect `packages/cli/src/commands/shared/ensure-adapters.ts` and the add, remove, and install command entry points for adapter discovery and zero-adapter-picker behavior.
-- [ ] 13.3 Explore: Inspect `packages/engine/src/install/run-install.ts` and Git/local facet resolvers for no-mutation exits, per-facet-loop ordering, and nested build invocations.
-- [ ] 13.4 Explore: Inspect drift removal, materialization, and CLI/TUI failure renderers for adapter method calls and exhaustive compatibility handling.
-- [ ] 13.5 Propose: Present command-level fail-closed inspection and defense-in-depth build/install preflights that share compatibility data and preserve exhaustive result handling.
+- [x] 13.1 Explore: Inspect `packages/cli/src/commands/build.ts`, `packages/cli/src/commands/publish/run-build-view.ts`, and `packages/engine/src/build/pipeline.ts` for build loading, failure rendering, and the first adapter method invocation.
+- [x] 13.2 Explore: Inspect `packages/cli/src/commands/shared/ensure-adapters.ts` and the add, remove, and install command entry points for adapter discovery and zero-adapter-picker behavior.
+- [x] 13.3 Explore: Inspect `packages/engine/src/install/run-install.ts` and Git/local facet resolvers for no-mutation exits, per-facet-loop ordering, and nested build invocations.
+- [x] 13.4 Explore: Inspect drift removal, materialization, and CLI/TUI failure renderers for adapter method calls and exhaustive compatibility handling.
+- [x] 13.5 Propose: Present command-level fail-closed inspection and defense-in-depth build/install preflights that share compatibility data and preserve exhaustive result handling.
 
 ## 14. Build and Facet-Operation Compatibility Gates — Implementation
 
-- [ ] 14.1 Implement: Gate build and publish-build commands on installed inspection before starting the pipeline, and add a distinct build incompatibility failure before metadata validation.
-- [ ] 14.2 Implement: Add an `ADAPTER_INCOMPATIBLE` install failure variant and route defense-in-depth preflight failures through the no-mutation path before the per-facet loop and any Git/local facet build.
-- [ ] 14.3 Implement: Update add, remove, and install command discovery to report incompatible/broken entries without launching the zero-adapter picker or invoking adapter methods.
-- [ ] 14.4 Implement: Retain materialization compatibility checks only as invariant defense and preserve receipt-driven removal without cache or network access after the compatibility gate passes.
-- [ ] 14.5 Implement: Add exhaustive CLI/TUI rendering for build and install compatibility failures and all collected repair commands.
-- [ ] 14.6 Implement: Add tests proving incompatible adapters block build, publish-build, add, remove, and install before methods or writes; multiple failures aggregate; compatible adapters preserve the normal path; a build with no installed adapters proceeds with unknown-adapter warnings for manifest metadata; and `facet adapter remove` remains available.
-- [ ] 14.7 Verify: Run targeted build, publish, add, remove, install, TUI, and type-check suites.
+- [x] 14.1 Implement: Gate build and publish-build commands on installed inspection before starting the pipeline, and add a distinct build incompatibility failure before metadata validation.
+- [x] 14.2 Implement: Add an `ADAPTER_INCOMPATIBLE` install failure variant and route defense-in-depth preflight failures through the no-mutation path before the per-facet loop and any Git/local facet build.
+- [x] 14.3 Implement: Update add, remove, and install command discovery to report incompatible/broken entries without launching the zero-adapter picker or invoking adapter methods.
+- [x] 14.4 Implement: Retain materialization compatibility checks only as invariant defense and preserve receipt-driven removal without cache or network access after the compatibility gate passes.
+- [x] 14.5 Implement: Add exhaustive CLI/TUI rendering for build and install compatibility failures and all collected repair commands.
+- [x] 14.6 Implement: Add tests proving incompatible adapters block build, publish-build, add, remove, and install before methods or writes; multiple failures aggregate; compatible adapters preserve the normal path; a build with no installed adapters proceeds with unknown-adapter warnings for manifest metadata; and `facet adapter remove` remains available.
+- [x] 14.7 Verify: Run targeted build, publish, add, remove, install, TUI, and type-check suites.
 
 ## 15. Documentation and Rollout — Research
 

--- a/packages/cli/src/__tests__/adapter-integration.test.ts
+++ b/packages/cli/src/__tests__/adapter-integration.test.ts
@@ -175,6 +175,7 @@ describe('adapter install-load-build integration', () => {
       const result = await runBuildPipeline(facetDir, loaded)
       expect(result.ok).toBe(false)
       if (!result.ok) {
+        if (result.kind !== 'validation') expect.unreachable()
         expect(result.errors.some((e) => e.message.includes('integ-test-adapter'))).toBe(true)
       }
     } finally {

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -239,3 +239,35 @@ describe('facet add — manifest snapshot rollback', () => {
     expect(after).toBe(before)
   })
 })
+
+describe('facet add — incompatible installed adapter gate', () => {
+  test('fails with a reinstall hint before any write and never launches the picker', async () => {
+    // Unmanaged legacy bundle with an unsupported API declaration.
+    const dir = join(adaptersDir, 'future-adapter')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'adapter.js'),
+      `export default {
+  name: 'future-adapter',
+  apiVersion: '9.9',
+  supportsInstall: true,
+  buildAssetMetadata() { throw new Error('contract method invoked despite incompatibility') },
+  async installAsset() { throw new Error('contract method invoked despite incompatibility') },
+  async readAsset() { throw new Error('contract method invoked despite incompatibility') },
+  async deleteAsset() { throw new Error('contract method invoked despite incompatibility') },
+}
+`,
+    )
+    const fixture = buildLocalFixture('viper-plans')
+    const relPath = `./${fixture.split('/').pop()}`
+
+    const { result: code, stderr } = await withTTY(true, () => captureStderr(() => addCommand.run([relPath], {})))
+    expect(code).toBe(1)
+    expect(stderr).toContain('future-adapter')
+    expect(stderr).toContain('facet adapter install future-adapter')
+    expect(stderr).not.toContain('No AI tools are connected yet')
+    // No project files were created.
+    expect(existsSync(join(projectRoot, 'facets.json'))).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,7 +9,7 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../commands.ts'
 import { BuildView } from '../tui/views/build/build-view.tsx'
-import { describeInstalledAdapterFailure } from '../util/adapter-install-errors.ts'
+import { buildFailureMessages, describeInstalledAdapterFailure } from '../util/adapter-install-errors.ts'
 import { writeCliError } from '../util/errors.ts'
 import { resolveTargetDir } from './resolve-dir.ts'
 
@@ -137,7 +137,10 @@ function printBuildJson(result: BuildResult | BuildFailure, verified: boolean): 
         schemaVersion: BUILD_JSON_SCHEMA_VERSION,
         ok: false,
         verified,
-        errors: result.errors.map((e) => ({ message: e.message, path: e.path })),
+        errors:
+          result.kind === 'validation'
+            ? result.errors.map((e) => ({ message: e.message, path: e.path }))
+            : buildFailureMessages(result).map((message) => ({ message, path: 'adapters' })),
         warnings: result.warnings,
       }
   process.stdout.write(`${JSON.stringify(doc, null, 2)}\n`)
@@ -161,10 +164,11 @@ function printBuildPlain(result: BuildResult | BuildFailure, verified: boolean, 
     }
     return
   }
+  const messages = buildFailureMessages(result)
   process.stderr.write(
-    `✗ ${verified ? 'Verification' : 'Build'} failed — ${result.errors.length} error${result.errors.length !== 1 ? 's' : ''}:\n`,
+    `✗ ${verified ? 'Verification' : 'Build'} failed — ${messages.length} error${messages.length !== 1 ? 's' : ''}:\n`,
   )
-  for (const err of result.errors) {
-    process.stderr.write(`  ${err.message}\n`)
+  for (const message of messages) {
+    process.stderr.write(`  ${message}\n`)
   }
 }

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -148,3 +148,40 @@ describe('facet install — CLI error paths', () => {
     expect(stderr).toContain('facet add')
   })
 })
+
+describe('facet install — incompatible installed adapter gate', () => {
+  /** Write an unmanaged legacy bundle with an unsupported API declaration. */
+  function installIncompatibleAdapter(baseDir: string, name: string): void {
+    const dir = join(baseDir, name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'adapter.js'),
+      `export default {
+  name: '${name}',
+  apiVersion: '9.9',
+  supportsInstall: true,
+  buildAssetMetadata() { throw new Error('contract method invoked despite incompatibility') },
+  async installAsset() { throw new Error('contract method invoked despite incompatibility') },
+  async readAsset() { throw new Error('contract method invoked despite incompatibility') },
+  async deleteAsset() { throw new Error('contract method invoked despite incompatibility') },
+}
+`,
+    )
+  }
+
+  test('fails with a reinstall hint and never launches the picker', async () => {
+    installIncompatibleAdapter(adaptersDir, 'future-adapter')
+    writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify({ facets: {} }))
+
+    // Even on a TTY (where the zero-adapter picker COULD run), the gate
+    // must report the incompatible adapter instead of launching it.
+    const { result: code, stderr } = await withTTY(true, () => captureStderr(() => installCommand.run([], {})))
+    expect(code).toBe(1)
+    expect(stderr).toContain('future-adapter')
+    expect(stderr).toContain('9.9')
+    expect(stderr).toContain('facet adapter install future-adapter')
+    expect(stderr).not.toContain('No AI tools are connected yet')
+    // Nothing was installed or written.
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/publish/__tests__/helpers.ts
+++ b/packages/cli/src/commands/publish/__tests__/helpers.ts
@@ -84,11 +84,11 @@ export async function buildFacetFixture(projectRoot: string, opts: FixtureOption
 
   const result = await runBuildPipeline(projectRoot, [])
   if (!result.ok) {
-    throw new Error(
-      `buildFacetFixture: build failed for ${opts.name}@${opts.version}: ${result.errors
-        .map((e) => `${e.path}: ${e.message}`)
-        .join('; ')}`,
-    )
+    const detail =
+      result.kind === 'validation'
+        ? result.errors.map((e) => `${e.path}: ${e.message}`).join('; ')
+        : result.failures.map((f) => `${f.adapter}: ${f.kind}`).join('; ')
+    throw new Error(`buildFacetFixture: build failed for ${opts.name}@${opts.version}: ${detail}`)
   }
   await writeBuildOutput(result, projectRoot)
   const distPath = buildArtifactPath(projectRoot, opts.name, opts.version)

--- a/packages/cli/src/tui/views/build/build-view.tsx
+++ b/packages/cli/src/tui/views/build/build-view.tsx
@@ -8,6 +8,7 @@ import {
 } from '@agent-facets/engine'
 import { Box, Text, useApp } from 'ink'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { buildFailureMessages } from '../../../util/adapter-install-errors.ts'
 import type { Stage } from '../../components/stage-row.tsx'
 import { StageRow } from '../../components/stage-row.tsx'
 import { THEME } from '../../theme.ts'
@@ -66,10 +67,17 @@ export function BuildView({
     setWarnings(pipelineResult.warnings)
 
     if (!pipelineResult.ok) {
-      const formatted = pipelineResult.errors.map((e) => e.message)
-      // Find the stage that failed and attach errors to it
-      setStages((prev) => prev.map((s) => (s.status === 'failed' ? { ...s, errors: formatted } : s)))
-      onFailure?.(pipelineResult.errors.length)
+      const formatted = buildFailureMessages(pipelineResult)
+      // Find the stage that failed and attach errors to it. The
+      // adapter-incompatible preflight fails before any stage starts,
+      // so attach its errors to the first stage for display.
+      setStages((prev) => {
+        const anyFailed = prev.some((s) => s.status === 'failed')
+        return prev.map((s, i) =>
+          (anyFailed ? s.status === 'failed' : i === 0) ? { ...s, status: 'failed' as const, errors: formatted } : s,
+        )
+      })
+      onFailure?.(formatted.length)
       // Defer exit so React renders the errors and failed stage status first
       setPendingExit(new Error('Build failed'))
       return

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -1,6 +1,7 @@
 import type { RunInstallFailure } from '@agent-facets/engine'
 import { Box, Text } from 'ink'
 import type React from 'react'
+import { describeCompatibilityFailure } from '../../../util/adapter-install-errors.ts'
 import { THEME } from '../../theme.ts'
 
 /**
@@ -251,6 +252,26 @@ export function FailureBlock({ failure }: { failure: RunInstallFailure }): React
             ✕ adapter {failure.adapter} does not support install
           </Text>
           <Text> update this adapter or remove it with `facet adapter remove {failure.adapter}`</Text>
+        </Box>
+      )
+    case 'ADAPTER_INCOMPATIBLE':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ incompatible adapter{failure.failures.length !== 1 ? 's' : ''} selected — nothing was installed
+          </Text>
+          {failure.failures.map((compat) => {
+            const described = describeCompatibilityFailure(compat)
+            return (
+              <Box key={compat.adapter} flexDirection="column">
+                <Text> {described.what}</Text>
+                <Text color={THEME.hint}>
+                  {' '}
+                  {described.detail} — {described.fix}
+                </Text>
+              </Box>
+            )
+          })}
         </Box>
       )
     case 'ADAPTER_READ_FAILED':

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -3,6 +3,7 @@ import type {
   AdapterInstallFailure,
   ApiDeclarationClassification,
   BundleFailure,
+  BuildFailure as EngineBuildFailure,
   InstalledAdapterFailure,
   NpmVersionRequest,
   PlaceAdapterFailure,
@@ -33,6 +34,21 @@ export function describeAdapterInstallFailure(failure: AdapterInstallFailure): {
     case 'place-failed':
       return describePlaceFailure(failure.adapter, failure.failure)
   }
+}
+
+/**
+ * Flatten a build failure into displayable message lines. Validation
+ * failures pass through their error messages; adapter-incompatibility
+ * failures render through the shared compatibility prose.
+ */
+export function buildFailureMessages(failure: EngineBuildFailure): string[] {
+  if (failure.kind === 'validation') {
+    return failure.errors.map((error) => error.message)
+  }
+  return failure.failures.map((compatibility) => {
+    const described = describeCompatibilityFailure(compatibility)
+    return `${described.what} — ${described.detail} (fix: ${described.fix})`
+  })
 }
 
 /** Render the repair command for an installed-adapter failure. */

--- a/packages/engine/src/__tests__/build-pipeline.test.ts
+++ b/packages/engine/src/__tests__/build-pipeline.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { defineAdapter } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION, type Adapter, defineAdapter } from '@agent-facets/adapter'
 import type { FacetManifest } from '@agent-facets/protocol'
 import { computeContentHash, detectNamingCollisions, validateCompactFacets } from '@agent-facets/protocol'
 import dedent from 'dedent'
@@ -352,6 +352,7 @@ describe('runBuildPipeline', () => {
     const result = await runBuildPipeline(dir)
     expect(result.ok).toBe(false)
     if (!result.ok) {
+      if (result.kind !== 'validation') expect.unreachable()
       expect(result.errors[0]?.path).toBe('skills.example')
       expect(result.errors[0]?.message).toContain('skills/example/SKILL.md')
     }
@@ -436,6 +437,7 @@ describe('runBuildPipeline', () => {
     const result = await runBuildPipeline(dir)
     expect(result.ok).toBe(false)
     if (!result.ok) {
+      if (result.kind !== 'validation') expect.unreachable()
       expect(result.errors[0]?.message).toContain('name@version')
     }
   })
@@ -518,6 +520,7 @@ describe('runBuildPipeline', () => {
     const result = await runBuildPipeline(dir, [rejectingAdapter])
     expect(result.ok).toBe(false)
     if (!result.ok) {
+      if (result.kind !== 'validation') expect.unreachable()
       expect(result.errors.length).toBeGreaterThan(0)
       expect(result.errors.some((e) => e.message.includes('rejecting-adapter'))).toBe(true)
     }
@@ -651,6 +654,7 @@ describe('content validation', () => {
     const result = await runBuildPipeline(dir)
     expect(result.ok).toBe(false)
     if (!result.ok) {
+      if (result.kind !== 'validation') expect.unreachable()
       expect(result.errors).toHaveLength(1)
       expect(result.errors[0]?.path).toBe('skills.empty')
       expect(result.errors[0]?.message).toContain('empty')
@@ -674,6 +678,7 @@ describe('content validation', () => {
     const result = await runBuildPipeline(dir)
     expect(result.ok).toBe(false)
     if (!result.ok) {
+      if (result.kind !== 'validation') expect.unreachable()
       expect(result.errors).toHaveLength(1)
       expect(result.errors[0]?.path).toBe('agents.blank')
       expect(result.errors[0]?.message).toContain('empty')
@@ -976,5 +981,85 @@ describe('runBuildPipeline — embedded manifest privacy', () => {
     if (!result.ok) expect.unreachable()
     const embedded = await readEmbeddedManifest(result.archiveBytes)
     expect('private' in embedded).toBe(false)
+  })
+})
+
+// --- Adapter API preflight (defense-in-depth gate) ---
+
+describe('runBuildPipeline — adapter API preflight', () => {
+  /** A structurally valid adapter whose declared API is not supported.
+   *  Contract methods throw so any invocation is loud. */
+  function incompatibleAdapter(name: string, apiVersion: unknown): Adapter {
+    return {
+      name,
+      apiVersion,
+      supportsInstall: true,
+      buildAssetMetadata: () => {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async installAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async readAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async deleteAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+    } as Adapter
+  }
+
+  async function validFixture(name: string): Promise<string> {
+    const dir = await createFixtureDir(name)
+    await Bun.write(join(dir, 'skills/example/SKILL.md'), '# Example skill')
+    await Bun.write(
+      join(dir, 'facet.json'),
+      JSON.stringify({
+        name,
+        version: '1.0.0',
+        skills: { example: { description: 'An example skill', adapters: { 'mock-adapter': {} } } },
+      }),
+    )
+    return dir
+  }
+
+  test('incompatible adapter fails before any stage runs or method is invoked', async () => {
+    const dir = await validFixture('preflight-incompatible')
+    const stages: string[] = []
+    const result = await runBuildPipeline(dir, [incompatibleAdapter('future-adapter', '9.9')], (progress) => {
+      stages.push(progress.stage)
+    })
+    if (result.ok) expect.unreachable()
+    if (result.kind !== 'adapter-incompatible') expect.unreachable()
+    expect(result.failures).toEqual([
+      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: [ADAPTER_API_VERSION] },
+    ])
+    // The preflight fires before stage 1 — no stage ever started.
+    expect(stages).toEqual([])
+  })
+
+  test('multiple incompatible adapters are all collected', async () => {
+    const dir = await validFixture('preflight-multiple')
+    const result = await runBuildPipeline(dir, [
+      incompatibleAdapter('undeclared', undefined),
+      incompatibleAdapter('malformed', '0.0.1'),
+    ])
+    if (result.ok) expect.unreachable()
+    if (result.kind !== 'adapter-incompatible') expect.unreachable()
+    expect(result.failures.map((f) => f.kind)).toEqual(['api-missing', 'api-malformed'])
+  })
+
+  test('build with no adapters proceeds and warns about unknown manifest adapters', async () => {
+    const dir = await validFixture('preflight-no-adapters')
+    const result = await runBuildPipeline(dir, [])
+    if (!result.ok) expect.unreachable()
+    expect(result.warnings.some((w) => w.includes('unknown adapter "mock-adapter"'))).toBe(true)
+  })
+
+  test('compatible SDK-stamped adapter passes the preflight', async () => {
+    const dir = await validFixture('preflight-compatible')
+    const result = await runBuildPipeline(dir, [mockAdapter])
+    if (!result.ok) expect.unreachable()
+    expect(result.warnings).toEqual([])
   })
 })

--- a/packages/engine/src/__tests__/materialize.test.ts
+++ b/packages/engine/src/__tests__/materialize.test.ts
@@ -424,3 +424,47 @@ describe('materialize — adapter-extras cannot override computed identity', () 
     expect(meta.extra).toBe('allowed-extra')
   })
 })
+
+describe('materialize — adapter API invariant check', () => {
+  test('an incompatible adapter fails before any method is invoked', async () => {
+    const manifest: ResolvedFacetManifest = {
+      name: 'viper-plans',
+      version: '0.1.0',
+      skills: { planning: { description: 'planning skill', prompt: '# planning content\n' } },
+    }
+    const incompatible = {
+      name: 'future-adapter',
+      apiVersion: '9.9',
+      supportsInstall: true,
+      buildAssetMetadata: () => {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async installAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async readAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async deleteAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+    } as unknown as Adapter
+
+    const result = await materialize({
+      facetName: 'viper-plans',
+      manifest,
+      adapters: [incompatible],
+      oldAssets: [],
+      newAssets: computeAssetList(manifest),
+      journal: new InstallJournal(),
+    })
+    if (result.ok) expect.unreachable()
+    if (result.failure.kind !== 'incompatible-adapter') expect.unreachable()
+    expect(result.failure.failure).toEqual({
+      kind: 'api-unsupported',
+      adapter: 'future-adapter',
+      found: '9.9',
+      supported: [ADAPTER_API_VERSION],
+    })
+  })
+})

--- a/packages/engine/src/adapters/api-compatibility.ts
+++ b/packages/engine/src/adapters/api-compatibility.ts
@@ -84,3 +84,23 @@ export type AdapterCompatibilityFailure =
       runtimeDeclared: string
       supported: readonly string[]
     }
+
+/**
+ * Classify a declared value and, when it is not supported, map it to
+ * the compatibility failure for `adapter`. Returns null for supported
+ * declarations. Shared by the build and install defense-in-depth
+ * preflights so classification-to-failure mapping exists once.
+ */
+export function compatibilityFailureFor(adapter: string, declared: unknown): AdapterCompatibilityFailure | null {
+  const classified = classifyApiDeclaration(declared)
+  switch (classified.kind) {
+    case 'supported':
+      return null
+    case 'missing':
+      return { kind: 'api-missing', adapter, supported: SUPPORTED_ADAPTER_APIS }
+    case 'malformed':
+      return { kind: 'api-malformed', adapter, found: classified.found, supported: SUPPORTED_ADAPTER_APIS }
+    case 'unsupported':
+      return { kind: 'api-unsupported', adapter, found: classified.api, supported: SUPPORTED_ADAPTER_APIS }
+  }
+}

--- a/packages/engine/src/adapters/inspect.ts
+++ b/packages/engine/src/adapters/inspect.ts
@@ -1,8 +1,4 @@
-import {
-  type AdapterCompatibilityFailure,
-  classifyApiDeclaration,
-  SUPPORTED_ADAPTER_APIS,
-} from './api-compatibility.ts'
+import { type AdapterCompatibilityFailure, compatibilityFailureFor } from './api-compatibility.ts'
 import { FIRST_PARTY_ADAPTERS } from './first-party.ts'
 import { generationBundlePath, generationDir, readInstallationReceipt } from './installation.ts'
 import { getAdapterBundlePath, getAdapterDir, listInstalledAdapters } from './placement.ts'
@@ -108,15 +104,9 @@ async function inspectManaged(
 
   // Reject a recorded unsupported API before importing anything — a
   // known-incompatible install must not run module initialization.
-  const recorded = classifyApiDeclaration(receipt.apiVersion)
-  if (recorded.kind !== 'supported') {
-    return {
-      kind: 'incompatible',
-      name,
-      managed: true,
-      failure: compatibilityFailureFromClassification(name, recorded),
-      repair,
-    }
+  const recordedFailure = compatibilityFailureFor(name, receipt.apiVersion)
+  if (recordedFailure !== null) {
+    return { kind: 'incompatible', name, managed: true, failure: recordedFailure, repair }
   }
 
   const genDir = generationDir(adapterDir, receipt.activeGeneration)
@@ -174,18 +164,4 @@ async function inspectUnmanaged(name: string, baseDir?: string): Promise<Install
     return { kind: 'incompatible', name, managed: false, failure: verified.failure.failure, repair }
   }
   return { kind: 'broken', name, managed: false, reason: { kind: 'load-failed', failure: verified.failure }, repair }
-}
-
-function compatibilityFailureFromClassification(
-  adapter: string,
-  classification: Exclude<ReturnType<typeof classifyApiDeclaration>, { kind: 'supported' }>,
-): AdapterCompatibilityFailure {
-  switch (classification.kind) {
-    case 'missing':
-      return { kind: 'api-missing', adapter, supported: SUPPORTED_ADAPTER_APIS }
-    case 'malformed':
-      return { kind: 'api-malformed', adapter, found: classification.found, supported: SUPPORTED_ADAPTER_APIS }
-    case 'unsupported':
-      return { kind: 'api-unsupported', adapter, found: classification.api, supported: SUPPORTED_ADAPTER_APIS }
-  }
 }

--- a/packages/engine/src/build/pipeline.ts
+++ b/packages/engine/src/build/pipeline.ts
@@ -14,6 +14,7 @@ import {
   validateCompactFacets,
   validateContentFiles,
 } from '@agent-facets/protocol'
+import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
 import { jsonFileText } from '../json-file-text.ts'
 import { loadManifest, resolvePrompts } from '../loaders/facet.ts'
 import { buildArtifactFilename } from '../registry/artifact-path.ts'
@@ -38,11 +39,18 @@ export interface BuildResult {
   manifestJson: string
 }
 
-export interface BuildFailure {
-  ok: false
-  errors: ValidationError[]
-  warnings: string[]
-}
+/**
+ * Discriminated build failure:
+ *
+ *   - `validation` — manifest/content/collision/adapter-metadata errors.
+ *   - `adapter-incompatible` — a supplied adapter does not declare a
+ *     CLI-supported API. Detected by a preflight before any pipeline
+ *     stage runs, so no adapter contract method is ever invoked and the
+ *     failure is never conflated with content validation.
+ */
+export type BuildFailure =
+  | { ok: false; kind: 'validation'; errors: ValidationError[]; warnings: string[] }
+  | { ok: false; kind: 'adapter-incompatible'; failures: AdapterCompatibilityFailure[]; warnings: string[] }
 
 /** Stage names emitted by the build pipeline via the onProgress callback. */
 export const BUILD_STAGES = [
@@ -79,13 +87,27 @@ export async function runBuildPipeline(
 ): Promise<BuildResult | BuildFailure> {
   const warnings: string[] = []
 
+  // Stage 0: adapter API preflight — defense-in-depth behind the
+  // command-level fail-closed load. Runs before any stage so an
+  // incompatible adapter can never reach a contract method or be
+  // misreported as a content-validation failure. A build with zero
+  // adapters proceeds normally (unknown adapters warn in stage 5).
+  const incompatible: AdapterCompatibilityFailure[] = []
+  for (const adapter of adapters) {
+    const failure = compatibilityFailureFor(adapter.name, adapter.apiVersion)
+    if (failure !== null) incompatible.push(failure)
+  }
+  if (incompatible.length > 0) {
+    return { ok: false, kind: 'adapter-incompatible', failures: incompatible, warnings }
+  }
+
   // Stage 1: Parse manifest
   onProgress?.({ stage: 'Parsing manifest', status: 'running' })
 
   const loadResult = await loadManifest(rootDir)
   if (!loadResult.ok) {
     onProgress?.({ stage: 'Parsing manifest', status: 'failed' })
-    return { ok: false, errors: loadResult.errors, warnings }
+    return { ok: false, kind: 'validation', errors: loadResult.errors, warnings }
   }
   const manifest = loadResult.data
 
@@ -97,7 +119,7 @@ export async function runBuildPipeline(
   const resolveResult = await resolvePrompts(manifest, rootDir)
   if (!resolveResult.ok) {
     onProgress?.({ stage: 'Resolving prompts', status: 'failed' })
-    return { ok: false, errors: resolveResult.errors, warnings }
+    return { ok: false, kind: 'validation', errors: resolveResult.errors, warnings }
   }
 
   onProgress?.({ stage: 'Resolving prompts', status: 'done' })
@@ -108,7 +130,7 @@ export async function runBuildPipeline(
   const contentErrors = validateContentFiles(resolveResult.data)
   if (contentErrors.length > 0) {
     onProgress?.({ stage: 'Validating assets', status: 'failed' })
-    return { ok: false, errors: contentErrors, warnings }
+    return { ok: false, kind: 'validation', errors: contentErrors, warnings }
   }
 
   onProgress?.({ stage: 'Validating assets', status: 'done' })
@@ -121,7 +143,7 @@ export async function runBuildPipeline(
   const checkErrors = [...collisionErrors, ...facetsErrors]
   if (checkErrors.length > 0) {
     onProgress?.({ stage: 'Checking collisions', status: 'failed' })
-    return { ok: false, errors: checkErrors, warnings }
+    return { ok: false, kind: 'validation', errors: checkErrors, warnings }
   }
 
   onProgress?.({ stage: 'Checking collisions', status: 'done' })
@@ -132,7 +154,12 @@ export async function runBuildPipeline(
   const adapterResult = validateAdapterMetadata(manifest, adapters)
   if (adapterResult.errors.length > 0) {
     onProgress?.({ stage: 'Validating adapters', status: 'failed' })
-    return { ok: false, errors: adapterResult.errors, warnings: [...warnings, ...adapterResult.warnings] }
+    return {
+      ok: false,
+      kind: 'validation',
+      errors: adapterResult.errors,
+      warnings: [...warnings, ...adapterResult.warnings],
+    }
   }
   warnings.push(...adapterResult.warnings)
 

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import type { BuildManifest } from '@agent-facets/protocol'
 
@@ -482,5 +483,61 @@ describe('runInstall — frozen-lockfile mode', () => {
     // Project files are byte-for-byte unchanged (no rewrite, no materialize).
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(facetsBefore)
     expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+  })
+})
+
+describe('runInstall — ADAPTER_INCOMPATIBLE preflight', () => {
+  /** Structurally valid adapter with an unsupported API; methods throw loud. */
+  function incompatibleAdapter(name: string, apiVersion: unknown): Adapter {
+    return {
+      name,
+      apiVersion,
+      supportsInstall: true,
+      buildAssetMetadata: () => {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async installAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async readAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async deleteAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+    } as Adapter
+  }
+
+  test('fails on the no-mutation path before any facet processing or write', async () => {
+    // The manifest content is irrelevant: the preflight fires before any
+    // facet is parsed, resolved, or built.
+    const manifestBytes = writeFacets({ 'gate-facet': './some-local-facet' })
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [incompatibleAdapter('future-adapter', '9.9')],
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
+    expect(result.failure.failures).toEqual([
+      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: [ADAPTER_API_VERSION] },
+    ])
+    expect(result.rollback.kind).toBe('not-needed')
+
+    // No writes: manifest byte-identical, no lockfile created.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBytes)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  test('collects every incompatible adapter', async () => {
+    writeFacets({})
+    const result = await runInstall({
+      projectRoot,
+      adapters: [incompatibleAdapter('undeclared', undefined), incompatibleAdapter('malformed', '0.0.1')],
+    })
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
+    expect(result.failure.failures.map((f) => f.kind)).toEqual(['api-missing', 'api-malformed'])
   })
 })

--- a/packages/engine/src/install/commit/resolve-git.ts
+++ b/packages/engine/src/install/commit/resolve-git.ts
@@ -109,7 +109,10 @@ export async function resolveGitFacet(args: ResolveGitFacetArgs): Promise<Resolv
       if (!buildResult.ok) {
         return {
           ok: false,
-          failure: { code: 'BUILD_FAILED', facet: facetName, errors: buildResult.errors },
+          failure:
+            buildResult.kind === 'adapter-incompatible'
+              ? { code: 'ADAPTER_INCOMPATIBLE', failures: buildResult.failures }
+              : { code: 'BUILD_FAILED', facet: facetName, errors: buildResult.errors },
         }
       }
 

--- a/packages/engine/src/install/commit/resolve-local.ts
+++ b/packages/engine/src/install/commit/resolve-local.ts
@@ -56,7 +56,10 @@ export async function resolveLocalFacet(args: ResolveLocalFacetArgs): Promise<Re
   if (!buildResult.ok) {
     return {
       ok: false,
-      failure: { code: 'BUILD_FAILED', facet: facetName, errors: buildResult.errors },
+      failure:
+        buildResult.kind === 'adapter-incompatible'
+          ? { code: 'ADAPTER_INCOMPATIBLE', failures: buildResult.failures }
+          : { code: 'BUILD_FAILED', facet: facetName, errors: buildResult.errors },
     }
   }
 

--- a/packages/engine/src/install/materialize-failure.ts
+++ b/packages/engine/src/install/materialize-failure.ts
@@ -13,6 +13,8 @@ export function materializeFailureToRunInstall(facet: string, failure: Materiali
   switch (failure.kind) {
     case 'unsupported-adapter':
       return { code: 'ADAPTER_UNSUPPORTED', facet, adapter: failure.adapter }
+    case 'incompatible-adapter':
+      return { code: 'ADAPTER_INCOMPATIBLE', failures: [failure.failure] }
     case 'read-failed':
       return {
         code: 'ADAPTER_READ_FAILED',

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -1,6 +1,7 @@
 import type { Adapter } from '@agent-facets/adapter'
 import { splitFrontMatter } from '@agent-facets/common'
 import type { LockfileAssetEntry, ResolvedFacetManifest } from '@agent-facets/protocol'
+import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
 import type { InstallJournal } from './journal.ts'
 import type { OnLog, StageEvent } from './types.ts'
 
@@ -88,6 +89,10 @@ export interface MaterializeCounts {
  *   - `unsupported-adapter` — caller passed an adapter whose
  *     `supportsInstall !== true`. Defense-in-depth beyond the picker
  *     filter; loud failure beats silent no-op.
+ *   - `incompatible-adapter` — caller passed an adapter that does not
+ *     declare a CLI-supported API. Invariant check only: the primary
+ *     gates are the command-level fail-closed load and the runInstall
+ *     preflight; reaching this arm means an upstream gate was bypassed.
  *   - `read-failed` — `adapter.readAsset` threw something other than
  *     ENOENT. ENOENT is the one "file didn't exist" signal we trust;
  *     anything else (EACCES, EIO, EISDIR, adapter bugs) means we don't
@@ -98,6 +103,7 @@ export interface MaterializeCounts {
  */
 export type MaterializeFailure =
   | { kind: 'unsupported-adapter'; adapter: string }
+  | { kind: 'incompatible-adapter'; failure: AdapterCompatibilityFailure }
   | { kind: 'read-failed'; adapter: string; asset: LockfileAssetEntry; cause: string }
   | { kind: 'install-failed'; adapter: string; asset: LockfileAssetEntry; cause: string }
   | { kind: 'delete-failed'; adapter: string; asset: LockfileAssetEntry; cause: string }
@@ -138,6 +144,14 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
     // the picker filter). Fail loud rather than silent no-op.
     if (adapter.supportsInstall !== true) {
       return { ok: false, failure: { kind: 'unsupported-adapter', adapter: adapter.name } }
+    }
+
+    // Invariant check only — the primary compatibility gates run at the
+    // command level and in the runInstall preflight, both before any
+    // materialization write. Reaching this arm means a gate was bypassed.
+    const incompatibility = compatibilityFailureFor(adapter.name, adapter.apiVersion)
+    if (incompatibility !== null) {
+      return { ok: false, failure: { kind: 'incompatible-adapter', failure: incompatibility } }
     }
 
     opts.onLog?.(() => `[verbose]   installing ${opts.facetName}@${opts.manifest.version} → ${adapter.name}`)

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import type { FacetsJson, Lockfile } from '@agent-facets/protocol'
+import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
 import { loadFacetsJson } from '../manifest/project-files.ts'
 import { applyManifestWritePolicy, mergeDeltaIntoManifest } from './commit/delta.ts'
 import { removeDriftedFacets } from './commit/drift-removal.ts'
@@ -97,6 +98,20 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     const conflict = delta.removals.find((r) => additionNames.has(r.facetName))
     if (conflict !== undefined) {
       return failureNoMutation({ code: 'DELTA_CONFLICT', facet: conflict.facetName })
+    }
+
+    // 3c. Adapter API preflight — defense-in-depth behind the
+    //     command-level fail-closed load. Runs on the no-mutation path
+    //     before the per-facet loop, which also precedes any Git/local
+    //     facet build, drift removal, and every materialization write.
+    //     Collects every incompatible adapter, not just the first.
+    const incompatibleAdapters: AdapterCompatibilityFailure[] = []
+    for (const adapter of adapters) {
+      const incompatibility = compatibilityFailureFor(adapter.name, adapter.apiVersion)
+      if (incompatibility !== null) incompatibleAdapters.push(incompatibility)
+    }
+    if (incompatibleAdapters.length > 0) {
+      return failureNoMutation({ code: 'ADAPTER_INCOMPATIBLE', failures: incompatibleAdapters })
     }
 
     // 4. Frozen-lockfile gates. A frozen commit with a non-empty delta is

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -1,6 +1,7 @@
 import type { Adapter } from '@agent-facets/adapter'
 import type { ValidationError } from '@agent-facets/common'
 import type { IntegrityFailure, Lockfile, LockfileAssetEntry } from '@agent-facets/protocol'
+import type { AdapterCompatibilityFailure } from '../adapters/api-compatibility.ts'
 import type { RegistryError } from '../registry/index.ts'
 import type { ParseError, Source } from '../sources/facet/types.ts'
 
@@ -192,6 +193,15 @@ export type RunInstallFailure =
    * beyond the picker filter — fail loud rather than silently no-op.
    */
   | { code: 'ADAPTER_UNSUPPORTED'; facet: string; adapter: string }
+  /**
+   * A selected adapter does not declare a CLI-supported adapter API.
+   * Detected by the preflight before the per-facet loop (which precedes
+   * any Git/local facet build, materialization write, or adapter
+   * contract method) — the primary gate is the command-level
+   * fail-closed load; this is defense-in-depth. Carries every
+   * incompatible adapter, not just the first.
+   */
+  | { code: 'ADAPTER_INCOMPATIBLE'; failures: ReadonlyArray<AdapterCompatibilityFailure> }
   /**
    * `adapter.readAsset` threw something other than ENOENT. The asset's
    * pre-install state is unknown, so we abort before writing rather


### PR DESCRIPTION
### Why

Incompatible adapters (those declaring an unsupported `apiVersion`) could previously reach adapter contract methods or be misreported as content-validation failures. This adds explicit compatibility gates at every entry point — build, install, add, and remove — so an incompatible adapter is always caught before any pipeline stage runs, any file is written, or any adapter method is invoked.

### Details

`BuildFailure` is now a discriminated union with two variants: `validation` (existing manifest/content/collision/adapter-metadata errors) and `adapter-incompatible` (new, emitted by a preflight that runs before stage 1). This means incompatibility failures are never conflated with content errors and callers must handle both arms exhaustively.

A shared `compatibilityFailureFor` helper in `api-compatibility.ts` centralizes the classification-to-failure mapping that was previously duplicated between `inspect.ts` and any new call sites. All three layers — the command-level fail-closed load, the `runInstall` preflight (step 3c, before the per-facet loop), and the `materialize` invariant check — use this single function.

`runInstall` gains an `ADAPTER_INCOMPATIBLE` failure variant that collects every incompatible adapter rather than stopping at the first. The same aggregation applies in the build preflight. The `materialize` check is retained only as a loud invariant guard for cases where an upstream gate is bypassed.

The TUI `FailureBlock` and plain-text renderers are updated to handle `ADAPTER_INCOMPATIBLE`, and `buildFailureMessages` in `adapter-install-errors.ts` flattens either failure variant into displayable lines for the build view and JSON output.

Git and local facet resolvers now map an `adapter-incompatible` build result to `ADAPTER_INCOMPATIBLE` rather than `BUILD_FAILED`, preserving the distinction through the install pipeline.

### Verification

New tests cover: incompatible adapters blocking build before any stage fires; multiple incompatible adapters being aggregated; a build with no adapters proceeding with unknown-adapter warnings; compatible adapters passing the preflight; `runInstall` failing on the no-mutation path before any facet processing or write; the `materialize` invariant check; and CLI-level gates for `add` and `install` confirming no picker is launched and no project files are created. Tasks 13 and 14 in the spec are marked complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core build and install paths and failure typing; behavior is heavily tested but regressions could block legitimate workflows if classification or gating is wrong.
> 
> **Overview**
> Adds **defense-in-depth adapter API compatibility gates** so unsupported `apiVersion` values fail before pipeline stages, writes, or adapter contract methods run—and are not mixed up with manifest validation errors.
> 
> **Engine:** `BuildFailure` is now a discriminated union (`validation` vs `adapter-incompatible`). `runBuildPipeline` runs a **stage-0 preflight** via shared `compatibilityFailureFor`. `runInstall` adds step **3c** and returns **`ADAPTER_INCOMPATIBLE`** with all incompatible adapters aggregated on the no-mutation path. Git/local resolvers map build `adapter-incompatible` to that code instead of `BUILD_FAILED`. `materialize` keeps an invariant check; `inspect` uses the same helper instead of local mapping.
> 
> **CLI:** `buildFailureMessages` drives plain, JSON, and TUI build output; install **FailureBlock** renders `ADAPTER_INCOMPATIBLE` with reinstall hints. **`facet add` / `facet install`** tests assert incompatible installs block work and skip the zero-adapter picker.
> 
> OpenSpec tasks **13–14** are marked complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31277a65baa746119892f42ab803ffd8847b3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->