### PR TITLE
Add OpenSpec change for cross-facet materialization aliasing

### DIFF
--- a/openspec/changes/add-materialization-aliasing/.openspec.yaml
+++ b/openspec/changes/add-materialization-aliasing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/add-materialization-aliasing/adversarial/artifacts/design.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/artifacts/design.md
@@ -1,0 +1,380 @@
+## Context
+
+Facets are installed by resolving each `facets.json` entry to a verified
+archive, deriving a per-asset plan (authored names + canonical inner-archive
+file paths + recomputed hashes), and materializing every asset to every
+selected adapter. Today the install loop in
+`packages/engine/src/install/commit/install-loop.ts` interleaves resolution
+and materialization per facet: facet A's assets are written to adapters
+before facet B is even resolved. Nothing evaluates the *union* of desired
+assets, so two independently published facets that both declare `skill:review`
+produce order-dependent, silently-overwriting state — and receipt-driven
+removal of one facet can delete a path the other still claims.
+
+Relevant current machinery:
+
+- `facets.json` is `Record<string, string>` (`FacetsJsonSchema`,
+  `packages/protocol/src/schemas/project-manifest.ts`) — facet name →
+  source-specifier string. There is no slot for per-asset intent.
+- `facets.lock` `0.2` (`CurrentLockfileSchema`) records per-facet asset
+  entries `{ scope, type, name, files[] }` where `files[].path` is the
+  canonical inner-archive path and `files[].integrity` its recomputed hash.
+  Version dispatch is exact (design D10 of the `0.2` change): readers accept
+  only versions they know.
+- The machine-local receipt (`packages/engine/src/install/receipt.ts`,
+  version `0.2`) mirrors lockfile ownership so offline removal deletes
+  exactly the owned files.
+- `buildVerifiedAssetPlan` is the single producer of asset identity +
+  ownership for all four resolve paths; `computeAssetList` /
+  `diffAssetsForDeletion` key drift deletion on `scope:type:name`.
+- Adapters receive one validated asset name per install/delete request and
+  are applied uniformly ("same thing per adapter").
+- Skills and commands share one namespace (mirrored by the authoring-side
+  collision check in `detectNamingCollisions` and the CLI wizard's
+  `validate-asset-name.ts`); agents occupy a separate namespace.
+
+The reconciled proposal commits to: transactional whole-set collision
+detection on every install path (including frozen), exactly one resolution
+per colliding asset (preserve / alias / omit), persisted project intent plus
+resolved installation state, unchanged adapter contracts, and unchanged
+archive/integrity identities.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect cross-facet collisions over the complete desired asset set before
+  any adapter write, on add, install, update, repair, and frozen paths.
+- Represent resolutions (alias, omit) as durable project intent in
+  `facets.json` and as resolved state in `facets.lock`, reproducible without
+  prompting for teammates, CI, and frozen installs.
+- Keep authored identity (archive paths, integrity, publisher-facing names)
+  fully separate from effective materialized identity (what adapters see).
+- Interactive resolution in `facet add` / `facet install`; structured,
+  no-mutation failure everywhere non-interactive.
+- Keep the adapter API structurally unchanged.
+
+**Non-Goals:**
+
+- Per-adapter resolutions or adapter-specific asset sets.
+- Publisher-declared aliases; any mutation of `facet.json` or archives.
+- Collision handling for MCP servers or future asset types.
+- Renaming facet identities or `facets.json` keys.
+- Changing single-facet (build-time) collision validation.
+- Automatic precedence: the system never picks a winner.
+
+## Decisions
+
+### D1. Two-phase install loop: resolve-all, gate, then materialize-all
+
+Restructure `runInstall` so the per-facet loop splits into:
+
+1. **Resolve phase** — resolve every desired facet through its source-kind
+   resolver, producing lockfile entries and `VerifiedAssetPlan`s. No adapter
+   writes occur here (resolution only touches cache/temp state), so this
+   phase stays on the no-mutation path.
+2. **Collision gate** — compute the desired *effective* asset set (D3) from
+   all plans plus recorded intent (D4); detect residual collisions; collect
+   resolutions or fail (D6/D7).
+3. **Materialize phase** — the existing per-facet reconcile + `materialize`
+   calls, under the journal, now iterating over already-resolved facets.
+
+**Why:** collision freedom is a property of the whole set; any per-facet or
+incremental check is order-dependent by construction — the exact defect the
+proposal names. Running the gate before the first adapter write is what makes
+the guarantee transactional: an unresolved collision MUST leave project,
+lockfile, receipt, and adapter state untouched, which is trivial when nothing
+has been written yet and requires no journal unwinding.
+
+**Alternatives considered:**
+
+- *Per-facet incremental check against previously-materialized state* —
+  rejected: order-dependent, cannot see collisions between two facets both
+  being updated in one run.
+- *Post-materialization verification with rollback* — rejected: turns a
+  planning-time property into a runtime failure needing rollback; violates
+  "fail without rewriting any state" for frozen installs.
+
+Plans carry paths and hashes, not bytes (`VerifiedAssetPlan` is deliberately
+byte-free), so holding all plans concurrently is cheap. Skill companion
+bytes continue to be read per facet during the materialize phase.
+
+### D2. Collision key and namespaces
+
+The collision key SHALL be `(scope, namespace, effectiveName)` where
+`namespace` is `skill-command` for skills and commands (shared) and `agent`
+for agents. Two assets collide iff their keys are equal and they belong to
+different facets. Same-facet duplicates remain a build-time concern
+(non-goal).
+
+Scope participates in the key because assets in different scopes do not
+share an on-disk tree; today every asset is `project`-scoped so this is
+forward-compatibility, not behavior.
+
+### D3. Authored vs. effective identity as a first-class pair
+
+Every planned asset SHALL carry both identities:
+
+- **authored name** — the name in `facet.json`, immutable, used for archive
+  paths, integrity records, and all publisher-facing messaging;
+- **effective name** — `alias ?? authoredName`, used for adapter
+  install/read/delete requests, drift keys, and on-disk layout.
+
+Concretely: `VerifiedAsset` (or a thin wrapper produced at the collision
+gate) gains an `effectiveName`; `assetKey` in `materialize.ts` and every
+drift diff SHALL key on effective identity, because drift is an on-disk
+concept. Integrity verification is untouched: it runs against the verified
+directory using canonical archive paths *before* materialization, and the
+lockfile `files[]` records keep authored archive paths (D5), so the 3-check
+and 1-check chains never see aliases.
+
+An omitted asset has no effective identity: it is excluded from the
+materialized set, its companions are not written, and it never enters drift
+diffs.
+
+### D4. Project intent: enriched `facets.json` entry, keyed by authored identity
+
+`FacetsJsonSchema` becomes a union per entry:
+
+```jsonc
+{
+  "facets": {
+    "acme/reviewer": "1.x",                       // compact form, unchanged
+    "beta/tools": {
+      "source": "2.*",
+      "assets": {
+        "skills":   { "review": "beta-review" },  // alias
+        "commands": { "ship": false }             // omit
+      }
+    }
+  }
+}
+```
+
+- The compact string form SHALL remain valid and semantically identical to
+  `{ "source": "<string>" }` with no resolutions — existing manifests parse
+  unchanged.
+- `assets` mirrors the `facet.json` section names (`skills` / `agents` /
+  `commands`), keying by **authored** name. Values are `string` (alias) or
+  `false` (omit). "Preserve" is the absence of an entry — see below.
+- The manifest writer SHALL emit the compact string form whenever a facet
+  has no resolutions, so projects that never hit a collision see zero diff
+  churn.
+
+**Preserve is implicit.** Recording explicit "keep" entries was considered
+and rejected: a keep can never *make* a set collision-free (two keeps of the
+same name still collide), so keeps carry no information the effective-set
+computation needs. Detection is always "apply recorded aliases/omissions,
+then require the residual effective set to be collision-free" — that
+reproduces the user's choices deterministically without prompting, which is
+the property the proposal actually requires. Fewer persisted entries also
+means fewer stale resolutions to garbage-collect when facets change.
+
+**Stale resolutions.** A resolution referencing an asset the facet no longer
+declares SHALL be reported as a warning and ignored during effective-set
+computation; interactive flows SHOULD offer to prune it. It is not an error:
+publishers remove assets routinely and intent files are hand-mergeable.
+
+**Alias validity.** An alias MUST satisfy the shared asset-name grammar
+(`validateAssetName`) and the resulting effective set MUST be collision-free
+(including alias-vs-authored and alias-vs-alias collisions in the shared
+skill/command namespace). Both are enforced at the collision gate and, for
+interactive entry, live in the prompt.
+
+**Alternatives considered:** a flat compound key (`"skill:review": ...`) —
+rejected as inventing a new key grammar when `facet.json`'s section shape
+already exists; a top-level `resolutions` block parallel to `facets` —
+rejected because intent is per-facet and would desynchronize on facet
+rename/removal.
+
+### D5. Lockfile: new exact version `0.3` with `as` on asset entries
+
+Introduce `LOCKFILE_VERSION 0.3` under the existing exact-dispatch regime
+(read `{1, 0.2, 0.3}`, exact match only):
+
+- Asset entries gain an OPTIONAL `as: string` field — present iff the asset
+  is aliased. `name` remains the authored name; `files[]` remains canonical
+  authored archive paths with recomputed integrity. Effective identity is
+  derivable (`as ?? name`), never stored redundantly.
+- Omitted assets SHALL NOT appear in `assets[]`: the lockfile's asset list
+  describes resolved *materialized* state, and removal/repair must delete or
+  repair exactly the files recorded as owned. Omission intent lives in
+  `facets.json` (D4); the frozen consistency gate (D8) cross-checks the two.
+- **Version-preserving write:** the writer SHALL emit `0.2` when no facet in
+  the project carries any resolution, and `0.3` once any resolution exists.
+  This confines the BREAKING format to projects that actually use the
+  feature (matching the proposal's compatibility bullet): teams that never
+  hit a collision keep full older-CLI interop. Implementation cost is one
+  serializer branch over a single in-memory model.
+
+**Why a version bump at all:** an older CLI reading an alias-bearing
+lockfile as `0.2` would silently materialize under authored names — exactly
+the silent-overwrite correctness failure this change exists to kill. Exact
+dispatch makes the old CLI fail loudly instead. The same loud-failure
+property holds for the manifest for free: old `FacetsJsonSchema` rejects
+object entries as `FACETS_JSON_INVALID`.
+
+**Alternative considered:** optional fields inside `0.2` without a bump —
+rejected: it converts a loud incompatibility into a silent misread.
+
+### D6. Engine/CLI seam: resolution via an inversion-of-control callback
+
+`runInstall` gains an optional `resolveCollisions` callback:
+
+```ts
+resolveCollisions?: (groups: CollisionGroup[]) =>
+  Promise<{ kind: 'resolved'; resolutions: ResolutionSet } | { kind: 'abort' }>
+```
+
+where `CollisionGroup` names the colliding effective identity and every
+member `{ facet, assetType, authoredName, currentResolution }`. When the
+gate finds residual collisions:
+
+- callback present (interactive `add` / `install`): engine invokes it, the
+  CLI renders an Ink flow (per group, per asset: keep / alias with live
+  grammar-and-uniqueness validation / omit), engine re-validates the
+  returned set against the gate, merges it into manifest intent, and
+  proceeds — all inside the single held install lock and transaction.
+- callback absent (CI, `--frozen-lockfile`, non-TTY): engine returns a new
+  structured failure `{ code: 'UNRESOLVED_COLLISIONS', groups }` on the
+  no-mutation path. The CLI renders the groups with the concrete
+  `facets.json` edit that would resolve them.
+
+**Why:** engine owns transactionality and holds the lock; the CLI owns
+display. A callback keeps prompt-then-commit atomic without engine growing
+display code (precedent: `onStage`/`onLog` are already inversion points).
+The alternative — a separate CLI-orchestrated detect pass followed by a
+second `runInstall` — was rejected: it drops the lock between detect and
+commit (TOCTOU against concurrent installs and registry `latest` movement)
+and duplicates resolution work.
+
+Non-interactive resolution for CI is deliberately *editing `facets.json`* —
+no `--resolve foo=bar` flag. Intent belongs in the committed file, not in
+ephemeral pipeline arguments.
+
+### D7. Every mutation path runs the gate
+
+The gate (D1 step 2) runs identically for `add`, plain `install`, updates
+(a facet update can introduce a brand-new collision), and repair — all of
+which already funnel through `runInstall`. `facet remove` also funnels
+through it; removals can only shrink the effective set, so the gate passes
+trivially but is not special-cased.
+
+### D8. Frozen reproduction: verify, never prompt, never rewrite
+
+Under `--frozen-lockfile` the existing no-mutation preflight
+(`detectLockfileDrift`) is extended with an intent-consistency check:
+
+- every recorded alias in `facets.json` MUST match the corresponding entry's
+  `as` in the lockfile;
+- every recorded omission MUST correspond to no asset entry;
+- the effective set derived from the lockfile MUST be collision-free.
+
+Any violation fails as `UNRESOLVED_COLLISIONS` (or `LOCKFILE_DRIFT` where it
+is literally version drift) with zero writes — before receipt-driven
+cleanup, preserving the established "frozen consistency before cleanup"
+ordering. Frozen materialization then reproduces effective names from
+`as ?? name` without prompting.
+
+### D9. Materialization, receipt, and removal use effective identity
+
+- `materialize` passes the effective name in every adapter
+  install/read/delete request; skill companion placement follows the
+  effective name's directory. The adapter API shape is unchanged — adapters
+  keep receiving one validated name and cannot tell an alias from an
+  authored name.
+- The receipt bumps to `0.3` (exact dispatch, mirroring D5): asset records
+  become `{ scope, type, name, as?, files }` with `name` authored and
+  deletion driven by `as ?? name`. Receipts are machine-local; `0.2`
+  receipts load with primary semantics unchanged (no `as` ⇒ effective =
+  authored), so no migration machinery beyond the schema union is needed.
+- Alias *changes* (user edits `beta-review` → `code-review`) fall out of
+  D3's effective-identity drift keys: `diffAssetsForDeletion` sees the old
+  effective identity leave the set and the new one enter, deleting and
+  writing exactly the right files.
+- Omission on an already-materialized asset likewise falls out: the asset
+  leaves the effective set, drift deletion removes its primary and owned
+  companions via the receipt's recorded files.
+
+### D10. Pure-protocol vs. engine split
+
+The collision-detection and effective-set computation are part of the spec
+("would survive a Rust rewrite"), so they land in `@agent-facets/protocol`
+as pure functions over asset identities + intent — alongside the extended
+`FacetsJsonSchema`, `0.3` lockfile schema, and an exported
+`effectiveAssetName` helper. Orchestration (two-phase loop, callback,
+journal, receipt) is engine. CLI gains the Ink resolution view and the
+structured-failure rendering.
+
+## Risks / Trade-offs
+
+- [Two-phase loop changes failure ordering: a facet late in the map now
+  fails *before* earlier facets materialize] → This is strictly safer
+  (fewer partial states) but changes observed progress events; `onStage`
+  gains explicit `resolve-phase` / `materialize-phase` events so the CLI
+  timeline stays honest.
+- [Version-preserving lockfile write (D5) means one project can oscillate
+  between `0.2` and `0.3` as resolutions come and go] → Acceptable: both
+  directions are lossless for a resolution-free state, and the serializer
+  branch is trivially testable. The alternative (always `0.3`) breaks older
+  CLIs for every project on first contact.
+- [Implicit "preserve" (D4) means a *new* collision introduced by an update
+  re-prompts even though the user previously kept one side] → Intended:
+  a new colliding member is genuinely new information; silently reusing an
+  old choice would pick a winner the user never approved.
+- [Stale resolutions accumulating in `facets.json`] → Warn-and-ignore plus
+  interactive pruning (D4); never a hard failure, so upstream asset renames
+  don't brick installs.
+- [Callback re-entrance: a buggy CLI callback returns an invalid resolution
+  set] → Engine re-runs the gate on the returned set and fails structurally
+  rather than trusting the callback; the callback is advisory input, not a
+  bypass.
+- [Aliased skill directories change companion paths on disk while lockfile
+  `files[]` keeps authored paths] → The receipt records what deletion needs
+  (effective identity + owned files); repair reads adapter state by
+  effective name and compares bytes against authored archive paths. The
+  pairing is exercised directly by repair/removal tests.
+
+## Migration Plan
+
+1. **Protocol**: extended `FacetsJsonSchema` union, `0.3` lockfile schema +
+   exact dispatch, pure collision/effective-set functions. Purely additive;
+   ships dark.
+2. **Engine**: two-phase `runInstall`, collision gate, `UNRESOLVED_COLLISIONS`
+   failure, receipt `0.3`, frozen consistency extension, version-preserving
+   writers. Projects without resolutions produce byte-identical outputs.
+3. **CLI**: interactive resolution flow in `add`/`install`, structured
+   failure rendering.
+4. **Docs** (see below), then changelog.
+
+Rollback within the compatibility story: a project that removes all
+resolutions from `facets.json` and reinstalls returns to a `0.2` lockfile
+readable by older CLIs. No forced migration exists for uninvolved projects.
+
+## Documentation Impact
+
+Per the proposal's doc survey, the following MUST be updated:
+`docs/specification/manifest.mdx` (namespace rules now consumer-facing),
+`docs/specification/project-manifest.mdx` (enriched entry form),
+`docs/specification/lockfile.mdx` (`0.3`, `as`, omission semantics),
+`docs/specification/install.mdx` and `docs/specification/commit.mdx`
+(collision gate placement, transactional guarantee, frozen behavior),
+`docs/specification/terminology.mdx` (authored vs. effective identity),
+`docs/cli/add.mdx` and `docs/cli/install.mdx` (interactive flow,
+`UNRESOLVED_COLLISIONS` failure), `docs/guides/install-facets.mdx` and
+`docs/guides/troubleshooting.mdx` (resolving collisions, CI guidance), and
+the root `README.md` if it demonstrates `facets.json` entries. No existing
+doc contradicts this design; the gap is purely additive coverage.
+
+## Open Questions
+
+- Should the interactive flow offer a "remember nothing, omit all newcomers"
+  bulk action for large collision groups, or is per-asset choice the only
+  mode in v1? (Leaning per-asset only; bulk actions can ship later without
+  format changes.)
+- Does `facet edit` (scanner/reconcile) need to learn the enriched manifest
+  entry in this change, or is read-tolerance sufficient until a follow-up?
+  Read-tolerance is the minimum bar: it MUST NOT corrupt object entries when
+  rewriting `facets.json`.
+- Exact wording of the failure-rendered `facets.json` edit suggestion —
+  should the CLI print a ready-to-paste JSON fragment per group?

--- a/openspec/changes/add-materialization-aliasing/adversarial/artifacts/proposal.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/artifacts/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Facets promise safe composition: install any set of independently published facets and get all of their assets. But asset names are validated only *within* a facet — nothing prevents two facets from both shipping a skill named `planning`, and both materialize to the same conventional path in every selected adapter. Today the install contract does not even define what happens: the effective outcome is silent overwrite or order-dependent state, which corrupts one facet's asset without any failure signal — and receipt-driven removal of one facet can then delete a file another facet still claims. As the registry grows, collisions on common names (`review`, `deploy`, `planning`) are inevitable. This is a latent correctness bug in the core install path, not a feature gap.
+
+## What Changes
+
+- Installation SHALL detect name collisions across the project's complete desired asset set — every facet in the manifest, not just the one being added — before any file is written. Skills and commands SHALL be evaluated in their shared namespace; agents SHALL be evaluated separately, mirroring the existing within-facet rules.
+- For each asset in a collision group, the user SHALL choose exactly one resolution: **keep** its authored name, **alias** it to a different valid name, or **omit** it from materialization. The resolved effective set MUST be collision-free, including against aliases; aliases MUST satisfy the existing single-segment asset-name grammar.
+- Resolutions SHALL be recorded in `facets.json` as version-controlled project intent, so a fresh clone plus install reproduces the same effective asset set with no prompting. Compact string entries SHALL remain valid and unchanged for facets needing no resolution; only facets with resolutions use an enriched entry form. **BREAKING**: a project that records resolutions SHALL require tooling that understands the enriched project-manifest and corresponding lockfile shape (string-only manifests remain readable by older tooling).
+- The lockfile SHALL record the effective materialized identity alongside the authored identity, so drift detection, repair, frozen verification, receipt ownership, and removal all operate on the files actually on disk. An omitted asset — including a skill's companions — SHALL NOT be materialized, and removal SHALL delete exactly the effectively-owned files.
+- Interactive add and install SHALL present each collision group (naming the facets, asset types, and names involved) and collect resolutions. Non-interactive and frozen installs with an unresolved collision SHALL fail with structured data identifying every colliding declaration, leaving manifest, lockfile, receipt, and adapter state untouched. Because facet updates can introduce new collisions, detection SHALL run on every install, not only on add.
+- Integrity verification SHALL be unchanged: archives, per-file hashes, and canonical archive paths keep authored identities; aliasing is purely a materialization-time mapping. The same resolution SHALL apply to every selected adapter.
+- Specification and user documentation SHALL be updated: project-manifest and lockfile schema pages, the install/commit transactional flow, and the install guide and troubleshooting page.
+
+## Capabilities
+
+### New Capabilities
+
+- None. Cross-facet collision handling is install behavior within existing domains.
+
+### Modified Capabilities
+
+- `installation`: detect cross-facet collisions over the full desired set before materialization; collect, persist, and reproduce per-asset resolutions (keep/alias/omit); prompt interactively and fail non-interactively with structured data; extend lockfile, receipt, drift-repair, frozen-consistency, and removal semantics to distinguish authored from effective identities.
+- `protocol__schemas`: enrich the project-manifest entry shape to carry resolution intent while preserving compact string entries, and extend the lockfile schema to record effective materialized identities alongside authored ones.
+
+The interactive prompting and non-interactive failure behavior lives in `installation`, where the analogous adapter-selection prompting requirements already live; the `cli` spec governs generic argument/dispatch/help behavior and is not expected to change at the requirements level.
+
+## Non-goals
+
+- No automatic winner selection: the system SHALL NOT resolve a collision by install order, precedence, or any heuristic. Unresolved means fail (non-interactive) or ask (interactive).
+- No per-adapter resolutions: one project-level resolution applies to every selected adapter; adapter contracts keep receiving one validated name per asset.
+- No publisher-side mechanisms: no author-declared aliases, registry-level name reservations, or changes to `facet.json`, archive layout, or published identities.
+- No change to within-facet collision validation at build or verify time.
+- MCP servers and future asset types are out of scope.
+- Renaming facet identities (the `facets.json` keys) is out of scope; only materialized asset names are affected.
+
+## Impact
+
+- `packages/protocol`: project-manifest and lockfile schemas, and the pure build/validate helpers that reason about asset identities. Lockfile format evolution and exact-version dispatch (the existing `0.2` exact-equality rule) need explicit design treatment.
+- `packages/engine`: install planning, collision evaluation, materialization mapping, receipt ownership, frozen consistency checks, drift repair, removal, and structured failure data.
+- `packages/cli`: the interactive collision-resolution flow in add/install views and rendering of the structured non-interactive failure.
+- Adapters: no structural contract change expected; an adapter receives the effective (possibly aliased) name through the existing request shape.
+- Documentation informing this proposal: `docs/specification/manifest.mdx` (asset-name grammar and the shared skill/command namespace), `docs/specification/project-manifest.mdx` and `docs/specification/lockfile.mdx` (intent vs. resolution split), `docs/specification/install.mdx` and `docs/specification/commit.mdx` (transactional tri-write, frozen mode, receipts), and `docs/guides/install-facets.mdx` plus `docs/guides/troubleshooting.mdx` (user-facing flow). All of these, the CLI add/install references, terminology, and the changelog SHALL be updated as scoped work.
+- No new runtime dependencies.

--- a/openspec/changes/add-materialization-aliasing/adversarial/artifacts/specs/cli/spec.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/artifacts/specs/cli/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Add and install present collision groups for interactive resolution
+
+When an interactive `add` or `install` detects an unresolved cross-facet asset collision, the rendered view SHALL present each collision group before any file is written. The presentation SHALL name each contributing facet, each colliding asset with its type, and the shared namespace involved, and SHALL offer the user exactly three choices per asset: keep the authored name, enter an alias, or omit the asset. An entered alias SHALL be validated immediately against the asset-name grammar and against the rest of the effective asset set, with the specific constraint violation shown on failure, and the user SHALL be able to correct it without restarting the operation. Cancelling SHALL exit without modifying the project.
+
+#### Scenario: Collision group names facets and assets
+
+- **WHEN** two facets both contribute skill `review` and a user runs `add` in an interactive terminal
+- **THEN** the rendered view SHALL show one collision group naming both facets and the colliding asset `review`
+- **AND** the view SHALL indicate that skills and commands share one namespace
+
+#### Scenario: User assigns an alias interactively
+
+- **WHEN** a user chooses to alias one colliding skill and enters `review-acme`
+- **THEN** the system SHALL validate the alias against the asset-name grammar and the effective asset set
+- **AND** on success the operation SHALL proceed with `review-acme` as that asset's effective name
+
+#### Scenario: Invalid alias input is corrected in place
+
+- **WHEN** a user enters an alias that violates the asset-name grammar or collides with another effective name
+- **THEN** the rendered view SHALL show the specific constraint that failed
+- **AND** the user SHALL be able to enter a different alias without restarting the command
+
+#### Scenario: Cancelling collision resolution aborts cleanly
+
+- **WHEN** a user cancels the collision prompt
+- **THEN** the process SHALL exit without modifying the project manifest, lockfile, or adapter state
+
+### Requirement: Unresolved collisions in non-interactive use render an actionable failure
+
+When a non-interactive `add` or `install` fails because of an unresolved collision, the rendered failure SHALL identify each collision group — naming every contributing facet and colliding asset — and SHALL state the available resolutions and that resolutions are recorded in the project manifest. The process SHALL exit with a non-zero code.
+
+#### Scenario: Non-interactive collision failure is actionable
+
+- **WHEN** a non-interactive install encounters skill `review` contributed by two facets with no recorded resolution
+- **THEN** the rendered failure SHALL name both facets and the colliding asset
+- **AND** the failure SHALL state that each colliding asset must be kept, aliased, or omitted via the project manifest
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Multiple collision groups are all reported at once
+
+- **WHEN** a non-interactive install encounters two independent collision groups
+- **THEN** the rendered failure SHALL report both groups in one run
+- **AND** the user SHALL NOT need a second failing run to discover the second group
+
+### Requirement: Recorded resolutions install without prompting and are visible in the summary
+
+When every collision is covered by a recorded resolution, `add` and `install` SHALL proceed without any collision prompt, and the final summary SHALL show each aliased asset's authored name together with its effective materialized name and SHALL identify omitted assets as omitted.
+
+#### Scenario: Recorded resolutions produce no prompt
+
+- **WHEN** a user runs `install` on a project whose recorded intent covers every collision
+- **THEN** no collision prompt SHALL appear
+- **AND** the operation SHALL materialize the recorded effective asset set
+
+#### Scenario: Summary shows authored and effective names
+
+- **WHEN** an install materializes skill `review` under the alias `review-acme` and omits command `deploy`
+- **THEN** the summary SHALL show `review` together with its effective name `review-acme`
+- **AND** the summary SHALL identify `deploy` as omitted

--- a/openspec/changes/add-materialization-aliasing/adversarial/artifacts/specs/installation/spec.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/artifacts/specs/installation/spec.md
@@ -1,0 +1,311 @@
+## ADDED Requirements
+
+### Requirement: Cross-facet asset collisions are detected before any materialization write
+
+Before writing any materialized asset, the system SHALL evaluate the complete desired asset set across every facet the project declares and SHALL detect every group of assets whose effective materialized identities collide. The evaluation SHALL run on every path that materializes assets: adding a facet, installing, updating a facet, repairing drift, and frozen installation. Skills and commands SHALL be evaluated in one shared namespace; agents SHALL be evaluated in a separate namespace. When an unresolved collision is detected, the system SHALL NOT write any materialized asset, manifest change, lockfile change, or receipt change for the operation.
+
+#### Scenario: Two facets declare the same skill name
+
+- **WHEN** a user adds a facet declaring skill `review` to a project whose installed facets already contribute a skill named `review`
+- **THEN** the system SHALL detect a collision between the two assets before any file is written
+- **AND** the system SHALL identify both contributing facets and both colliding assets
+
+#### Scenario: A skill and a command from different facets collide
+
+- **WHEN** the desired asset set contains a skill named `deploy` from one facet and a command named `deploy` from another facet
+- **THEN** the system SHALL detect a collision, because skills and commands share one namespace
+
+#### Scenario: An agent and a skill with the same name do not collide
+
+- **WHEN** the desired asset set contains an agent named `review` from one facet and a skill named `review` from another facet
+- **THEN** the system SHALL NOT report a collision, because agents occupy a separate namespace
+
+#### Scenario: A facet update introduces a new collision
+
+- **WHEN** an installed facet's newly resolved version declares an asset whose name collides with an asset from another installed facet
+- **AND** no recorded resolution covers the new collision
+- **THEN** the update SHALL stop before any materialization write
+- **AND** the system SHALL surface the new collision for resolution
+
+#### Scenario: Collision within a single facet is unchanged
+
+- **WHEN** a single facet's own manifest declares two assets with the same name in one namespace
+- **THEN** the existing single-facet manifest validation SHALL reject it as it does today
+- **AND** cross-facet collision handling SHALL NOT alter that behavior
+
+### Requirement: Every colliding asset receives exactly one explicit resolution
+
+For every detected collision group, each asset in the group SHALL receive exactly one resolution: preserve its authored name, materialize under an alias, or be omitted from materialization. The system SHALL NOT choose a winner silently, SHALL NOT infer precedence from install order or declaration order, and SHALL NOT overwrite one facet's asset with another's. A resolution set MAY alias multiple assets in a group and MAY omit every asset in a group, but the resulting effective materialized set MUST be collision-free.
+
+#### Scenario: Aliasing one asset resolves a two-asset group
+
+- **WHEN** two facets contribute skill `review` and the user assigns one of them the alias `review-acme`
+- **AND** the other keeps its authored name
+- **THEN** the resolution SHALL be accepted
+- **AND** the effective materialized set SHALL contain `review` and `review-acme`
+
+#### Scenario: Omitting every asset in a group is valid
+
+- **WHEN** the user omits both colliding assets in a group
+- **THEN** the resolution SHALL be accepted
+- **AND** neither asset SHALL be materialized
+
+#### Scenario: A resolution that still collides is rejected
+
+- **WHEN** a proposed resolution assigns two assets in the shared skill/command namespace the same effective name — whether by aliasing both to one name, or by aliasing one onto another asset's preserved authored name
+- **THEN** the system SHALL reject the resolution
+- **AND** the system SHALL identify the assets whose effective names still collide
+
+#### Scenario: The system never resolves a collision implicitly
+
+- **WHEN** a collision group has no recorded resolution and no user input is available
+- **THEN** the system SHALL NOT materialize any asset in the group under any precedence rule
+- **AND** the operation SHALL fail rather than pick a winner
+
+### Requirement: Interactive operations collect collision resolutions from the user
+
+When an add or install runs in an interactive environment and detects a collision group with no recorded resolution, the system SHALL identify the colliding facets and assets and collect the user's resolution for each asset before proceeding. If the user cancels, the system SHALL leave the project manifest, lockfile, receipt, and on-disk adapter state unchanged.
+
+#### Scenario: Interactive add prompts for a resolution
+
+- **WHEN** a user interactively adds a facet that introduces an unresolved collision
+- **THEN** the system SHALL present the collision group naming each contributing facet and asset
+- **AND** the system SHALL collect one resolution per asset before any materialization write
+
+#### Scenario: Cancelling resolution leaves the project unchanged
+
+- **WHEN** a user cancels interactive collision resolution
+- **THEN** the project manifest, lockfile, receipt, and adapter state SHALL be unchanged
+- **AND** the operation SHALL exit without installing the facet
+
+### Requirement: Non-interactive operations fail on unresolved collisions without modifying state
+
+When a non-interactive operation encounters a collision group with no recorded resolution, the system SHALL fail with structured data identifying each colliding facet, each colliding asset, the shared namespace involved, and the available resolutions. The failure SHALL leave the project manifest, lockfile, receipt, and on-disk adapter state unchanged.
+
+#### Scenario: CI install fails with structured collision data
+
+- **WHEN** a non-interactive install encounters an unresolved collision between skill `review` in two facets
+- **THEN** the operation SHALL exit with a non-zero status
+- **AND** the failure data SHALL identify both facets, the colliding asset names, and the resolutions available
+- **AND** no project or adapter state SHALL change
+
+### Requirement: Collision resolutions are recorded and reproduced without prompting again
+
+The system SHALL record each collision resolution as project intent alongside the facet's source declaration, and SHALL record the resulting effective materialized identities as resolved installation state. Subsequent installs, repairs, updates, frozen installs, and removals — on the same machine or another — SHALL reproduce the same effective asset set from the recorded intent without prompting. Existing compact string entries SHALL remain valid for facets that require no explicit resolution. A recorded resolution that references an asset the facet no longer declares SHALL be reported as stale with structured data and SHALL NOT by itself fail the operation.
+
+#### Scenario: A teammate reproduces recorded resolutions without prompts
+
+- **WHEN** a teammate clones a project whose recorded intent aliases skill `review` to `review-acme` and runs install
+- **THEN** the install SHALL materialize `review-acme` without prompting
+- **AND** the effective asset set SHALL match the machine where the resolution was recorded
+
+#### Scenario: A facet without resolutions keeps its compact entry
+
+- **WHEN** a project declares a facet that participates in no collision group
+- **THEN** its manifest entry MAY remain a compact string
+- **AND** installation SHALL NOT rewrite it into an enriched form to add empty resolution data
+
+#### Scenario: A stale resolution is reported, not fatal
+
+- **WHEN** a recorded resolution references an asset name the facet's resolved version no longer declares
+- **THEN** the install SHALL complete for the assets the facet does declare
+- **AND** the system SHALL report the stale resolution with structured data identifying the facet and the missing asset
+
+### Requirement: Aliases satisfy the asset-name grammar and apply uniformly to every adapter
+
+A materialized alias SHALL satisfy the same asset-name grammar and namespace rules as an authored asset name. One project-level resolution SHALL apply to every selected adapter: the system SHALL NOT record or apply adapter-specific aliases or adapter-specific omissions, and every selected adapter SHALL receive the same effective asset set.
+
+#### Scenario: An invalid alias is rejected
+
+- **WHEN** a user proposes the alias `Review--Code` or an alias longer than the permitted length
+- **THEN** the system SHALL reject the alias with the naming constraint that failed
+- **AND** no resolution SHALL be recorded
+
+#### Scenario: The same effective set reaches every adapter
+
+- **WHEN** a project with two selected adapters records an alias for a colliding skill
+- **THEN** both adapters SHALL materialize the skill under the same effective name
+- **AND** neither adapter SHALL receive an adapter-specific variant of the resolution
+
+### Requirement: Omission excludes the asset and its owned companions from materialization
+
+When a resolution omits an asset, the system SHALL NOT materialize the asset's primary file or any of its owned companion files into any adapter, and SHALL NOT record ownership of any file for the omitted asset. Other assets contributed by the same facet SHALL install normally.
+
+#### Scenario: An omitted skill writes nothing
+
+- **WHEN** a resolution omits skill `review`, which owns `SKILL.md` and two companions
+- **THEN** no file belonging to that skill SHALL be written into any selected adapter
+- **AND** the receipt SHALL record no owned file for the omitted skill
+
+#### Scenario: Sibling assets of an omitted asset still install
+
+- **WHEN** a facet contributes an omitted skill and a non-colliding agent
+- **THEN** the agent SHALL be materialized normally
+- **AND** the facet's lockfile entry SHALL still verify against its authored archive
+
+### Requirement: Authored identities govern verification; effective identities govern materialized state
+
+Integrity verification SHALL continue to use the facet's authored asset identities and canonical archive paths: aliasing SHALL NOT change any archive path, per-file integrity value, or archive integrity value. The receipt, drift repair, and removal SHALL operate on effective materialized identities: the system SHALL record as owned exactly the files it materialized under effective names, SHALL repair drift at those effective paths, and SHALL delete exactly the recorded owned files on removal.
+
+#### Scenario: An aliased skill verifies against its authored archive paths
+
+- **WHEN** skill `review` is materialized under alias `review-acme`
+- **THEN** integrity verification SHALL check the archive entries under the authored `skills/review/` paths
+- **AND** verification SHALL NOT look for `review-acme` inside the archive
+
+#### Scenario: Drift repair restores the aliased path
+
+- **WHEN** a file of a skill materialized under an alias is modified on disk
+- **THEN** re-running install SHALL repair the file at its effective materialized path
+- **AND** the repaired content SHALL reproduce the authored file's locked integrity
+
+#### Scenario: Removal deletes the aliased files, not the authored names
+
+- **WHEN** a user removes a facet whose skill was materialized under an alias
+- **THEN** the system SHALL delete the files recorded as owned at their effective materialized paths
+- **AND** the system SHALL NOT attempt deletion under the authored name
+- **AND** no file owned by another facet SHALL be deleted
+
+### Requirement: Frozen installation reproduces resolved collision state or fails without rewriting
+
+Frozen installation SHALL reproduce recorded collision resolutions exactly and SHALL NOT prompt. When frozen installation encounters an unresolved collision — including one introduced by lockfile or manifest edits pulled from version control — it SHALL fail before any materialization write and SHALL NOT rewrite the manifest, lockfile, receipt, or adapter state.
+
+#### Scenario: Frozen install reproduces recorded aliases
+
+- **WHEN** a frozen install runs on a project whose recorded intent and lockfile carry collision resolutions
+- **THEN** the system SHALL materialize the recorded effective asset set exactly
+- **AND** the system SHALL NOT prompt or re-resolve anything
+
+#### Scenario: Frozen install fails on an unresolved collision
+
+- **WHEN** a frozen install computes a desired asset set containing a collision no recorded resolution covers
+- **THEN** the operation SHALL fail before any file is written
+- **AND** the manifest, lockfile, receipt, and adapter state SHALL be unchanged
+
+### Requirement: Successful normal operations migrate legacy project manifests transactionally
+
+A legacy unversioned string-only project manifest SHALL remain valid input. A successful normal (non-frozen) operation that writes the project manifest SHALL migrate it to the current versioned format in the same transaction as the rest of the operation's state; a failed operation SHALL leave the legacy manifest byte-for-byte untouched. Frozen installation SHALL accept a legacy manifest and SHALL NOT rewrite it.
+
+#### Scenario: A successful add migrates the legacy manifest
+
+- **WHEN** a user successfully adds a facet to a project with a legacy unversioned manifest
+- **THEN** the written manifest SHALL carry the current format version
+- **AND** every previously declared entry SHALL be preserved with unchanged meaning
+
+#### Scenario: A failed operation does not migrate
+
+- **WHEN** an operation on a project with a legacy manifest fails after resolution begins
+- **THEN** the manifest SHALL remain in its legacy form, unchanged
+
+#### Scenario: Frozen install retains the legacy manifest
+
+- **WHEN** a frozen install runs on a project with a legacy unversioned manifest and a covering lockfile
+- **THEN** the install MAY proceed
+- **AND** the manifest SHALL NOT be rewritten
+
+## MODIFIED Requirements
+
+### Requirement: Lockfile declares a version
+
+The lockfile SHALL declare `lockfileVersion`. Current lockfiles SHALL use numeric `0.3`. Version selection SHALL use exact equality rather than numeric ordering: numeric `1` SHALL identify only the closed-alpha schema, numeric `0.2` SHALL identify only the preceding alpha schema, and numeric `0.3` SHALL identify only the current schema. Missing or unsupported versions SHALL produce structured rejection data.
+
+A normal install MAY migrate a verified legacy numeric-`1` or numeric-`0.2` lockfile to `0.3` only after the resolved artifacts satisfy every current integrity check. Frozen installation SHALL retain legacy behavior without rewriting a numeric-`1` or numeric-`0.2` lockfile, and SHALL fail without rewriting any state when the project's recorded intent carries collision resolutions that the legacy lockfile format cannot represent. A current `0.2` archive SHALL require a `0.2`-or-current lockfile in frozen mode. Before a future stable lockfile v1 reuses numeric `1`, legacy-alpha support SHALL be removed and old-shape files SHALL receive actionable delete-and-regenerate guidance rather than shape-based reinterpretation.
+
+#### Scenario: Missing lockfile version
+
+- **WHEN** a lockfile omits `lockfileVersion`
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Current lockfile version is accepted
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 0.3` and satisfies the current schema
+- **THEN** the system SHALL accept it as current
+
+#### Scenario: Preceding alpha version is selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 0.2`
+- **THEN** the system SHALL interpret it under the preceding alpha schema only
+- **AND** it SHALL NOT infer a schema from the remaining shape
+
+#### Scenario: Legacy alpha version is selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 1`
+- **THEN** the system SHALL interpret it under the closed-alpha schema only
+- **AND** it SHALL NOT infer a schema from the remaining shape
+
+#### Scenario: Unsupported lockfile version is rejected
+
+- **WHEN** a lockfile declares an unsupported version
+- **THEN** the system SHALL reject it with structured data identifying the observed and supported versions
+
+#### Scenario: Normal install migrates verified legacy state
+
+- **WHEN** a non-frozen install loads a valid legacy `1` or `0.2` lockfile and verifies the resolved artifacts
+- **THEN** it MAY write an equivalent `0.3` lockfile after successful installation
+
+#### Scenario: Frozen install does not migrate legacy state
+
+- **WHEN** frozen installation uses a valid legacy lockfile whose format can represent the project's recorded intent
+- **THEN** it SHALL retain legacy behavior and SHALL NOT rewrite the lockfile
+
+#### Scenario: Frozen install fails when resolutions require the current format
+
+- **WHEN** frozen installation runs on a project whose recorded intent carries collision resolutions
+- **AND** the lockfile declares a legacy version that cannot represent effective materialized identities
+- **THEN** the operation SHALL fail without rewriting any state
+
+### Requirement: Each facet entry lists its assets, adapter-agnostically
+
+Every current facet entry SHALL include an `assets` array. Each member SHALL record the authored `scope`, `type`, `name`, and a required `files` array sorted deterministically by canonical path. `scope` SHALL be `system`, `user`, or `project`; `type` SHALL be `skill`, `agent`, or `command`. Each file record SHALL contain canonical inner-archive `path` and `sha256:<hex>` `integrity` over canonical archive bytes. The lockfile SHALL contain no adapter-specific fields or adapter-encoded hashes.
+
+When a recorded resolution assigns the asset a materialized alias, the entry SHALL additionally record the effective materialized name, which SHALL satisfy the same asset-name grammar as an authored name. When a recorded resolution omits the asset, the entry SHALL record the omission. An entry recording neither an alias nor an omission SHALL denote materialization under the authored name. Aliasing and omission SHALL NOT change any file record: `files` SHALL continue to list canonical inner-archive paths and integrity values derived from the authored archive.
+
+A skill's file records SHALL include `skills/<name>/SKILL.md` and every declared companion. An agent or command SHALL contain exactly its conventional primary file record. Companions SHALL remain subordinate to their owning skill and SHALL NOT become independent assets or receive their own scopes. Archive-only supplementary files SHALL NOT appear in an asset's files.
+
+#### Scenario: Valid multi-file skill entry
+
+- **WHEN** a skill named `planning` owns `SKILL.md` and two companions
+- **THEN** its lockfile asset entry SHALL contain three sorted canonical file records with integrity values
+
+#### Scenario: Valid single-file asset entry
+
+- **WHEN** an agent entry has `scope: "user"`, `type: "agent"`, and `name: "reviewer"`
+- **THEN** its `files` array SHALL contain exactly `agents/reviewer.md` and its integrity
+
+#### Scenario: Aliased asset records both identities
+
+- **WHEN** skill `review` is materialized under the alias `review-acme`
+- **THEN** its lockfile asset entry SHALL record the authored name `review` and the effective materialized name `review-acme`
+- **AND** its `files` array SHALL still list the canonical `skills/review/...` archive paths
+
+#### Scenario: Omitted asset records its omission
+
+- **WHEN** a recorded resolution omits command `deploy`
+- **THEN** the lockfile asset entry for `deploy` SHALL record the omission
+- **AND** the entry SHALL retain its authored identity and file records so the archive remains verifiable
+
+#### Scenario: Missing files array is rejected
+
+- **WHEN** a current asset entry omits `files`
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Companion is not an independent asset
+
+- **WHEN** skill `review` owns companion `references/api.md`
+- **THEN** the companion SHALL appear only in the skill's `files` array
+- **AND** it SHALL NOT appear as another asset entry
+
+#### Scenario: Archive-only path is excluded
+
+- **WHEN** a facet archive contains declared root `README.md`
+- **THEN** no lockfile asset's `files` array SHALL contain `README.md`
+
+#### Scenario: Unknown asset scope
+
+- **WHEN** an asset entry has `scope: "global"`
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Unknown asset type
+
+- **WHEN** an asset entry has `type: "hook"`
+- **THEN** the system SHALL reject the lockfile

--- a/openspec/changes/add-materialization-aliasing/adversarial/artifacts/specs/protocol__schemas/spec.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/artifacts/specs/protocol__schemas/spec.md
@@ -1,0 +1,135 @@
+## MODIFIED Requirements
+
+### Requirement: A project manifest schema is published as part of the protocol
+
+The shape of a project manifest (`facets.json`) SHALL be published as a normative schema. Any system that reads, writes, or interprets a project manifest SHALL conform to the published schema. The schema SHALL define how facet sources are listed, how version specifiers are expressed, and how compact and selective forms are distinguished.
+
+The schema SHALL define an explicit format-version field selected by exact equality rather than numeric ordering. A manifest that omits the field SHALL be interpreted as the legacy string-only form, in which every entry value is a compact source or version-specifier string; the legacy form SHALL remain valid input. An unsupported format version SHALL be rejected with structured data identifying the observed and supported versions.
+
+The current versioned form SHALL permit each facet entry to be either the compact string form or an enriched form that carries the same source information plus per-asset collision resolutions. A resolution SHALL identify one declared asset of the facet and SHALL be exactly one of: an alias assigning a materialized name, or an omission excluding the asset from materialization. An alias value SHALL satisfy the published asset-name grammar. An enriched entry SHALL NOT assign more than one resolution to the same asset and SHALL NOT express adapter-specific resolutions; one resolution applies to every adapter. Compact string entries SHALL remain valid within the current form for facets that require no resolution.
+
+#### Scenario: A consumer interprets a project manifest correctly
+
+- **WHEN** a system reads a `facets.json` containing a list of facet sources with version specifiers
+- **THEN** the system SHALL interpret each source per the published schema
+- **AND** ambiguous interpretations SHALL be rejected with a structured error
+
+#### Scenario: A producer writes a project manifest conforming to the schema
+
+- **WHEN** a system adds a new facet to a project's `facets.json`
+- **THEN** the resulting file SHALL satisfy the published schema
+- **AND** another facet-compatible system SHALL accept the file after validating it
+
+#### Scenario: A legacy unversioned manifest is accepted as legacy
+
+- **WHEN** a system reads a `facets.json` with no format-version field whose entries are all compact strings
+- **THEN** the system SHALL interpret it under the legacy string-only form
+- **AND** the system SHALL NOT reject it for lacking a format version
+
+#### Scenario: An enriched entry with a valid alias is accepted
+
+- **WHEN** a current-format manifest entry declares a facet source and aliases one of the facet's assets to a name satisfying the asset-name grammar
+- **THEN** the system SHALL accept the entry
+- **AND** the system SHALL interpret the alias as the asset's effective materialized name for every adapter
+
+#### Scenario: An alias violating the asset-name grammar is rejected
+
+- **WHEN** an enriched entry aliases an asset to `Review--Code`, a name with a `/`, or a name exceeding the permitted length
+- **THEN** the system SHALL reject the manifest
+- **AND** the structured failure SHALL identify the invalid alias and the naming constraint
+
+#### Scenario: Conflicting resolutions for one asset are rejected
+
+- **WHEN** an enriched entry assigns the same asset both an alias and an omission, or two different aliases
+- **THEN** the system SHALL reject the manifest with a structured error identifying the doubly-resolved asset
+
+#### Scenario: Adapter-specific resolutions are rejected
+
+- **WHEN** a manifest entry attempts to scope a resolution to a particular adapter
+- **THEN** the system SHALL reject the manifest
+- **AND** the failure SHALL state that resolutions are project-level
+
+#### Scenario: An unsupported manifest format version is rejected
+
+- **WHEN** a `facets.json` declares a format version the system does not support
+- **THEN** the system SHALL reject it with structured data identifying the observed and supported versions
+
+### Requirement: A lockfile schema is published as part of the protocol
+
+The shape of a lockfile (`facets.lock`) SHALL be published as a normative schema. Any system that reads, writes, or interprets a lockfile SHALL conform to the published schema. The schema SHALL define the lockfile version, source-provenance fields, identity-and-integrity fields, the asset list and its materialized-file integrity records, the representation of collision resolutions, and the rules for unrecognized fields.
+
+Version dispatch SHALL use exact equality rather than numeric ordering. Legacy numeric `1` SHALL identify only the closed-alpha schema, numeric `0.2` SHALL identify only the preceding alpha schema, and numeric `0.3` SHALL identify the current schema. Archive-format and lockfile-format versions SHALL be interpreted independently even when they have the same numeric value. A lockfile JSON document containing duplicate object member names SHALL be rejected before schema validation.
+
+The published schema's source-provenance fields SHALL take a tagged form keyed on the source kind, so that the provenance fields meaningful for each kind are explicit. The published schema SHALL define a registry source that records the registry origin, a git source that records the repository URL and a required resolved commit, and a local source that records the resolved path. A lockfile whose entry source does not declare a recognized kind, or omits a field required for its declared kind, SHALL NOT satisfy the published schema. A source MAY carry additional unrecognized keys and still satisfy the published schema.
+
+Every current asset entry SHALL record the authored `scope`, `type`, and `name` plus a required `files` array sorted deterministically by canonical path. Each file record SHALL contain exactly the canonical inner-archive `path` and its `sha256:<hex>` `integrity` over canonical archive bytes. An asset entry MAY additionally record exactly one of: an effective materialized name satisfying the published asset-name grammar, or an omission marker. An entry recording neither denotes materialization under the authored name. Aliasing and omission SHALL NOT alter the `files` records, which always describe the authored archive. A skill entry SHALL list `skills/<name>/SKILL.md` and every declared companion below that skill. An agent entry SHALL list exactly `agents/<name>.md`; a command entry SHALL list exactly `commands/<name>.md`. Archive-only supplementary files SHALL NOT appear in an asset's `files` array, and companion files SHALL NOT appear as independent assets.
+
+#### Scenario: A consumer interprets a lockfile written by a different system
+
+- **WHEN** a system reads a `facets.lock` written by a different facet-compatible system
+- **THEN** the system SHALL interpret every field per the published schema
+- **AND** the system SHALL accept the lockfile as valid input for installation
+
+#### Scenario: A producer writes a lockfile that any consumer can read
+
+- **WHEN** a system writes a `facets.lock` after resolving facet sources and collision resolutions
+- **THEN** the resulting file SHALL satisfy the published schema
+- **AND** another facet-compatible system SHALL be able to read the file and reproduce the same effective install state
+
+#### Scenario: Source provenance is tagged by kind
+
+- **WHEN** a facet-compatible system reads an entry's source provenance from a `facets.lock`
+- **THEN** the source SHALL declare its kind as registry, git, or local
+- **AND** a registry source SHALL record the registry origin and SHALL NOT carry a version specifier
+- **AND** a git source SHALL record the repository URL and a required resolved commit, and SHALL NOT record a symbolic ref
+- **AND** a local source SHALL record the resolved path
+
+#### Scenario: A git source missing its required commit is rejected
+
+- **WHEN** a facet-compatible system reads a lockfile whose entry declares a git source with no commit
+- **THEN** the lockfile SHALL NOT satisfy the published schema
+- **AND** the system SHALL reject the lockfile
+
+#### Scenario: A source with extra unrecognized keys is accepted
+
+- **WHEN** a facet-compatible system reads a lockfile whose entry source declares a recognized kind with all its required fields plus unrecognized keys
+- **THEN** the lockfile SHALL satisfy the published schema
+- **AND** the system SHALL accept the lockfile
+
+#### Scenario: Current skill entry lists every materialized file
+
+- **WHEN** a `0.3` lockfile records skill `review` with companions `references/api.md` and `scripts/run.ts`
+- **THEN** the skill's sorted `files` array SHALL contain `skills/review/SKILL.md`, `skills/review/references/api.md`, and `skills/review/scripts/run.ts`
+- **AND** each record SHALL contain a canonical path and `sha256:<hex>` integrity
+
+#### Scenario: Aliased asset entry distinguishes authored and effective identity
+
+- **WHEN** a `0.3` lockfile records skill `review` materialized under the alias `review-acme`
+- **THEN** the asset entry SHALL record the authored name `review` and the effective materialized name `review-acme`
+- **AND** the `files` array SHALL still list canonical `skills/review/...` paths with authored-archive integrity
+
+#### Scenario: An invalid effective name fails the schema
+
+- **WHEN** a `0.3` asset entry records an effective materialized name that violates the published asset-name grammar
+- **THEN** the lockfile SHALL NOT satisfy the published schema
+
+#### Scenario: An entry cannot be both aliased and omitted
+
+- **WHEN** a `0.3` asset entry records both an effective materialized name and an omission marker
+- **THEN** the lockfile SHALL NOT satisfy the published schema
+
+#### Scenario: Single-file assets list one file
+
+- **WHEN** a `0.3` lockfile records agent `reviewer` and command `review`
+- **THEN** each asset's `files` array SHALL contain exactly its conventional primary path
+
+#### Scenario: Archive-only file is excluded from asset records
+
+- **WHEN** a verified facet contains a declared root `README.md`
+- **THEN** no current asset entry SHALL list `README.md`
+
+#### Scenario: Legacy versions are selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 1` or numeric `lockfileVersion: 0.2`
+- **THEN** the system SHALL interpret it only with the matching legacy schema
+- **AND** the system SHALL NOT reinterpret its shape as `0.3`

--- a/openspec/changes/add-materialization-aliasing/adversarial/reviews/design-review.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/reviews/design-review.md
@@ -1,0 +1,189 @@
+# Comparison review: `design` — add-materialization-aliasing
+
+**Main**: `openspec/changes/add-materialization-aliasing/design.md`
+**Adversary**: `openspec/changes/add-materialization-aliasing/adversarial/artifacts/design.md`
+Both were derived from the reconciled proposal; the adversary authored blind to Main.
+
+**Grading bar**: correct design-artifact mechanics (template sections, RFC 2119
+for normative statements, alternatives per decision, Article III documentation
+duties), decision quality (rationale grounded in the actual codebase),
+coverage of every proposal commitment (transactional whole-set detection,
+persisted intent + resolved state, authored/effective identity split,
+interactive + structured-failure flows, frozen behavior, compatibility), and
+technical correctness against the current engine/protocol implementation.
+
+## Convergence (high confidence)
+
+The two designs independently agree on the architectural spine, which is the
+strongest possible signal that it is right:
+
+- Restructure the interleaved per-facet loop into resolve-everything →
+  whole-set collision gate → materialize, with the gate on the no-mutation
+  path before any adapter write (Main D5, Adversary D1).
+- A pure, deterministic planner and the namespace mapping
+  (skill+command shared, agent separate) live in **protocol**, not engine
+  (Main D1/D4, Adversary D2/D10). Scope participates in the collision key.
+- "Keep" is not persisted; only aliases and omissions are recorded, and
+  detection is always "apply overrides, require the residual effective set
+  to be collision-free" (identical reasoning in both, independently derived).
+- Enriched `facets.json` entry: per-facet object with per-type maps keyed by
+  authored name; compact string form stays canonical when no overrides
+  exist; old CLIs fail loudly on the object shape before any mutation
+  (Main D2, Adversary D4).
+- Lockfile `0.3` + receipt `0.3` under exact version dispatch; `name` stays
+  authored; `files[]` stays canonical archive paths; integrity chains never
+  see aliases (Main D3, Adversary D5/D9).
+- Engine↔CLI seam is an optional async resolver callback under the held
+  install lock; no callback ⇒ structured no-mutation failure with all
+  groups; frozen never prompts and never migrates; cancellation is a value
+  (Main D6, Adversary D6/D8).
+- Adapter API unchanged; adapters receive the effective name and cannot
+  tell an alias from an authored name.
+
+None of this needs relitigating at reconciliation.
+
+## Material divergences
+
+### 1. Omitted assets in the lockfile — **Main is stronger**
+
+Main keeps every authored asset in `assets[]` with a required tagged
+`materialization` disposition (omitted assets keep their `files[]` hashes);
+Adversary drops omitted assets from `assets[]` and derives omission from
+manifest intent. Main explicitly anticipated and rejected the adversary's
+choice ("Drop omitted assets from the lockfile. Rejected because the
+lockfile must record the resolved asset set and compare it with project
+intent"). Main's shape is better on three counts: locked-vs-plan
+reconciliation stays intent-independent; the tagged union follows the
+illegal-states-unrepresentable doctrine where Adversary's optional `as`
+plus absence-encoding splits one concept across two mechanisms; and the
+frozen consistency check becomes largely lockfile-internal. Adopt Main.
+
+### 2. Lockfile write policy — **genuine decision point; Main is simpler, Adversary preserves more compatibility**
+
+Main migrates every project to `0.3` on the first successful normal install
+(precedent: the 1→0.2 rollout). Adversary proposes a **version-preserving
+write**: emit `0.2` while the project has zero resolutions, `0.3` once any
+exists — confining the BREAKING format to projects that opted in, at the
+cost of a bimodal serializer and possible 0.2↔0.3 oscillation. Main's
+unconditional migration is simpler and precedent-aligned but breaks older
+CLIs for *every* project on next install, not just resolution users —
+arguably wider than the proposal's BREAKING bullet implies. **Recommend:**
+keep Main's unconditional migration for simplicity, but the design MUST add
+the version-preserving write as a named considered-and-rejected alternative
+with this compatibility trade-off stated — right now Main's D3 does not
+acknowledge that its migration choice breaks uninvolved projects, and Main's
+rollback section should note the Adversary's observation that under
+unconditional migration, "remove resolutions and reinstall" does NOT return
+a project to `0.2`.
+
+### 3. Manifest override value shape — **Main is stronger, with an ergonomics debt**
+
+Main uses tagged objects (`{ "kind": "aliased", "as": ... }` /
+`{ "kind": "omitted" }`); Adversary uses compact `string | false`. Main's
+shape is the same disposition type as protocol's model (single source of
+truth) and extensible; Adversary's is far friendlier to the hand-editing CI
+workflow both designs mandate. Keep Main's shape, but fold in the
+Adversary's mitigation: the structured `UNRESOLVED_COLLISIONS` rendering
+SHOULD print a ready-to-paste `facets.json` fragment per group (Adversary's
+open question; Main's failure rendering doesn't commit to this).
+
+### 4. Stale overrides — **Main is stronger, one caveat**
+
+Main: overrides survive collision disappearance (durable intent), absent-
+asset overrides are reported and pruned only inside a successful tri-write,
+frozen treats them as drift and fails. Adversary: warn-and-ignore, prune
+only interactively. Main's frozen-drift failure is the correct
+reproducibility stance and auto-prune-on-commit avoids warning fatigue.
+Caveat worth carrying: auto-pruning discards intent that a facet
+*downgrade* would re-activate; Main already confines pruning to successful
+normal installs, which is acceptable — but the prune SHOULD be surfaced as
+a distinct stage event, not just a log line.
+
+### 5. Companion-byte lifetime — **Main is stronger**
+
+Adversary keeps plans byte-free and re-reads companion bytes per facet
+during materialization; Main holds resolved bytes eagerly through compose
+precisely to avoid a time-of-check/time-of-use gap for local sources, and
+carries the memory cost as an explicit risk with a deferred lazy-read
+optimization. Main caught a correctness hazard the Adversary's "cheap
+plans" framing misses. Adopt Main.
+
+### 6. Global ownership transfer and duplicate receipt claims — **Main only; important**
+
+Main's D7 is coverage the Adversary lacks entirely: cross-facet ownership
+transfer (an old adapter key retained by any desired asset is never
+deleted), aggregation of historical duplicate receipt claims (which
+pre-collision-detection installs can legitimately contain — the very bug
+this change fixes), and delete-once semantics per adapter key. The
+Adversary's per-facet effective-identity diff would mishandle exactly the
+broken pre-existing states this feature is built to clean up. Adopt Main
+verbatim; this is the single largest quality gap between the two versions,
+in Main's favor.
+
+### 7. Portable-name collision keys and duplicate JSON members — **Main only**
+
+Main normalizes collision keys with the existing portable (NFC + case-fold)
+rules and rejects duplicate JSON members before schema validation.
+Adversary used raw effective names and standard parsing. Both Main
+hardenings are correct and cheap; keep them.
+
+## Where the Adversary is stronger
+
+- **No non-interactive resolution flag — decided, not open.** Adversary
+  rules out a `--resolve`-style flag with a principled rationale (intent
+  belongs in the committed manifest, not pipeline arguments); Main leaves
+  the same question open. Recommend Main adopt the Adversary's position and
+  close its first open question, or at minimum record the rationale.
+- **`facet edit` / other `facets.json` writers.** Adversary explicitly
+  flags that the edit machinery (`packages/engine/src/edit/` scanner,
+  manifest-writer, reconcile) rewrites `facets.json` and MUST at minimum be
+  read-tolerant of expanded entries — silently collapsing an object entry
+  back to a string would destroy user intent (data loss). Main's migration
+  step 2 covers "manifest mutations and source write policy" but never
+  names the edit flow. This is a coverage gap in Main.
+- **`remove` path statement.** Adversary explicitly notes `facet remove`
+  funnels through the gate and passes trivially without special-casing;
+  Main is silent. One sentence of completeness worth adding.
+
+## Artifact mechanics
+
+Both use RFC 2119 correctly, both carry alternatives per decision, both
+satisfy Article III with concrete doc lists. Main's documentation section is
+broader and more precise (adds `planning.mdx`, `custom-adapters.mdx`,
+`instructions.mdx`, changelog, and an explicit README review concluding no
+change needed — the Adversary only conditionally mentioned README). Main
+also adds an update-classification rule (disposition change ⇒ facet
+"updated") and a resolver re-invocation loop for alias-induced collisions —
+both good details the Adversary lacks. Main's Migration Plan is more
+operationally sequenced (enable `0.3` writes last). Main is the better
+artifact overall.
+
+## Merge recommendation (per decision)
+
+1. **D1/D4 (identity model, planner, keys)** — keep Main; no changes.
+2. **D2 (manifest shape)** — keep Main; add the ready-to-paste-fragment
+   commitment to the failure rendering (from Adversary).
+3. **D3 (lockfile/receipt 0.3)** — keep Main's omitted-assets-stay shape;
+   ADD the version-preserving write as a named rejected alternative and fix
+   the rollback narrative to acknowledge unconditional migration's blast
+   radius (from Adversary).
+4. **D5 (phases)** — keep Main.
+5. **D6 (resolver callback)** — keep Main; close Open Question 1 by
+   adopting the Adversary's no-CLI-flag decision with its rationale.
+6. **D7 (global ownership)** — keep Main verbatim.
+7. **Migration Plan step 2** — extend to name the `facet edit`
+   scanner/manifest-writer explicitly: it MUST preserve (not collapse)
+   expanded entries, with test coverage (from Adversary).
+8. **Add one sentence** noting `remove` passes the gate trivially.
+
+## Blocking items before archive
+
+1. **Lockfile write policy must be settled explicitly** (divergence 2):
+   unconditional `0.3` migration vs. version-preserving write changes the
+   lockfile spec deltas, the frozen-migration rules, and the rollback
+   documentation. The specs artifact cannot be authored coherently until
+   the design records the decision *and* its rejected alternative.
+2. **`facets.json` writer inventory** (divergence — edit flow): every code
+   path that rewrites `facets.json` must be enumerated in the design (or
+   tasks) with the preservation requirement, or user intent can be silently
+   destroyed — a data-loss class defect, not a polish item.

--- a/openspec/changes/add-materialization-aliasing/adversarial/reviews/proposal-review.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/reviews/proposal-review.md
@@ -1,0 +1,68 @@
+# Comparison Review: `proposal` — add-materialization-aliasing
+
+**Main**: `openspec/changes/add-materialization-aliasing/proposal.md`
+**Adversary**: `openspec/changes/add-materialization-aliasing/adversarial/artifacts/proposal.md`
+
+The adversarial proposal was authored from the main proposal's intent (the `proposal` exception) but re-derived its framing independently from `docs/specification/*` and the permanent specs (`installation`, `protocol__schemas`, `cli`, `spec-governance`).
+
+## Grading bar
+
+- Proposal mechanics: Why / What Changes / Capabilities / Impact per template; Non-goals section present; under word limits; docs citation rule satisfied.
+- RFC 2119 keywords for normative statements.
+- Capabilities name product domains that match `openspec/specs/` (the contract for the specs phase).
+- Smallest customer-valuable scope; "why" not "how".
+- Coverage: does each version capture the full behavioral surface (detection, resolution, persistence, reproduction, integrity, lifecycle, docs)?
+
+Both versions pass the mechanical bar: correct sections, Non-goals present, BREAKING marked, docs cited, RFC 2119 used, within word limits (Main ~700 words, Adversary ~850).
+
+## Coverage comparison
+
+Shared coverage (equivalent substance, differing wording): pre-write collision evaluation over the complete desired asset set; skills+commands in one namespace, agents separate; per-asset keep/alias/omit with a collision-free result; alias grammar reuse; interactive collection vs. structured non-interactive failure leaving all state untouched; persistence as version-controlled intent with compact string entries preserved; lockfile distinguishing authored from effective identities; receipt/repair/removal operating on effectively-owned files; integrity anchored to authored archive identities; one project-level resolution for all adapters; omission excluding a skill's companions; BREAKING tooling requirement; docs updates including troubleshooting and changelog; no new runtime dependency.
+
+Material divergences:
+
+### 1. Why framing — Adversary stronger
+
+Main states the gap abstractly ("the current install contract does not resolve collisions … facets cannot be composed safely"). Adversary names the concrete present-day failure: undefined behavior today means silent overwrite / order-dependent state, and — sharper — **receipt-driven removal of one facet can delete a file another facet still claims**, since both record ownership of the same conventional path. That reframes the change from "feature gap" to "latent correctness bug in the core install path," which is a materially stronger "why now" and directly motivates the transactional pre-write gate.
+
+**Recommendation**: merge the Adversary's concrete failure mode (silent overwrite, order dependence, cross-facet receipt deletion hazard) into Main's Why. Keep Main's composability sentence as the lead.
+
+### 2. Capabilities — Main stronger (Adversary's omission of `cli` is wrong)
+
+Adversary lists only `installation` and `protocol__schemas`, arguing prompting requirements live in `installation` (citing the adapter-selection prompt precedent there) and that the `cli` spec covers only generic argv/dispatch/help. That argument is factually incomplete: the `cli` spec *also* carries command-level requirements for exactly this territory — "Add launches adapter selection when none is selected," "Add and install render a unified progress view," "Add and install report integrity failures clearly." A collision-resolution prompt and structured-failure rendering would need `cli` deltas by direct analogy. Main's three-capability list is correct.
+
+**Recommendation**: keep Main's Capabilities section as-is. Carry forward one useful residue of the Adversary's argument as guidance for the specs phase: behavior-level requirements (what must be detected, resolved, persisted, failed) belong in `installation`; the `cli` delta should carry only command/presentation-level requirements (prompt flow, rendering of collision groups and failures), mirroring how adapter selection is split between the two specs today.
+
+### 3. Detection on every install — Adversary explicit, Main implicit
+
+Adversary states detection "SHALL run on every install, not only on add," calling out that **facet updates can introduce new collisions** (the sneaky path: a teammate updates a facet, and a previously clean project collides in CI). Main's "before any materialization write … complete desired asset set" technically implies this, but never names the update-introduced case, and its frozen-mode mention is buried in the reproduction bullet.
+
+**Recommendation**: make it explicit in Main's What Changes that evaluation happens on every install path (add, install, update, frozen, repair) and that a frozen install encountering an unresolved collision fails without rewriting any state.
+
+### 4. Resolution-group flexibility — Main stronger
+
+Main explicitly says "A resolution MAY alias multiple assets or omit every asset in the group" — preempting a plausible misreading that exactly one asset must keep the authored name. Adversary's per-asset "choose exactly one resolution: keep/alias/omit" plus the collision-free constraint is equivalent but leaves that MAY to inference.
+
+**Recommendation**: keep Main's sentence. Optionally adopt the Adversary's crisp per-asset enumeration ("exactly one of keep, alias, omit per asset") as the lead-in, since it is the cleaner contract statement, with Main's MAY clause as the clarifier.
+
+### 5. Non-goals — minor Adversary addition
+
+The lists are otherwise equivalent (per-adapter resolution, publisher-side aliasing, silent winner selection, within-facet validation, MCP/future asset types). Adversary adds one Main lacks: **renaming facet identities (the `facets.json` keys) is out of scope — only materialized asset names are affected**. Cheap to add and closes a real ambiguity (a user hitting a collision might expect to rename the facet instead).
+
+**Recommendation**: add that non-goal to Main.
+
+### 6. Impact — equivalent
+
+Both name the same package surfaces, the lockfile exact-version-dispatch design question, unchanged adapter contract shape, and the same docs set (Main's "troubleshooting guidance" ≈ Adversary's explicit troubleshooting page). No merge needed beyond what #1 and #3 already imply.
+
+## Merge recommendation (summary, per section)
+
+- **Why**: adopt Adversary's concrete failure-mode framing (silent overwrite, order dependence, receipt cross-deletion) into Main.
+- **What Changes**: add Adversary's explicit "detection on every install, updates can introduce new collisions, frozen fails without rewriting"; keep everything else from Main, including the multi-alias/omit-all MAY clause.
+- **Capabilities**: keep Main (three capabilities). Note the behavior-vs-presentation split between `installation` and `cli` for the specs phase.
+- **Non-goals**: add "facet identity renaming is out of scope."
+- **Impact**: no change.
+
+## Blocking items
+
+None. The one contract-level divergence (whether `cli` is a modified capability) resolves in Main's favor on the evidence of existing `cli`-spec requirements, so the Capabilities contract feeding the specs phase stands as written.

--- a/openspec/changes/add-materialization-aliasing/adversarial/reviews/specs-review.md
+++ b/openspec/changes/add-materialization-aliasing/adversarial/reviews/specs-review.md
@@ -1,0 +1,86 @@
+# Comparison Review: `specs` — add-materialization-aliasing
+
+**Main**: `specs/installation/spec.md`, `specs/protocol__schemas/spec.md`, `specs/cli/spec.md` (change root)
+**Adversary**: `adversarial/artifacts/specs/{installation,protocol__schemas,cli}/spec.md`
+
+Both versions were derived from the reconciled proposal. The adversarial version was authored blind to Main.
+
+## Grading bar
+
+- **Value-centric** (spec-governance litmus: would a user/developer care if it stopped working?)
+- **RFC 2119** keyword discipline
+- **Atomic + testable** requirements and scenarios
+- **Correct delta mechanics** — especially the MODIFIED rule: *copy the ENTIRE requirement block and edit*; partial/condensed content silently loses normative text at archive time
+- **Coverage** of the proposal's contract: transactional collision detection on every path, exactly-one resolution per asset, persisted intent, authored-vs-effective identity split, alias grammar, format versioning with exact dispatch, frozen behavior, docs-relevant CLI behavior
+
+## Coverage comparison
+
+Both versions cover the proposal's core: cross-facet collision detection before any write on all install paths, shared skill/command namespace with agents separate, keep/alias/omit with exactly-one resolution per asset and a collision-free result, no silent winner, persisted intent reproduced without prompting, alias grammar enforcement, project-level (never per-adapter) resolutions, authored identities for verification vs effective identities for materialized state, omission excluding companions, lockfile `0.3` with exact dispatch, project-manifest format versioning with legacy string-only manifests still valid, transactional migration, frozen fail-without-rewrite, interactive resolution + structured non-interactive failure.
+
+**Main goes materially further than Adversary in:**
+
+- **Collision identity model** — Main defines collision as same *scope* + namespace + *portable* effective name, and states assets in different scopes don't collide. Adversary never considered the scope dimension or filesystem-portability (case-fold) of effective names. Main is stronger and more correct.
+- **Evaluation paths** — Main includes *removal* in the evaluation set (needed for its ownership-transfer semantics). Adversary stopped at the proposal's five paths.
+- **Resolution expressiveness** — Main explicitly permits name transfer from an omitted asset and exchanging effective names when the final set is unique. Adversary's "still collides → reject" covers correctness but not these legal-and-useful rearrangements.
+- **Ownership reconciliation** ("Materialized ownership is reconciled against the complete effective set") — cross-facet identity transfer without delete-then-lose, duplicate historical claim aggregation, alias-change moves owned files transactionally, omission toggling, disposition-only change reported as an update. Adversary has only drift-repair/removal-at-effective-path scenarios. This is Main's single biggest coverage win; it addresses real correctness failures Adversary's version would leave unspecified.
+- **Durable + stale intent** — Main: overrides survive the collision that motivated them (alias remains after the other facet is removed); stale overrides are reported and pruned *only in a successful commit*, preserved on failure, and treated as blocking drift in frozen mode. Adversary's "stale is reported, not fatal, never pruned" is weaker and leaves permanent garbage in the manifest. Main's transactional prune + mandatory CLI notice is the better design.
+- **Receipt** — Main modifies the receipt requirement to schema `0.3` with dispositions and omitted-assets-excluded (including bootstrap). Adversary never touched the receipt schema; its omission handling exists only as an ADDED requirement, leaving the receipt version story implicit.
+- **Migration decisiveness** — Main: every successful non-frozen install SHALL write `0.3`, resolution-free projects included, and removing all overrides never downgrades. Adversary's "MAY migrate" is indecisive and would permit divergent implementations.
+- **Protocol shape** — Main's ADDED "Materialization dispositions use one published tagged shape" (three arms; alias must carry a name; effective name on other arms rejected; project intent admits only `aliased`/`omitted` because absence means authored; resolved state requires all three). This makes illegal states unrepresentable and is cleaner than Adversary's optional alias-or-omission markers with a default. Main's lockfile also *requires* the disposition, catching truncated writes that Adversary's optional-field default would silently accept.
+- **Project-manifest schema concreteness** — Main pins `manifestVersion: 0.1` exact dispatch, expanded entries with typed `skills`/`commands`/`agents` maps keyed by authored name, compact-string canonical when no overrides, preservation and collapse rules for producers, duplicate-member rejection, and — correctly — that an override naming an absent asset stays *schema*-valid because document validation must not require source resolution. Adversary left the format version abstract (weakly testable), specified no grouping shape, omitted duplicate-member rejection, and its phrase "a resolution SHALL identify one declared asset of the facet" wrongly implies resolution-time validation inside schema validation. Main wins this file almost wholesale.
+- **CLI interaction depth** — Main specifies the overview-then-focused-group workspace, live global revalidation with draft-conflict states that stay editable, status distinguishable without color (accessibility), interrupt-safe cancellation, non-interactive failures that point at the exact `facets.json` location with valid snippets and explicitly never generate a winner, and stale-intent prune notices without `--verbose`. Adversary's CLI file is a correct but thin subset.
+
+**Adversary is stronger in a small number of specific places:**
+
+1. **Preserved normative clauses in "Lockfile declares a version"** — Adversary's MODIFIED block retains (a) the forward-compat guard "Before a future stable lockfile v1 reuses numeric `1`, legacy-alpha support SHALL be removed and old-shape files SHALL receive actionable delete-and-regenerate guidance…" and (b) an updated archive/lockfile frozen pairing rule ("A current `0.2` archive SHALL require a `0.2`-or-current lockfile in frozen mode"). Main's MODIFIED block **drops both sentences**, which deletes them from the permanent spec at archive time.
+2. **Frozen + legacy lockfile + resolutions scenario** — Main states the rule in requirement text ("SHALL fail if its schema cannot represent the project manifest's materialization intent") but has no scenario for it. Adversary has a dedicated scenario.
+3. **CLI summary surfaces the mapping** — Adversary requires the final summary to show each aliased asset's authored name *together with* its effective name, and to identify omitted assets as omitted. Main only requires classifying a disposition-only change as "updated" — a user watching Main's install never sees what `review` actually materialized as. This is a genuine user-value gap.
+4. **Migration preserves entries** — Adversary's scenario asserts a migrated manifest preserves every declared entry with unchanged meaning. Main covers producer preservation in the schemas file but its installation migration requirement doesn't say it.
+
+## Divergences and verdicts
+
+| Topic | Main | Adversary | Stronger |
+| --- | --- | --- | --- |
+| Collision identity (scope, portability) | scope + namespace + portable name | name + namespace only | **Main** |
+| Evaluation paths | + removal | proposal's five | **Main** |
+| Ownership reconciliation / transfer | full requirement | partial scenarios | **Main** |
+| Stale overrides | transactional prune + notice; frozen = drift | report-only, never prune | **Main** |
+| Receipt schema | bumped to 0.3, omitted excluded | untouched | **Main** |
+| Lockfile migration | unconditional 0.3 | MAY migrate | **Main** |
+| Disposition shape | required tagged three-arm, published | optional markers, default authored | **Main** |
+| Manifest schema (version, typed maps, producer rules, dup members) | concrete `0.1`, complete | abstract, thin | **Main** |
+| CLI workspace, accessibility, actionable failures, stale notices | rich | thin | **Main** |
+| MODIFIED fidelity to permanent spec text | **condenses; drops normative sentences** | preserves full text + edits | **Adversary** |
+| Frozen-legacy-lockfile-with-resolutions scenario | text only | scenario present | **Adversary** |
+| Summary shows authored→effective / omitted | absent | present | **Adversary** |
+
+## 🚨 Blocking cross-cutting item: Main's MODIFIED blocks condense the permanent spec
+
+The specs instruction is explicit: a MODIFIED requirement must contain the **entire updated requirement block**, because at archive time it *replaces* the permanent requirement wholesale — "using MODIFIED with partial content loses detail at archive time." Main's installation MODIFIED blocks are rewritten summaries, not full-copy-plus-edit. Verified against `openspec/specs/installation/spec.md`, the following normative content would be silently deleted:
+
+- **"Lockfile declares a version"**: the v1-numeric-reuse guard sentence; the frozen archive/lockfile pairing sentence (see Adversary win #1).
+- **"Frozen-lockfile install treats the lockfile as authoritative"**: "Because frozen mode never creates a lockfile entry, it SHALL NOT require integrity confirmation against the registry; its only permitted network activity is downloading already-locked content"; the "frozen mode constrains the locked set, not the machine's materialized state" framing; several scenario AND-clauses (e.g., failure messages identifying manifest specifier and locked version).
+- **"A machine-local record tracks what each project has materialized"**: per-project receipt isolation ("two projects SHALL never share one", no cross-project contention); "the receipt SHALL survive lockfile changes made outside the system"; the untrusted-receipt validation specifics (project identity, record shape, path containment); the legacy primary-only-ownership refinement rationale.
+- **"Integrity is verified before any asset is written"**: "Normal resolution SHALL write a replacement lock entry only after all checks succeed"; "expected and actual integrity when available".
+- **"Removing a facet uninstalls it"**: the adapter-compatibility precondition detail (positional `0.0` vs tagged `0.1` axis, precondition requires neither cache nor network, repair-then-offline-removal guarantee) and the "Other facets are left intact" scenario.
+
+Each of these MODIFIED requirements must be re-diffed against the permanent spec and restored to full-text-plus-edits — or each dropped sentence explicitly justified as an intentional removal (which would then belong under REMOVED semantics with reason/migration, not silent omission). **This must be settled before archive.**
+
+Additionally, one apparent drift bug: Main's CLI MODIFIED "unified progress view" scenario changed the stage list from "fetch, verification, build, and materialization" to "fetch, verification, build, **composition**, and materialization". Facet composition is explicitly rejected by the permanent installation spec and this change's proposal touches nothing called composition. Revert the word or justify it.
+
+## Merge recommendation (per capability)
+
+**`installation`** — keep Main as the base; it is broader and better on nearly every axis. Then:
+1. **(Blocking)** Restore full permanent-spec text in every MODIFIED requirement, re-applying Main's edits on top (list above).
+2. Add Adversary's scenario "Frozen install fails when resolutions require the current format" under "Lockfile declares a version".
+3. Consider Adversary's "migration preserves every entry with unchanged meaning" assertion in the manifest-migration requirement (one AND-line).
+
+**`protocol__schemas`** — keep Main wholesale. The tagged disposition requirement, `manifestVersion: 0.1` dispatch, typed override maps, producer preservation/collapse rules, and duplicate-member rejection are all stronger than Adversary's equivalents. No Adversary content needs merging; its "cannot be both aliased and omitted" and "adapter-scoped resolutions rejected" concerns are already made unrepresentable by Main's shapes.
+
+**`cli`** — keep Main as the base. Then:
+1. Adopt Adversary's summary requirement: the final summary SHALL show each aliased asset's authored name together with its effective materialized name and SHALL identify omitted assets as omitted (fold into Main's modified progress-view requirement or add as a scenario there).
+2. **(Fix)** Revert or justify the "composition" stage word in the modified progress-view scenario.
+
+## Bottom line
+
+Main is the substantially stronger artifact — richer collision model, ownership reconciliation, transactional stale-intent handling, a well-typed published disposition shape, and a far more complete CLI contract. Its one serious defect is mechanical, not conceptual: its MODIFIED blocks are condensations that would silently delete permanent normative text at archive time, plus one drift bug ("composition"). Reconcile by restoring full MODIFIED fidelity, then fold in the three small Adversary wins (frozen-legacy scenario, summary mapping visibility, migration-preserves-entries).

--- a/openspec/changes/add-materialization-aliasing/adversarial/state.json
+++ b/openspec/changes/add-materialization-aliasing/adversarial/state.json
@@ -1,0 +1,46 @@
+{
+  "change": "add-materialization-aliasing",
+  "schema": "spec-driven",
+  "entries": {
+    "proposal": {
+      "artifactId": "proposal",
+      "mainPaths": ["proposal.md"],
+      "adversarialPaths": ["adversarial/artifacts/proposal.md"],
+      "reviewPath": "adversarial/reviews/proposal-review.md",
+      "dependencies": [],
+      "status": "reconciled",
+      "authoredAt": "2026-07-26T21:00:32Z",
+      "comparedAt": "2026-07-26T21:04:00Z",
+      "reconciledAt": "2026-07-26T21:08:31Z",
+      "notes": "Adopted concrete correctness-failure framing, explicit collision checks across every install path including frozen reproduction, exactly-one per-asset resolutions, and facet-identity renaming as a non-goal. Retained the main proposal's three-capability contract and existing impact analysis."
+    },
+    "design": {
+      "artifactId": "design",
+      "mainPaths": ["design.md"],
+      "adversarialPaths": ["adversarial/artifacts/design.md"],
+      "reviewPath": "adversarial/reviews/design-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-07-26T21:45:00Z",
+      "comparedAt": "2026-07-26T21:58:00Z",
+      "reconciledAt": "2026-07-26T21:58:01Z",
+      "notes": "Retained the main design's tagged dispositions, omitted lockfile assets, global ownership model, portable keys, and eager companion bytes. Adopted an explicit unconditional 0.3 migration decision with the version-preserving alternative rejected, structured stale-override events, non-interactive manifest-edit guidance without generated winners, no resolution flags, actual facets.json writer preservation coverage, and the shared remove path. Rejected the facet edit preservation claim because that subsystem writes facet.json rather than facets.json."
+    },
+    "specs": {
+      "artifactId": "specs",
+      "mainPaths": ["specs/cli/spec.md", "specs/installation/spec.md", "specs/protocol__schemas/spec.md"],
+      "adversarialPaths": [
+        "adversarial/artifacts/specs/cli/spec.md",
+        "adversarial/artifacts/specs/installation/spec.md",
+        "adversarial/artifacts/specs/protocol__schemas/spec.md"
+      ],
+      "reviewPath": "adversarial/reviews/specs-review.md",
+      "dependencies": ["proposal"],
+      "status": "reconciled",
+      "authoredAt": "2026-07-26T23:59:00Z",
+      "comparedAt": "2026-07-27T00:14:00Z",
+      "reconciledAt": "2026-07-26T23:21:56Z",
+      "notes": "Retained the main collision, ownership, tagged-disposition, manifest, and CLI models. Restored full permanent normative behavior across modified installation and protocol lockfile requirements; adopted frozen legacy-format failure coverage, migration entry preservation, authored-to-effective and omitted summary output, and clearer collision-checking terminology. Rejected the adversary's weaker optional alias-or-omission representation."
+    }
+  }
+}

--- a/openspec/changes/add-materialization-aliasing/design.md
+++ b/openspec/changes/add-materialization-aliasing/design.md
@@ -1,0 +1,336 @@
+## Context
+
+Installation currently resolves, verifies, and materializes one facet before resolving the next. That structure means the complete desired asset set does not exist before the first adapter write, so cross-facet collisions cannot be detected transactionally. The same authored asset `name` is also used for two different identities: canonical archive paths and integrity checks, and the adapter-facing name written on disk. Aliasing requires those identities to diverge without weakening verification.
+
+The project has two materialization namespaces: skills and commands share one namespace, while agents occupy another. All current assets are project-scoped, but scope is already part of the lockfile identity and MUST remain part of collision keys. The same effective set is applied to every selected adapter.
+
+The existing transaction model remains load-bearing: `facets.json`, `facets.lock`, and the machine-local receipt commit together; adapter writes are journaled; and handled failures return structured values. The design also preserves the protocol/engine/CLI layering: protocol owns artifact schemas and pure normative rules, engine owns installation and adapter I/O, and CLI owns TTY detection and prompts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect every collision in the complete desired set before any adapter mutation.
+- Allow each colliding asset to remain authored, receive an alias, or be omitted, including alias-all and omit-all outcomes.
+- Persist the effective choice as project intent and resolved state so installs are deterministic across machines and in CI.
+- Keep archive identity, canonical paths, and integrity anchored to authored names while using effective names for adapter I/O.
+- Make alias changes, omissions, updates, repairs, drift removal, and facet removal transactionally safe.
+- Keep old compact `facets.json` entries valid and make older CLIs fail closed on projects that use the new representation.
+
+**Non-Goals:**
+
+- MCP server collisions and future asset types.
+- Publisher-authored aliases, facet identity renaming, or changes to `facet.json` and archive layout.
+- Per-adapter aliases, exclusions, or materialized sets.
+- Automatic precedence, install-order winners, or heuristic renaming.
+- Changing the adapter API or existing within-facet namespace validation behavior.
+- Adding schema-format versions to `facet.json` or `server.json`; archive compatibility continues to be governed by the versioned build manifest.
+
+## Decisions
+
+### 1. Define one authored-to-materialized identity model in protocol
+
+Protocol SHALL define the materialization disposition once and derive narrower uses from it:
+
+```ts
+type MaterializationDisposition =
+  | { kind: 'authored' }
+  | { kind: 'aliased'; as: string }
+  | { kind: 'omitted' }
+
+type ProjectAssetOverride = Exclude<
+  MaterializationDisposition,
+  { kind: 'authored' }
+>
+
+type MaterializedDisposition = Exclude<
+  MaterializationDisposition,
+  { kind: 'omitted' }
+>
+```
+
+The CLI label **Keep** maps to `{ kind: "authored" }`. It is not persisted as an override because absence already means “use the authored name.” A collision cannot disappear merely because this default is applied: the complete effective set is always checked after all overrides are applied. Persisting only aliases and omissions avoids two spellings for the same state while still reproducing every resolved set.
+
+Protocol SHALL also provide the single namespace mapping used by facet-manifest validation, build validation, and cross-facet planning:
+
+- `skill` and `command` → `skill-command`
+- `agent` → `agent`
+
+Two distinct keys SHALL be used:
+
+- A **collision key** of `(scope, namespace, portable effective name)` enforces logical namespace uniqueness.
+- An **adapter key** of `(scope, type, effective name)` identifies the concrete asset read, written, or deleted through an adapter.
+
+The portable name key SHALL use the existing normalization and case-folding rules used for portable archive collisions. Current names and aliases are already lowercase ASCII, while this also protects migration of legacy names.
+
+**Alternative considered:** keep the namespace helper and planner in engine. Rejected because these are normative, pure rules that another conforming implementation MUST reproduce.
+
+### 2. Version and widen `facets.json` with exact dispatch
+
+This change SHALL introduce the first explicit project-manifest format version. The current schema SHALL use top-level `manifestVersion: 0.1`:
+
+```json
+{
+  "manifestVersion": 0.1,
+  "facets": {
+    "facet-a": "1.*",
+    "facet-b": {
+      "source": "github:example/facet-b#main",
+      "materialization": {
+        "skills": {
+          "review": { "kind": "aliased", "as": "facet-b-review" }
+        },
+        "commands": {
+          "deploy": { "kind": "omitted" }
+        }
+      }
+    }
+  }
+}
+```
+
+Project-manifest versioning SHALL remain independent from archive `facetVersion` and lockfile `lockfileVersion`; each format evolves on its own axis. Exact dispatch SHALL recognize:
+
+- **Legacy unversioned:** no `manifestVersion`; every facet value MUST be a compact source string.
+- **Current version 0.1:** `manifestVersion` is exactly numeric `0.1`; facet values MAY use compact strings or expanded entries.
+- **Unsupported:** any other explicit value SHALL fail with structured data identifying the observed and supported versions. The loader SHALL NOT infer a declared version from the remaining shape or fall back to another schema after validation fails.
+
+A successful normal add, install, update, or remove SHALL write current `manifestVersion: 0.1` as part of the transactional tri-write, including when the input was legacy unversioned and no materialization override exists. Frozen installation MAY read a valid legacy unversioned manifest but SHALL NOT migrate or rewrite it. An expanded entry in an unversioned document SHALL be rejected rather than reinterpreted as current.
+
+Compact string entries remain canonical when no override exists. A current-version facet with overrides uses the expanded form shown above. The `materialization` object MAY contain `skills`, `commands`, and `agents` maps. Keys identify authored assets; map values are the `aliased` or `omitted` arms only. Maps avoid duplicate typed asset records, and nesting avoids inventing a parseable `type:name` string grammar. Alias values MUST satisfy the current single-segment asset-name grammar. Authored keys SHALL use the path-safe asset-name grammar so legacy assets remain addressable.
+
+An expanded entry MUST contain at least one override. The canonical writer SHALL collapse an empty expanded entry back to its source string while retaining `manifestVersion: 0.1`. Updating or re-adding a facet SHALL change only `source` and preserve its overrides. Parsing SHALL reject duplicate JSON members before version dispatch and schema validation so duplicate decisions cannot collapse through parser-specific last-member-wins behavior.
+
+The project-manifest mutation inventory is `packages/engine/src/manifest/mutations.ts`, `packages/engine/src/manifest/project-files.ts`, `packages/engine/src/install/commit/delta.ts`, and `packages/engine/src/install/commit/tri-write.ts`. Every path SHALL preserve `manifestVersion` and expanded entries for untouched facets, and source updates SHALL preserve the target facet's materialization overrides. Read-only consumers such as `facet list` SHALL obtain the source from either entry form. `packages/engine/src/edit/` writes author-side `facet.json`, not project `facets.json`, so it requires no expanded project-entry preservation change.
+
+Previously released CLIs may ignore the unknown top-level `manifestVersion` field. They still fail closed on alias-bearing projects because their schema requires every facet value to be a string and rejects expanded entries before acquiring the install lock. Current and future readers gain explicit dispatch, migration, and unsupported-version diagnostics.
+
+Overrides remain active even when the original collision disappears. An alias or omission is project intent and SHALL NOT be silently removed merely because another facet was removed. If an override references an authored asset absent from the resolved facet version, a normal install SHALL report it and prune it only as part of a successful tri-write; a frozen install SHALL report manifest/lockfile drift and perform no write. Each automatic prune SHALL emit a dedicated structured stage event identifying the facet, asset type, and authored name; it SHALL NOT be visible only through verbose logging.
+
+**Alternatives considered:**
+
+- Continue distinguishing project-manifest generations only by entry shape. Rejected because shape inference provides no explicit compatibility axis or unsupported-version diagnostic.
+- Version `facet.json` and `server.json` in the same change. Rejected because their compatibility contracts are independent from consumer-side materialization, and archive compatibility is already dispatched through the build manifest.
+
+### 3. Introduce lockfile and receipt version `0.3`
+
+Lockfile `0.3` SHALL retain `name` as the authored name and add a required `materialization` disposition to every asset. Its `files` array SHALL continue to contain canonical authored inner-archive paths and per-file hashes, including for an omitted asset. This keeps reconciliation and integrity independent from where, or whether, an asset is materialized.
+
+```json
+{
+  "scope": "project",
+  "type": "skill",
+  "name": "review",
+  "materialization": { "kind": "aliased", "as": "facet-b-review" },
+  "files": [
+    {
+      "path": "skills/review/SKILL.md",
+      "integrity": "sha256:..."
+    }
+  ]
+}
+```
+
+Exact version dispatch SHALL recognize legacy alpha `1`, previous `0.2`, and current `0.3`; it SHALL NOT infer a version from shape. Normal installation can losslessly refine every older asset to `{ kind: "authored" }` and write `0.3` after verification. Frozen installation SHALL NOT migrate.
+
+Every successful non-frozen install SHALL write lockfile `0.3`, even when the project has no materialization overrides. This follows the existing migration policy, keeps one canonical current writer schema, and prevents format oscillation. The compatibility cost is deliberate: the first successful normal install with a supporting CLI makes the lockfile unreadable to older CLIs even for a resolution-free project.
+
+Receipt `0.3` SHALL record authored `name`, authored owned-file paths, and a `MaterializedDisposition` for each asset actually present on disk. Omitted assets SHALL be absent from the receipt. This makes an “omitted but materialized” receipt state unrepresentable while retaining both names needed for offline deletion. Receipt `1` and `0.2` assets refine to authored materialization during load.
+
+Archive, build-manifest, and adapter API versions do not change. Archive bytes and adapter request shapes remain unchanged.
+
+**Alternatives considered:**
+
+- Reuse `name` for the alias and add an authored name. Rejected because canonical paths and integrity are authored-domain data, so the existing meaning of `name` remains the stable anchor.
+- Add an optional alias beside `name`. Rejected because optional fields would encode the disposition indirectly and permit inconsistent combinations with omission.
+- Drop omitted assets from the lockfile. Rejected because the lockfile must record the resolved asset set and compare it with project intent; only the machine-local receipt excludes non-materialized assets.
+- Preserve `0.2` while no overrides exist and write `0.3` only after a project uses aliasing or omission. Rejected because it creates a bimodal serializer, permits `0.2`/`0.3` oscillation as overrides come and go, and leaves two writable “current” shapes. It would narrow the compatibility break to participating projects, but the selected design prioritizes one canonical format and the established migrate-forward policy.
+
+### 4. Resolve materialization with one deterministic pure planner
+
+Protocol SHALL expose a pure planner over resolved authored contributions plus normalized project overrides. It SHALL:
+
+1. Sort facets and assets deterministically using code-unit ordering and the existing asset-type order.
+2. Match overrides to `(facet, type, authored name)` and validate alias names.
+3. Derive one disposition and effective name for every authored asset.
+4. Exclude omitted assets from the effective set.
+5. Group the remaining assets by collision key and return every group with two or more members.
+6. Return a materialization plan only when the effective set is collision-free.
+
+Collision results SHALL carry structured member data: facet, scope, type, authored name, effective name, and current disposition. Groups and members SHALL be deterministically ordered. All groups SHALL be reported in one pass rather than forcing users through repeated install attempts.
+
+The same planner SHALL support live evaluation of an in-progress resolution draft. A draft MAY remain temporarily colliding; the planner returns every linked collision group and member rather than discarding the choices. The CLI uses those results for live status, and the engine uses the same planner for final defense-in-depth validation. A materialization plan is returned only for a collision-free draft.
+
+The planner applies aliases once against authored identity, then checks the resulting set once. It is not an ordering-dependent or fixed-point resolver. Alias swaps are valid; duplicate alias targets fail; a skill may share an effective name with an agent but not with a skill or command; and omitting every member is valid. Skill companions never participate independently and follow their owning skill's disposition.
+
+### 5. Split installation into resolve, compose, and apply phases
+
+The existing interleaved install loop SHALL become five explicit phases, each with ordered substeps.
+
+#### Phase 1: Preflight
+
+1. **Load project intent:** read `facets.json`, reject duplicate members, dispatch its exact manifest version, and normalize legacy/current compact and expanded entries.
+2. **Acquire project lock:** acquire the install lock before reading mutable locked or receipt state.
+3. **Load resolved and machine state:** exact-dispatch `facets.lock`; load the receipt or bootstrap it from the lockfile; report and skip unsafe receipt entries.
+4. **Validate invocation:** reject conflicting additions/removals and incompatible selected adapters.
+5. **Merge desired intent:** apply additions and removals to an in-memory project manifest without writing it.
+6. **Run frozen gates:** reject frozen deltas and detect manifest/lockfile source, version, materialization, orphan, and stale-override drift before any receipt cleanup.
+7. **Start progress:** emit the install-start event with the complete desired facet count.
+
+#### Phase 2: Resolve all
+
+For each desired facet, in deterministic order:
+
+1. **Parse intent:** extract the source specifier and persisted materialization overrides.
+2. **Select resolution path:** determine whether to use a satisfying locked entry or perform fresh registry, Git, or local resolution.
+3. **Acquire content:** use the audited cache, download, clone, or build as required by the source.
+4. **Verify integrity:** verify facet-level and per-file integrity before trusting content.
+5. **Load authored content:** load `facet.json`, resolve authored prompt bodies, and capture companion bytes.
+6. **Derive authored plan:** produce canonical authored asset identities, paths, hashes, and ownership.
+7. **Reconcile locked state:** compare previous authored lock state with the verified plan.
+8. **Accumulate:** retain the complete resolved record for Compose.
+
+No adapter method SHALL be invoked during Resolve all. The resolved record SHALL use a tagged union for “fresh verified plan with companion bytes” versus “inherited locked entry,” replacing the current parallel optional fields.
+
+#### Phase 3: Compose
+
+1. **Normalize contributions:** deterministically order every resolved facet and authored asset.
+2. **Apply persisted intent:** match aliases and omissions to authored identities; diagnose stale overrides.
+3. **Derive effective identities:** retain authored names for integrity while computing each materialized asset's effective name and excluding omitted assets.
+4. **Detect collisions:** group the complete effective set by logical collision key and collect every unresolved group.
+5. **Resolve interactively or fail:** in frozen or non-interactive mode, return structured no-mutation failure; otherwise open one typed CLI resolution workspace over the complete authored set and current overrides.
+6. **Validate the workspace:** evaluate every in-session edit with the pure planner, permit temporary draft collisions, and accept only a collision-free final choice map or cancellation. After the resolver returns, the engine SHALL run one final defense-in-depth validation and SHALL NOT reopen the resolver automatically.
+7. **Build global plan:** produce per-facet lockfile dispositions, the collision-free materialization set, retained adapter keys, and effective ownership needed by Apply.
+
+No journal SHALL exist during Compose. No project file or adapter state SHALL be written.
+
+#### Phase 4: Apply
+
+1. **Create journal:** create the rollback journal only after Compose returns a collision-free plan.
+2. **Index previous ownership:** derive old effective adapter keys from the receipt, with lockfile-bootstrap state as the fallback, and aggregate duplicate historical claims and companion ownership.
+3. **Plan deletions:** identify each old adapter key absent from the desired set; retain any key still claimed by a desired asset.
+4. **Delete obsolete assets:** delete each obsolete key exactly once across every selected adapter and journal its complete prior bundle.
+5. **Materialize desired assets:** read, compare, and install every non-omitted asset under its effective name, carrying authored content and companion ownership.
+6. **Repair or skip:** skip byte-identical assets; repair drifted primary or companion content; journal every mutation.
+7. **Finalize outcomes:** classify installed, updated, repaired, unchanged, and removed facets and record obsolete receipt ownership for removal.
+8. **Handle failure or cancellation:** convert handled failures to structured results and replay the journal before returning.
+
+#### Phase 5: Commit
+
+1. **Finalize project intent:** apply source write policy, merge approved collision choices, prune reported stale overrides, and canonicalize empty expanded entries.
+2. **Build lockfile:** construct lockfile `0.3` with every authored asset, its materialization disposition, canonical authored paths, and integrity records.
+3. **Build receipt:** construct receipt `0.3` from assets actually materialized, excluding omitted assets and removed ownership.
+4. **Respect frozen mode:** leave `facets.json` and `facets.lock` byte-for-byte unchanged and write only the machine-local receipt.
+5. **Capture pre-images:** for a normal operation, capture manifest, lockfile, and receipt bytes immediately before the first project-state write.
+6. **Tri-write:** atomically write `facets.json`, `facets.lock`, and the receipt; restore every pre-image if any write fails.
+7. **Complete:** emit final progress and summary data, then release the project lock through the existing `finally` boundary.
+
+The substeps make mutation and identity boundaries explicit; they do not require a separate all-facets barrier for every substep. In particular, each facet MAY complete all Resolve-all substeps before the next facet begins. The load-bearing global barrier is between Resolve all and Compose: every desired facet MUST have verified authored state before materialization overrides are applied.
+
+Compose is the sole authored-to-effective transformation. Resolution and integrity verification SHALL NOT observe aliases. Compose SHALL preserve verified authored plans, derive a separate effective materialization plan, and keep newly collected choices in memory until Commit persists them transactionally.
+
+Resolved prompt and companion bytes remain eagerly held through compose. This increases peak memory from the largest facet to the complete desired set, but avoids a time-of-check/time-of-use gap for local sources and requires no cache-lifetime redesign.
+
+The initial implementation SHALL NOT introduce a bounded-memory threshold, disk spilling, or a durable-versus-volatile content split. Facets are expected to remain small and are normally added incrementally; the collision planner itself consumes asset metadata and runs as soon as the complete desired asset plan is available, before journal creation or materialization. Eager companion bytes remain the simpler correctness choice for local-source time-of-check/time-of-use safety. Memory-specific machinery MAY be reconsidered only if production measurements demonstrate a real problem.
+
+The project install lock remains held across all phases, including an interactive resolution prompt. Releasing it would require re-resolving or inventing a second staleness protocol before commit. The journal starts only after a collision-free plan exists, so cancellation or collision failure requires no rollback.
+
+`facet remove` SHALL run through the same resolve-and-compose gate without a special case. Because removal only shrinks the desired contribution set, it cannot introduce a new collision, while the shared path still validates remaining persisted overrides and ownership.
+
+**Alternatives considered:**
+
+- Dry-run the existing loop and run it again. Rejected because it repeats resolution/build work and represents mutation behavior with a mode flag.
+- Detect from the old lockfile before resolution. Rejected because new versions can introduce assets and collisions.
+- Detect inside adapters. Rejected because it is ordering-dependent, adapter-specific, and occurs after mutation begins.
+
+### 6. Let CLI resolve collisions through a typed engine callback
+
+Normal installation MAY receive an optional async collision resolver. The engine provides the complete authored contribution set and current in-memory overrides as one resolution workspace. The resolver returns either a collision-free typed choice map or a cancellation value. Expected cancellation is a value, not a thrown error.
+
+The resolver SHALL evaluate the full draft with the pure protocol planner after every Keep, Alias, or Omit edit. It MAY retain temporarily colliding choices so users can revisit either side of a conflict, but it SHALL NOT return a resolved result until the complete draft is collision-free. The engine SHALL validate the returned map once as defense-in-depth; an invalid callback result becomes a structured no-mutation failure rather than causing the resolver to reopen.
+
+If no resolver is supplied, installation SHALL return a structured materialization-collision failure containing every group. Frozen installation SHALL never invoke the resolver; unresolved collisions fail on the no-mutation path. The CLI supplies the resolver only for an interactive TTY.
+
+Non-interactive failure rendering SHALL identify the exact expanded-entry locations to edit and show valid alias and omit snippets for each claimant. It SHALL NOT synthesize a complete resolution, select a winner, or derive aliases heuristically.
+
+`InstallView` SHALL implement a phase machine inside its existing Ink mount: progress → collision-resolution workspace → progress → result. It SHALL NOT start a nested Ink renderer. The workspace uses the shared planner and asset-name validator for live global validation. SIGINT or cancellation resolves the callback as cancelled, after which `runInstall` releases the lock through its existing `finally` path.
+
+Choices are held in memory and folded into the normalized project manifest only after the planner accepts them. They reach disk solely through the final tri-write, so a later verification, adapter, or write failure leaves the committed project intent unchanged.
+
+The initial release SHALL NOT add non-interactive resolution flags. CI and automation SHALL record durable intent by editing and committing `facets.json`; pipeline-only flags would duplicate the project manifest as a source of truth.
+
+**Alternatives considered:**
+
+- Return an in-process resumable handle. Rejected because it exposes lock/resource lifecycle and consumed-handle states to the CLI without improving the transaction.
+- Return a collision failure, prompt, and run installation again. Rejected because local facets rebuild and all facets re-verify, and users see the progress flow twice.
+- Write choices to `facets.json` before rerunning. Rejected because it violates the transactional manifest-write policy.
+
+### 7. Resolve one collision group at a time
+
+The initial TUI SHALL treat one collision group as the focused unit of work while maintaining one global in-memory resolution draft. When several groups exist, it SHALL present an overview of all affected assets and their live status. Selecting an item opens a focused view showing its claimant assets and current dispositions; the view MAY support asset-content previews without making previews a prerequisite for the initial implementation.
+
+Each affected item SHALL display one of three semantic states, using labels or icons in addition to color:
+
+- **Red — unresolved:** the original or persisted effective set still contains a collision not yet addressed.
+- **Yellow — draft conflict:** current in-session choices collide with another proposed alias or effective asset. Every claimant in the linked draft collision SHALL be yellow and mutually navigable.
+- **Green — resolved:** the current effective identity is unique across the complete draft set.
+
+Within the focused view, every Keep, Alias, or Omit edit SHALL update the global draft immediately and rerun the pure planner. The UI SHALL allow a user to retain a yellow alias temporarily, return to the overview, follow its linked claimant, and revise either side. For example, if a green item is later targeted by another proposed alias, both items become yellow; once either receives a unique effective name, both are reevaluated and may become green.
+
+Installation resumes only when every affected item is green and the engine's final validation accepts the complete choice map.
+
+The initial release SHALL NOT provide a bulk editor that modifies several collision groups simultaneously. Multi-group handling SHALL be orchestration around the same focused single-group component, keeping the single-collision experience as the source of truth.
+
+**Alternative considered:** edit every collision group on one screen and submit them together. Rejected because it combines navigation, validation, previews, and multiple independent decisions into one complex interaction before the single-group workflow is proven.
+
+### 8. Apply ownership globally using effective adapter identities
+
+The apply phase SHALL derive old ownership primarily from the receipt, with lockfile bootstrap as today, and new ownership from the composed plan. It SHALL index ownership by adapter key, separately from logical collision keys.
+
+For each selected adapter, apply performs two deterministic passes:
+
+1. Delete each old adapter key absent from the new set exactly once.
+2. Materialize every non-omitted planned asset under its effective name.
+
+An old key retained by any desired asset SHALL NOT be deleted, even when ownership transfers between facets. The replacement write uses the union of recorded old companion ownership for that adapter key, preventing historical duplicate receipt claims from deleting a surviving asset or leaving stale companions. Every delete and write remains journaled.
+
+Content, descriptions, adapter metadata lookup, companion extraction, reconciliation, and integrity use the authored name. Adapter read/install/delete requests and generated front-matter `name` use the effective name. A skill's companion paths are stripped relative to its authored archive directory and then installed beneath its effective directory.
+
+Changing an alias becomes delete-old plus write-new; changing to omitted deletes the old effective asset; removing omission writes the new effective asset. A materialization-disposition change at the same facet version SHALL classify the facet as updated, while a disk-only repair remains repaired.
+
+## Risks / Trade-offs
+
+- **[Peak memory grows with the complete desired set]** → Keep eager bytes for correctness in the first implementation; measure real projects before introducing a tagged durable-versus-volatile lazy-read optimization.
+- **[The project lock is held while a user decides]** → Display that installation is awaiting collision resolution, honor cancellation promptly, and rely on existing stale-lock recovery after process death.
+- **[The first upgraded install may expose collisions that were previously silent]** → Fail before writes with every claimant listed and offer the interactive resolver when available.
+- **[Manifest and lockfile evolution expands compatibility logic]** → Use exact three-version dispatch, version-stamped schema names, and fixtures proving there is no shape fallback.
+- **[A malformed or stale override could target the wrong asset]** → Validate authored keys and aliases, reject duplicate JSON members, prune absent-asset overrides only in a successful normal transaction, and fail frozen drift.
+- **[An alias may break prompt text or external references that mention the authored name]** → Treat aliasing as placement identity only; document that content is not rewritten and users must choose aliases compatible with their workflows.
+- **[Historical receipts may contain duplicate claims]** → Aggregate old ownership by effective adapter key and never delete a key retained by the new global plan.
+- **[Third-party adapters may have undocumented assumptions about names]** → Keep the request shape unchanged, pass only names satisfying the existing grammar, and add adapter conformance coverage using aliased names.
+- **[Resolving all facets before applying changes alters failure ordering and latency]** → Preserve deterministic facet ordering and first resolution failure for the initial implementation; collision collection itself remains exhaustive.
+
+## Migration Plan
+
+1. Add protocol namespace/disposition types, legacy-unversioned and current-version-`0.1` project-manifest schemas with exact dispatch, lockfile `0.3` schemas, and the pure planner. Existing lockfile `1` and `0.2` readers remain available.
+2. Normalize legacy and current compact/expanded project entries at the engine load boundary. Update every project-manifest mutation and writer—`manifest/mutations.ts`, `manifest/project-files.ts`, `install/commit/delta.ts`, and `install/commit/tri-write.ts`—to preserve expanded entries, write `manifestVersion: 0.1`, and canonicalize empty expanded entries. Add exact-dispatch, migration, frozen-retention, preservation, add, update, install, remove, and `facet list` read-tolerance coverage.
+3. Add receipt `0.3` and lossless `1`/`0.2` refinement to authored materialization. Omitted lockfile assets are filtered when bootstrapping a receipt.
+4. Refactor installation into resolve/compose/apply and add global effective-ownership planning before enabling any writer to emit `0.3`.
+5. Add structured engine failures and the CLI phase-machine resolver. Non-interactive and frozen paths remain fully usable without the callback and fail closed on unresolved groups.
+6. Enable `0.3` writes only after protocol, engine, CLI, migration, rollback, and adapter tests pass together. A successful normal install performs lockfile and receipt migration in the existing transaction; a failed install writes no migrated state.
+
+Downgrading is fail-closed: an old CLI rejects an expanded manifest value, and a CLI that accepts only `0.2` rejects a `0.3` lockfile. Because every successful normal install migrates forward, removing all overrides and reinstalling SHALL NOT downgrade the lockfile to `0.2`. Restoring `0.2` requires an explicit compatibility rollback after all aliased or omitted assets have been reconciled to authored materialization—for example, restoring the pre-migration lockfile from version control. Deleting only the new lockfile while aliased state remains on disk is not safe.
+
+## Documentation Updates
+
+The following user-facing documentation conflicts with or omits the new behavior and MUST be updated:
+
+- `docs/specification/project-manifest.mdx`: compact/expanded entry schema, override semantics, validation, and write policy.
+- `docs/specification/lockfile.mdx`: version `0.3`, authored paths, materialization dispositions, and exact dispatch.
+- `docs/specification/install.mdx`, `docs/specification/planning.mdx`, and `docs/specification/commit.mdx`: global pre-write composition, prompt boundary, frozen behavior, receipt ownership, and tri-write.
+- `docs/specification/manifest.mdx` and `docs/specification/terminology.mdx`: distinguish authored names, effective/materialized names, logical namespaces, aliases, and omissions.
+- `docs/guides/install-facets.mdx` and `docs/guides/custom-adapters.mdx`: collision walkthrough, persisted examples, on-disk layout, and confirmation that adapters receive the effective name through the existing API.
+- `docs/cli/add.mdx`, `docs/cli/install.mdx`, `docs/cli/instructions.mdx`, and `docs/guides/troubleshooting.mdx`: interactive choices, non-interactive failures, frozen guidance, and recovery.
+- `docs/changelog/index.mdx`: user-visible format and install behavior change.
+
+The root `README.md` was reviewed. Its quickstart and high-level statement that add resolves and installs in one step remain accurate, so no README change is required.

--- a/openspec/changes/add-materialization-aliasing/proposal.md
+++ b/openspec/changes/add-materialization-aliasing/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Independently published facets can declare assets with the same name, but the current install contract does not resolve cross-facet collisions before materialization; the resulting order-dependent state can silently overwrite one facet's asset, and receipt-driven removal can delete a path another facet still claims. Because skills and commands share one namespace while agents occupy another, arbitrary facets cannot be composed safely without an explicit, reproducible way for users to keep, alias, or omit each colliding asset.
+
+## What Changes
+
+- Before any materialization write, the system SHALL evaluate the complete desired asset set for collisions across facets on every add, install, update, repair, and frozen-reproduction path. This check SHALL detect collisions introduced by facet updates; a frozen install that encounters an unresolved collision SHALL fail without rewriting any state. Skills and commands SHALL be checked together, while agents SHALL be checked separately.
+- For every collision group, each asset SHALL receive exactly one resolution: preserve its authored name, assign a valid materialized alias, or omit it from materialization. A resolution MAY alias multiple assets or omit every asset in the group, but the resulting materialized set MUST be collision-free.
+- Interactive add and install flows SHALL identify the colliding facets and assets and collect the user's choices. A non-interactive install with an unresolved collision SHALL fail with structured, actionable information and SHALL leave project and adapter state unchanged.
+- Collision resolutions SHALL be recorded as project intent and resolved installation state so teammates, CI, frozen installs, repairs, updates, and removals reproduce the same effective asset set without prompting again. Existing compact string entries in `facets.json` SHALL remain valid for facets that require no explicit resolution.
+- Aliases SHALL satisfy the existing asset-name grammar and namespace rules. One project-level resolution SHALL apply consistently to every selected adapter; adapter-specific aliases or exclusions SHALL NOT be introduced.
+- Integrity verification SHALL continue to use the facet's authored archive identities and canonical archive paths. Aliasing SHALL change only the effective materialized identity, while omission SHALL prevent the selected asset and its owned companion files from being written.
+- Lockfile, receipt, drift-repair, and removal behavior SHALL distinguish authored identities from effective materialized identities and SHALL delete or repair exactly the files recorded as owned.
+- **BREAKING** Projects that use collision resolutions SHALL require a CLI and protocol implementation that understand the enriched project-manifest intent and the corresponding lockfile format. Older string-only project-manifest entries SHALL remain supported.
+- The project manifest SHALL gain an explicit format-version field with exact dispatch. Existing unversioned string-only manifests SHALL remain valid legacy input; successful normal operations SHALL migrate them transactionally, while frozen installation SHALL retain them without rewriting.
+- User and specification documentation SHALL be updated to explain namespace collisions, available resolutions, persisted intent, and the resulting on-disk layout.
+
+## Capabilities
+
+### New Capabilities
+
+- None. Materialization collision resolution is part of the existing installation product domain.
+
+### Modified Capabilities
+
+- `installation`: Detect cross-facet namespace collisions transactionally, apply aliases and omissions, reproduce persisted choices, and reconcile the effective asset set during install, repair, frozen operation, drift removal, and facet removal.
+- `protocol__schemas`: Extend the published project-manifest and lockfile schemas to represent collision-resolution intent and distinguish authored asset identities from effective materialized identities without weakening archive integrity.
+- `cli`: Present collision groups and resolution choices interactively, and render actionable structured failures when unresolved collisions occur in non-interactive use.
+
+## Non-goals
+
+- Resolving collisions for MCP servers or future asset types is not included.
+- Publishers SHALL NOT define consumer aliases, and installation SHALL NOT modify `facet.json`, archive paths, or published asset identities.
+- The system SHALL NOT silently choose a winner, infer precedence from install order, or overwrite one facet's asset with another.
+- Per-adapter resolution, adapter-specific materialized asset sets, and adapter API shape changes are not included.
+- This change SHALL NOT alter existing validation for collisions within a single facet.
+- This change SHALL NOT rename facet identities or `facets.json` keys; only materialized asset names may change.
+- This change SHALL NOT add schema-format version fields to `facet.json` or `server.json`; archive compatibility remains governed by the versioned build manifest.
+
+## Impact
+
+- Protocol consumers and producers will encounter enriched `facets.json` entries and a lockfile representation that preserves both authored and materialized identities. Compatibility and exact lockfile-version dispatch will require explicit treatment in design.
+- Installation planning, materialization, reconciliation, receipts, frozen consistency checks, and structured failure data in `packages/engine` will be affected. CLI install views and failure rendering in `packages/cli` will gain the interactive resolution flow.
+- Adapter contracts are expected to remain structurally unchanged: adapters will continue receiving a validated asset name, but that name may be the project's effective alias. The same resolved asset set will continue to be applied to every selected adapter.
+- This proposal was informed by `docs/specification/manifest.mdx` (asset grammar and namespaces), `docs/specification/install.mdx` and `docs/specification/commit.mdx` (transactional materialization and receipts), `docs/specification/project-manifest.mdx` and `docs/specification/lockfile.mdx` (intent and resolved state), and `docs/guides/install-facets.mdx` (the user-facing install flow). Those pages, the CLI add/install references, troubleshooting guidance, terminology, and the changelog will require corresponding updates.
+- No new runtime dependency is expected.

--- a/openspec/changes/add-materialization-aliasing/specs/cli/spec.md
+++ b/openspec/changes/add-materialization-aliasing/specs/cli/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: Interactive add and install let users resolve every materialization collision
+
+When `add` or `install` encounters unresolved materialization collisions in an interactive terminal, the system SHALL show one overview containing every collision group and affected asset before materialization begins. Users SHALL be able to focus one group at a time and assign Keep, Alias, or Omit to each claimant. Every claimant SHALL be identified by facet, scope, asset type, authored name, effective name, and current disposition.
+
+The system SHALL request choices only after adapter compatibility and facet integrity have been established. Frozen installation SHALL NOT request choices.
+
+#### Scenario: One collision group is resolved
+
+- **WHEN** two facets contribute project-scoped skill `review` during an interactive add
+- **THEN** the system SHALL show both facets and both authored assets in one collision group
+- **AND** it SHALL offer Keep, Alias, and Omit for each claimant
+
+#### Scenario: Multiple groups are available from one overview
+
+- **WHEN** an interactive install encounters multiple collision groups
+- **THEN** the overview SHALL list every affected asset and its current resolution status
+- **AND** the user SHALL be able to open and revise each group before installation resumes
+
+#### Scenario: Every claimant can be omitted
+
+- **WHEN** a user chooses Omit for every claimant in a group
+- **THEN** the system SHALL accept the group as resolved
+
+#### Scenario: Frozen installation never prompts
+
+- **WHEN** frozen installation encounters an unresolved collision in an interactive terminal
+- **THEN** the system SHALL report the collision without opening the resolution workspace
+
+#### Scenario: Earlier failure prevents prompting
+
+- **WHEN** adapter compatibility or facet integrity validation fails
+- **THEN** the system SHALL report that failure without requesting collision choices
+
+### Requirement: Collision choices receive live global and accessible validation
+
+After every Keep, Alias, or Omit edit, the system SHALL reevaluate the complete in-memory choice set and update every affected item's status. The overview and focused group SHALL distinguish unresolved, draft-conflicting, and resolved items using text or icons in addition to red, yellow, and green color. A draft conflict SHALL identify every linked claimant and SHALL remain editable rather than discarding the user's choice.
+
+Alias input SHALL be validated with the published asset-name rules and SHALL display a specific validation reason when invalid. Installation SHALL resume only when every affected item is resolved and the complete final choice set passes validation.
+
+#### Scenario: New alias conflicts with another group
+
+- **WHEN** a user enters an alias already claimed elsewhere in the complete draft
+- **THEN** every linked claimant SHALL be marked as a draft conflict
+- **AND** the user SHALL be able to navigate to and revise either side
+
+#### Scenario: Previously resolved item becomes conflicting
+
+- **WHEN** a later edit targets the effective name of an item already marked resolved
+- **THEN** both items SHALL change to draft-conflicting status
+
+#### Scenario: Invalid alias explains the problem
+
+- **WHEN** a user enters an alias outside the asset-name grammar
+- **THEN** the system SHALL display the validation reason
+- **AND** it SHALL NOT allow confirmation while that alias remains invalid
+
+#### Scenario: Status does not depend on color alone
+
+- **WHEN** the workspace displays resolution statuses
+- **THEN** each status SHALL include a label or icon that distinguishes unresolved, draft-conflicting, and resolved states without color
+
+#### Scenario: Complete collision-free draft resumes installation
+
+- **WHEN** every affected item has a globally unique effective identity or is omitted
+- **AND** the user confirms the draft
+- **THEN** installation SHALL resume using the confirmed choices
+
+### Requirement: Cancelling collision resolution leaves the project unchanged
+
+Users SHALL be able to cancel the collision workspace, including by interrupting the command. Cancellation SHALL end the operation without persisting draft choices or changing the project manifest, lockfile, receipt, or materialized assets.
+
+#### Scenario: User cancels from the workspace
+
+- **WHEN** a user cancels before confirming a collision-free draft
+- **THEN** the command SHALL end without applying any draft choice
+- **AND** project and adapter state SHALL remain unchanged
+
+#### Scenario: User interrupts resolution
+
+- **WHEN** a user sends an interrupt while the collision workspace is open
+- **THEN** the command SHALL end without displaying a successful install summary
+- **AND** project and adapter state SHALL remain unchanged
+
+### Requirement: Non-interactive collision failures are complete and actionable
+
+When `add` or `install` cannot interactively resolve an unresolved collision, the system SHALL write an error to stderr, exit with a non-zero code, and identify every collision group and claimant. For each claimant, the error SHALL identify the facet, scope, type, authored name, and current effective name, and SHALL point to the corresponding expanded `facets.json` entry that can record an alias or omission.
+
+The error SHALL include syntactically valid alias and omission examples. It SHALL NOT select a winner, invent an alias, or present a generated complete resolution as authoritative. It SHALL state that no project or materialized state was changed.
+
+#### Scenario: Non-interactive install reports all groups
+
+- **WHEN** a non-interactive install encounters multiple unresolved collision groups
+- **THEN** one failure SHALL list every group and claimant
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Failure shows editable manifest locations
+
+- **WHEN** a claimant requires durable materialization intent
+- **THEN** the error SHALL identify its facet, typed asset map, and authored asset key in `facets.json`
+- **AND** it SHALL show valid alias and omission snippets for that location
+
+#### Scenario: Failure does not prescribe a winner
+
+- **WHEN** two assets claim the same effective name
+- **THEN** the error SHALL NOT describe either claimant as preferred
+- **AND** it SHALL NOT derive a replacement alias automatically
+
+#### Scenario: Non-interactive failure confirms no mutation
+
+- **WHEN** collision resolution is unavailable
+- **THEN** the error SHALL state that the manifest, lockfile, receipt, and materialized assets were not changed
+
+### Requirement: Users are notified when stale materialization intent is removed
+
+When a successful non-frozen operation removes an override whose authored asset no longer exists, the normal command output SHALL identify the facet, asset type, and authored name. This notice SHALL appear without requiring verbose output. Frozen installation SHALL instead report the stale override as blocking drift.
+
+#### Scenario: Successful install reports pruned intent
+
+- **WHEN** a normal install succeeds after finding an override for a missing authored asset
+- **THEN** the output SHALL identify the removed override by facet, type, and authored name
+- **AND** the notice SHALL appear without `--verbose`
+
+#### Scenario: Frozen install reports stale intent as drift
+
+- **WHEN** frozen installation finds an override for a missing locked asset
+- **THEN** the error SHALL identify the facet, type, and authored name
+- **AND** it SHALL state that no override was removed
+
+## MODIFIED Requirements
+
+### Requirement: Add and install render a unified progress view
+
+The `add` and `install` commands SHALL present progress through a single shared rendering. A user watching either command SHALL see the same shape of output: a per-facet section that names each facet, indicates its current stage, and shows whether it succeeded, failed, or is in progress, followed by a final summary that lists each affected facet on its own line.
+
+When interactive materialization choices are required, the same command view SHALL transition from progress to the collision overview and focused resolution workspace, then return to progress after confirmation. It SHALL indicate that installation is awaiting collision resolution. A materialization-disposition change at an unchanged facet version SHALL be reported as an update; repair of disk-only drift SHALL remain reported as a repair. When materialization dispositions affect the result, the final summary SHALL show every aliased asset's authored name together with its effective materialized name and SHALL identify every omitted asset as omitted.
+
+#### Scenario: Single-facet operation shows per-facet detail
+
+- **WHEN** a user runs `add` or `install` with exactly one facet to install or update
+- **THEN** the rendered view SHALL show the facet's name and its current stage as it progresses through fetch, verification, build, collision checking, and materialization
+- **AND** on completion the view SHALL show a one-line summary of the facet's resolved version
+
+#### Scenario: Multi-facet operation shows aggregate progress
+
+- **WHEN** a user runs `add` or `install` with multiple facets to install or update
+- **THEN** the rendered view SHALL show progress for each facet
+- **AND** on completion the view SHALL show one summary line per affected facet identifying the action and resolved version
+
+#### Scenario: No-op install renders an empty summary
+
+- **WHEN** a user runs `install` and the lockfile already matches on-disk state
+- **THEN** the view SHALL render a summary indicating no changes were applied
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Progress pauses for collision choices
+
+- **WHEN** an interactive operation finishes resolving and verifying facets but requires collision choices
+- **THEN** the view SHALL indicate that installation is awaiting resolution
+- **AND** after confirmation it SHALL return to progress without starting a separate command output stream
+
+#### Scenario: Disposition-only change is shown as an update
+
+- **WHEN** an alias or omission changes while the facet version remains unchanged
+- **THEN** the final summary SHALL classify the facet as updated rather than repaired
+
+#### Scenario: Summary shows aliases and omissions
+
+- **WHEN** an install materializes skill `review` as `vendor-review` and omits command `deploy`
+- **THEN** the summary SHALL show `review` together with `vendor-review`
+- **AND** it SHALL identify `deploy` as omitted

--- a/openspec/changes/add-materialization-aliasing/specs/installation/spec.md
+++ b/openspec/changes/add-materialization-aliasing/specs/installation/spec.md
@@ -1,0 +1,564 @@
+## ADDED Requirements
+
+### Requirement: Namespace collisions are evaluated across the complete desired set before any write
+
+Before writing or deleting any materialized asset, project manifest, lockfile, or receipt, the system SHALL evaluate every authored asset contributed by the complete post-operation facet set. This evaluation SHALL run for add, install, update, repair, removal, and frozen reproduction. It SHALL report every collision group in one pass and SHALL NOT choose a winner, infer precedence from declaration or resolution order, or overwrite one facet's asset with another.
+
+Two assets SHALL collide when they have the same scope, materialization namespace, and portable effective name. Skills and commands SHALL share one namespace; agents SHALL occupy another. Assets in different scopes SHALL NOT collide. Skill companions SHALL follow their skill and SHALL NOT be independent claimants. Existing within-facet validation and MCP server behavior SHALL remain unchanged.
+
+#### Scenario: Added facet collides with an installed facet
+
+- **WHEN** an added facet and an already-declared facet each contribute project-scoped skill `review`
+- **THEN** the system SHALL report both claimants before any write
+- **AND** neither asset SHALL overwrite the other
+
+#### Scenario: Update introduces a collision
+
+- **WHEN** a newly resolved facet version introduces a name that collides with another desired asset
+- **THEN** the system SHALL detect it before materialization
+- **AND** project and adapter state SHALL remain unchanged until resolution
+
+#### Scenario: Skill and command collide
+
+- **WHEN** a skill and a command in the same scope have effective name `deploy`
+- **THEN** the system SHALL place them in one collision group
+
+#### Scenario: Agent and skill coexist
+
+- **WHEN** an agent and a skill in the same scope have effective name `review`
+- **THEN** the system SHALL NOT report a collision between them
+
+#### Scenario: All groups are reported
+
+- **WHEN** the desired set contains three collision groups
+- **THEN** one evaluation SHALL report all three groups and every claimant
+
+#### Scenario: Declaration order does not select a winner
+
+- **WHEN** an unresolved collision is present
+- **THEN** reordering facet declarations SHALL NOT change the failure or materialize either claimant
+
+### Requirement: Every colliding asset receives one Keep, Alias, or Omit resolution
+
+Each colliding asset SHALL receive exactly one outcome: Keep its authored name, Alias it to a valid effective name, or Omit it from materialization. The accepted draft MUST be collision-free across the complete desired set. The system SHALL allow aliasing all claimants, omitting all claimants, transferring a name from an omitted asset, and exchanging effective names when the final set is unique. An alias MUST satisfy the current single-segment asset-name grammar and SHALL be rejected rather than normalized when invalid.
+
+Resolutions SHALL be consumer project intent. They SHALL NOT rename the facet, mutate `facet.json`, alter published archive bytes, or be declared by publishers.
+
+#### Scenario: One claimant is aliased
+
+- **WHEN** two skills claim `review` and one is aliased to `vendor-review`
+- **THEN** the effective set SHALL contain both `review` and `vendor-review`
+
+#### Scenario: Every claimant is aliased
+
+- **WHEN** every claimant is assigned a distinct alias
+- **THEN** the system SHALL accept the collision-free result
+
+#### Scenario: Every claimant is omitted
+
+- **WHEN** every claimant is omitted
+- **THEN** the system SHALL accept the empty result for that collision group
+
+#### Scenario: Duplicate alias remains a collision
+
+- **WHEN** two assets resolve to the same alias in one namespace and scope
+- **THEN** the system SHALL report both as still colliding
+
+#### Scenario: Invalid alias is rejected
+
+- **WHEN** an alias contains uppercase letters, a slash, or another disallowed form
+- **THEN** the system SHALL reject it with the asset-name validation reason
+
+### Requirement: Aliases and omissions affect materialization without changing authored integrity
+
+An alias SHALL change only the effective name supplied for materialization. Authored name, content, canonical archive paths, and integrity values SHALL remain unchanged, and occurrences of the authored name inside content SHALL NOT be rewritten. An omission SHALL prevent the asset and all owned companions from being written, while the complete authored asset remains verified and recorded in the lockfile. Omitted assets SHALL be absent from machine-local materialized ownership.
+
+One project-level disposition SHALL apply to every selected adapter. Per-adapter aliases, omissions, and asset sets SHALL NOT be accepted.
+
+#### Scenario: Aliased content remains authored
+
+- **WHEN** skill `review` is materialized as `vendor-review`
+- **THEN** every adapter SHALL receive the verified authored content under `vendor-review`
+- **AND** canonical integrity paths SHALL remain under `skills/review/`
+
+#### Scenario: Omitted skill writes nothing
+
+- **WHEN** a skill with companions is omitted
+- **THEN** no selected adapter SHALL receive its primary or companion files
+- **AND** its authored files SHALL remain verified and locked
+
+#### Scenario: All adapters receive one effective set
+
+- **WHEN** multiple adapters are selected
+- **THEN** each SHALL receive the same aliases and omissions
+
+### Requirement: Recorded materialization intent is durable and stale intent is handled transactionally
+
+Materialization overrides in the project manifest SHALL remain durable after the collision that motivated them disappears. Teammates, automation, repair, update, and reproduction SHALL use recorded intent without prompting when it produces a collision-free set. A change to an override SHALL re-materialize the affected asset without requiring version resolution when the locked version still satisfies the source specifier.
+
+When an override names an asset absent from the resolved facet version, a non-frozen operation SHALL report the facet, asset type, and authored name and SHALL prune the override only in a successful commit. A failed operation SHALL preserve it. Frozen installation SHALL treat it as drift and write nothing.
+
+#### Scenario: Teammate reproduces aliases without prompting
+
+- **WHEN** a teammate installs committed manifest and lockfile state whose dispositions are collision-free
+- **THEN** the same effective set SHALL be materialized without prompting
+
+#### Scenario: Alias remains after another facet is removed
+
+- **WHEN** the facet that originally caused a collision is removed
+- **THEN** the surviving alias SHALL remain effective
+
+#### Scenario: Missing authored asset is pruned only on success
+
+- **WHEN** a resolved facet no longer contains an asset named by an override
+- **AND** a normal install succeeds
+- **THEN** the system SHALL report and remove that override in the successful commit
+
+#### Scenario: Failed install retains stale override
+
+- **WHEN** an operation that discovered a stale override fails
+- **THEN** the project manifest SHALL retain the override
+
+### Requirement: Interactive resolution completes before mutation and unresolved collisions fail safely
+
+When interactive resolution is available, the system SHALL expose the complete authored contribution set and current overrides for revision until the final effective set is collision-free or the user cancels. Temporary draft collisions SHALL be allowed before confirmation. The final choices SHALL be validated again before mutation and SHALL reach disk only through the operation's successful commit.
+
+When resolution is unavailable, cancelled, or forbidden by frozen mode, the system SHALL return structured data for every group and claimant and SHALL leave manifest, lockfile, receipt, and materialized assets unchanged. Adapter compatibility and facet integrity failures SHALL occur before collision choices are requested.
+
+#### Scenario: User resolves every collision
+
+- **WHEN** an interactive user confirms a collision-free set of choices
+- **THEN** materialization SHALL proceed with that effective set
+- **AND** intent and resolved state SHALL commit together on success
+
+#### Scenario: Temporary draft conflict is retained
+
+- **WHEN** a user proposes an alias that collides with an earlier draft choice
+- **THEN** the draft SHALL retain and report the linked conflict for further revision
+- **AND** materialization SHALL NOT begin
+
+#### Scenario: Cancellation changes nothing
+
+- **WHEN** the user cancels collision resolution
+- **THEN** manifest, lockfile, receipt, and materialized assets SHALL remain unchanged
+
+#### Scenario: Non-interactive unresolved collision changes nothing
+
+- **WHEN** an unresolved collision is encountered without an interactive resolver
+- **THEN** the operation SHALL fail with every group and claimant identified
+- **AND** no adapter write or deletion SHALL occur
+
+#### Scenario: Adapter incompatibility precedes resolution
+
+- **WHEN** a selected adapter is incompatible and the desired set would collide
+- **THEN** the operation SHALL fail for adapter incompatibility without requesting collision choices
+
+### Requirement: Materialized ownership is reconciled against the complete effective set
+
+The system SHALL plan deletion and replacement from the complete previous ownership and complete desired effective set. A materialized identity SHALL be deleted only when no desired asset still claims its adapter identity. Cross-facet ownership transfer SHALL replace content without leaving the retained identity deleted. Duplicate historical claims SHALL be aggregated, each obsolete identity SHALL be deleted at most once per adapter, and all recorded owned companions absent from the new owner SHALL be removed while unowned files remain untouched.
+
+Changing an alias SHALL delete the old effective identity and write the new one transactionally. Changing to omitted SHALL delete prior ownership; removing omission SHALL materialize the asset. A disposition-only change SHALL be reported as updated, while disk-only drift SHALL remain repaired.
+
+#### Scenario: Ownership transfer retains the identity
+
+- **WHEN** one facet is removed while another desired asset takes its effective name
+- **THEN** the identity SHALL contain the new owner's content after success
+- **AND** it SHALL NOT be left deleted
+
+#### Scenario: Alias change moves owned files
+
+- **WHEN** an alias changes from `vendor-review` to `partner-review`
+- **THEN** the old owned files SHALL be deleted and the new effective asset SHALL be written in one operation
+
+#### Scenario: Historical duplicate claims do not delete a survivor
+
+- **WHEN** a receipt has duplicate historical claims for one adapter identity and the desired set retains that identity
+- **THEN** the identity SHALL NOT be deleted
+- **AND** companions absent from the retained ownership SHALL be removed
+
+### Requirement: Project-manifest format migration is transactional
+
+A successful non-frozen add, install, update, or removal SHALL write current `manifestVersion: 0.1`, including when reading a valid legacy unversioned compact manifest. A failed operation SHALL leave the prior bytes unchanged. Frozen installation SHALL accept valid legacy unversioned input when consistency checks pass and SHALL NOT migrate or rewrite it. Expanded entries in an unversioned manifest and unsupported explicit versions SHALL fail before mutation.
+
+#### Scenario: Successful normal install migrates unversioned input
+
+- **WHEN** a normal install succeeds from a valid unversioned compact manifest
+- **THEN** the committed manifest SHALL declare `manifestVersion: 0.1`
+- **AND** every previously declared facet entry SHALL be preserved with unchanged meaning
+
+#### Scenario: Failed operation does not migrate
+
+- **WHEN** an operation fails while reading a valid unversioned compact manifest
+- **THEN** the manifest SHALL remain byte-for-byte unversioned
+
+#### Scenario: Frozen operation retains legacy manifest
+
+- **WHEN** frozen installation succeeds with a valid unversioned compact manifest
+- **THEN** it SHALL NOT rewrite the manifest
+
+## MODIFIED Requirements
+
+### Requirement: Lockfile declares a version
+
+The lockfile SHALL declare `lockfileVersion`. Current lockfiles SHALL use numeric `0.3`. Version selection SHALL use exact equality rather than numeric ordering: numeric `1` SHALL identify only the preceding closed-alpha schema, numeric `0.2` SHALL identify only the preceding schema, and numeric `0.3` SHALL identify only the current schema. Shape inference and cross-version fallback SHALL NOT occur. Missing or unsupported versions SHALL produce structured rejection data.
+
+Every successful non-frozen install SHALL write `0.3`, including when no materialization overrides exist. A verified numeric-`1` or `0.2` lockfile SHALL be migrated only after every resolved artifact satisfies every current integrity check, with each earlier asset refined to authored materialization. Removing all overrides SHALL NOT downgrade the lockfile. Frozen installation SHALL retain legacy behavior without rewriting a numeric-`1` or `0.2` lockfile and SHALL fail if its schema cannot represent the project manifest's materialization intent. A current `0.2` archive SHALL require a `0.2`-or-current lockfile in frozen mode. Before a future stable lockfile v1 reuses numeric `1`, legacy-alpha support SHALL be removed and old-shape files SHALL receive actionable delete-and-regenerate guidance rather than shape-based reinterpretation.
+
+#### Scenario: Missing lockfile version
+
+- **WHEN** a lockfile omits `lockfileVersion`
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Current lockfile version is accepted
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 0.3` and satisfies the current schema
+- **THEN** the system SHALL accept it as current
+
+#### Scenario: Previous version is selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 0.2`
+- **THEN** the system SHALL interpret it only under the preceding schema
+- **AND** each asset SHALL be understood as authored materialization
+
+#### Scenario: Legacy alpha version is selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 1`
+- **THEN** the system SHALL interpret it under the earliest alpha schema only
+- **AND** it SHALL NOT infer a schema from the remaining shape
+
+#### Scenario: Unsupported lockfile version is rejected
+
+- **WHEN** a lockfile declares an unsupported version
+- **THEN** the system SHALL reject it with structured observed and supported versions
+
+#### Scenario: Normal install migrates verified earlier state
+
+- **WHEN** a non-frozen install loads a valid `1` or `0.2` lockfile and verifies every resolved artifact
+- **THEN** it SHALL write equivalent `0.3` state after successful installation
+
+#### Scenario: Resolution-free project still migrates
+
+- **WHEN** a non-frozen install succeeds without any override
+- **THEN** the committed lockfile SHALL declare `0.3`
+
+#### Scenario: Frozen install does not migrate
+
+- **WHEN** frozen installation uses a supported earlier lockfile whose consistency check passes
+- **THEN** it SHALL NOT rewrite the lockfile
+
+#### Scenario: Frozen install fails when resolutions require the current format
+
+- **WHEN** frozen installation uses a numeric-`1` or `0.2` lockfile
+- **AND** the project manifest records materialization intent that format cannot represent
+- **THEN** the operation SHALL fail without rewriting any state
+
+#### Scenario: Frozen current archive requires a compatible lockfile
+
+- **WHEN** frozen installation encounters a current `0.2` archive with a numeric-`1` lockfile
+- **THEN** it SHALL fail without rewriting any state
+
+### Requirement: Each facet entry lists its assets, adapter-agnostically
+
+Every current facet entry SHALL include an `assets` array. Each member SHALL record authored `scope`, `type`, and `name`, a required materialization disposition, and a required `files` array sorted deterministically by canonical authored path. `scope` SHALL be `system`, `user`, or `project`; `type` SHALL be `skill`, `agent`, or `command`. Each file record SHALL contain canonical inner-archive `path` and `sha256:<hex>` `integrity` over canonical archive bytes. The lockfile SHALL contain no adapter-specific fields, hashes, or dispositions.
+
+The disposition SHALL state authored, aliased with a valid effective name, or omitted. Omitted assets SHALL remain listed with every authored file record. A skill's file records SHALL include `skills/<name>/SKILL.md` and every declared companion. An agent or command SHALL contain exactly its conventional primary file record. Skill companions SHALL remain subordinate to their owning skill, follow its disposition, and SHALL NOT become independent assets or receive their own scopes. Archive-only supplementary files SHALL NOT appear in an asset's files.
+
+#### Scenario: Valid multi-file skill entry
+
+- **WHEN** a skill owns `SKILL.md` and two companions
+- **THEN** its entry SHALL contain three sorted authored file records and a disposition
+
+#### Scenario: Valid single-file asset entry
+
+- **WHEN** an agent entry records scope, type, and authored name `reviewer`
+- **THEN** its files SHALL contain exactly `agents/reviewer.md` and its integrity
+
+#### Scenario: Missing files array is rejected
+
+- **WHEN** a `0.3` asset entry omits `files`
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Missing disposition is rejected
+
+- **WHEN** a `0.3` asset entry omits materialization
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Aliased asset keeps authored files
+
+- **WHEN** skill `review` is aliased to `vendor-review`
+- **THEN** its name and paths SHALL remain authored as `review`
+- **AND** its disposition SHALL record the alias
+
+#### Scenario: Omitted asset remains listed
+
+- **WHEN** command `deploy` is omitted
+- **THEN** its entry SHALL retain `commands/deploy.md` and its integrity
+
+#### Scenario: Companion is not an independent asset
+
+- **WHEN** skill `review` owns companion `references/api.md`
+- **THEN** the companion SHALL appear only in the skill's files
+- **AND** it SHALL NOT appear as another asset entry
+
+#### Scenario: Archive-only path is excluded
+
+- **WHEN** an archive contains root `README.md`
+- **THEN** no asset's files SHALL contain it
+
+#### Scenario: Unknown asset scope
+
+- **WHEN** an asset scope is `global`
+- **THEN** the system SHALL reject the lockfile
+
+#### Scenario: Unknown asset type
+
+- **WHEN** an asset type is `hook`
+- **THEN** the system SHALL reject the lockfile
+
+### Requirement: A machine-local record tracks what each project has materialized
+
+The system SHALL maintain a machine-local receipt describing the asset and file ownership successfully materialized for each project. The receipt SHALL be separate from version-controlled state, identified by canonical project location, and sufficient for offline rollback and removal without cache or network access. Each canonical project location SHALL have its own receipt; two projects SHALL never share one, and concurrent operations in different projects SHALL NOT contend on the same receipt. The receipt SHALL survive lockfile changes made outside the system. Current receipts SHALL use schema version `0.3` and record only assets actually materialized, with authored identity, authored owned-file paths, and the authored-or-aliased materialization disposition needed to address the effective adapter identity, without storing adapter-encoded hashes. Omitted assets SHALL NOT appear. A project without a receipt SHALL bootstrap one from the non-omitted assets in its current lockfile. Receipt `1` and `0.2` assets SHALL refine losslessly to authored materialization. A legacy receipt that predates companion ownership MAY be refined to primary-only ownership because legacy installation could not materialize companions.
+
+The receipt, lockfile, and materialized state SHALL commit together: within one operation, handled failures SHALL roll back all three, and an interruption that prevents rollback SHALL be recoverable by re-running installation, whose per-file integrity reconciliation converges disk, lockfile, and receipt without deleting unowned files. Receipt-driven deletion SHALL aggregate duplicate historical claims by effective adapter identity, delete each obsolete identity at most once, and pass each skill's validated authored companion ownership into the adapter deletion request so removal after a pulled lockfile drops an entry deletes exactly the recorded owned files without cache or network access. The receipt SHALL determine what is currently materialized when pulled version-control changes remove lockfile entries. In frozen-lockfile mode, receipt-driven cleanup SHALL begin only after the frozen consistency check passes. If that check rejects an orphaned lockfile entry, installation SHALL fail before cleanup changes any materialized state. Receipt data SHALL be treated as untrusted: project identity, record shape, and path containment within the selected adapter's storage SHALL be validated before deletion. Invalid or escaping records SHALL be reported and SHALL NOT cause deletion; files not recorded as owned SHALL never be deleted.
+
+#### Scenario: Pulled change cleans up a multi-file skill
+
+- **WHEN** pulled state removes a facet but the receipt records its effective skill and companions
+- **THEN** install SHALL supply the validated recorded companion paths in the adapter deletion request
+- **AND** it SHALL delete every recorded owned file from each selected adapter
+- **AND** no network or cache content SHALL be required
+
+#### Scenario: Interrupted install converges on re-run
+
+- **WHEN** installation is interrupted after some skill-bundle writes but before lockfile and receipt commit
+- **THEN** re-running SHALL compare locked per-file integrity against disk and complete or repair the bundle
+- **AND** the re-run SHALL NOT delete any file not recorded as owned
+
+#### Scenario: Removal needs neither cache nor network
+
+- **WHEN** an unwanted facet is uncached and its registry unavailable
+- **THEN** the system SHALL remove recorded files using the receipt
+
+#### Scenario: Project without a receipt bootstraps one
+
+- **WHEN** a project has a lockfile but no receipt
+- **THEN** the next operation SHALL create a project-specific receipt from non-omitted current locked ownership
+
+#### Scenario: Omitted asset is excluded from receipt
+
+- **WHEN** a lockfile asset is omitted
+- **THEN** receipt bootstrap SHALL NOT record it as materialized
+
+#### Scenario: Escaping receipt path is not deleted
+
+- **WHEN** a receipt companion path resolves outside its selected adapter's storage through traversal, an absolute path, or a link
+- **THEN** the system SHALL NOT delete that path
+- **AND** it SHALL report the invalid record while continuing to process valid owned paths safely
+
+#### Scenario: Mismatched project receipt is ignored
+
+- **WHEN** receipt project identity differs from the active project
+- **THEN** the system SHALL NOT delete anything based on that receipt
+- **AND** it SHALL recreate ownership from the non-omitted assets in the current lockfile
+
+#### Scenario: Unowned file survives cleanup
+
+- **WHEN** a skill directory contains a file absent from receipt ownership
+- **THEN** skill removal SHALL leave it unchanged
+
+### Requirement: Integrity is verified before any asset is written
+
+The system SHALL verify fetched or locally built facet content before writing any asset. For a current install, it SHALL require exact agreement between the lockfile's facet integrity and recomputed archive integrity; lockfile authored asset identities and verified authored identities; each asset's complete locked canonical authored path set and its verified owned-file set; and each per-file locked integrity, recomputed entry hash, and verified build-manifest hash. Materialization aliases and omissions SHALL NOT alter or bypass any comparison. Any disagreement SHALL abort before materialization and return structured data identifying the facet, asset, canonical authored path, expected integrity, and actual integrity when available. Normal resolution SHALL write a replacement lock entry only after all checks succeed; frozen mode SHALL fail without rewriting.
+
+#### Scenario: Registry content fails declared integrity
+
+- **WHEN** fetched content differs from registry-declared integrity
+- **THEN** installation SHALL abort before writing asset or project state
+- **AND** the failure SHALL identify the facet and expected and observed hashes
+
+#### Scenario: Registry content fails self-declared integrity
+
+- **WHEN** registry integrity matches but the archive does not reproduce its self-declared integrity
+- **THEN** installation SHALL abort with structured corruption data
+
+#### Scenario: Cached content fails locked integrity
+
+- **WHEN** cached content does not reproduce the lockfile's facet integrity
+- **THEN** installation SHALL abort and identify the facet
+
+#### Scenario: Git or local content fails computed integrity
+
+- **WHEN** a built git or local artifact differs from its locked facet integrity
+- **THEN** installation SHALL abort and identify the facet
+
+#### Scenario: Aliasing does not change verification identity
+
+- **WHEN** authored skill `review` is aliased to `vendor-review`
+- **THEN** verification SHALL still compare authored `skills/review/` paths and hashes
+
+#### Scenario: Companion integrity mismatch identifies exact path
+
+- **WHEN** locked `skills/review/references/api.md` differs from the recomputed archive-entry hash
+- **THEN** installation SHALL abort before any write
+- **AND** the failure SHALL contain that authored path and expected and actual integrity values
+
+#### Scenario: Locked file-set mismatch is rejected
+
+- **WHEN** a skill's locked `files` set has a missing or extra path relative to verified owned files
+- **THEN** installation SHALL abort with structured data identifying the differing path
+
+#### Scenario: Frozen mismatch does not rewrite
+
+- **WHEN** current per-file verification fails in frozen mode
+- **THEN** manifest, lockfile, receipt, and adapter state SHALL remain unchanged
+
+### Requirement: Frozen-lockfile install treats the lockfile as authoritative
+
+The system SHALL provide a frozen-lockfile mode for install in which the manifest and lockfile are treated as authoritative and reproduced exactly: no extra facets, no missing facets, no source changes, no content changes, and no materialization-intent changes. In this mode the system SHALL NOT perform version resolution, prompt for collision choices, migrate or write the manifest, or write the lockfile. Content download for a locked exact version absent from the cache SHALL remain permitted, because downloading already-locked bytes is reproduction, not drift. Because adding or removing a facet changes the locked set, the system SHALL reject a frozen-lockfile operation that carries any explicit add or removal before inspecting the lockfile.
+
+Before cleanup or materialization, the system SHALL verify that the manifest uses a supported form and that the lockfile fully and consistently covers its sources and materialization intent. The system SHALL fail without modifying the project if any of the following is true: the operation carries an explicit add or removal; no lockfile exists; the lockfile cannot be read or does not satisfy its selected published schema; the manifest declares an unsupported explicit version; the manifest declares a facet that has no lockfile entry; a lockfile entry's recorded version does not satisfy its manifest specifier; manifest overrides differ from locked dispositions, name an absent locked asset, or leave an unresolved effective-name collision; the lockfile pins a facet the manifest no longer declares; or a git or local facet's manifest source string no longer matches its recorded provenance. Valid legacy unversioned manifests and supported earlier lockfiles MAY be reproduced without rewriting when their authored materialization agrees.
+
+When the lockfile fully covers the manifest, the system SHALL install exactly the versions, integrity hashes, and effective materialized assets recorded in the lockfile, downloading any whose content is not cached. It SHALL verify that every facet—including cached content and local sources, which a non-frozen install would rebuild from disk—reproduces its recorded integrity and SHALL fail if any content does not match. Because frozen mode never creates a lockfile entry, it SHALL NOT require integrity confirmation against the registry; its only permitted network activity is downloading already-locked content.
+
+Frozen mode constrains the locked set, not the machine's materialized state: assets that the receipt shows as materialized but that the lockfile-covered manifest no longer wants SHALL still be removed, and the receipt SHALL be updated to match, while the lockfile and manifest SHALL never be written. Receipt-driven cleanup SHALL begin only after every frozen consistency check passes.
+
+#### Scenario: Frozen install proceeds when locked state covers intent
+
+- **WHEN** a user runs install in frozen-lockfile mode
+- **AND** manifest sources and materialization intent exactly match supported locked state
+- **THEN** the system SHALL reproduce exact versions, integrity, and effective assets without resolution or prompt
+- **AND** it SHALL NOT write the manifest or lockfile
+
+#### Scenario: Frozen mode downloads absent locked content
+
+- **WHEN** a locked exact version's content is absent from the cache
+- **THEN** the system SHALL download and verify that exact content
+- **AND** it SHALL NOT treat the download as drift
+
+#### Scenario: Frozen mode verifies cached content
+
+- **WHEN** cached content differs from locked integrity
+- **THEN** the system SHALL fail with an integrity error before materialization
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode cleans receipt-only orphan
+
+- **WHEN** manifest and lockfile both dropped a facet still present in the receipt
+- **THEN** frozen consistency SHALL pass and receipt-driven cleanup SHALL remove its effective ownership
+- **AND** the receipt SHALL be updated so it no longer lists the facet
+- **AND** the manifest and lockfile SHALL remain unchanged
+
+#### Scenario: Frozen mode rejects explicit delta
+
+- **WHEN** frozen installation carries an add or removal
+- **THEN** it SHALL fail before inspecting the lockfile or resolving any facet
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode rejects missing lockfile
+
+- **WHEN** no lockfile exists
+- **THEN** frozen installation SHALL fail with an error stating the lockfile is missing
+- **AND** it SHALL NOT create or modify the lockfile
+
+#### Scenario: Frozen mode rejects an unsupported manifest version
+
+- **WHEN** the manifest declares an unsupported explicit `manifestVersion`
+- **THEN** frozen installation SHALL fail with the observed and supported versions
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode rejects uncovered facet
+
+- **WHEN** a manifest facet has no lockfile entry
+- **THEN** frozen installation SHALL fail identifying that facet
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode rejects version drift
+
+- **WHEN** a locked version does not satisfy its manifest source
+- **THEN** frozen installation SHALL fail identifying the facet, manifest specifier, and locked version
+- **AND** it SHALL NOT perform version resolution
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode rejects materialization drift
+
+- **WHEN** manifest overrides disagree with locked dispositions or leave a collision
+- **THEN** frozen installation SHALL fail identifying every affected asset
+- **AND** it SHALL NOT prompt or write state
+
+#### Scenario: Frozen mode rejects stale override
+
+- **WHEN** an override names an asset absent from locked content
+- **THEN** frozen installation SHALL fail identifying the facet, type, and authored name
+- **AND** it SHALL NOT remove the override or write any state
+
+#### Scenario: Frozen mode rejects orphaned lockfile entry
+
+- **WHEN** the lockfile pins a facet absent from the manifest
+- **THEN** frozen installation SHALL fail identifying the orphaned facet and its locked version
+- **AND** it SHALL NOT prune the orphaned facet's assets
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode rejects changed git or local source
+
+- **WHEN** manifest source differs from locked git or local provenance
+- **THEN** frozen installation SHALL fail identifying the facet, manifest source, and locked source
+- **AND** it SHALL NOT clone, resolve, or build from the changed source
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+#### Scenario: Frozen mode rejects local content drift
+
+- **WHEN** local content no longer reproduces locked integrity
+- **THEN** frozen installation SHALL fail with an integrity error rather than rebuilding and overwriting the entry
+- **AND** it SHALL leave the manifest, lockfile, receipt, and adapter state unchanged
+
+### Requirement: Removing a facet uninstalls it
+
+When a user removes a facet from a project, the system SHALL drop the facet from the project manifest, reconcile its effective materialized ownership across every selected adapter, and update the lockfile and receipt so neither records the facet—all in a single operation. A user SHALL NOT need to run a separate install step after removing. The ownership to reconcile SHALL be taken from the receipt, so removal SHALL require neither cache nor network access. The system SHALL delete a recorded effective adapter identity only when no desired asset retains it, SHALL delete each obsolete identity once, and SHALL aggregate historical duplicate claims so a surviving desired asset is never deleted. Skill deletion SHALL supply the validated authored companion ownership in the adapter deletion request and SHALL remove the primary and every obsolete owned companion atomically while leaving unowned files untouched.
+
+Before deleting any materialized asset, the system SHALL verify that every selected installed adapter loads as a valid adapter and declares an API supported by the CLI. When a selected adapter has a missing, malformed, unsupported, or metadata-inconsistent API declaration, or cannot be loaded as a valid adapter, removal SHALL fail before deleting any materialized asset and SHALL leave the project manifest, lockfile, receipt, and materialized assets unchanged. An adapter declaring the superseded positional API `0.0` SHALL be unsupported by a CLI whose supported set is the tagged-contract API `0.1` and SHALL trigger this failure. This compatibility precondition SHALL require neither cache access nor network access; once the adapter incompatibility is repaired, removal SHALL remain able to use the receipt without either resource.
+
+#### Scenario: Removing a declared facet uninstalls it
+
+- **WHEN** a user removes a facet declared in the project manifest
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** its manifest entry, lockfile entry, receipt entry, and obsolete effective ownership SHALL be removed in one command
+
+#### Scenario: Removing multi-file skill preserves unowned content
+
+- **WHEN** a removed facet owns `skills/review/SKILL.md` and `skills/review/references/api.md` but not `skills/review/notes.txt`
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** deletion SHALL remove the primary and obsolete owned companion
+- **AND** it SHALL preserve `notes.txt`
+
+#### Scenario: Other facets are left intact
+
+- **WHEN** one facet is removed from a project with several facets
+- **AND** no effective adapter identity transfers to another desired owner
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** every other facet's manifest, lockfile, receipt, and materialized files SHALL remain unchanged
+
+#### Scenario: Other facet retaining an identity is not deleted
+
+- **WHEN** another desired facet owns the same effective adapter identity after removal
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** that identity SHALL remain and contain the desired owner's content
+
+#### Scenario: Removing the last facet leaves an empty project
+
+- **WHEN** the only declared facet is removed
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** manifest and lockfile SHALL remain valid and contain no facets
+
+#### Scenario: Removal works offline
+
+- **WHEN** removed facet content is uncached and its registry unreachable
+- **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
+- **THEN** receipt ownership SHALL allow removal without any cache read or network access
+
+#### Scenario: Incompatible adapter blocks removal
+
+- **WHEN** a selected installed adapter is incompatible or cannot be loaded as a valid adapter
+- **THEN** removal SHALL fail before deleting materialized assets
+- **AND** the project manifest, lockfile, receipt, and materialized assets SHALL remain unchanged
+- **AND** the failure SHALL NOT require or result from cache access or network access
+- **AND** after the adapter incompatibility is repaired, removal SHALL remain able to use the receipt without cache or network access

--- a/openspec/changes/add-materialization-aliasing/specs/protocol__schemas/spec.md
+++ b/openspec/changes/add-materialization-aliasing/specs/protocol__schemas/spec.md
@@ -1,0 +1,215 @@
+## ADDED Requirements
+
+### Requirement: Materialization dispositions use one published tagged shape
+
+The protocol SHALL publish a materialization disposition with exactly three arms: `authored`, meaning the asset is materialized under its authored name; `aliased`, which MUST carry the effective name; and `omitted`, meaning the asset is not materialized. An aliased effective name MUST satisfy the current single-segment asset-name grammar and SHALL NOT change the asset's authored scope, type, archive paths, or integrity values.
+
+An artifact that records project intent SHALL admit only the `aliased` and `omitted` arms because absence of an override means authored materialization. An artifact that records resolved state SHALL require one of all three arms. Illegal combinations, including an alias without an effective name or an effective name on another arm, SHALL be rejected.
+
+#### Scenario: Valid aliased disposition
+
+- **WHEN** a disposition declares `aliased` with effective name `vendor-review`
+- **THEN** the disposition SHALL satisfy the published schema
+- **AND** the authored asset identity SHALL remain unchanged
+
+#### Scenario: Valid omitted disposition
+
+- **WHEN** a disposition declares `omitted` without an effective name
+- **THEN** the disposition SHALL satisfy the published schema
+
+#### Scenario: Alias without an effective name is rejected
+
+- **WHEN** a disposition declares `aliased` but omits its effective name
+- **THEN** the disposition SHALL NOT satisfy the published schema
+
+#### Scenario: Non-aliased disposition carrying a name is rejected
+
+- **WHEN** an `authored` or `omitted` disposition also carries an effective name
+- **THEN** the disposition SHALL NOT satisfy the published schema
+
+#### Scenario: Invalid effective name is rejected
+
+- **WHEN** an aliased disposition uses `Review`, `review/code`, `-review`, or another name outside the current asset-name grammar
+- **THEN** the disposition SHALL NOT satisfy the published schema
+- **AND** the name SHALL NOT be normalized or sanitized
+
+#### Scenario: Authored is not a project override
+
+- **WHEN** a project-manifest override explicitly declares `authored`
+- **THEN** the override SHALL NOT satisfy the published project-manifest schema
+- **AND** authored materialization SHALL be expressed by omitting the override
+
+## MODIFIED Requirements
+
+### Requirement: A project manifest schema is published as part of the protocol
+
+The shape of a project manifest (`facets.json`) SHALL be published as a normative schema. Any system that reads, writes, or interprets a project manifest SHALL conform to the published schema. The schema SHALL define exact format-version dispatch, how facet sources and version specifiers are expressed, how compact and expanded facet entries are distinguished, and how per-asset materialization overrides are declared.
+
+Version selection SHALL recognize exactly two supported forms: a document without `manifestVersion` SHALL be interpreted only under the legacy unversioned schema, and a document declaring numeric `manifestVersion: 0.1` SHALL be interpreted only under the current schema. Any other explicit value SHALL be rejected with structured data identifying the observed and supported versions. A document that fails its selected schema SHALL NOT be retried under another schema, and its version SHALL NOT be inferred from the remaining shape.
+
+Every legacy unversioned facet entry MUST be a compact source string. Under the current `0.1` schema, an entry SHALL be either a compact source string or an expanded object containing `source` and a non-empty `materialization` object. Materialization overrides SHALL be grouped into optional `skills`, `commands`, and `agents` maps keyed by authored asset name. Each value SHALL be an `aliased` or `omitted` disposition. Alias values MUST satisfy the current single-segment asset-name grammar; authored keys MUST remain safe to address, including for supported legacy assets.
+
+The compact string SHALL be canonical when a facet has no overrides. A producer SHALL preserve `manifestVersion`, sources, and overrides it does not intentionally change, SHALL preserve overrides when changing a facet's source, and SHALL collapse an expanded entry to its compact source only after its final override is removed. An override naming an asset absent from a resolved facet SHALL remain schema-valid because document validation SHALL NOT require source resolution.
+
+A project-manifest JSON document containing duplicate object member names SHALL be rejected before version dispatch and schema validation.
+
+#### Scenario: A consumer interprets a project manifest correctly
+
+- **WHEN** a system reads a `facets.json` containing facet sources and version specifiers
+- **THEN** the system SHALL interpret each source under the selected schema
+- **AND** ambiguous interpretations SHALL be rejected with a structured error
+
+#### Scenario: A producer writes a project manifest conforming to the schema
+
+- **WHEN** a system adds a new facet to a project's `facets.json`
+- **THEN** the resulting file SHALL satisfy the current schema
+- **AND** it SHALL declare `manifestVersion: 0.1`
+- **AND** another facet-compatible system SHALL accept it after validation
+
+#### Scenario: Legacy unversioned compact manifest is accepted
+
+- **WHEN** a manifest omits `manifestVersion` and every facet value is a source string
+- **THEN** the system SHALL accept it under the legacy unversioned schema
+
+#### Scenario: Expanded legacy entry is rejected
+
+- **WHEN** a manifest omits `manifestVersion` and contains an expanded facet entry
+- **THEN** the system SHALL reject it
+- **AND** the system SHALL NOT reinterpret it as current
+
+#### Scenario: Current manifest version is selected exactly
+
+- **WHEN** a manifest declares numeric `manifestVersion: 0.1`
+- **THEN** the system SHALL validate it only under the current schema
+
+#### Scenario: Unsupported manifest version is structured
+
+- **WHEN** a manifest declares `manifestVersion: 0.2`
+- **THEN** the system SHALL reject it with structured data identifying `0.2` and the supported versions
+
+#### Scenario: Expanded entry records typed overrides
+
+- **WHEN** a current manifest records an alias for skill `review` and an omission for command `deploy`
+- **THEN** the system SHALL associate each override with its facet, asset type, and authored name
+
+#### Scenario: Compact entry is canonical without overrides
+
+- **WHEN** a current manifest producer emits a facet with no materialization override
+- **THEN** the facet value SHALL be its compact source string
+- **AND** the document SHALL retain `manifestVersion: 0.1`
+
+#### Scenario: Source update preserves overrides
+
+- **WHEN** a producer changes the source of a facet whose expanded entry has overrides
+- **THEN** the new entry SHALL preserve every existing override for that facet
+
+#### Scenario: Absent authored asset does not invalidate the document
+
+- **WHEN** an override names an asset absent from the resolved facet version
+- **THEN** the project manifest SHALL still satisfy its schema
+
+#### Scenario: Duplicate members are rejected
+
+- **WHEN** a `facets.json` document contains a duplicate facet or override member
+- **THEN** the system SHALL reject it before version dispatch and schema validation
+
+### Requirement: A lockfile schema is published as part of the protocol
+
+The shape of a lockfile (`facets.lock`) SHALL be published as a normative schema. Any system that reads, writes, or interprets a lockfile SHALL conform to the published schema. The schema SHALL define the lockfile version, source-provenance fields, identity-and-integrity fields, the complete authored asset list, each asset's materialization disposition and canonical file-integrity records, and the rules for unrecognized fields.
+
+Version dispatch SHALL use exact equality. Numeric `1` SHALL identify only the earliest alpha schema, numeric `0.2` SHALL identify only the preceding schema, and numeric `0.3` SHALL identify only the current schema. A malformed document SHALL NOT be retried under another version, and an unsupported version SHALL be rejected with structured observed and supported values. Project-manifest, lockfile, archive, and adapter-contract versions SHALL be interpreted independently. Duplicate lockfile members SHALL be rejected before schema validation.
+
+The published source provenance SHALL remain tagged by source kind: registry records the registry origin, git records the repository URL and required resolved commit, and local records the resolved path. A source missing a required field SHALL NOT satisfy the schema; a source MAY carry unrecognized keys.
+
+Every `0.3` asset entry SHALL record `scope`, `type`, authored `name`, a required materialization disposition, and a required `files` array sorted by canonical path. Each file record SHALL contain exactly the canonical inner-archive path derived from the authored name and its `sha256:<hex>` integrity. Aliased and omitted dispositions SHALL NOT change those paths or hashes. An omitted asset SHALL remain in the lockfile with all authored file records. Skill companions SHALL remain subordinate records, and archive-only supplementary files SHALL NOT appear in an asset's files.
+
+Every `0.2` asset entry SHALL retain its preceding `{ scope, type, name, files }` shape and SHALL be understood as materialized under its authored name. Materialization dispositions SHALL be recognized only in `0.3`.
+
+#### Scenario: A consumer interprets a lockfile written by a different system
+
+- **WHEN** a system reads a `facets.lock` written by another facet-compatible system
+- **THEN** it SHALL interpret every field under the declared schema
+- **AND** it SHALL accept the lockfile as valid installation input
+
+#### Scenario: A producer writes a reproducible lockfile
+
+- **WHEN** a system writes `facets.lock` after resolving sources and materialization intent
+- **THEN** the file SHALL satisfy the published schema
+- **AND** another conforming system SHALL reproduce the same effective asset set
+
+#### Scenario: Source provenance is tagged by kind
+
+- **WHEN** a system reads source provenance from a lockfile entry
+- **THEN** the source SHALL declare its kind as registry, git, or local
+- **AND** a registry source SHALL record the registry origin and SHALL NOT carry a version specifier
+- **AND** a git source SHALL record the repository URL and a required resolved commit, and SHALL NOT record a symbolic ref
+- **AND** a local source SHALL record the resolved path
+
+#### Scenario: Git source without a commit is rejected
+
+- **WHEN** a git source records a URL but no resolved commit
+- **THEN** the lockfile SHALL NOT satisfy the published schema
+- **AND** the system SHALL reject the lockfile
+
+#### Scenario: Source with unrecognized keys is accepted
+
+- **WHEN** a recognized source carries every required field plus unrecognized keys
+- **THEN** the lockfile SHALL satisfy the published schema
+- **AND** the system SHALL accept the lockfile
+
+#### Scenario: Current skill entry lists every authored file
+
+- **WHEN** a `0.3` lockfile records skill `review` with companions `references/api.md` and `scripts/run.ts`
+- **THEN** its sorted `files` array SHALL contain `skills/review/SKILL.md`, `skills/review/references/api.md`, and `skills/review/scripts/run.ts`
+- **AND** each record SHALL contain a canonical authored path and `sha256:<hex>` integrity
+- **AND** the entry SHALL declare a materialization disposition
+
+#### Scenario: Single-file assets list one file
+
+- **WHEN** a `0.3` lockfile records agent `reviewer` and command `review`
+- **THEN** each asset's `files` array SHALL contain exactly its authored conventional primary path
+
+#### Scenario: Aliased asset retains authored records
+
+- **WHEN** skill `review` is recorded as aliased to `vendor-review`
+- **THEN** its `name` SHALL remain `review`
+- **AND** its files SHALL remain under canonical `skills/review/` paths
+- **AND** its disposition SHALL record `vendor-review`
+
+#### Scenario: Omitted asset remains recorded
+
+- **WHEN** command `deploy` is recorded as omitted
+- **THEN** its lockfile asset entry SHALL remain present with `commands/deploy.md` and its integrity
+
+#### Scenario: Missing current disposition is rejected
+
+- **WHEN** a `0.3` asset entry omits its materialization disposition
+- **THEN** the lockfile SHALL NOT satisfy the published schema
+
+#### Scenario: Archive-only file is excluded
+
+- **WHEN** a verified facet contains root `README.md`
+- **THEN** no `0.2` or `0.3` asset entry SHALL list it
+
+#### Scenario: Legacy alpha is selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 1`
+- **THEN** it SHALL be interpreted only under the earliest alpha schema
+- **AND** the system SHALL NOT reinterpret its shape as `0.3`
+
+#### Scenario: Previous version is selected exactly
+
+- **WHEN** a lockfile declares numeric `lockfileVersion: 0.2`
+- **THEN** it SHALL be interpreted only under the preceding schema
+- **AND** every asset SHALL be understood as materialized under its authored name
+- **AND** the system SHALL NOT reinterpret its shape as `0.3`
+
+#### Scenario: Malformed current lockfile is not reinterpreted
+
+- **WHEN** a lockfile declares `lockfileVersion: 0.3` but violates the current schema
+- **THEN** it SHALL be rejected without fallback to `0.2` or `1`
+
+#### Scenario: Unsupported version is structured
+
+- **WHEN** a lockfile declares an unsupported version
+- **THEN** it SHALL be rejected with structured observed and supported versions

--- a/openspec/changes/add-materialization-aliasing/tasks.md
+++ b/openspec/changes/add-materialization-aliasing/tasks.md
@@ -1,0 +1,123 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+
+## 1. Protocol Identity and Schema Contracts — Research
+
+- [ ] 1.1 Explore: Inspect the existing asset-name validators, portable collision normalization, shared skill/command validation, and canonical authored-path derivation in `packages/protocol` and `packages/common`.
+- [ ] 1.2 Explore: Inspect the project-manifest, lockfile, and build-manifest schemas/loaders and their exact-dispatch, duplicate-member, fixture, and public-export test patterns.
+- [ ] 1.3 Explore: Inspect protocol package release metadata and all downstream consumers of project-manifest and lockfile types/constants so compatibility shims and the `0.3` writer flip are sequenced safely.
+- [ ] 1.4 Propose: Define the protocol implementation approach for one namespace mapping, tagged dispositions, legacy/current manifest dispatch, lockfile `0.3`, canonical identity helpers, and a deterministic planner without duplicating existing sources of truth.
+
+## 2. Protocol Identity and Schema Contracts — Implementation
+
+- [ ] 2.1 Implement: Add the shared materialization namespace, collision-key, adapter-key, and canonical authored-path helpers; refactor existing facet/build collision validation to consume the shared rules; add focused namespace and portability tests.
+- [ ] 2.2 Implement: Add the three-arm `MaterializationDisposition` schema/type and derive project-override and materialized-only variants; enforce the single-segment alias grammar and rejection of stray or missing alias fields; add scenario-complete tests.
+- [ ] 2.3 Implement: Implement legacy-unversioned and exact `manifestVersion: 0.1` schemas in `packages/protocol/src/schemas/project-manifest.ts` plus a project-manifest loader that rejects duplicate members before exact version dispatch and never falls back by shape; cover compact/expanded entries, typed override maps, invalid aliases, unsupported versions, and empty-expanded-entry rejection.
+- [ ] 2.4 Implement: Add lockfile `0.3` with required dispositions while preserving exact readers for `1` and `0.2`; factor shared file-record validation, keep authored names/paths for aliases and omissions, and test malformed-current no-fallback behavior.
+- [ ] 2.5 Implement: Implement the pure deterministic materialization planner as a discriminated result union, reporting every ordered collision group and supporting scope separation, shared skill/command names, aliases, omissions, name transfers, swaps, temporary draft conflicts, and declaration-order independence.
+- [ ] 2.6 Implement: Export the new protocol contracts through the curated public surface and update protocol release notes/metadata according to repository conventions without changing archive or adapter API versions.
+- [ ] 2.7 Verify: Run the protocol unit tests, typecheck, and public-surface/build checks; confirm the new schema and planner scenario suites pass.
+
+## 3. Project Manifest Intent and Migration — Research
+
+- [ ] 3.1 Explore: Trace every `facets.json` reader, mutation, empty-document producer, source update, delta merge, serializer, and tri-write path across engine and CLI, including comment-preserving behavior and `facet list`.
+- [ ] 3.2 Explore: Trace frozen and normal migration boundaries for legacy unversioned manifests and identify where unsupported versions, expanded legacy entries, source updates, empty override collapse, and stale overrides are handled transactionally.
+- [ ] 3.3 Propose: Define the normalized in-memory manifest shape and write policy that preserve comments, untouched expanded entries, and overrides while keeping the protocol schema as the source of truth.
+
+## 4. Project Manifest Intent and Migration — Implementation
+
+- [ ] 4.1 Implement: Route engine project-manifest loading through the protocol loader and normalize legacy/current compact and expanded entries without losing comment metadata or structured version failures.
+- [ ] 4.2 Implement: Update `packages/engine/src/manifest/mutations.ts`, `manifest/project-files.ts`, `install/commit/delta.ts`, and `install/commit/tri-write.ts` so source changes preserve overrides, empty expanded entries collapse canonically, and successful non-frozen commits write `manifestVersion: 0.1`.
+- [ ] 4.3 Implement: Add transactional tests proving successful legacy migration preserves every entry, failed operations leave prior manifest bytes unchanged, frozen operations retain legacy bytes, duplicate members fail before mutation, and unrelated add/update/remove operations preserve expanded entries.
+- [ ] 4.4 Implement: Update `facet list` and any other read-only consumers to obtain a facet source from either compact or expanded entries; add legacy/current read-tolerance tests.
+- [ ] 4.5 Verify: Run targeted engine manifest, add, remove, list, frozen, and tri-write tests plus engine typechecking.
+
+## 5. Resolve and Compose Pipeline — Research
+
+- [ ] 5.1 Explore: Trace the current interleaved install loop, source-specific resolvers, verified authored plans, integrity reconciliation, journal lifecycle, lock scope, outcome classification, stage events, and structured failure unions.
+- [ ] 5.2 Explore: Trace adapter preflight and every pre-materialization failure path to establish which failures must precede collision resolution and which paths must guarantee no mutation.
+- [ ] 5.3 Propose: Define the resolve-all, compose, resolver-callback, and apply handoff types so fresh versus inherited content and resolved versus colliding plans cannot represent illegal mixed states.
+
+## 6. Resolve and Compose Pipeline — Implementation
+
+- [ ] 6.1 Implement: Replace parallel optional resolved-facet fields with a tagged fresh/inherited union and extract deterministic resolve-all behavior that retains authored plans/bytes without invoking adapters.
+- [ ] 6.2 Implement: Implement Compose over the complete desired set: apply persisted overrides, report stale overrides, derive effective identities, call the protocol planner, and produce lockfile dispositions, retained adapter keys, and effective ownership only for collision-free results.
+- [ ] 6.3 Implement: Add the optional typed collision-resolver callback and structured collision, invalid-resolution, and cancellation results/events; frozen mode and calls without a resolver must return every group without prompting or mutation.
+- [ ] 6.4 Implement: Refactor `runInstall` into preflight, resolve-all, compose, apply, and commit boundaries; keep the project lock across resolution, create the journal only after Compose succeeds, and final-validate callback choices without reopening the resolver.
+- [ ] 6.5 Implement: Update reuse and outcome classification so disposition-only changes at unchanged versions are `updated`, disk-only drift remains `repaired`, and source/integrity failures still retain deterministic ordering.
+- [ ] 6.6 Implement: Add tests for no adapter calls during resolve/compose, all-group collision failures, adapter/integrity precedence, resolver success, invalid callback output, cancellation, stale-override retention on failure, and successful transactional pruning.
+- [ ] 6.7 Verify: Run targeted resolve, compose, callback, run-install, add, remove, and outcome-classification tests plus engine typechecking.
+
+## 7. Effective Ownership, Receipts, and Frozen Reproduction — Research
+
+- [ ] 7.1 Explore: Trace materialization, drift removal, receipt bootstrap/validation, companion ownership, journal replay, and adapter request construction to distinguish authored identity from effective adapter identity at every read/write/delete boundary.
+- [ ] 7.2 Explore: Trace receipt and lockfile version dispatch plus every frozen consistency check, including legacy formats, local/git provenance, orphan cleanup, and current no-network/no-registry-confirmation guarantees.
+- [ ] 7.3 Propose: Define the global two-pass apply and migration approach for ownership transfer, duplicate historical claims, alias changes, omissions, frozen materialization drift, and rollback safety.
+
+## 8. Effective Ownership, Receipts, and Frozen Reproduction — Implementation
+
+- [ ] 8.1 Implement: Add receipt `0.3` with authored identity, authored owned paths, and authored/aliased disposition; refine receipt `1` and `0.2` to authored, filter omitted lockfile assets during bootstrap, and retain all untrusted-path/project-isolation safeguards.
+- [ ] 8.2 Implement: Replace per-facet deletion planning with a global effective-adapter-key apply pass that aggregates historical claims, retains identities claimed by any desired asset, deletes obsolete identities once, and safely handles cross-facet ownership transfer.
+- [ ] 8.3 Implement: Materialize non-omitted assets under effective names while keeping content lookup, integrity, descriptions, metadata, and companion extraction authored; ensure generated front matter and adapter read/install/delete requests use the effective name.
+- [ ] 8.4 Implement: Make alias changes delete old ownership and write new ownership transactionally, make omission toggles remove/restore complete bundles, preserve unowned files, and cover journal rollback after partial global apply.
+- [ ] 8.5 Implement: Extend frozen gates for manifest version, locked dispositions, stale overrides, unresolved effective collisions, and legacy lockfiles that cannot represent intent while preserving exact-version downloads, no registry confirmation, and receipt-only cleanup.
+- [ ] 8.6 Implement: Add receipt, ownership-transfer, duplicate-claim, companion-cleanup, alias/omit drift, offline removal, frozen, integrity, and rollback tests covering all retained legacy safeguards.
+- [ ] 8.7 Verify: Run targeted materialization/apply, receipt, removal, frozen-drift, integrity, and journal tests plus engine typechecking.
+
+## 9. CLI Collision Resolution Experience — Research
+
+- [ ] 9.1 Explore: Inspect `packages/cli/src/tui/views/install/`, existing overview/focused-item editors, focus/navigation hooks, inline input validation, cancellation handling, semantic colors/icons, and Ink test helpers.
+- [ ] 9.2 Explore: Inspect add/install/remove command wiring, stdin/stdout TTY and raw-mode capability checks, SIGINT behavior, install stage events, exhaustive failure rendering, stderr formatting, and final summary construction.
+- [ ] 9.3 Propose: Define the single-mount progress-to-workspace phase machine, global draft state, accessible status vocabulary, linked-conflict navigation, resolver bridge, and non-interactive error presentation.
+
+## 10. CLI Collision Resolution Experience — Implementation
+
+- [ ] 10.1 Implement: Add one shared interactive-capability check for stdin/stdout/raw-mode support and an accessible unresolved/draft-conflict/resolved presentation whose labels or icons remain distinguishable without color.
+- [ ] 10.2 Implement: Implement the global collision draft and focused resolution workspace under `packages/cli/src/tui/views/install/`, with an all-groups overview, Keep/Alias/Omit controls, validated alias input, linked conflict navigation, and confirmation only when every item is resolved.
+- [ ] 10.3 Implement: Integrate the workspace into the existing `InstallView` mount as progress → resolution → progress → result, wire the typed engine callback only for interactive non-frozen commands, and make cancellation/SIGINT return a cancellation value with accurate no-change messaging.
+- [ ] 10.4 Implement: Render non-interactive collision failures to stderr with every group and claimant, exact expanded `facets.json` locations, parseable alias/omit snippets, no generated winner, a non-zero exit, and an explicit no-mutation statement.
+- [ ] 10.5 Implement: Render stale-override pruning without `--verbose`, frozen stale-override drift, the visible collision-checking stage, disposition-only updates, authored-to-effective alias summaries, and omitted assets without counting them as materialized.
+- [ ] 10.6 Implement: Add status/draft/component keyboard tests, InstallView phase/cancellation tests, stderr formatter tests, command tests, and collision e2e coverage for interactive, non-interactive, frozen, and adapter-precedence behavior.
+- [ ] 10.7 Verify: Run CLI unit tests, typechecking, build-dependent e2e tests, and adapter conformance tests using aliased names.
+
+## 11. User and Specification Documentation — Research
+
+- [ ] 11.1 Explore: Re-audit `docs/specification/project-manifest.mdx`, `lockfile.mdx`, `install.mdx`, `planning.mdx`, `commit.mdx`, `manifest.mdx`, `integrity.mdx`, and `terminology.mdx` against the implemented schemas and phase boundaries, preserving existing inbound anchors.
+- [ ] 11.2 Explore: Re-audit `docs/cli/add.mdx`, `install.mdx`, `instructions.mdx`, `remove.mdx`, and `list.mdx` plus `docs/guides/install-facets.mdx`, `custom-adapters.mdx`, and `troubleshooting.mdx` against final CLI output and recovery behavior.
+- [ ] 11.3 Explore: Inspect `docs/changelog/index.mdx`, documentation conventions, navigation/link requirements, and root `README.md`; confirm whether the reviewed README quickstart remains accurate.
+- [ ] 11.4 Propose: Define one non-duplicative documentation update plan covering schema references, install behavior, CLI workflows, guides, recovery, changelog, links, and the README disposition.
+
+## 12. User and Specification Documentation — Implementation
+
+- [ ] 12.1 Implement: Update `docs/specification/project-manifest.mdx` for `manifestVersion: 0.1`, exact dispatch, legacy migration, compact/expanded entries, typed overrides, preservation/collapse rules, duplicate rejection, and frozen behavior.
+- [ ] 12.2 Implement: Update `docs/specification/lockfile.mdx` for lockfile `0.3`, required dispositions, authored paths, omitted records, exact legacy dispatch, migration policy, and receipt/effective-ownership implications.
+- [ ] 12.3 Implement: Update install pipeline documentation in `docs/specification/install.mdx`, `planning.mdx`, `commit.mdx`, `manifest.mdx`, `integrity.mdx`, and `terminology.mdx` for authored/effective identities, Resolve-all/Compose/Apply, global ownership, frozen behavior, and the four independent version axes while preserving existing anchors.
+- [ ] 12.4 Implement: Update `docs/cli/add.mdx`, `docs/cli/install.mdx`, and `docs/guides/install-facets.mdx` with the interactive resolution workflow, red/yellow/green status model with non-color cues, persisted examples, non-interactive/frozen behavior, cancellation, summaries, and resulting on-disk layout.
+- [ ] 12.5 Implement: Update `docs/cli/instructions.mdx`, `remove.mdx`, `list.mdx`, `docs/guides/custom-adapters.mdx`, and `troubleshooting.mdx` for manual CI intent, effective adapter names, expanded-entry reading, ownership-safe removal, unsupported versions, stale overrides, and recovery.
+- [ ] 12.6 Implement: Add the newest-first changelog entry for the breaking manifest/lockfile/receipt formats and collision workflow, including required RSS metadata and links, without rewriting historical entries; leave README unchanged unless final behavior invalidates the reviewed quickstart.
+- [ ] 12.7 Verify: Run documentation formatting/link checks and stale-text searches for lockfile/receipt `0.2`, three-version-axis claims, string-only manifests, and the interleaved install loop.
+
+## 13. Migration Rollout and Cross-Layer Validation — Research
+
+- [ ] 13.1 Explore: Audit all protocol, engine, CLI, adapter, fixture, and documentation tests affected by the manifest/lockfile/receipt version changes and identify any remaining permissive legacy types or alias-unaware helpers that could drop dispositions.
+- [ ] 13.2 Propose: Define the final rollout gate that enables current `0.3` writers only after protocol, engine, CLI, migration, rollback, adapter, and documentation behavior is green together.
+
+## 14. Migration Rollout and Cross-Layer Validation — Implementation
+
+- [ ] 14.1 Implement: Remove or narrow permissive manifest/lockfile compatibility paths that could silently drop expanded entries or dispositions while retaining explicit legacy `1`, `0.2`, and unversioned readers.
+- [ ] 14.2 Implement: Enable unconditional non-frozen lockfile/receipt `0.3` writes and transactional project-manifest `0.1` migration only after all effective-ownership and CLI paths are wired; verify frozen operations retain loaded manifest/lockfile versions and write only safe machine-local receipt state.
+- [ ] 14.3 Implement: Add cross-package migration fixtures and tests for resolution-free upgrades, alias/omit projects, downgrade fail-closed behavior, failed-write restoration, teammate/CI reproduction, and removing all overrides without format downgrade.
+- [ ] 14.4 Verify: Run `bun check` for the complete repository and resolve every test, type, lint, formatting, e2e, documentation, and build failure before marking the change implementation-ready.


### PR DESCRIPTION
### Why

Independently published facets can declare assets with the same name, but installation currently has no way to resolve cross-facet collisions before materialization. The order-dependent result can silently overwrite one facet's asset, and receipt-driven removal can delete a path another facet still claims. This PR lands the OpenSpec change that specifies a reproducible way for users to keep, alias, or omit each colliding asset.

### Details

This PR contains **only OpenSpec artifacts** for the `add-materialization-aliasing` change — no runtime code. All product behavior changes land in follow-up implementation PRs driven by `tasks.md`.

The change specifies:

- Cross-facet collision detection across the complete desired set before any write, on every install path including frozen reproduction. Skills and commands share one namespace; agents are separate; scope is part of the collision key.
- Per-claimant resolution — keep, alias, or omit — with a required collision-free effective set, persisted as project intent so teammates, CI, and frozen installs reproduce it without prompting.
- Enriched `facets.json` with `manifestVersion: 0.1` (legacy string-only manifests remain valid), plus lockfile and receipt `0.3` carrying tagged materialization dispositions. Authored archive paths and integrity stay unchanged; adapters receive the effective name.
- A resolve-all → compose → apply install pipeline, an optional typed CLI collision resolver, global effective-ownership reconciliation, and fail-without-mutation behavior for frozen and non-interactive runs.

The artifacts were authored through the adversarial workflow: proposal, design, and specs each have an independent adversarial version and comparison review, all reconciled into the main artifacts (retained under `adversarial/` for history).

### Verification

Not applicable — specification and planning artifacts only. `bun openspec validate add-materialization-aliasing --strict` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install/add/update/repair now detect and block cross-facet asset name collisions before any writes.
  * Users can resolve collision groups interactively (keep authored name, set a validated alias, or omit); non-interactive runs fail with complete actionable collision details and no state changes.
  * Aliasing/omission outcomes are recorded for reproducible installs, repairs, removals, and frozen operations using authored vs effective identities.
* **Documentation**
  * Added detailed specifications for collision semantics, manifest/lockfile/receipt schemas, intent persistence, versioned migration rules, and frozen integrity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and specification only; no production code paths change until separate implementation PRs land.
> 
> **Overview**
> This PR **only adds OpenSpec planning artifacts** under `openspec/changes/add-materialization-aliasing/`; implementation is deferred to follow-up work in `tasks.md`.
> 
> It specifies **cross-facet asset name collision handling** before any install write: evaluate the full desired set on every path (add/install/update/repair/frozen), with skills and commands in one namespace and agents separate. Each claimant gets **keep, alias, or omit**; the effective set must be collision-free. Choices persist in enriched **`facets.json`** (`manifestVersion: 0.1`, compact entries unchanged when unused) and resolved state in **lockfile/receipt `0.3`** with tagged materialization dispositions, while **authored archive paths and integrity stay unchanged** and adapters receive the **effective** name.
> 
> The design calls for a **resolve-all → compose → apply** pipeline, optional **CLI collision resolver**, **global effective-ownership** reconciliation, and **fail-without-mutation** for frozen and non-interactive runs. Normative deltas land in **`installation`**, **`protocol__schemas`**, and **`cli`** specs, plus adversarial drafts, comparison reviews, and reconciled `state.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0947a4dcf391db1e6c4f1cbca0496d9abf5fa798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->