### PR TITLE
Bump `viper-plans` to 1.2.1

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "1.2.0",
+    "viper-plans": "1.2.1",
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.2",

--- a/facets.lock
+++ b/facets.lock
@@ -254,8 +254,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.2.0",
-      "integrity": "sha256:5c0cad2c96b3ce57c7c8a79bd482302622d9e44f121514fb2987e3043dc6cf50",
+      "version": "1.2.1",
+      "integrity": "sha256:cb6f0be50bf57cdaaa664eb24fd69e486490b2ff1228a96b00fbc9addc1990a0",
       "assets": [
         {
           "scope": "project",
@@ -264,7 +264,7 @@
           "files": [
             {
               "path": "skills/viper-execution-rules/SKILL.md",
-              "integrity": "sha256:13cd22a370049d60e5b3b367c34797e2c3d00c64bd5110f6979740751667b4e3"
+              "integrity": "sha256:6b70bed17556faf5e131b2771c6475db23e93d26a39197ef21e143509545514f"
             }
           ]
         },
@@ -275,7 +275,7 @@
           "files": [
             {
               "path": "skills/viper-planning/SKILL.md",
-              "integrity": "sha256:68dbfd63d3a1d058642fcfa8772e7bba7e8d43624784ecf1e64b52179761ec90"
+              "integrity": "sha256:cf326cb73bad44540fadd11f4c985b3f8634f734db7c8f87f9e8230bf895284c"
             }
           ]
         },


### PR DESCRIPTION
### Why

Bumps the `viper-plans` facet from version `1.2.0` to `1.2.1`.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only facet version bump with no runtime code changes in this repository.
> 
> **Overview**
> Updates the **`viper-plans`** facet from **1.2.0** to **1.2.1** in `facets.json` and refreshes `facets.lock` with the new package integrity and updated hashes for bundled assets (including **`viper-execution-rules`** and **`viper-planning`** skills).
> 
> This is a dependency pin bump only; no application source in the repo is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a75c571a5d89bd95ae942ab59fa5c0131c240d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->