### PR TITLE
Correct 0.2 archive minimum-release mapping to the activation version 0.29.0

### DIFF
--- a/packages/cli/src/util/__tests__/archive-compatibility.test.ts
+++ b/packages/cli/src/util/__tests__/archive-compatibility.test.ts
@@ -7,7 +7,7 @@ describe('archiveCompatibilityGuidance', () => {
     expect(g.what).toContain('archive format 0.2')
     expect(g.detail).toContain('supported archive formats: 0.1')
     // Known format → concrete minimum release, not a bare "update to latest".
-    expect(g.fix).toContain('0.31.0 or later')
+    expect(g.fix).toContain('0.29.0 or later')
   })
 
   test('advises updating to latest for an unknown future format without inventing a minimum', () => {

--- a/packages/cli/src/util/archive-compatibility.ts
+++ b/packages/cli/src/util/archive-compatibility.ts
@@ -31,7 +31,7 @@ const MINIMUM_RELEASE_FOR_FORMAT: Readonly<Record<string, string>> = {
   // The first `agent-facets` release that emits/consumes the `0.2` archive
   // format. A CLI that supports `0.2` never renders `0.2` as unsupported; this
   // entry is what an *older* pre-`0.2` CLI is told to update to.
-  '0.2': '0.31.0',
+  '0.2': '0.29.0',
 }
 
 export interface ArchiveCompatibilityGuidance {


### PR DESCRIPTION
## Why

The held CLI activation changeset (#462) projects **`agent-facets@0.29.0`**, not `0.31.0`. When the linked changeset group was decoupled (#464), `agent-facets` began versioning off its own `0.28.0` baseline plus one minor, rather than tracking protocol's higher version line.

The archive-format compatibility table still named `0.31.0` as the first `0.2`-supporting release (set provisionally during the 16.4 readiness work). An older, pre-`0.2` CLI encountering a `0.2` archive would be told to `Update agent-facets to 0.31.0 or later` — a version that skips the actual first `0.2` release.

## Change

- `MINIMUM_RELEASE_FOR_FORMAT['0.2']`: `0.31.0` → **`0.29.0`**
- Its unit test assertion updated to match.

## Sequencing

This must land on `main` **before** #462 is versioned/released, so the shipped `0.29.0` binary carries the correct self-referential mapping. It is intentionally separate from the held changeset PR (#462), which stays changeset-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes upgrade guidance text for unsupported archive formats; no runtime behavior or security impact.
> 
> **Overview**
> Corrects the **archive format compatibility** mapping so pre-`0.2` CLIs are told to upgrade to **`0.29.0 or later`**, not `0.31.0`, when they hit a `0.2` archive.
> 
> Updates `MINIMUM_RELEASE_FOR_FORMAT['0.2']` in `archive-compatibility.ts` and the matching unit test expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748ce778f4b191caaa16e54ea1fc24453e04d97e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->