### PR TITLE
Add held agent-facets CLI release gate for supplementary-file activation

### DIFF
--- a/.changeset/activate-supplementary-files.md
+++ b/.changeset/activate-supplementary-files.md
@@ -1,0 +1,15 @@
+---
+'agent-facets': minor
+---
+
+**BREAKING (pre-1.0 minor):** activate supplementary-file support, archive and lockfile format `0.2`, and adapter API `0.1`.
+
+Every `facet build` now emits `facetVersion: 0.2` with a complete per-entry hash map. Facets can explicitly declare opaque supplementary files: skill companions install and remove atomically with their owning skill, while root and other archive-only files remain integrity-protected without being materialized. Valid legacy `0.1` archives remain installable during the compatibility window.
+
+Current lockfiles and machine-local receipts use format `0.2` with canonical per-file integrity and ownership records, enabling exact-path drift reporting, repair, rollback, and offline removal without deleting unowned files.
+
+`facet create` writes and declares an editable `README.md` by default, with `--no-readme` as the headless opt-out. `facet edit` manages both `README.md` and the extensionless `README` and reconciles supplementary declarations transactionally.
+
+New manifests require single-segment Agent Skills names, and skills and commands cannot share a name. Existing published `0.1` archives retain legacy naming behavior, but affected source manifests must be renamed before rebuilding as `0.2`.
+
+This CLI supports only the tagged adapter API `0.1`. Positional `0.0` adapters fail closed before contract calls or project mutation with reinstall guidance. Rebuild custom adapters against the current `@agent-facets/adapter` SDK and reinstall incompatible adapters before continuing.


### PR DESCRIPTION
**HELD — do not merge until authorized.**

This draft is the sole activation lever for the `support-non-asset-files` change: a single CLI-only pre-1.0 minor Changeset for `agent-facets`. It contains exactly one file — `.changeset/activate-supplementary-files.md` — and nothing else.

## What merging this does

Once merged and versioned, the released CLI flips to the already-implemented and already-merged behavior:

- `facet build` emits archive `0.2` with a complete per-entry hash map
- lockfiles/receipts use format `0.2`
- skill companions materialize atomically with their owning skill
- first-class `README` authoring in create/edit
- the CLI supported adapter API becomes exactly `{0.1}` (positional `0.0` adapters fail closed with reinstall guidance)

Projected release: **`agent-facets@0.29.0`**. No protocol or adapter changeset is included.

## Merge conditions (all required before this leaves draft)

1. The source/readiness stack through #461 is merged.
2. The adapter SDK + all three first-party adapters have published `facetAdapterApiVersion: 0.1` (16.6).
3. The deployed registry's dual-format behavior is verified (16.7).
4. A candidate `0.2` archive round-trips against the stage registry (16.8).
5. The full repository suite and strict OpenSpec validation pass (16.4/16.9).
6. **The user explicitly authorizes the Changesets version-and-publish sequence.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application code changes—only a release metadata file; operational risk is limited to timing of the version/publish sequence relative to the PR’s stated merge conditions.
> 
> **Overview**
> Adds a single **Changesets** entry (`.changeset/activate-supplementary-files.md`) that bumps **`agent-facets`** with a **pre-1.0 minor** and records the user-facing release notes for behavior already merged on `main`.
> 
> Merging and running the version/publish flow is the **activation lever**: it does not change runtime code in this diff, but it schedules the next CLI release so shipped **`agent-facets`** documents and changelog reflect archive **`0.2`**, lockfile/receipt **`0.2`**, supplementary skill companions, default **`README.md`** in create/edit, stricter manifest naming, and **adapter API `0.1` only** (positional **`0.0`** adapters fail closed). The changeset text is the authoritative consumer-facing summary of that flip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0025d6a0d4f3e5bb20bb2c11bf9a53c5e5f7438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->