### PR TITLE
Bump `viper-plans` from 1.1.4 to 1.2.0

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "1.1.4",
+    "viper-plans": "1.2.0",
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.1",

--- a/facets.lock
+++ b/facets.lock
@@ -131,8 +131,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.1.4",
-      "integrity": "sha256:541e612339660d35d0ed891f478b041fe4041e8b0fe9938d03e5c9d198d5d9e4",
+      "version": "1.2.0",
+      "integrity": "sha256:5c0cad2c96b3ce57c7c8a79bd482302622d9e44f121514fb2987e3043dc6cf50",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Bumps `viper-plans` from version `1.1.4` to `1.2.0`.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no application code changes; behavior shifts only if `viper-plans` 1.2.0 differs from 1.1.4 in the installed agent skills/commands.
> 
> **Overview**
> This PR **bumps the `viper-plans` facet** from `1.1.4` to `1.2.0` in `facets.json` and updates `facets.lock` with the new resolved version and `sha256` integrity for the registry download.
> 
> The locked asset set is unchanged (same project-scoped skills and `viper-*` commands); only the pinned dependency version moves forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d98f46fc256804b1a77d6dca0ec044b43a579d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Viper Plans facet version from 1.1.4 to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->