### PR TITLE
Add README scaffolding to create wizard: default-on toggle, seeded template, authored-content preservation, and atomic write transaction

### DIFF
--- a/openspec/changes/support-non-asset-files/tasks.md
+++ b/openspec/changes/support-non-asset-files/tasks.md
@@ -116,15 +116,15 @@
 
 ## 12. Create and Edit Authoring — Research
 
-- [ ] 12.1 Explore: Trace scaffold options, manifest generation, templates, previews, and create wizard state/editor round-trips
-- [ ] 12.2 Explore: Trace edit scanner, reconciliation, context, operation, manifest-rewrite, confirmation, and transactional apply types
-- [ ] 12.3 Explore: Inspect create/edit focus management and exhaustive UI switches that must represent two independent README paths and path-bearing reconciliation items
-- [ ] 12.4 Propose: Define tagged README and supplementary-file states, stable reconciliation identities, headless-create behavior, and an exact-path operation preview for the full authoring block
+- [x] 12.1 Explore: Trace scaffold options, manifest generation, templates, previews, and create wizard state/editor round-trips
+- [x] 12.2 Explore: Trace edit scanner, reconciliation, context, operation, manifest-rewrite, confirmation, and transactional apply types
+- [x] 12.3 Explore: Inspect create/edit focus management and exhaustive UI switches that must represent two independent README paths and path-bearing reconciliation items
+- [x] 12.4 Propose: Define tagged README and supplementary-file states, stable reconciliation identities, headless-create behavior, and an exact-path operation preview for the full authoring block
 
 ## 13. Create and Edit Authoring — Implementation
 
-- [ ] 13.1 Implement: Add an editable default `README.md` scaffold option and template that writes the file and top-level declaration atomically without regenerating authored content after identity edits
-- [ ] 13.2 Implement: Add the dedicated create README card/editor flow, optional disable behavior, state snapshotting, and explicit confirmation preview, and align headless create with the documented policy
+- [x] 13.1 Implement: Add an editable default `README.md` scaffold option and template that writes the file and top-level declaration atomically without regenerating authored content after identity edits
+- [x] 13.2 Implement: Add the dedicated create README card/editor flow, optional disable behavior, state snapshotting, and explicit confirmation preview, and align headless create with the documented policy
 - [ ] 13.3 Implement: Extend edit scanning and reconciliation for undeclared skill companions, common root files, and missing declared supplementary files while routing only exact `README.md` and `README` paths to a dedicated panel
 - [ ] 13.4 Implement: Add independent tagged states and actions for both conventional README paths, preserving bytes on adoption and retaining exact paths for scaffold, edit, removal, and declaration changes
 - [ ] 13.5 Implement: Replace string-parsed reconciliation keys with stable structured identities and represent file/declaration operations as tagged variants with no invalid combinations

--- a/packages/cli/src/__tests__/create-build.e2e.test.ts
+++ b/packages/cli/src/__tests__/create-build.e2e.test.ts
@@ -74,6 +74,7 @@ describe('writeScaffold', () => {
         skills: ['code-review', 'testing-guide'],
         agents: ['reviewer'],
         commands: ['deploy'],
+        readme: { kind: 'disabled' },
       },
       dir,
     )
@@ -122,6 +123,7 @@ describe('writeScaffold', () => {
         skills: ['minimal'],
         agents: [],
         commands: [],
+        readme: { kind: 'disabled' },
       },
       dir,
     )
@@ -148,6 +150,7 @@ describe('writeScaffold', () => {
         skills: ['example'],
         agents: [],
         commands: [],
+        readme: { kind: 'disabled' },
       },
       dir,
     )
@@ -169,6 +172,7 @@ describe('writeScaffold', () => {
         skills: ['cowsay'],
         agents: [],
         commands: [],
+        readme: { kind: 'disabled' },
       },
       dir,
     )
@@ -196,6 +200,7 @@ describe('writeScaffold', () => {
         skills: ['helper'],
         agents: ['assistant'],
         commands: [],
+        readme: { kind: 'disabled' },
       },
       dir,
     )
@@ -329,7 +334,15 @@ describe('facet build --verify', () => {
   async function scaffoldValid(name: string): Promise<string> {
     const dir = await createFixtureDir(name)
     await writeScaffold(
-      { name: 'verifiable', version: DEFAULT_VERSION, description: 'x', skills: ['helper'], agents: [], commands: [] },
+      {
+        name: 'verifiable',
+        version: DEFAULT_VERSION,
+        description: 'x',
+        skills: ['helper'],
+        agents: [],
+        commands: [],
+        readme: { kind: 'disabled' },
+      },
       dir,
     )
     return dir

--- a/packages/cli/src/__tests__/modify.e2e.test.ts
+++ b/packages/cli/src/__tests__/modify.e2e.test.ts
@@ -44,6 +44,7 @@ async function fixture(name: string): Promise<string> {
       skills: ['greet'],
       agents: ['helper'],
       commands: [],
+      readme: { kind: 'disabled' },
     },
     dir,
   )

--- a/packages/cli/src/commands/create/__tests__/headless.test.ts
+++ b/packages/cli/src/commands/create/__tests__/headless.test.ts
@@ -26,7 +26,25 @@ describe('decideCreate — headless validation', () => {
       skills: ['greet'],
       agents: ['helper'],
       commands: [],
+      // README is on by default, seeded from the (empty) description.
+      readme: { kind: 'enabled', content: '# my-facet\n' },
     })
+  })
+
+  test('README is enabled by default and seeded from identity', () => {
+    const d = decideCreate({ name: 'my-facet', description: 'Neat tools', skill: ['greet'] })
+    if (d.mode !== 'headless') expect.unreachable()
+    expect(d.options.readme).toEqual({ kind: 'enabled', content: '# my-facet\n\nNeat tools\n' })
+  })
+
+  test('--no-readme opts out (readme: false)', () => {
+    const d = decideCreate({ name: 'my-facet', skill: ['greet'], readme: false })
+    if (d.mode !== 'headless') expect.unreachable()
+    expect(d.options.readme).toEqual({ kind: 'disabled' })
+  })
+
+  test('a lone --no-readme does not trigger headless mode', () => {
+    expect(decideCreate({ readme: false }).mode).toBe('wizard')
   })
 
   test('honors version, description, and private', () => {

--- a/packages/cli/src/commands/create/headless.ts
+++ b/packages/cli/src/commands/create/headless.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_VERSION, isValidSemVer, type ScaffoldOptions } from '@agent-facets/engine'
+import { DEFAULT_VERSION, isValidSemVer, readmeTemplate, type ScaffoldOptions } from '@agent-facets/engine'
 import { validateAssetNameSegment, validateFacetName } from '@agent-facets/protocol'
 import type { CliError } from '../../util/errors.ts'
 
@@ -99,6 +99,12 @@ export function decideCreate(flags: Record<string, unknown>): CreateDecision {
     }
   }
 
+  // README is on by default; `--no-readme` (parsed as `readme: false`) opts out.
+  // Headless and interactive create therefore produce the same seeded README by
+  // default, matching design D11's "never diverge by default" policy.
+  const readme: ScaffoldOptions['readme'] =
+    flags.readme === false ? { kind: 'disabled' } : { kind: 'enabled', content: readmeTemplate(name, description) }
+
   const options: ScaffoldOptions = {
     name,
     version,
@@ -106,6 +112,7 @@ export function decideCreate(flags: Record<string, unknown>): CreateDecision {
     skills,
     agents,
     commands,
+    readme,
     ...(flags.private === true ? { private: true as const } : {}),
   }
 

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -53,6 +53,7 @@ export const createCommand: Command = {
     skill: { type: 'array', description: 'Skill to scaffold, repeatable (headless mode)' },
     agent: { type: 'array', description: 'Agent to scaffold, repeatable (headless mode)' },
     command: { type: 'array', description: 'Command to scaffold, repeatable (headless mode)' },
+    readme: { type: 'boolean', description: 'Scaffold a README.md (default on; pass --no-readme to skip)' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON to stdout (headless mode)' },
   },
   run: async (args: string[], flags: Record<string, unknown>): Promise<number> => {

--- a/packages/cli/src/commands/create/wizard.tsx
+++ b/packages/cli/src/commands/create/wizard.tsx
@@ -1,15 +1,8 @@
 import type { ScaffoldOptions as CreateOptions } from '@agent-facets/engine'
 import { render } from 'ink'
-import type { AssetSectionKey } from '../../tui/context/form-state-context.ts'
 import { openInEditorSync } from '../../tui/editor.ts'
-import type { WizardSnapshot } from '../../tui/views/create/wizard.tsx'
+import type { EditorRequest, WizardSnapshot } from '../../tui/views/create/wizard.tsx'
 import { CreateWizard } from '../../tui/views/create/wizard.tsx'
-
-interface EditorRequest {
-  section: AssetSectionKey
-  name: string
-  description: string
-}
 
 export interface RunCreateWizardOptions {
   /** Write the scaffold to disk and return the list of created file paths. */
@@ -46,8 +39,8 @@ export async function runCreateWizardInk(options: RunCreateWizardOptions): Promi
           onSnapshot={(s) => {
             snapshot = s
           }}
-          onRequestEditor={(section, name, description) => {
-            pendingEditor = { section, name, description }
+          onRequestEditor={(request) => {
+            pendingEditor = request
             instance.clear()
             instance.unmount()
           }}
@@ -57,33 +50,56 @@ export async function runCreateWizardInk(options: RunCreateWizardOptions): Promi
       instance.waitUntilExit().then(() => resolve())
     })
 
-    if (pendingEditor) {
-      const req = pendingEditor as EditorRequest
-      const edited = openInEditorSync(req.description, `${req.name}.md`)
-      if (snapshot) {
-        const section = snapshot.form.assets[req.section]
-        snapshot = {
-          ...snapshot,
-          selectedItem: undefined,
-          form: {
-            ...snapshot.form,
-            assets: {
-              ...snapshot.form.assets,
-              [req.section]: {
-                ...section,
-                descriptions: {
-                  ...section.descriptions,
-                  ...(edited !== null ? { [req.name]: edited.trim() } : {}),
-                },
-              },
-            },
-          },
-        }
-      }
+    if (pendingEditor && snapshot) {
+      const req: EditorRequest = pendingEditor
+      snapshot = mergeEditorResult(snapshot, req)
     } else {
       done = true
     }
   }
 
   return completed
+}
+
+/**
+ * Open the external editor for one request and merge its result back into the
+ * wizard snapshot. Asset descriptions are trimmed (single-line semantics);
+ * README content is stored verbatim and marked authored so later identity edits
+ * never regenerate it.
+ */
+function mergeEditorResult(snapshot: WizardSnapshot, req: EditorRequest): WizardSnapshot {
+  if (req.kind === 'asset-description') {
+    const edited = openInEditorSync(req.content, `${req.name}.md`)
+    const section = snapshot.form.assets[req.section]
+    return {
+      ...snapshot,
+      selectedItem: undefined,
+      form: {
+        ...snapshot.form,
+        assets: {
+          ...snapshot.form.assets,
+          [req.section]: {
+            ...section,
+            descriptions: {
+              ...section.descriptions,
+              ...(edited !== null ? { [req.name]: edited.trim() } : {}),
+            },
+          },
+        },
+      },
+    }
+  }
+  // README: preserve exact author bytes; mark authored so it is never re-seeded.
+  const edited = openInEditorSync(req.content, 'README.md')
+  return {
+    ...snapshot,
+    selectedItem: undefined,
+    form: {
+      ...snapshot.form,
+      readme: {
+        ...snapshot.form.readme,
+        ...(edited !== null ? { draft: { origin: 'authored' as const, content: edited } } : {}),
+      },
+    },
+  }
 }

--- a/packages/cli/src/tui/context/__tests__/readme-state.test.tsx
+++ b/packages/cli/src/tui/context/__tests__/readme-state.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import type { ScaffoldReadme } from '@agent-facets/engine'
+import { render } from 'ink-testing-library'
+import { useEffect } from 'react'
+import { FormStateProvider, useFormState } from '../form-state-context.ts'
+
+/**
+ * Drives a sequence of form mutations on mount, then reports the narrowed
+ * `toCreateOptions().readme` on every render so assertions observe the settled
+ * state after React flushes updates.
+ */
+function Probe({
+  steps,
+  report,
+}: {
+  steps: (ctx: ReturnType<typeof useFormState>) => void
+  report: (r: ScaffoldReadme) => void
+}) {
+  const ctx = useFormState()
+  useEffect(() => {
+    steps(ctx)
+  }, [steps, ctx])
+  report(ctx.toCreateOptions().readme)
+  return null
+}
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+async function run(steps: (ctx: ReturnType<typeof useFormState>) => void): Promise<ScaffoldReadme> {
+  let result: ScaffoldReadme = { kind: 'disabled' }
+  const instance = render(
+    <FormStateProvider>
+      <Probe steps={steps} report={(r) => (result = r)} />
+    </FormStateProvider>,
+  )
+  await nextTick()
+  instance.unmount()
+  return result
+}
+
+describe('create README form state', () => {
+  test('README is enabled by default', async () => {
+    const readme = await run(() => {})
+    expect(readme.kind).toBe('enabled')
+  })
+
+  test('seeded content re-seeds from identity edits', async () => {
+    const readme = await run((ctx) => {
+      ctx.setFieldValue('name', 'my-facet')
+      ctx.setFieldValue('description', 'Neat tools')
+    })
+    if (readme.kind !== 'enabled') expect.unreachable()
+    expect(readme.content).toBe('# my-facet\n\nNeat tools\n')
+  })
+
+  test('authored content is preserved across later identity edits', async () => {
+    const readme = await run((ctx) => {
+      ctx.setFieldValue('name', 'my-facet')
+      ctx.setReadmeContent('# Custom\n\nHand-written docs.\n')
+      // A later identity edit MUST NOT regenerate the authored content.
+      ctx.setFieldValue('name', 'renamed')
+    })
+    if (readme.kind !== 'enabled') expect.unreachable()
+    expect(readme.content).toBe('# Custom\n\nHand-written docs.\n')
+  })
+
+  test('disable then re-enable preserves the draft', async () => {
+    const readme = await run((ctx) => {
+      ctx.setReadmeContent('# Kept\n')
+      ctx.setReadmeEnabled(false)
+      ctx.setReadmeEnabled(true)
+    })
+    if (readme.kind !== 'enabled') expect.unreachable()
+    expect(readme.content).toBe('# Kept\n')
+  })
+
+  test('disabled narrows to a disabled scaffold option', async () => {
+    const readme = await run((ctx) => {
+      ctx.setReadmeEnabled(false)
+    })
+    expect(readme).toEqual({ kind: 'disabled' })
+  })
+})

--- a/packages/cli/src/tui/context/focus-order-context.ts
+++ b/packages/cli/src/tui/context/focus-order-context.ts
@@ -8,7 +8,7 @@ import { createContext, createElement, useCallback, useContext, useMemo, useStat
  * toggle (`field-private`) uses Tab to flip Public/Private; ↓ still advances,
  * and Shift+Tab still moves backward.
  */
-export const TAB_TOGGLE_FOCUS_IDS: ReadonlySet<string> = new Set(['field-private'])
+export const TAB_TOGGLE_FOCUS_IDS: ReadonlySet<string> = new Set(['field-private', 'field-readme'])
 
 interface FocusOrderState {
   focusedId: string | null

--- a/packages/cli/src/tui/context/form-state-context.ts
+++ b/packages/cli/src/tui/context/form-state-context.ts
@@ -1,4 +1,4 @@
-import type { ScaffoldOptions as CreateOptions } from '@agent-facets/engine'
+import { type ScaffoldOptions as CreateOptions, readmeTemplate } from '@agent-facets/engine'
 import { validateAssetNameSegment } from '@agent-facets/protocol'
 import type { ReactNode } from 'react'
 import { createContext, createElement, useCallback, useContext, useMemo, useState } from 'react'
@@ -21,6 +21,22 @@ export interface AssetSectionState {
   adding: boolean
 }
 
+/**
+ * Create-wizard README state.
+ *
+ * `enabled` is the author's default-on/opt-out choice; the `draft` is always
+ * present so toggling README off and back on never loses authored content.
+ *
+ * `draft.origin` guards regeneration: while `seeded`, identity edits refresh
+ * the template; the first explicit README edit flips it to `authored` and it
+ * is then preserved verbatim across later identity edits (design D11 — "the
+ * generated template is an initial value only").
+ */
+export interface ReadmeState {
+  enabled: boolean
+  draft: { origin: 'seeded' | 'authored'; content: string }
+}
+
 export interface FormState {
   fields: {
     name: FieldState
@@ -34,6 +50,7 @@ export interface FormState {
   // in the manifest is a serialization concern handled at the output boundary
   // (scaffold generation for create, `buildManifest` for edit), not here.
   private: boolean
+  readme: ReadmeState
   assets: {
     skill: AssetSectionState
     command: AssetSectionState
@@ -52,6 +69,10 @@ interface FormStateContextValue {
 
   // Privacy operation
   setPrivate: (value: boolean) => void
+
+  // README operations
+  setReadmeEnabled: (value: boolean) => void
+  setReadmeContent: (content: string) => void
 
   // Asset operations
   addAsset: (section: AssetSectionKey, name: string) => void
@@ -74,6 +95,12 @@ const defaultAssetSection: AssetSectionState = {
   adding: false,
 }
 
+/** README defaults on for interactive create, seeded from the (empty) identity. */
+const defaultReadme: ReadmeState = {
+  enabled: true,
+  draft: { origin: 'seeded', content: readmeTemplate('', '') },
+}
+
 const defaultForm: FormState = {
   fields: {
     name: { value: '', status: 'empty' },
@@ -81,6 +108,7 @@ const defaultForm: FormState = {
     version: { value: '', status: 'empty' },
   },
   private: false,
+  readme: { enabled: defaultReadme.enabled, draft: { ...defaultReadme.draft } },
   assets: {
     skill: { ...defaultAssetSection },
     command: { ...defaultAssetSection },
@@ -93,13 +121,23 @@ const FormStateContext = createContext<FormStateContextValue>({
   setFieldValue: () => {},
   setFieldStatus: () => {},
   setPrivate: () => {},
+  setReadmeEnabled: () => {},
+  setReadmeContent: () => {},
   addAsset: () => {},
   removeAsset: () => {},
   renameAsset: () => {},
   setAssetDescription: () => {},
   setAssetAdding: () => {},
   setAssetEditing: () => {},
-  toCreateOptions: () => ({ name: '', version: '', description: '', skills: [], commands: [], agents: [] }),
+  toCreateOptions: () => ({
+    name: '',
+    version: '',
+    description: '',
+    skills: [],
+    commands: [],
+    agents: [],
+    readme: { kind: 'enabled', content: readmeTemplate('', '') },
+  }),
 })
 
 // --- Provider ---
@@ -108,13 +146,21 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
   const [form, setForm] = useState<FormState>(initialState ?? defaultForm)
 
   const setFieldValue = useCallback((field: RequiredFieldKey, value: string) => {
-    setForm((prev) => ({
-      ...prev,
-      fields: {
+    setForm((prev) => {
+      const fields = {
         ...prev.fields,
         [field]: { ...prev.fields[field], value },
-      },
-    }))
+      }
+      // While the README draft is still the seeded template, identity edits
+      // re-seed it from the new name/description. Once authored, it is frozen.
+      let readme = prev.readme
+      if ((field === 'name' || field === 'description') && prev.readme.draft.origin === 'seeded') {
+        const nextName = field === 'name' ? value : prev.fields.name.value
+        const nextDescription = field === 'description' ? value : prev.fields.description.value
+        readme = { ...prev.readme, draft: { origin: 'seeded', content: readmeTemplate(nextName, nextDescription) } }
+      }
+      return { ...prev, fields, readme }
+    })
   }, [])
 
   const setFieldStatus = useCallback((field: RequiredFieldKey, status: FieldStatus) => {
@@ -129,6 +175,15 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
 
   const setPrivate = useCallback((value: boolean) => {
     setForm((prev) => ({ ...prev, private: value }))
+  }, [])
+
+  const setReadmeEnabled = useCallback((value: boolean) => {
+    setForm((prev) => ({ ...prev, readme: { ...prev.readme, enabled: value } }))
+  }, [])
+
+  const setReadmeContent = useCallback((content: string) => {
+    // An explicit edit freezes the draft: identity edits no longer re-seed it.
+    setForm((prev) => ({ ...prev, readme: { ...prev.readme, draft: { origin: 'authored', content } } }))
   }, [])
 
   const addAsset = useCallback((section: AssetSectionKey, name: string) => {
@@ -235,6 +290,7 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
       skills: form.assets.skill.items,
       commands: form.assets.command.items,
       agents: form.assets.agent.items,
+      readme: form.readme.enabled ? { kind: 'enabled', content: form.readme.draft.content } : { kind: 'disabled' },
       // True-only: public is represented by omission, never `private: false`.
       ...(form.private ? { private: true } : {}),
     }),
@@ -247,6 +303,8 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
       setFieldValue,
       setFieldStatus,
       setPrivate,
+      setReadmeEnabled,
+      setReadmeContent,
       addAsset,
       removeAsset,
       renameAsset,
@@ -260,6 +318,8 @@ export function FormStateProvider({ children, initialState }: { children: ReactN
       setFieldValue,
       setFieldStatus,
       setPrivate,
+      setReadmeEnabled,
+      setReadmeContent,
       addAsset,
       removeAsset,
       renameAsset,

--- a/packages/cli/src/tui/views/__tests__/confirm-privacy.test.tsx
+++ b/packages/cli/src/tui/views/__tests__/confirm-privacy.test.tsx
@@ -13,6 +13,7 @@ function formWith(isPrivate: boolean): FormState {
       version: { value: '0.0.0', status: 'confirmed' },
     },
     private: isPrivate,
+    readme: { enabled: false, draft: { origin: 'seeded', content: '' } },
     assets: {
       skill: { items: ['cowsay'], descriptions: { cowsay: 'A skill' }, editing: undefined, adding: false },
       command: { items: [], descriptions: {}, editing: undefined, adding: false },
@@ -33,6 +34,7 @@ function renderCreate(isPrivate: boolean) {
             skills: ['cowsay'],
             agents: [],
             commands: [],
+            readme: { kind: 'disabled' },
             ...(isPrivate ? { private: true as const } : {}),
           }}
           onConfirm={() => {}}

--- a/packages/cli/src/tui/views/create/create-view.tsx
+++ b/packages/cli/src/tui/views/create/create-view.tsx
@@ -20,9 +20,19 @@ const ASSET_LABELS: Record<AssetType, string> = {
 }
 
 function computeFocusIds(form: ReturnType<typeof useFormState>['form']): string[] {
-  // NOTE: `field-private` sits between `field-version` and the asset controls.
-  // This focus list is duplicated in edit-view.tsx; keep both in lockstep.
-  const ids: string[] = ['field-name', 'field-description', 'field-version', 'field-private']
+  // NOTE: `field-private` sits between `field-version` and the asset controls,
+  // followed by the create-only README card (`field-readme`, `readme-edit-btn`).
+  // The identity/privacy prefix mirrors edit-view.tsx; the README card is
+  // create-only (edit routes README through its dedicated panel). Both README
+  // ids are always present so toggling README off never churns the focus set.
+  const ids: string[] = [
+    'field-name',
+    'field-description',
+    'field-version',
+    'field-private',
+    'field-readme',
+    'readme-edit-btn',
+  ]
 
   for (const type of ASSET_TYPES) {
     const section = form.assets[type]
@@ -42,11 +52,13 @@ function computeFocusIds(form: ReturnType<typeof useFormState>['form']): string[
 export function CreateView({
   onSubmit,
   onEditDescription,
+  onEditReadme,
 }: {
   onSubmit: () => void
   onEditDescription?: (section: import('../../context/form-state-context.ts').AssetSectionKey, name: string) => void
+  onEditReadme?: () => void
 }) {
-  const { form, setPrivate } = useFormState()
+  const { form, setPrivate, setReadmeEnabled } = useFormState()
   const { setFocusIds, focus, focusedId } = useFocusOrder()
 
   // Facet identity: an unscoped slug (`my-facet`) or a scoped `@scope/name`
@@ -140,8 +152,28 @@ export function CreateView({
         offLabel="Public"
         onToggle={setPrivate}
         dimmed={!assetsReady}
-        onConfirm={() => focus(`add-${ASSET_TYPES[0]}`)}
+        onConfirm={() => focus('field-readme')}
       />
+
+      <BooleanToggle
+        id="field-readme"
+        label="README"
+        value={form.readme.enabled}
+        onLabel="Enabled"
+        offLabel="Disabled"
+        onToggle={setReadmeEnabled}
+        dimmed={!assetsReady}
+        onConfirm={() => focus('readme-edit-btn')}
+      />
+
+      <Box marginLeft={2}>
+        <Button
+          id="readme-edit-btn"
+          label="[ Edit README ]"
+          disabled={!form.readme.enabled}
+          onPress={() => onEditReadme?.()}
+        />
+      </Box>
 
       {ASSET_TYPES.map((type) => (
         <Box key={type} marginTop={0}>

--- a/packages/cli/src/tui/views/create/wizard.tsx
+++ b/packages/cli/src/tui/views/create/wizard.tsx
@@ -21,6 +21,15 @@ export interface WizardSnapshot {
   }
 }
 
+/**
+ * An external-editor round-trip request. Tagged so an asset-description edit and
+ * a README-body edit cannot be confused: each arm carries exactly the content
+ * that must be handed to the editor and merged back on return.
+ */
+export type EditorRequest =
+  | { kind: 'asset-description'; section: AssetSectionKey; name: string; content: string }
+  | { kind: 'readme'; content: string }
+
 export interface CreateWizardProps {
   onComplete: (opts: CreateOptions) => void
   onCancel: () => void
@@ -30,7 +39,7 @@ export interface CreateWizardProps {
   buildArg?: string
   snapshot?: WizardSnapshot
   onSnapshot?: (snapshot: WizardSnapshot) => void
-  onRequestEditor?: (section: AssetSectionKey, name: string, description: string) => void
+  onRequestEditor?: (request: EditorRequest) => void
 }
 
 type Phase = 'editing' | 'confirming' | 'done'
@@ -76,10 +85,14 @@ function CreateWizardInner({
   const handleEditDescription = useCallback(
     (section: AssetSectionKey, name: string) => {
       const description = form.assets[section].descriptions[name] ?? ''
-      onRequestEditor?.(section, name, description)
+      onRequestEditor?.({ kind: 'asset-description', section, name, content: description })
     },
     [form, onRequestEditor],
   )
+
+  const handleEditReadme = useCallback(() => {
+    onRequestEditor?.({ kind: 'readme', content: form.readme.draft.content })
+  }, [form, onRequestEditor])
 
   const handleConfirm = useCallback(async () => {
     const opts = toCreateOptions()
@@ -118,6 +131,7 @@ function CreateWizardInner({
         setMode('form-confirmation')
       }}
       onEditDescription={handleEditDescription}
+      onEditReadme={handleEditReadme}
     />
   )
 }

--- a/packages/cli/src/tui/views/edit/manifest-to-form.ts
+++ b/packages/cli/src/tui/views/edit/manifest-to-form.ts
@@ -38,6 +38,10 @@ export function manifestToFormState(manifest: FacetManifest): FormState {
     // public UI state. The omission-vs-explicit-false distinction is preserved
     // at the output boundary (`buildManifest`), not carried in the form.
     private: manifest.private === true,
+    // Edit does not use the create-wizard README card (README is handled by the
+    // dedicated edit README panel and manifest preservation). This inert value
+    // satisfies the shared FormState shape without affecting edit output.
+    readme: { enabled: false, draft: { origin: 'seeded', content: '' } },
     assets,
   }
 }

--- a/packages/engine/src/__tests__/scaffold.test.ts
+++ b/packages/engine/src/__tests__/scaffold.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from 'bun:test'
-import { generateScaffoldManifest, type ScaffoldOptions } from '../scaffold/index.ts'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  generateScaffoldManifest,
+  previewScaffoldFiles,
+  type ScaffoldOptions,
+  type ScaffoldReadme,
+  writeScaffold,
+} from '../scaffold/index.ts'
 
 function baseOptions(overrides: Partial<ScaffoldOptions> = {}): ScaffoldOptions {
   return {
@@ -9,9 +18,12 @@ function baseOptions(overrides: Partial<ScaffoldOptions> = {}): ScaffoldOptions 
     skills: ['cowsay'],
     agents: [],
     commands: [],
+    readme: { kind: 'disabled' },
     ...overrides,
   }
 }
+
+const enabled = (content: string): ScaffoldReadme => ({ kind: 'enabled', content })
 
 describe('generateScaffoldManifest privacy', () => {
   test('omits `private` when public (option absent)', () => {
@@ -40,5 +52,79 @@ describe('generateScaffoldManifest privacy', () => {
   test('serialized manifest ends with a trailing newline', () => {
     const json = generateScaffoldManifest(baseOptions())
     expect(json.endsWith('}\n')).toBe(true)
+  })
+})
+
+describe('generateScaffoldManifest README declaration', () => {
+  test('declares top-level README.md when README is enabled', () => {
+    const manifest = JSON.parse(generateScaffoldManifest(baseOptions({ readme: enabled('# cowsay\n') })))
+    expect(manifest.files).toEqual(['README.md'])
+  })
+
+  test('omits the files declaration when README is disabled', () => {
+    const manifest = JSON.parse(generateScaffoldManifest(baseOptions({ readme: { kind: 'disabled' } })))
+    expect('files' in manifest).toBe(false)
+  })
+
+  test('declares README after asset sections', () => {
+    const json = generateScaffoldManifest(baseOptions({ readme: enabled('# cowsay\n') }))
+    const keys = Object.keys(JSON.parse(json))
+    expect(keys).toEqual(['name', 'version', 'description', 'skills', 'files'])
+  })
+})
+
+describe('previewScaffoldFiles', () => {
+  test('lists README.md immediately after the manifest when enabled', () => {
+    const files = previewScaffoldFiles(baseOptions({ readme: enabled('# cowsay\n') }))
+    expect(files).toEqual(['facet.json', 'README.md', 'skills/cowsay/SKILL.md'])
+  })
+
+  test('omits README.md when disabled', () => {
+    const files = previewScaffoldFiles(baseOptions({ readme: { kind: 'disabled' } }))
+    expect(files).toEqual(['facet.json', 'skills/cowsay/SKILL.md'])
+  })
+})
+
+describe('writeScaffold', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'facet-scaffold-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('writes manifest, README, and asset files atomically', async () => {
+    const files = await writeScaffold(baseOptions({ readme: enabled('# cowsay\n\nCowsay tools\n') }), dir)
+    expect(files).toEqual(['facet.json', 'README.md', 'skills/cowsay/SKILL.md'])
+    expect(existsSync(join(dir, 'facet.json'))).toBe(true)
+    expect(existsSync(join(dir, 'README.md'))).toBe(true)
+    expect(existsSync(join(dir, 'skills/cowsay/SKILL.md'))).toBe(true)
+  })
+
+  test('writes the exact provided README content verbatim', async () => {
+    const authored = '# Custom Title\n\nAuthored prose that must not be regenerated.\n'
+    await writeScaffold(baseOptions({ readme: enabled(authored) }), dir)
+    expect(readFileSync(join(dir, 'README.md'), 'utf8')).toBe(authored)
+  })
+
+  test('writes no README when disabled', async () => {
+    await writeScaffold(baseOptions({ readme: { kind: 'disabled' } }), dir)
+    expect(existsSync(join(dir, 'README.md'))).toBe(false)
+    const manifest = JSON.parse(readFileSync(join(dir, 'facet.json'), 'utf8'))
+    expect('files' in manifest).toBe(false)
+  })
+
+  test('rolls back to preexisting content when a write fails', async () => {
+    // Pre-seed a manifest, then make skills/ a FILE so the SKILL.md write fails
+    // (cannot mkdir a directory under an existing file).
+    writeFileSync(join(dir, 'facet.json'), 'ORIGINAL')
+    writeFileSync(join(dir, 'skills'), 'not a directory')
+
+    await expect(writeScaffold(baseOptions({ readme: enabled('# cowsay\n') }), dir)).rejects.toThrow()
+
+    // Manifest restored to its original bytes; README not left behind.
+    expect(readFileSync(join(dir, 'facet.json'), 'utf8')).toBe('ORIGINAL')
+    expect(existsSync(join(dir, 'README.md'))).toBe(false)
   })
 })

--- a/packages/engine/src/fs-transaction.ts
+++ b/packages/engine/src/fs-transaction.ts
@@ -1,0 +1,123 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+/**
+ * A shared, engine-owned multi-file transaction.
+ *
+ * Both scaffold (`facet create`) and edit (`facet edit`) apply a batch of
+ * file writes and deletions that must land as a unit: `facet.json`,
+ * `README.md`, starter asset files, companion files. A partial application
+ * — the manifest written but a file write failing — leaves the project in a
+ * state that declares an asset it has no file for, or vice versa.
+ *
+ * This module captures a preimage of every affected path before mutating
+ * anything, applies each mutation atomically (tmp + rename for writes), and
+ * on any handled failure restores every preimage. Expected filesystem
+ * failures are returned as discriminated data, never thrown, so callers that
+ * can recover (the edit apply path) discriminate on the result.
+ *
+ * Rollback is best-effort in the same sense as the install journal: if a
+ * restore step itself fails, `rollback.ok` is `false` and the failing paths
+ * are reported, but the transaction still returns rather than throwing.
+ */
+
+/** A single planned mutation against an exact absolute path. */
+export type FsMutation = { kind: 'write'; path: string; bytes: Uint8Array } | { kind: 'delete'; path: string }
+
+/** Preimage of one affected path, captured before any mutation runs. */
+type Preimage = { path: string; existed: false } | { path: string; existed: true; bytes: Uint8Array }
+
+/** Outcome of a best-effort rollback after a failed apply. */
+export type FsRollback = { ok: true } | { ok: false; failedPaths: string[] }
+
+/** Result of applying a transaction. */
+export type FsTransactionResult =
+  | { ok: true }
+  | {
+      ok: false
+      /** The exact path whose mutation failed. */
+      failedPath: string
+      /** Human-readable reason (the caught error's message). */
+      reason: string
+      /** Whether every prior mutation was successfully reverted. */
+      rollback: FsRollback
+    }
+
+function capturePreimage(path: string): Preimage {
+  if (!existsSync(path)) return { path, existed: false }
+  return { path, existed: true, bytes: readFileSync(path) }
+}
+
+function applyMutation(mutation: FsMutation): void {
+  if (mutation.kind === 'write') {
+    mkdirSync(dirname(mutation.path), { recursive: true })
+    // tmp + rename so a reader never observes a half-written file.
+    const tmp = `${mutation.path}.tmp`
+    writeFileSync(tmp, mutation.bytes)
+    renameSync(tmp, mutation.path)
+    return
+  }
+  // delete: a missing target is not an error — the desired end state is "gone".
+  rmSync(mutation.path, { force: true })
+}
+
+function restorePreimage(preimage: Preimage): void {
+  if (!preimage.existed) {
+    // Path did not exist before the transaction; ensure it does not exist now.
+    rmSync(preimage.path, { force: true })
+    return
+  }
+  mkdirSync(dirname(preimage.path), { recursive: true })
+  const tmp = `${preimage.path}.tmp`
+  writeFileSync(tmp, preimage.bytes)
+  renameSync(tmp, preimage.path)
+}
+
+/**
+ * Apply `mutations` as a unit. On success every mutation is committed; on the
+ * first failure, all captured preimages are restored (LIFO) and the result
+ * carries the failed path plus rollback status.
+ */
+export function applyFsTransaction(mutations: readonly FsMutation[]): FsTransactionResult {
+  // Capture preimages for every distinct affected path before touching disk.
+  const seen = new Set<string>()
+  const preimages: Preimage[] = []
+  for (const mutation of mutations) {
+    if (seen.has(mutation.path)) continue
+    seen.add(mutation.path)
+    preimages.push(capturePreimage(mutation.path))
+  }
+
+  const applied: FsMutation[] = []
+  for (const mutation of mutations) {
+    try {
+      applyMutation(mutation)
+      applied.push(mutation)
+    } catch (err) {
+      const rollback = rollbackApplied(preimages)
+      return {
+        ok: false,
+        failedPath: mutation.path,
+        reason: err instanceof Error ? err.message : String(err),
+        rollback,
+      }
+    }
+  }
+
+  return { ok: true }
+}
+
+function rollbackApplied(preimages: readonly Preimage[]): FsRollback {
+  const failedPaths: string[] = []
+  // Restore in reverse capture order so nested-directory creation unwinds cleanly.
+  for (let i = preimages.length - 1; i >= 0; i--) {
+    const preimage = preimages[i]
+    if (!preimage) continue
+    try {
+      restorePreimage(preimage)
+    } catch {
+      failedPaths.push(preimage.path)
+    }
+  }
+  return failedPaths.length === 0 ? { ok: true } : { ok: false, failedPaths }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -173,6 +173,9 @@ export {
 // manifest project files (I/O bridge)
 export type { LoadFacetsJsonResult } from './manifest/project-files.ts'
 export { loadFacetsJson, writeFacetsJson } from './manifest/project-files.ts'
+// readme (shared by scaffold + edit)
+export type { ReadmePath } from './readme.ts'
+export { isReadmePath, README_EXTENSIONLESS, README_MD, README_PATHS, readmeTemplate } from './readme.ts'
 // registry
 export type {
   DiscoverArtifactResult,
@@ -222,7 +225,7 @@ export {
   writeCredentialsToken,
 } from './registry/index.ts'
 // scaffold
-export type { ScaffoldOptions } from './scaffold/index.ts'
+export type { ScaffoldOptions, ScaffoldReadme } from './scaffold/index.ts'
 export {
   agentTemplate,
   commandTemplate,

--- a/packages/engine/src/readme.ts
+++ b/packages/engine/src/readme.ts
@@ -1,0 +1,34 @@
+/**
+ * Canonical README support shared by scaffold (`facet create`) and edit
+ * (`facet edit`). Both conventional paths are recognized as first-class facet
+ * documents; `README.md` is the preferred authored form and the default for
+ * new creation. Neither gets a README-specific manifest field — they are
+ * ordinary top-level `files` declarations.
+ */
+
+/** The preferred conventional README path and the default for new creation. */
+export const README_MD = 'README.md'
+
+/** The extensionless conventional README path, also first-class. */
+export const README_EXTENSIONLESS = 'README'
+
+/** Both exact conventional README paths, each managed independently. */
+export const README_PATHS = [README_MD, README_EXTENSIONLESS] as const
+
+export type ReadmePath = (typeof README_PATHS)[number]
+
+/** True for exactly the two conventional README paths. */
+export function isReadmePath(path: string): path is ReadmePath {
+  return path === README_MD || path === README_EXTENSIONLESS
+}
+
+/**
+ * Seed initial `README.md` content from the facet identity. This is an initial
+ * value only: once an author edits it, callers MUST preserve the authored bytes
+ * and MUST NOT re-seed from later identity edits.
+ */
+export function readmeTemplate(name: string, description: string): string {
+  const heading = `# ${name}\n`
+  const body = description.trim().length > 0 ? `\n${description.trim()}\n` : ''
+  return `${heading}${body}`
+}

--- a/packages/engine/src/scaffold/index.ts
+++ b/packages/engine/src/scaffold/index.ts
@@ -1,9 +1,19 @@
-import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { FACET_MANIFEST_FILE } from '@agent-facets/protocol'
+import { applyFsTransaction, type FsMutation } from '../fs-transaction.ts'
 import { jsonFileText } from '../json-file-text.ts'
+import { README_MD } from '../readme.ts'
 
 // --- Types ---
+
+/**
+ * README scaffolding intent, narrowed from the create UI / headless flags. The
+ * enabled arm carries the exact content to write verbatim (seeded or authored);
+ * the engine never regenerates it. Disabled writes no README file or
+ * declaration. Tagged so an "enabled but no content" or "disabled but has
+ * content" state is unrepresentable.
+ */
+export type ScaffoldReadme = { kind: 'enabled'; content: string } | { kind: 'disabled' }
 
 export interface ScaffoldOptions {
   name: string
@@ -18,6 +28,10 @@ export interface ScaffoldOptions {
   skills: string[]
   agents: string[]
   commands: string[]
+  // README scaffolding intent. Required and tagged: callers decide the
+  // default-on policy (interactive/headless create) and hand the engine an
+  // explicit enabled/disabled decision.
+  readme: ScaffoldReadme
 }
 
 // --- Defaults ---
@@ -141,6 +155,12 @@ export function generateScaffoldManifest(opts: ScaffoldOptions): string {
     manifest.commands = commands
   }
 
+  // README is an ordinary top-level supplementary declaration — no
+  // README-specific manifest field. Declared last, after asset sections.
+  if (opts.readme.kind === 'enabled') {
+    manifest.files = [README_MD]
+  }
+
   return jsonFileText(manifest)
 }
 
@@ -148,6 +168,9 @@ export function generateScaffoldManifest(opts: ScaffoldOptions): string {
 
 export function previewScaffoldFiles(opts: ScaffoldOptions): string[] {
   const files: string[] = [FACET_MANIFEST_FILE]
+  if (opts.readme.kind === 'enabled') {
+    files.push(README_MD)
+  }
   for (const skill of opts.skills) {
     files.push(`skills/${skill}/SKILL.md`)
   }
@@ -162,34 +185,65 @@ export function previewScaffoldFiles(opts: ScaffoldOptions): string[] {
 
 // --- Scaffold writing ---
 
-export async function writeScaffold(opts: ScaffoldOptions, targetDir: string): Promise<string[]> {
-  const files: string[] = []
-
-  // Write manifest
-  const manifestPath = join(targetDir, FACET_MANIFEST_FILE)
-  await Bun.write(manifestPath, generateScaffoldManifest(opts))
-  files.push(FACET_MANIFEST_FILE)
-
-  // Write skill files (Agent Skills directory convention: skills/<name>/SKILL.md)
+/**
+ * Derive the exact, ordered set of file mutations for a scaffold. Kept pure so
+ * both `writeScaffold` and its tests can inspect the planned bytes without
+ * touching disk. Order matches `previewScaffoldFiles`.
+ */
+function scaffoldMutations(opts: ScaffoldOptions, targetDir: string): FsMutation[] {
+  const encoder = new TextEncoder()
+  const mutations: FsMutation[] = [
+    {
+      kind: 'write',
+      path: join(targetDir, FACET_MANIFEST_FILE),
+      bytes: encoder.encode(generateScaffoldManifest(opts)),
+    },
+  ]
+  if (opts.readme.kind === 'enabled') {
+    mutations.push({ kind: 'write', path: join(targetDir, README_MD), bytes: encoder.encode(opts.readme.content) })
+  }
+  // Agent Skills directory convention: skills/<name>/SKILL.md
   for (const skill of opts.skills) {
-    await mkdir(join(targetDir, 'skills', skill), { recursive: true })
-    await Bun.write(join(targetDir, `skills/${skill}/SKILL.md`), skillTemplate(skill))
-    files.push(`skills/${skill}/SKILL.md`)
+    mutations.push({
+      kind: 'write',
+      path: join(targetDir, `skills/${skill}/SKILL.md`),
+      bytes: encoder.encode(skillTemplate(skill)),
+    })
   }
-
-  // Write agent files
   for (const agent of opts.agents) {
-    await mkdir(join(targetDir, 'agents'), { recursive: true })
-    await Bun.write(join(targetDir, `agents/${agent}.md`), agentTemplate(agent))
-    files.push(`agents/${agent}.md`)
+    mutations.push({
+      kind: 'write',
+      path: join(targetDir, `agents/${agent}.md`),
+      bytes: encoder.encode(agentTemplate(agent)),
+    })
   }
-
-  // Write command files
   for (const command of opts.commands) {
-    await mkdir(join(targetDir, 'commands'), { recursive: true })
-    await Bun.write(join(targetDir, `commands/${command}.md`), commandTemplate(command))
-    files.push(`commands/${command}.md`)
+    mutations.push({
+      kind: 'write',
+      path: join(targetDir, `commands/${command}.md`),
+      bytes: encoder.encode(commandTemplate(command)),
+    })
   }
+  return mutations
+}
 
-  return files
+/**
+ * Write a scaffold as one atomic transaction: `facet.json`, README (when
+ * enabled), and every starter asset commit together, or the target directory is
+ * left as it was. Returns the list of relative paths written on success.
+ *
+ * A transaction failure here is an environment-level filesystem error with no
+ * caller recovery path (create has nowhere to fall back to), so it is thrown
+ * after rollback rather than returned. The transaction primitive itself is
+ * result-shaped for the edit apply path, which can recover.
+ */
+export async function writeScaffold(opts: ScaffoldOptions, targetDir: string): Promise<string[]> {
+  const result = applyFsTransaction(scaffoldMutations(opts, targetDir))
+  if (!result.ok) {
+    throw new Error(
+      `scaffold write failed at ${result.failedPath}: ${result.reason}` +
+        (result.rollback.ok ? '' : ` (rollback incomplete: ${result.rollback.failedPaths.join(', ')})`),
+    )
+  }
+  return previewScaffoldFiles(opts)
 }


### PR DESCRIPTION
### Why

Tasks 12 and 13.1–13.2 are complete. This adds first-class README scaffolding to `facet create`: the wizard and headless paths both produce a `README.md` by default, seeded from the facet name and description, with an explicit opt-out via `--no-readme`.

### Details

**README state model (`ReadmeState` / `ScaffoldReadme`)**
The form tracks a `draft` with an `origin` field (`seeded` | `authored`). While `seeded`, identity edits (name, description) automatically regenerate the template. The first explicit edit — either through the in-wizard editor button or the external editor round-trip — flips origin to `authored`, after which the content is frozen regardless of later identity changes. Toggling README off and back on never discards the draft, so authored content survives a disable/re-enable cycle.

**Manifest declaration**
An enabled README is declared as an ordinary `files: ["README.md"]` top-level entry — no README-specific manifest field. The declaration is written last, after asset sections. A disabled README produces no `files` key.

**Atomic scaffold writes (`fs-transaction.ts`)**
`writeScaffold` previously wrote files sequentially with no rollback. It now builds a list of `FsMutation` values and applies them through `applyFsTransaction`, which captures a preimage of every affected path before touching disk, applies each mutation via tmp-then-rename, and restores all preimages in reverse order on any failure. The transaction result is discriminated data for callers that can recover (the future edit apply path); `writeScaffold` itself throws on failure since create has no fallback.

**Wizard editor round-trips**
`onRequestEditor` previously took `(section, name, description)` positional arguments. It now receives a tagged `EditorRequest` union (`asset-description` | `readme`) so the two editor flows cannot be confused and each arm carries exactly the fields it needs. `mergeEditorResult` in `wizard.tsx` dispatches on the tag: asset descriptions are trimmed (single-line semantics); README content is stored verbatim and marked `authored`.

**Headless parity**
`decideCreate` seeds the same `readmeTemplate(name, description)` the wizard uses, so headless and interactive create never diverge by default. `--no-readme` (parsed as `readme: false`) produces `{ kind: 'disabled' }`.

**Edit isolation**
`manifestToFormState` sets an inert `readme: { enabled: false, draft: { origin: 'seeded', content: '' } }` to satisfy the shared `FormState` shape. The edit flow routes README through its own dedicated panel and is unaffected by this field.

### Verification

New and updated unit tests cover: default-enabled README in headless mode, `--no-readme` opt-out, authored-content freeze across identity edits, disable/re-enable draft preservation, manifest declaration presence and ordering, `previewScaffoldFiles` ordering, `writeScaffold` verbatim content, disabled-README omission, and transactional rollback when a write fails mid-batch. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Create/scaffold path only; behavior is additive with explicit opt-out and transactional writes reduce partial-failure risk. Edit authoring for supplementary files remains future work.
> 
> **Overview**
> Adds **default-on `README.md` scaffolding** to `facet create`, aligned with the non-asset-files work (tasks 13.1–13.2).
> 
> **Engine:** `ScaffoldOptions` now requires a tagged `readme` (`enabled` with verbatim content, or `disabled`). Enabled READMEs are written as `README.md` and declared via ordinary top-level `files: ["README.md"]` (no README-specific manifest field). Shared helpers live in `readme.ts` (`readmeTemplate`, path constants). `writeScaffold` applies manifest + README + assets through new **`applyFsTransaction`** (preimage capture, tmp+rename writes, rollback on failure).
> 
> **CLI:** Interactive create gets README **toggle**, **Edit README** (external editor), and form state with **seeded vs authored** drafts—identity edits re-seed only while seeded; authored bytes stay frozen. Headless create seeds the same template by default; **`--no-readme`** opts out without forcing headless mode. Editor round-trips use a tagged **`EditorRequest`** union (`asset-description` | `readme`). Existing e2e scaffolds pass `readme: { kind: 'disabled' }` where README is irrelevant.
> 
> **Tests:** Engine scaffold/manifest/preview/rollback coverage; headless README defaults; TUI README state tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f652119c7d3d05030455eed2cc98000be1efe14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->