### PR TITLE
Refresh `facet instructions` for 0.29.0: generated topic index, typed topic registry, and updated authoring/usage/manifest guidance

### DIFF
--- a/.changeset/smart-goats-hug.md
+++ b/.changeset/smart-goats-hug.md
@@ -1,0 +1,9 @@
+---
+"agent-facets": patch
+---
+
+Refresh `facet instructions` for the 0.29.0 CLI. The default overview now opens
+with a generated index of every instruction topic (derived from one typed topic
+registry, so it can't drift), and the topic prompts now cover README and
+supplementary-file authoring, current single-segment asset naming and the shared
+skill/command namespace, and adapter API `0.1` compatibility recovery.

--- a/docs/cli/instructions.mdx
+++ b/docs/cli/instructions.mdx
@@ -11,7 +11,7 @@ facet instructions [topic]
 
 `facet instructions` prints agent-oriented usage guidance for the CLI. It is **for AI agents**: workflow guidance that tells an autonomous agent how to author and use facets, rather than per-flag help (for that, use `facet <command> --help`).
 
-The default topic is `overview`. It routes the agent to the right domain — authoring a facet, or using facets in a project — and indexes the other topics.
+The default topic is `overview`. It opens with a generated index of every instruction topic, then routes the agent to the right domain — authoring a facet, or using facets in a project. The index is generated from the CLI's own topic list, so it always lists exactly the topics the CLI serves.
 
 <Note>
   Requires the facet CLI **v0.24.0 or newer**. If `facet instructions` reports *"Unknown command"*, update with [`facet self-update`](/cli/self-update).
@@ -20,19 +20,19 @@ The default topic is `overview`. It routes the agent to the right domain — aut
 ## Topics
 
 <ResponseField name="overview" type="default">
-  What facets are, the three artifact files, and the two workflows: authoring vs. using.
+  What facets are, the three artifact files, the two workflows (authoring vs. using), and a generated index of every topic.
 </ResponseField>
 
 <ResponseField name="manifest" type="topic">
-  The `facet.json` structure, plus the JSON Schema generated live from the schema definition.
+  The `facet.json` structure — including top-level and per-skill supplementary `files` — plus the JSON Schema generated live from the schema definition.
 </ResponseField>
 
 <ResponseField name="authoring" type="topic">
-  Writing facets: scaffold → modify → verify, including per-asset adapter configuration.
+  Writing facets: scaffold → modify → verify, including README and supplementary-file authoring and per-asset adapter configuration.
 </ResponseField>
 
 <ResponseField name="usage" type="topic">
-  Project management: add/update/remove facets (registry-first), and install adapter tooling.
+  Project management: add/update/remove facets (registry-first), and install adapter tooling (including adapter API `0.1` recovery).
 </ResponseField>
 
 ```sh
@@ -51,7 +51,7 @@ facet instructions usage      # how to use facets in a project
 
 ## The manifest schema is generated
 
-The `manifest` topic appends the `facet.json` **JSON Schema generated at runtime from the schema definition** — it is never a hand-maintained copy, so it always matches the CLI you are running. The narrow business rules the schema cannot express (at least one asset, kebab-case asset names, valid facet name) are described in prose alongside it; run [`facet build --verify`](/cli/authoring/build) to check them against a real facet.
+The `manifest` topic appends the `facet.json` **JSON Schema generated at runtime from the schema definition** — it is never a hand-maintained copy, so it always matches the CLI you are running. The narrow business rules the schema cannot express (at least one asset, single-segment asset names, a skill and command not sharing a name, exact and collision-free supplementary `files` paths, a valid facet name) are described in prose alongside it; run [`facet build --verify`](/cli/authoring/build) to check them against a real facet.
 
 ## Related commands
 

--- a/packages/cli/src/__tests__/instructions.e2e.test.ts
+++ b/packages/cli/src/__tests__/instructions.e2e.test.ts
@@ -23,16 +23,41 @@ describe('facet instructions', () => {
     expect(result.stdout).toContain('facet instructions authoring')
   })
 
-  test('usage topic leads with the registry', async () => {
+  test('default output opens with a topic index listing every topic', async () => {
+    const result = await runCli('instructions')
+    expect(result.exitCode).toBe(0)
+    const indexAt = result.stdout.indexOf('Instruction topics')
+    expect(indexAt).toBeGreaterThanOrEqual(0)
+    for (const topic of ['overview', 'manifest', 'authoring', 'usage']) {
+      expect(result.stdout).toContain(`facet instructions ${topic}`)
+    }
+    // The index appears before the workflow routing, so an agent sees it first.
+    expect(indexAt).toBeLessThan(result.stdout.indexOf('AUTHORING a facet'))
+    // The injection marker must never leak into the printed output.
+    expect(result.stdout).not.toContain('{{TOPIC_INDEX}}')
+  })
+
+  test('authoring topic covers README and supplementary-file authoring', async () => {
+    const result = await runCli('instructions', 'authoring')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('--no-readme')
+    expect(result.stdout).toContain('README.md')
+    expect(result.stdout).toContain('facet build --verify')
+  })
+
+  test('usage topic leads with the registry and covers adapter compatibility', async () => {
     const result = await runCli('instructions', 'usage')
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('agentfacets.io')
     expect(result.stdout).toContain('facet add viper-plans')
+    expect(result.stdout).toContain('adapter API 0.1')
+    expect(result.stdout).toContain('facet adapter list')
   })
 
-  test('manifest topic appends the generated JSON Schema', async () => {
+  test('manifest topic documents supplementary files and appends the generated JSON Schema', async () => {
     const result = await runCli('instructions', 'manifest')
     expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('archive-only')
     // The generated JSON Schema follows the "(generated)" marker; the prose
     // above it also contains braces, so split on the marker rather than the
     // first `{`.

--- a/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
+++ b/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
@@ -1,24 +1,86 @@
 import { describe, expect, test } from 'bun:test'
 import { FacetManifestSchema } from '@agent-facets/protocol'
-import { DEFAULT_TOPIC, INSTRUCTION_TOPICS, isInstructionTopic, PROMPTS } from '../../../prompts/index.ts'
+import {
+  DEFAULT_TOPIC,
+  INSTRUCTION_TOPICS,
+  isInstructionTopic,
+  promptFor,
+  renderTopicIndex,
+  TOPICS,
+} from '../../../prompts/index.ts'
 import { instructionsCommand } from '../index.ts'
 
 describe('instruction topics', () => {
-  test('default topic is overview and is present', () => {
+  test('default topic is overview and has a non-empty prompt', () => {
     expect(DEFAULT_TOPIC).toBe('overview')
-    expect(PROMPTS.overview.length).toBeGreaterThan(0)
+    expect(TOPICS.overview.prompt.length).toBeGreaterThan(0)
   })
 
-  test('all four domain topics exist and are non-empty', () => {
+  test('all four domain topics exist with a prompt and a summary', () => {
     expect(INSTRUCTION_TOPICS.sort()).toEqual(['authoring', 'manifest', 'overview', 'usage'])
     for (const topic of INSTRUCTION_TOPICS) {
-      expect(PROMPTS[topic].length).toBeGreaterThan(0)
+      expect(TOPICS[topic].prompt.length).toBeGreaterThan(0)
+      expect(TOPICS[topic].summary.length).toBeGreaterThan(0)
     }
   })
 
   test('isInstructionTopic narrows valid and rejects invalid', () => {
     expect(isInstructionTopic('authoring')).toBe(true)
     expect(isInstructionTopic('nope')).toBe(false)
+  })
+})
+
+describe('topic index', () => {
+  test('renders one line per topic, each with its invocation and summary', () => {
+    const index = renderTopicIndex()
+    expect(index).toContain('Instruction topics')
+    for (const topic of INSTRUCTION_TOPICS) {
+      expect(index).toContain(`facet instructions ${topic}`)
+      expect(index).toContain(TOPICS[topic].summary)
+    }
+  })
+
+  test('overview prompt substitutes the generated index before workflow routing', () => {
+    const overview = promptFor('overview')
+    // The marker must be replaced, not printed literally.
+    expect(overview).not.toContain('{{TOPIC_INDEX}}')
+    // Every topic is listed, and the index precedes the AUTHORING/USING routing.
+    for (const topic of INSTRUCTION_TOPICS) {
+      expect(overview).toContain(`facet instructions ${topic}`)
+    }
+    expect(overview.indexOf('Instruction topics')).toBeLessThan(overview.indexOf('AUTHORING a facet'))
+  })
+
+  test('non-overview prompts are returned verbatim (no marker substitution)', () => {
+    for (const topic of INSTRUCTION_TOPICS) {
+      if (topic === 'overview') continue
+      expect(promptFor(topic)).toBe(TOPICS[topic].prompt)
+    }
+  })
+})
+
+describe('0.29 guidance is present in the prompts', () => {
+  test('authoring covers README default, --no-readme, top-level files, and verify', () => {
+    const authoring = TOPICS.authoring.prompt
+    expect(authoring).toContain('README.md')
+    expect(authoring).toContain('--no-readme')
+    expect(authoring).toContain('"files"')
+    expect(authoring).toContain('facet build --verify')
+  })
+
+  test('manifest documents top-level and per-skill supplementary files', () => {
+    const manifest = TOPICS.manifest.prompt
+    expect(manifest).toContain('files')
+    expect(manifest).toContain('archive-only')
+    expect(manifest).toContain('companion')
+    // The generated-schema marker must be preserved for the append step.
+    expect(manifest).toContain('--- JSON Schema (generated) ---')
+  })
+
+  test('usage covers adapter API 0.1 recovery guidance', () => {
+    const usage = TOPICS.usage.prompt
+    expect(usage).toContain('adapter API 0.1')
+    expect(usage).toContain('facet adapter list')
   })
 })
 

--- a/packages/cli/src/commands/instructions/index.ts
+++ b/packages/cli/src/commands/instructions/index.ts
@@ -1,6 +1,6 @@
 import { FacetManifestSchema } from '@agent-facets/protocol'
 import type { Command } from '../../commands.ts'
-import { DEFAULT_TOPIC, INSTRUCTION_TOPICS, isInstructionTopic, PROMPTS } from '../../prompts/index.ts'
+import { DEFAULT_TOPIC, INSTRUCTION_TOPICS, isInstructionTopic, promptFor } from '../../prompts/index.ts'
 import { writeCliError } from '../../util/errors.ts'
 
 /**
@@ -8,7 +8,8 @@ import { writeCliError } from '../../util/errors.ts'
  *
  * This command is FOR AI AGENTS. The prompts are curated workflow guidance
  * (not per-flag help) that tell an autonomous agent how to author and use
- * facets. Topics: overview (default), manifest, authoring, usage.
+ * facets. The overview (default) opens with a generated index of every topic;
+ * topics: overview (default), manifest, authoring, usage.
  */
 export const instructionsCommand: Command = {
   name: 'instructions',
@@ -22,13 +23,14 @@ export const instructionsCommand: Command = {
       writeCliError({
         what: `unknown instructions topic "${topic}"`,
         detail: `valid topics: ${INSTRUCTION_TOPICS.join(', ')}`,
-        fix: 'run: facet instructions [overview|manifest|authoring|usage]',
+        fix: `run: facet instructions [${INSTRUCTION_TOPICS.join('|')}]`,
       })
       return 1
     }
 
-    process.stdout.write(PROMPTS[topic])
-    if (!PROMPTS[topic].endsWith('\n')) process.stdout.write('\n')
+    const prompt = promptFor(topic)
+    process.stdout.write(prompt)
+    if (!prompt.endsWith('\n')) process.stdout.write('\n')
 
     // The manifest topic appends the JSON Schema generated live from the
     // protocol arktype schema — a single source of truth, never hand-copied.

--- a/packages/cli/src/prompts/authoring.txt
+++ b/packages/cli/src/prompts/authoring.txt
@@ -6,10 +6,12 @@ non-interactively. Do NOT use `facet edit` (it is an interactive TTY wizard);
 use `facet modify` or edit files directly, then verify.
 
 Asset file layout (relative to the facet root)
-  skills/<name>/SKILL.md    A skill.
+  skills/<name>/SKILL.md    A skill (may ship companion files beside it).
   agents/<name>.md          An agent.
-  commands/<name>.md        A command.
-Asset names are kebab-case (lowercase letters, digits, single hyphens).
+  commands/<name>.md         A command.
+Asset names are a single segment: 1-64 chars, lowercase letters/digits/hyphens,
+no leading/trailing/consecutive hyphens, and no slashes. A skill and a command
+must NOT share a name (agents are a separate namespace).
 
 1) SCAFFOLD a new facet — `facet create`
    Pass headless flags to skip the interactive wizard:
@@ -21,6 +23,8 @@ Asset names are kebab-case (lowercase letters, digits, single hyphens).
    Repeat --skill / --agent / --command for multiple assets. Use --private to
    mark the facet private, --force to overwrite an existing facet.json, and
    --json for structured output. At least one asset is required.
+   By default `facet create` also writes and declares an editable README.md
+   (seeded from the name and description). Pass --no-readme to skip it.
 
 2) CHANGE an existing facet — `facet modify`
    Grammar: facet modify <target> <name> [directory] [flags]
@@ -43,8 +47,31 @@ Asset names are kebab-case (lowercase letters, digits, single hyphens).
    - --description and adapter flags may accompany --add or --rename, or stand
      alone. --remove takes no other field flags.
    - Add --json for a structured change summary.
+   - `facet modify` manages asset primaries only. It does NOT manage
+     supplementary files (README.md, LICENSE, skill companions) — handle those
+     by editing facet.json directly (see step 3).
 
-3) ADAPTER CONFIG — per-asset, per-adapter settings
+3) SUPPLEMENTARY FILES — README.md and other non-asset files
+   A facet may ship non-asset files that are integrity-protected but are not
+   installable assets. They are declared as EXACT paths (no globs). There are
+   two declaration sites:
+   - Top-level `files` (an array on the manifest): repo-relative paths like
+     README.md or LICENSE. These ship in the archive but are NEVER written to
+     disk at install time (archive-only).
+   - A skill descriptor's `files` (an array on that skill): paths relative to
+     the skill directory. These are companions — they materialize and are
+     removed atomically with their owning skill. A companion cannot be
+     SKILL.md itself. A top-level path must NOT resolve under skills/.
+
+   To add or manage a README on an EXISTING facet, non-interactively:
+     1. Write or edit the file (e.g. README.md) at the facet root.
+     2. Declare its exact path in the manifest's top-level `files` array, e.g.
+          "files": ["README.md"]
+     3. Verify: facet build --verify
+   Both README.md and the extensionless README are ordinary top-level `files`
+   entries — there is no README-specific manifest field.
+
+4) ADAPTER CONFIG — per-asset, per-adapter settings
    Each skill/agent/command may carry an `adapters` block in facet.json: a map
    of adapter name to a free-form config object that the CLI passes through to
    that adapter at install time. Set it with a name-embedded flag whose value
@@ -66,7 +93,7 @@ Asset names are kebab-case (lowercase letters, digits, single hyphens).
      }
    Hand-edits round-trip safely; the CLI preserves unknown descriptor fields.
 
-4) VERIFY — always validate after changes
+5) VERIFY — always validate after changes
    Run the full build pipeline WITHOUT writing any output:
      facet build --verify
    Add --json for a machine-readable result (ok, errors, warnings). A clean

--- a/packages/cli/src/prompts/index.ts
+++ b/packages/cli/src/prompts/index.ts
@@ -4,23 +4,83 @@ import overview from './overview.txt' with { type: 'text' }
 import usage from './usage.txt' with { type: 'text' }
 
 /**
- * The instruction topics an agent can request via `facet instructions [topic]`.
- * The keys are the source of truth for the valid-topic list; the command and
- * its error message both derive from `INSTRUCTION_TOPICS`.
+ * One typed record per instruction topic: its prompt body and a one-line
+ * summary. This is the single source of truth for the topic set — the valid
+ * topic list, the unknown-topic error, the `fix:` invocation, and the topic
+ * index rendered at the top of the overview all derive from it, so a new topic
+ * cannot drift out of any of them.
  */
-export const PROMPTS = {
-  overview,
-  manifest,
-  authoring,
-  usage,
-} as const
+type TopicMeta = {
+  /** The full instruction text printed for this topic. */
+  prompt: string
+  /** One-line summary shown in the overview's topic index. */
+  summary: string
+}
 
-export type InstructionTopic = keyof typeof PROMPTS
+/**
+ * The instruction topics an agent can request via `facet instructions [topic]`.
+ * Declaration order is the display order in the overview index; `overview`
+ * comes first so the default topic heads its own index.
+ */
+export const TOPICS = {
+  overview: {
+    prompt: overview,
+    summary: 'Overview and topic index (default; `facet instructions` is equivalent).',
+  },
+  manifest: {
+    prompt: manifest,
+    summary: 'facet.json fields and the generated JSON Schema.',
+  },
+  authoring: {
+    prompt: authoring,
+    summary: 'Scaffold, change, and verify a facet non-interactively.',
+  },
+  usage: {
+    prompt: usage,
+    summary: 'Manage facets and adapter tooling in a project.',
+  },
+} as const satisfies Record<string, TopicMeta>
+
+export type InstructionTopic = keyof typeof TOPICS
 
 export const DEFAULT_TOPIC: InstructionTopic = 'overview'
 
-export const INSTRUCTION_TOPICS = Object.keys(PROMPTS) as InstructionTopic[]
+export const INSTRUCTION_TOPICS = Object.keys(TOPICS) as InstructionTopic[]
 
 export function isInstructionTopic(value: string): value is InstructionTopic {
-  return value in PROMPTS
+  return value in TOPICS
+}
+
+/**
+ * The marker in `overview.txt` where the generated topic index is injected.
+ * Keeping the index generated (rather than hand-listed in the prompt) means
+ * the topic set and its summaries live in exactly one place — {@link TOPICS}.
+ */
+export const OVERVIEW_INDEX_MARKER = '{{TOPIC_INDEX}}'
+
+/**
+ * Render the topic index block injected into the overview. Each line is the
+ * exact invocation an agent would run, padded to a shared column, followed by
+ * the topic's summary — so the overview always advertises every topic the CLI
+ * actually serves.
+ */
+export function renderTopicIndex(): string {
+  const rows = INSTRUCTION_TOPICS.map((topic) => ({
+    invocation: `facet instructions ${topic}`,
+    summary: TOPICS[topic].summary,
+  }))
+  const width = Math.max(...rows.map((row) => row.invocation.length))
+  const lines = rows.map((row) => `  ${row.invocation.padEnd(width)}  ${row.summary}`)
+  return `Instruction topics\n${lines.join('\n')}`
+}
+
+/**
+ * The full instruction text for a topic. For `overview`, the generated topic
+ * index is substituted at {@link OVERVIEW_INDEX_MARKER}; other topics are
+ * returned verbatim.
+ */
+export function promptFor(topic: InstructionTopic): string {
+  const body = TOPICS[topic].prompt
+  if (topic === 'overview') return body.replace(OVERVIEW_INDEX_MARKER, renderTopicIndex())
+  return body
 }

--- a/packages/cli/src/prompts/manifest.txt
+++ b/packages/cli/src/prompts/manifest.txt
@@ -1,15 +1,16 @@
 facet — manifest (facet.json) structure for AI agents
 
 facet.json is the authoring manifest for a facet. It declares the facet's
-identity and its assets. Minimal example:
+identity, its assets, and any supplementary files it ships. Example:
 
   {
     "name": "my-facet",
     "version": "0.1.0",
     "description": "What this facet does",
-    "skills":   { "greet":  { "description": "Greets the user" } },
+    "skills":   { "greet":  { "description": "Greets the user", "files": ["references/api.md"] } },
     "agents":   { "helper": { "description": "Reviews code" } },
-    "commands": { "run":    { "description": "Runs the task" } }
+    "commands": { "run":    { "description": "Runs the task" } },
+    "files":    ["README.md", "LICENSE"]
   }
 
 Field notes
@@ -19,16 +20,34 @@ Field notes
   description Optional facet description.
   private    Optional. `true` declares private publish intent. Omit for public.
   skills / agents / commands
-             Maps of kebab-case asset name to a descriptor. Each descriptor
-             has a required `description` and an optional `adapters` object
-             (per-adapter config passed through at install time — see
-             `facet instructions authoring`).
+             Maps of asset name to a descriptor. Each descriptor has a required
+             `description` and an optional `adapters` object (per-adapter config
+             passed through at install time — see `facet instructions
+             authoring`). A skill descriptor may also carry a `files` array of
+             companion paths (see below).
+  files      Optional. Top-level supplementary files: an array of EXACT
+             repo-relative paths (no globs) to non-asset files like README.md
+             or LICENSE. They ship in the archive and are integrity-protected,
+             but are NEVER written to disk at install (archive-only). A path
+             must not resolve under skills/.
   facets     Optional. Compose other facets (advanced).
   servers    Optional. Declare MCP servers (advanced).
 
+Supplementary files (README, LICENSE, skill companions)
+  - Top-level `files`: archive-only, never materialized on install.
+  - A skill's `files`: companions relative to the skill directory; they
+    materialize and are removed atomically with the skill and cannot list
+    SKILL.md itself.
+  - Supplementary files are NOT assets: they do not count toward the
+    "at least one asset" rule below, and they carry no description or adapters.
+
 Business rules the JSON Schema below cannot express
   - A facet must declare at least one asset (skill, agent, command, or facet).
-  - Asset names must be kebab-case and filesystem-safe (no "..", no slashes).
+    Supplementary `files` alone do not satisfy this.
+  - Asset names must be a single segment (1-64 chars, lowercase
+    letters/digits/hyphens, no leading/trailing/consecutive hyphens, no slash).
+  - A skill and a command must not share a name (agents are separate).
+  - Supplementary `files` paths must be exact, portable, and collision-free.
   - `name` must be a valid facet identity as described above.
 Run `facet build --verify` to check all of these against a real facet.
 

--- a/packages/cli/src/prompts/overview.txt
+++ b/packages/cli/src/prompts/overview.txt
@@ -1,8 +1,11 @@
 facet — instructions for AI agents
 
+{{TOPIC_INDEX}}
+
 This CLI manages "facets": portable bundles of skills, agents, and commands
-for AI coding tools. As an agent you will do one of two things with it. Decide
-which, then read the matching topic before acting.
+(plus optional supplementary files like README.md) for AI coding tools. As an
+agent you will do one of two things with it. Decide which, then read the
+matching topic before acting.
 
   AUTHORING a facet  — you are writing or changing a facet (its facet.json and
                        its skill/agent/command files). Run:
@@ -15,9 +18,10 @@ which, then read the matching topic before acting.
 
 The three artifact files
   facet.json   The authoring manifest. Declares a facet's identity (name,
-               version) and its assets (skills, agents, commands) with their
-               descriptions and optional per-adapter config. You edit this when
-               AUTHORING. See: facet instructions manifest
+               version), its assets (skills, agents, commands) with their
+               descriptions and optional per-adapter config, and any
+               supplementary files it ships. You edit this when AUTHORING.
+               See: facet instructions manifest
   facets.json  A consuming project's dependency list: which facets it installs.
                You touch this when USING facets (via `facet add`).
   facets.lock  The install lockfile. Managed by the CLI; do not hand-edit.
@@ -29,8 +33,7 @@ Command index
   facet edit           Interactive editing wizard (TTY only — prefer `modify`).
   facet add            Add a facet to a project and install it.
   facet adapter        Install / list / remove adapter tooling.
-  facet instructions   Print these instructions. Topics: overview (default),
-                       manifest, authoring, usage.
+  facet instructions   Print these instructions (see the topic index above).
 
 Machine-readable output
   `facet create`, `facet modify`, and `facet build` accept `--json` for

--- a/packages/cli/src/prompts/usage.txt
+++ b/packages/cli/src/prompts/usage.txt
@@ -41,6 +41,15 @@ Adapter tooling — `facet adapter`
     facet adapter list                    List installed adapters.
     facet adapter remove <name>           Remove an installed adapter.
 
+  This CLI supports adapter API 0.1. An adapter that declares an older or
+  unsupported API fails closed before any project files change. If `facet
+  build`, `facet add`, or `facet install` reports an incompatible adapter:
+    1. Run `facet adapter list` to see each adapter's API and status. Failing
+       entries print the exact reinstall command to run.
+    2. Reinstall an unsupported first-party adapter: facet adapter install <name>
+    3. For a CUSTOM adapter, rebuild it against the current
+       @agent-facets/adapter SDK first, then reinstall from that source.
+
   NOTE: This is about installing the adapter TOOLING. Configuring a facet's
   per-asset adapter settings (the `adapters` block in facet.json) is an
   AUTHORING task — see: facet instructions authoring


### PR DESCRIPTION
### Why

The `facet instructions` prompts needed a refresh for the 0.29.0 CLI to cover new capabilities and constraints that agents would otherwise have no guidance on.

### Details

**Generated topic index in the overview**

The overview prompt now opens with a generated index of every instruction topic before routing the agent to the authoring or usage workflow. The index is produced by `renderTopicIndex()`, which derives its content from the `TOPICS` registry — the single source of truth for the topic set. This means the index, the valid-topic error message, and the `fix:` invocation all stay in sync automatically when topics are added or renamed.

To support this, `PROMPTS` has been replaced by a typed `TOPICS` registry where each entry carries both a `prompt` and a one-line `summary`. The `promptFor()` function handles marker substitution (`{{TOPIC_INDEX}}`) for the overview and returns other topics verbatim.

**Updated prompt content**

- `authoring`: covers README and supplementary-file authoring (top-level `files` vs. skill companion `files`), the `--no-readme` flag, and the updated single-segment asset naming rule (no slashes, no shared skill/command names).
- `manifest`: documents top-level and per-skill `files` arrays, the `archive-only` install behaviour for top-level files, and the expanded business rules the JSON Schema cannot express.
- `usage`: adds adapter API `0.1` compatibility recovery guidance, including how to use `facet adapter list` to diagnose failing adapters and reinstall first-party or custom adapters.
- `overview`: updated to mention supplementary files and points to the generated topic index rather than listing topics inline.

### Verification

New and updated unit tests cover the topic registry structure, `renderTopicIndex()` output, marker substitution in `promptFor()`, and the presence of specific 0.29.0 guidance strings in each prompt. E2E tests verify the generated index appears before workflow routing in the default output and that the `{{TOPIC_INDEX}}` marker never leaks into printed output. CI covers it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI instruction text, prompt plumbing, docs, and tests; no runtime install, auth, or protocol behavior is modified.
> 
> **Overview**
> Refreshes **`facet instructions`** for the 0.29.0 CLI so agent-facing guidance matches current manifest and workflow behavior.
> 
> **Topic registry and overview index:** `PROMPTS` is replaced by a typed **`TOPICS`** map (each topic has a `prompt` and one-line `summary`). Valid topics, unknown-topic errors, and the overview’s **`{{TOPIC_INDEX}}`** block all derive from that registry via **`renderTopicIndex()`** and **`promptFor()`**, so the printed index cannot drift from what the CLI serves. The default overview now leads with that generated index before authoring vs. usage routing.
> 
> **Prompt updates:** **Authoring** documents default README creation, **`--no-readme`**, supplementary **`files`** (top-level archive-only vs. skill companions), single-segment asset naming, and skill/command name collisions. **Manifest** covers supplementary **`files`** and expanded prose business rules. **Usage** adds **adapter API 0.1** fail-closed behavior and recovery via **`facet adapter list`** / reinstall. Docs in **`instructions.mdx`** and a changeset align with the new text.
> 
> **Tests:** Unit and e2e coverage assert index ordering, no leaked marker, and key 0.29 strings in each topic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ff743f2173594b6d5626a3f83d4cb940113efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->