### PR TITLE
Add `graphite` facet at version 0.1.0

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -4,6 +4,7 @@
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.1",
-    "@agentfacets/address-pr-feedback": "latest"
+    "@agentfacets/address-pr-feedback": "latest",
+    "graphite": "0.1.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -228,6 +228,27 @@
         }
       ]
     },
+    "graphite": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.agentfacets.io"
+      },
+      "version": "0.1.0",
+      "integrity": "sha256:b179a91169fd8b82050b3306b50197749552789cb6f91c5a50cb2ef18d4ce550",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "using-graphite",
+          "files": [
+            {
+              "path": "skills/using-graphite/SKILL.md",
+              "integrity": "sha256:d6fdc7020a0c2e583b1e2c60c5508def4120848f666d8aa9011bd0ea17804f2e"
+            }
+          ]
+        }
+      ]
+    },
     "viper-plans": {
       "source": {
         "kind": "registry",


### PR DESCRIPTION
### Why

Adds the `graphite` facet (v0.1.0) so the agent has knowledge of how to use Graphite.

### Details

The `graphite` facet installs a `using-graphite` skill (`skills/using-graphite/SKILL.md`) scoped to the project, sourced from the AgentFacets registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile-only change with no runtime or security logic modified; risk is limited to facet install/sync behavior.
> 
> **Overview**
> Adds the **`graphite`** facet at **0.1.0** to project facet dependencies so agents can follow Graphite usage guidance in this repo.
> 
> `facets.json` declares the new dependency; `facets.lock` pins registry source, package integrity, and the project-scoped **`using-graphite`** skill (`skills/using-graphite/SKILL.md`) from the AgentFacets registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f1f8e9bc8f7afd0ef7b387c113604ca2dbedbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->