### PR TITLE
Decouple linked changeset versioning for agent-facets packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": ["@changesets/changelog-github", { "repo": "agent-facets/facets" }],
   "commit": false,
   "fixed": [],
-  "linked": [["agent-facets", "@agent-facets/adapter", "@agent-facets/protocol"]],
+  "linked": [],
   "ignore": ["@agent-facets/engine", "@agent-facets/common"],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
### Why

The packages `agent-facets`, `@agent-facets/adapter`, and `@agent-facets/protocol` were previously linked in the changeset configuration, meaning they would always share the same version. Decoupling them allows each package to be versioned independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-config only; no runtime code changes, though future releases may diverge in version numbers across those packages.
> 
> **Overview**
> Removes the Changesets **linked** group that tied `agent-facets`, `@agent-facets/adapter`, and `@agent-facets/protocol` to a single shared version. **`linked` is now `[]`**, so each of those packages can ship its own semver on the next release instead of moving in lockstep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782f99d43bf7e6ff638d7f0f0f994136e241d47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->