### PR TITLE
Close compatibility test gaps; name `latest` in rejected-selector hints

### DIFF
--- a/.changeset/whole-seals-sleep.md
+++ b/.changeset/whole-seals-sleep.md
@@ -1,0 +1,8 @@
+---
+"@agent-facets/adapter-claude-code": minor
+"@agent-facets/adapter-opencode": minor
+"@agent-facets/adapter-codex": minor
+"@agent-facets/adapter": minor
+---
+
+Declare adapter API `0.0` across the adapter toolchain. `defineAdapter()` now stamps a readonly `apiVersion` (`"0.0"`) onto every runtime adapter — the definition type excludes it, so authors cannot supply a conflicting value — and the SDK exports the canonical constants (`ADAPTER_API_VERSION`, `ADAPTER_API_VERSION_PACKAGE_FIELD`) from the new dependency-free `@agent-facets/adapter/api-version` subpath. First-party adapter packages now publish `"facetAdapterApiVersion": "0.0"` in their manifests (injected at pack time from the SDK constants) so compatibility-aware CLIs can select a compatible release from npm metadata before downloading it. The positional adapter method contract itself is unchanged: these releases remain fully consumable by already-published CLIs.

--- a/openspec/changes/add-adapter-api-version-negotiation/tasks.md
+++ b/openspec/changes/add-adapter-api-version-negotiation/tasks.md
@@ -147,12 +147,12 @@
 
 - [x] 17.1 Explore: Audit the completed implementation and tests against every reconciled SDK, adapter-management, and installation scenario and every design failure boundary.
 - [x] 17.2 Explore: Inspect for duplicated API literals, metadata field names, alias maps, compatibility classifiers, or user-facing engine messages that violate the single-source-of-truth design.
-- [ ] 17.3 Propose: Present the final gap-closing changes and a verification matrix covering unit, integration, end-to-end, packed-artifact, documentation, and OpenSpec validation.
+- [x] 17.3 Propose: Present the final gap-closing changes and a verification matrix covering unit, integration, end-to-end, packed-artifact, documentation, and OpenSpec validation.
 
 ## 18. Integrated Coverage Audit — Implementation
 
-- [ ] 18.1 Implement: Apply the approved gap-closing tests or corrections found by the coverage and duplication audit.
-- [ ] 18.2 Implement: Run `bun format` and apply any remaining non-formatting corrections required before final verification.
-- [ ] 18.3 Verify: Run the complete `bun check` pipeline and stop on any lint, type, unit, or end-to-end failure.
-- [ ] 18.4 Verify: Run strict OpenSpec validation and check the implementation and documentation against every reconciled requirement and migration constraint.
-- [ ] 18.5 Verify: Run automated representative npm, Git, local, managed, unmanaged, compatible, incompatible, replacement-failure, list, build, and facet-operation flows end to end.
+- [x] 18.1 Implement: Apply the approved gap-closing tests or corrections found by the coverage and duplication audit.
+- [x] 18.2 Implement: Run `bun format` and apply any remaining non-formatting corrections required before final verification.
+- [x] 18.3 Verify: Run the complete `bun check` pipeline and stop on any lint, type, unit, or end-to-end failure.
+- [x] 18.4 Verify: Run strict OpenSpec validation and check the implementation and documentation against every reconciled requirement and migration constraint.
+- [x] 18.5 Verify: Run automated representative npm, Git, local, managed, unmanaged, compatible, incompatible, replacement-failure, list, build, and facet-operation flows end to end.

--- a/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
@@ -592,6 +592,25 @@ describe('facet adapter list — inspection-backed output', () => {
       await rm(facetDir, { recursive: true, force: true })
     }
   })
+
+  test('remains usable with a broken entry (invalid receipt) and shows recovery', async () => {
+    const facetDir = await makeFacetDir()
+    try {
+      // Fabricate a managed directory whose installation.json is garbage.
+      const brokenDir = join(adaptersIn(facetDir), 'broken-tool')
+      await mkdir(brokenDir, { recursive: true })
+      await writeFile(join(brokenDir, 'installation.json'), '{not json')
+
+      const listResult = await runCli(['adapter', 'list'], { FACET_DIR: facetDir })
+      expect(listResult.exitCode).toBe(0)
+      expect(listResult.stdout).toContain('broken-tool')
+      expect(listResult.stdout).toContain('api unknown')
+      expect(listResult.stdout).toContain('broken (invalid installation record)')
+      expect(listResult.stdout).toContain('facet adapter install broken-tool')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('FACET_DIR redirect', () => {

--- a/packages/cli/src/commands/__tests__/build-gate.test.ts
+++ b/packages/cli/src/commands/__tests__/build-gate.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+import { captureStderr } from '../../__tests__/helpers/capture-std.ts'
+import { buildCommand } from '../build.ts'
+
+/**
+ * Command-level gate: `facet build` fails closed on an incompatible
+ * installed adapter, rendering the full diagnostic (adapter, declared
+ * API, supported set, reinstall command) before the pipeline starts.
+ */
+
+let projectRoot: string
+let originalCwd: string
+let fakeHome: string
+let originalHome: string | undefined
+let adaptersDir: string
+let originalFacetDir: string | undefined
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-build-gate-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-home-')))
+  const facetDir = join(fakeHome, '.facet')
+  adaptersDir = join(facetDir, 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+  process.env.HOME = fakeHome
+  process.env.FACET_DIR = facetDir
+  process.chdir(projectRoot)
+
+  // A valid facet source tree — the build would succeed if the gate let
+  // the pipeline run.
+  writeFileSync(
+    join(projectRoot, 'facet.json'),
+    JSON.stringify({ name: 'gate-facet', version: '0.1.0', skills: { planning: { description: 'planning skill' } } }),
+  )
+  mkdirSync(join(projectRoot, 'skills/planning'), { recursive: true })
+  writeFileSync(join(projectRoot, 'skills/planning/SKILL.md'), '# planning\n')
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('facet build — incompatible installed adapter gate', () => {
+  test('exits 1 with the full diagnostic before the pipeline starts', async () => {
+    // Unmanaged bundle declaring an unsupported API; contract methods
+    // throw loudly so any invocation fails the test.
+    const dir = join(adaptersDir, 'future-adapter')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'adapter.js'),
+      `export default {
+  name: 'future-adapter',
+  apiVersion: '9.9',
+  supportsInstall: true,
+  buildAssetMetadata() { throw new Error('contract method invoked despite incompatibility') },
+  async installAsset() { throw new Error('contract method invoked despite incompatibility') },
+  async readAsset() { throw new Error('contract method invoked despite incompatibility') },
+  async deleteAsset() { throw new Error('contract method invoked despite incompatibility') },
+}
+`,
+    )
+
+    const { result: code, stderr } = await captureStderr(() => buildCommand.run([], { verify: true }))
+    expect(code).toBe(1)
+
+    // The diagnostic identifies the adapter, its declared API, the
+    // supported set, and the reinstall command.
+    expect(stderr).toContain('future-adapter')
+    expect(stderr).toContain('9.9')
+    expect(stderr).toContain(ADAPTER_API_VERSION)
+    expect(stderr).toContain('facet adapter install future-adapter')
+
+    // The pipeline never ran: no dist/ output was produced.
+    expect(existsSync(join(projectRoot, 'dist'))).toBe(false)
+  })
+})

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -525,9 +525,13 @@ describe('runInstall — ADAPTER_INCOMPATIBLE preflight', () => {
     ])
     expect(result.rollback.kind).toBe('not-needed')
 
-    // No writes: manifest byte-identical, no lockfile created.
+    // No writes: manifest byte-identical, no lockfile created, no
+    // install receipt written (the receipt only exists after a
+    // successful tri-write).
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBytes)
     expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    const { receiptPath } = await import('../receipt.ts')
+    expect(existsSync(receiptPath(projectRoot))).toBe(false)
   })
 
   test('collects every incompatible adapter', async () => {

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 
 /**
@@ -307,6 +308,61 @@ describe('prepareRemove — read-only validation', () => {
     expect(result.json.facets.cowsay).toBe('0.1.1')
     // Filtered names contains every requested name (all declared).
     expect(result.names).toEqual(['cowsay'])
+  })
+})
+
+describe('runRemove — adapter compatibility is not bypassed', () => {
+  /** Structurally valid adapter with an unsupported API; methods throw loud. */
+  function incompatibleAdapter(name: string, apiVersion: unknown): Adapter {
+    return {
+      name,
+      apiVersion,
+      supportsInstall: true,
+      buildAssetMetadata: () => {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async installAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async readAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+      async deleteAsset() {
+        throw new Error('contract method invoked despite incompatibility')
+      },
+    } as Adapter
+  }
+
+  test('removal with an incompatible selected adapter fails before deleting anything', async () => {
+    await installFacet('cowsay', '0.1.1')
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(true)
+    const { receiptPath } = await import('../receipt.ts')
+    const before = {
+      facets: readFileSync(join(projectRoot, 'facets.json'), 'utf8'),
+      lock: readFileSync(join(projectRoot, 'facets.lock'), 'utf8'),
+      receipt: readFileSync(receiptPath(projectRoot), 'utf8'),
+    }
+
+    const result = await runRemove({
+      projectRoot,
+      names: ['cowsay'],
+      adapters: [incompatibleAdapter('future-adapter', '9.9')],
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.phase !== 'install') expect.unreachable()
+    if (result.install.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
+    expect(result.install.failure.failures).toEqual([
+      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: [ADAPTER_API_VERSION] },
+    ])
+    expect(result.install.rollback.kind).toBe('not-needed')
+
+    // Nothing was deleted: the materialized asset survives and every
+    // project file is byte-for-byte unchanged.
+    expect(existsSync(assetPath('test-adapter', 'cowsay'))).toBe(true)
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(before.facets)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(before.lock)
+    expect(readFileSync(receiptPath(projectRoot), 'utf8')).toBe(before.receipt)
   })
 })
 

--- a/packages/engine/src/sources/adapter/__tests__/specifier.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/specifier.test.ts
@@ -174,6 +174,11 @@ describe('parseAdapterSpecifier — rejected npm selectors', () => {
     if (result.reason !== 'invalid-npm-selector') expect.unreachable()
     expect(result.error.code).toBe(code as never)
     expect(result.specifier).toBe(specifier)
+    // The rejection SHALL identify the accepted exact, wildcard, and
+    // `latest` forms so the user can self-correct.
+    expect(result.error.fix).toContain('latest')
+    expect(result.error.fix).toContain('1.2.3')
+    expect(result.error.fix).toMatch(/1\.\*|1\.2\.\*/)
   })
 
   test('rejected selector reports the alias-resolved package name', () => {

--- a/packages/engine/src/sources/facet/parse-version.ts
+++ b/packages/engine/src/sources/facet/parse-version.ts
@@ -29,26 +29,34 @@ export function parseVersionSpec(input: string): ParseResult<VersionSpec> {
     return err(
       'CARET_RANGE',
       `caret ranges are not supported (got "${input}")`,
-      'use 1.* for major-pinned, 1.2.* for minor-pinned, or 1.2.3 for exact',
+      'use 1.* for major-pinned, 1.2.* for minor-pinned, 1.2.3 for exact, or latest',
     )
   }
   if (input.startsWith('~')) {
     return err(
       'TILDE_RANGE',
       `tilde ranges are not supported (got "${input}")`,
-      'use 1.2.* for minor-pinned or 1.2.3 for exact',
+      'use 1.2.* for minor-pinned, 1.2.3 for exact, or latest',
     )
   }
   if (/^[<>]=?/.test(input)) {
-    return err('COMPARATOR_RANGE', `comparator ranges are not supported (got "${input}")`, 'use 1.* or 1.2.3 instead')
+    return err(
+      'COMPARATOR_RANGE',
+      `comparator ranges are not supported (got "${input}")`,
+      'use 1.*, 1.2.3, or latest instead',
+    )
   }
   if (input.includes('||')) {
-    return err('OR_RANGE', `OR ranges are not supported (got "${input}")`, 'pick one version specifier — 1.* or 1.2.3')
+    return err(
+      'OR_RANGE',
+      `OR ranges are not supported (got "${input}")`,
+      'pick one version specifier — 1.*, 1.2.3, or latest',
+    )
   }
   // Hyphen ranges: `1.0.0 - 2.0.0`. We detect the space-hyphen-space
   // pattern to avoid catching pre-release identifiers like `1.0.0-rc.1`.
   if (/\s-\s/.test(input)) {
-    return err('COMPARATOR_RANGE', `hyphen ranges are not supported (got "${input}")`, 'use 1.* or 1.2.3')
+    return err('COMPARATOR_RANGE', `hyphen ranges are not supported (got "${input}")`, 'use 1.*, 1.2.3, or latest')
   }
 
   // Literal `latest` tag.
@@ -63,7 +71,11 @@ export function parseVersionSpec(input: string): ParseResult<VersionSpec> {
 
   // x-style placeholders: 1.x, 1.2.x, 1.X
   if (/^\d+(?:\.\d+)?\.[xX]$/.test(input) || /^\d+\.[xX]$/.test(input)) {
-    return err('X_RANGE', `x-style ranges are not supported (got "${input}")`, 'use * (e.g., 1.* or 1.2.*) instead')
+    return err(
+      'X_RANGE',
+      `x-style ranges are not supported (got "${input}")`,
+      'use * (e.g., 1.* or 1.2.*), 1.2.3, or latest instead',
+    )
   }
 
   // Major-wildcard: `<major>.*`


### PR DESCRIPTION
### Why

The integrated coverage audit (spec tasks 17–18) checked every reconciled scenario against the implementation and found no logic violations, but five gaps: one message-content shortfall and four scenarios whose gates existed without proof at their outermost layer. This closes them, completing the adapter API version negotiation change (89/89 tasks).

### Details

The only production change is copy: rejected version selectors (caret, tilde, comparator, OR, hyphen, x-range) now name all three accepted form families — exact, wildcard, and `latest` — as the spec requires. `parse-version.ts` is shared by facet and adapter specifier parsing, and `latest` is valid in both domains, so the amended hints are correct for both consumers.

The rest is tests for previously unproven scenarios:

- Removal with an incompatible adapter was the one facet operation with zero coverage — now proven to delete nothing, leaving `facets.json`, `facets.lock`, and the receipt byte-identical.
- `facet build`'s command-level diagnostic (adapter, found API, supported set, reinstall command) was only unit-tested in pieces — now asserted end-to-end at the command layer, with no `dist/` produced.
- `facet adapter list` had no coverage for broken entries — an unparseable `installation.json` now proves `api unknown` / `broken (invalid installation record)` rendering with a recovery command and exit 0.
- The incompatible-install preflight additionally asserts no install receipt is written (the receipt only exists after a successful tri-write).

### Verification

`bun check` (33/33 turbo tasks), strict OpenSpec validation, and the representative end-to-end flows (npm, git, local, managed, unmanaged, compatible, incompatible, replacement-failure, list, build, facet operations) all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly tests and user-facing error copy in version parsing; compatibility gate behavior is unchanged and only asserted more strongly.
> 
> **Overview**
> Finishes the integrated coverage audit (OpenSpec tasks 17–18) by closing test gaps around adapter API compatibility gates and tightening user-facing parse hints.
> 
> **Production:** Rejected facet/adapter version selectors (caret, tilde, comparators, OR/hyphen ranges, `x` ranges) now mention **`latest`** in the `fix` text alongside exact (`1.2.3`) and wildcard (`1.*` / `1.2.*`) forms in shared `parse-version.ts`, which adapter specifier parsing reuses.
> 
> **Tests:** Adds command-level proof that **`facet build`** exits before the pipeline when an installed adapter declares an unsupported API (full stderr diagnostic, no `dist/`). Adds e2e coverage for **`facet adapter list`** with corrupt `installation.json` (`api unknown`, broken status, reinstall hint, exit 0). Proves **`runRemove`** does not delete materialized assets or mutate `facets.json` / lock / receipt on `ADAPTER_INCOMPATIBLE`. Extends install preflight to assert **no install receipt** is written on incompatible adapter failure. Specifier tests lock in the expanded rejection hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9093e80dfc91db140ad880804e12ac1dd3a22c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

