### PR TITLE
Implement normalized project manifest with comment preservation, version migration, and materialization aliasing support

### DIFF
--- a/openspec/changes/add-materialization-aliasing/tasks.md
+++ b/openspec/changes/add-materialization-aliasing/tasks.md
@@ -33,17 +33,17 @@
 
 ## 3. Project Manifest Intent and Migration — Research
 
-- [ ] 3.1 Explore: Trace every `facets.json` reader, mutation, empty-document producer, source update, delta merge, serializer, and tri-write path across engine and CLI, including comment-preserving behavior and `facet list`.
-- [ ] 3.2 Explore: Trace frozen and normal migration boundaries for legacy unversioned manifests and identify where unsupported versions, expanded legacy entries, source updates, empty override collapse, and stale overrides are handled transactionally.
-- [ ] 3.3 Propose: Define the normalized in-memory manifest shape and write policy that preserve comments, untouched expanded entries, and overrides while keeping the protocol schema as the source of truth.
+- [x] 3.1 Explore: Trace every `facets.json` reader, mutation, empty-document producer, source update, delta merge, serializer, and tri-write path across engine and CLI, including comment-preserving behavior and `facet list`.
+- [x] 3.2 Explore: Trace frozen and normal migration boundaries for legacy unversioned manifests and identify where unsupported versions, expanded legacy entries, source updates, empty override collapse, and stale overrides are handled transactionally.
+- [x] 3.3 Propose: Define the normalized in-memory manifest shape and write policy that preserve comments, untouched expanded entries, and overrides while keeping the protocol schema as the source of truth.
 
 ## 4. Project Manifest Intent and Migration — Implementation
 
-- [ ] 4.1 Implement: Route engine project-manifest loading through the protocol loader and normalize legacy/current compact and expanded entries without losing comment metadata or structured version failures.
-- [ ] 4.2 Implement: Update `packages/engine/src/manifest/mutations.ts`, `manifest/project-files.ts`, `install/commit/delta.ts`, and `install/commit/tri-write.ts` so source changes preserve overrides, empty expanded entries collapse canonically, and successful non-frozen commits write `manifestVersion: 0.1`.
-- [ ] 4.3 Implement: Add transactional tests proving successful legacy migration preserves every entry, failed operations leave prior manifest bytes unchanged, frozen operations retain legacy bytes, duplicate members fail before mutation, and unrelated add/update/remove operations preserve expanded entries.
-- [ ] 4.4 Implement: Update `facet list` and any other read-only consumers to obtain a facet source from either compact or expanded entries; add legacy/current read-tolerance tests.
-- [ ] 4.5 Verify: Run targeted engine manifest, add, remove, list, frozen, and tri-write tests plus engine typechecking.
+- [x] 4.1 Implement: Route engine project-manifest loading through the protocol loader and normalize legacy/current compact and expanded entries without losing comment metadata or structured version failures.
+- [x] 4.2 Implement: Update `packages/engine/src/manifest/mutations.ts`, `manifest/project-files.ts`, `install/commit/delta.ts`, and `install/commit/tri-write.ts` so source changes preserve overrides, empty expanded entries collapse canonically, and successful non-frozen commits write `manifestVersion: 0.1`.
+- [x] 4.3 Implement: Add transactional tests proving successful legacy migration preserves every entry, failed operations leave prior manifest bytes unchanged, frozen operations retain legacy bytes, duplicate members fail before mutation, and unrelated add/update/remove operations preserve expanded entries.
+- [x] 4.4 Implement: Update `facet list` and any other read-only consumers to obtain a facet source from either compact or expanded entries; add legacy/current read-tolerance tests.
+- [x] 4.5 Verify: Run targeted engine manifest, add, remove, list, frozen, and tri-write tests plus engine typechecking.
 
 ## 5. Resolve and Compose Pipeline — Research
 

--- a/packages/cli/src/commands/list/index.ts
+++ b/packages/cli/src/commands/list/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { FACETS_LOCK_FILE, loadFacetsJson, loadLockfile } from '@agent-facets/engine'
+import { describeManifestFailure, FACETS_LOCK_FILE, loadLockfile, loadProjectManifest } from '@agent-facets/engine'
 import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
@@ -49,17 +49,22 @@ export const listCommand: Command = {
       return 0
     }
 
-    const facetsJsonResult = loadFacetsJson(projectRoot)
-    if (!facetsJsonResult.ok) {
+    const manifestResult = loadProjectManifest(projectRoot)
+    if (!manifestResult.ok) {
+      const unsupported =
+        manifestResult.reason === 'invalid' && manifestResult.failure.code === 'unsupported-manifest-version'
       writeCliError({
-        what: 'facets.json is malformed',
-        detail: facetsJsonResult.error,
-        fix: 'fix the JSON syntax or schema errors and try again',
+        what: unsupported ? 'facets.json declares an unsupported manifestVersion' : 'facets.json is malformed',
+        detail:
+          manifestResult.reason === 'read' ? manifestResult.error : describeManifestFailure(manifestResult.failure),
+        fix: unsupported
+          ? 'upgrade the CLI to a version that understands this manifest'
+          : 'fix the JSON syntax or schema errors and try again',
       })
       return 1
     }
 
-    const declared = Object.entries(facetsJsonResult.data.facets)
+    const declared = Object.entries(manifestResult.manifest.facets)
     if (declared.length === 0) {
       process.stdout.write(
         [
@@ -85,9 +90,12 @@ export const listCommand: Command = {
       )
     }
 
-    const rows = declared.map(([name, source]) => {
+    // The normalized entry exposes `source` uniformly, so a compact and an
+    // expanded entry render identically — a facet with materialization
+    // overrides is not a different kind of dependency.
+    const rows = declared.map(([name, entry]) => {
       const lockEntry = lockfile?.facets[name]
-      const value = lockEntry !== undefined ? lockEntry.version : source
+      const value = lockEntry !== undefined ? lockEntry.version : entry.source
       return { name, value }
     })
 

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -61,7 +61,7 @@ export const removeCommand: Command = {
     // adapters — avoids a misleading "no adapters installed" error when the
     // user removes a facet that was never declared.
     if (prepared.names.length === 0) {
-      const facetCount = Object.keys(prepared.json.facets).length
+      const facetCount = Object.keys(prepared.manifest.facets).length
       const elapsed = `${((performance.now() - startTime) / 1000).toFixed(2)}s`
       const instance = render(
         createElement(

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -35,6 +35,21 @@ export function FailureBlock({ failure }: { failure: RunInstallFailure }): React
           <Text> {failure.error}</Text>
         </Box>
       )
+    case 'FACETS_JSON_UNSUPPORTED_VERSION':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ facets.json declares an unsupported manifestVersion
+          </Text>
+          <Text color={THEME.hint}> {failure.path}</Text>
+          <Text>
+            {' '}
+            found {failure.observed ?? 'a non-numeric value'}; this CLI supports {failure.supported.join(', ')} and
+            unversioned manifests
+          </Text>
+          <Text color={THEME.hint}> Upgrade the CLI to a version that understands this manifest.</Text>
+        </Box>
+      )
     case 'LOCKFILE_INVALID':
       return (
         <Box flexDirection="column" marginTop={1}>

--- a/packages/engine/src/__tests__/manifest-mutations.test.ts
+++ b/packages/engine/src/__tests__/manifest-mutations.test.ts
@@ -1,152 +1,260 @@
 import { describe, expect, test } from 'bun:test'
 import {
-  emptyFacetsJson,
-  parseFacetsJson,
-  removeFacetFromManifest,
-  serializeFacetsJson,
-  upsertFacetInManifest,
+  applyDesiredFacets,
+  countOverrides,
+  emptyProjectManifest,
+  type NormalizedFacetEntry,
+  parseProjectManifest,
+  serializeProjectManifest,
+  stripJsonComments,
 } from '../manifest/mutations.ts'
 
-describe('parseFacetsJson', () => {
-  test('valid facets.json parses and validates', () => {
+const entry = (source: string, overrides?: NormalizedFacetEntry['overrides']): NormalizedFacetEntry => ({
+  source,
+  overrides,
+})
+
+/** Parse, apply a desired set, and serialize — the production write path. */
+function roundTrip(raw: string, desired: Record<string, NormalizedFacetEntry>): string {
+  const parsed = parseProjectManifest(raw)
+  if (!parsed.ok) expect.unreachable()
+  applyDesiredFacets(parsed.manifest.document, desired)
+  return serializeProjectManifest(parsed.manifest.document)
+}
+
+describe('parseProjectManifest', () => {
+  test('a legacy unversioned manifest normalizes to compact entries', () => {
+    const result = parseProjectManifest('{"facets":{"viper-plans":"github:agent-facets/viper-plans#main"}}')
+    if (!result.ok) expect.unreachable()
+    expect(result.manifest.loadedVersion).toBe('legacy-unversioned')
+    expect(result.manifest.facets['viper-plans']).toEqual({
+      source: 'github:agent-facets/viper-plans#main',
+      overrides: undefined,
+    })
+  })
+
+  test('an empty facets object is valid', () => {
+    const result = parseProjectManifest('{"facets": {}}')
+    if (!result.ok) expect.unreachable()
+    expect(result.manifest.facets).toEqual({})
+  })
+
+  test('malformed JSON is a structured failure', () => {
+    const result = parseProjectManifest('{not valid')
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('invalid-json')
+  })
+
+  test('a shape mismatch is a structured failure', () => {
+    const result = parseProjectManifest('{"other": {}}')
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('schema-violation')
+  })
+
+  test('a legacy entry that is not a string is rejected', () => {
+    const result = parseProjectManifest('{"facets":{"viper-plans":{"source":"github:a/b"}}}')
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('schema-violation')
+  })
+
+  test('a current manifest normalizes compact and expanded entries uniformly', () => {
     const raw = JSON.stringify({
+      manifestVersion: 0.1,
       facets: {
-        'viper-plans': 'github:agent-facets/viper-plans#main',
+        a: '1.*',
+        b: {
+          source: 'github:a/b#main',
+          materialization: { skills: { review: { kind: 'aliased', as: 'b-review' } } },
+        },
       },
     })
-    const result = parseFacetsJson(raw)
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.data.facets['viper-plans']).toBe('github:agent-facets/viper-plans#main')
-    }
-  })
-
-  test('empty facets object is valid', () => {
-    const result = parseFacetsJson('{"facets": {}}')
-    expect(result.ok).toBe(true)
-  })
-
-  test('malformed JSON returns a parse error', () => {
-    const result = parseFacetsJson('{not valid')
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.errors[0]?.message).toContain('syntax error')
-    }
-  })
-
-  test('shape mismatch returns a validation error', () => {
-    const result = parseFacetsJson('{"other": {}}')
-    expect(result.ok).toBe(false)
-  })
-
-  test('non-string source value is rejected', () => {
-    const raw = JSON.stringify({ facets: { 'viper-plans': { source: 'github:a/b' } } })
-    const result = parseFacetsJson(raw)
-    expect(result.ok).toBe(false)
+    const result = parseProjectManifest(raw)
+    if (!result.ok) expect.unreachable()
+    expect(result.manifest.facets.a?.source).toBe('1.*')
+    expect(result.manifest.facets.b?.source).toBe('github:a/b#main')
+    expect(result.manifest.facets.b?.overrides?.skills?.review).toEqual({ kind: 'aliased', as: 'b-review' })
   })
 })
 
-describe('serializeFacetsJson', () => {
-  test('round-trips basic shape', () => {
-    const parsed = parseFacetsJson('{"facets": {"viper-plans": "github:x/y#main"}}')
-    expect(parsed.ok).toBe(true)
-    if (parsed.ok) {
-      const serialized = serializeFacetsJson(parsed.data)
-      expect(serialized).toContain('"viper-plans"')
-      expect(serialized).toContain('"github:x/y#main"')
-    }
+describe('stripJsonComments', () => {
+  test('replaces comment spans with spaces, preserving length', () => {
+    const input = '{"a": 1} // trailing'
+    const out = stripJsonComments(input)
+    expect(out.length).toBe(input.length)
+    expect(out.trimEnd()).toBe('{"a": 1}')
   })
 
-  test('preserves comments on keys not being mutated', () => {
-    const raw = `{
-  // top-level comment
+  test('preserves newlines inside block comments so line numbers hold', () => {
+    const input = '{\n/* one\ntwo */\n"a": 1}'
+    const out = stripJsonComments(input)
+    expect(out.split('\n').length).toBe(input.split('\n').length)
+    expect(JSON.parse(out)).toEqual({ a: 1 })
+  })
+
+  test('leaves comment-like text inside strings alone', () => {
+    const input = '{"url": "https://example.com/x", "note": "/* not a comment */"}'
+    expect(stripJsonComments(input)).toBe(input)
+  })
+
+  test('handles an escaped quote without losing string tracking', () => {
+    const input = '{"a": "he said \\"//hi\\"", "b": 1}'
+    expect(stripJsonComments(input)).toBe(input)
+  })
+
+  // The reason spans become spaces rather than being deleted: the member
+  // structure must survive so duplicate detection still sees both members.
+  test('preserves duplicate members across a comment', () => {
+    const out = stripJsonComments('{"a": 1, // note\n"a": 2}')
+    expect(out).toContain('"a": 1')
+    expect(out).toContain('"a": 2')
+  })
+
+  test('tolerates an unterminated block comment', () => {
+    expect(stripJsonComments('{"a": 1} /* never closed').trimEnd()).toBe('{"a": 1}')
+  })
+})
+
+describe('countOverrides', () => {
+  test('counts across every asset type', () => {
+    expect(countOverrides(undefined)).toBe(0)
+    expect(countOverrides({})).toBe(0)
+    expect(countOverrides({ skills: {}, commands: {} })).toBe(0)
+    expect(
+      countOverrides({
+        skills: { a: { kind: 'omitted' }, b: { kind: 'omitted' } },
+        commands: { c: { kind: 'omitted' } },
+      }),
+    ).toBe(3)
+  })
+})
+
+describe('emptyProjectManifest', () => {
+  test('starts at the current format version with no facets', () => {
+    const manifest = emptyProjectManifest()
+    expect(manifest.loadedVersion).toBe(0.1)
+    expect(manifest.facets).toEqual({})
+    expect(serializeProjectManifest(manifest.document)).toBe('{\n  "manifestVersion": 0.1,\n  "facets": {}\n}\n')
+  })
+})
+
+describe('applyDesiredFacets — canonical form', () => {
+  test('a facet with no overrides is written as a compact string', () => {
+    const out = roundTrip('{"facets":{}}', { a: entry('1.*') })
+    expect(JSON.parse(out).facets.a).toBe('1.*')
+  })
+
+  test('a facet with overrides is written as an expanded entry', () => {
+    const out = roundTrip('{"facets":{}}', {
+      a: entry('1.*', { skills: { review: { kind: 'omitted' } } }),
+    })
+    expect(JSON.parse(out).facets.a).toEqual({
+      source: '1.*',
+      materialization: { skills: { review: { kind: 'omitted' } } },
+    })
+  })
+
+  // An expanded entry exists only to carry overrides, so removing the last
+  // one must collapse it rather than leave an empty object behind.
+  test('an expanded entry collapses to a string when its last override is pruned', () => {
+    const raw = JSON.stringify({
+      manifestVersion: 0.1,
+      facets: { a: { source: '1.*', materialization: { skills: { review: { kind: 'omitted' } } } } },
+    })
+    const out = roundTrip(raw, { a: entry('1.*') })
+    expect(JSON.parse(out).facets.a).toBe('1.*')
+  })
+
+  test('an entry with only empty override maps collapses too', () => {
+    const out = roundTrip('{"facets":{}}', { a: entry('1.*', { skills: {}, commands: {} }) })
+    expect(JSON.parse(out).facets.a).toBe('1.*')
+  })
+
+  test('removed facets are deleted from the document', () => {
+    const out = roundTrip('{"facets":{"a":"1.*","b":"2.*"}}', { a: entry('1.*') })
+    expect(JSON.parse(out).facets).toEqual({ a: '1.*' })
+  })
+})
+
+describe('applyDesiredFacets — version stamping', () => {
+  test('a legacy document is stamped with the current version', () => {
+    const out = roundTrip('{"facets":{"a":"1.*"}}', { a: entry('1.*') })
+    expect(JSON.parse(out).manifestVersion).toBe(0.1)
+  })
+
+  test('a current document keeps its version', () => {
+    const out = roundTrip('{"manifestVersion":0.1,"facets":{"a":"1.*"}}', { a: entry('1.*') })
+    expect(JSON.parse(out).manifestVersion).toBe(0.1)
+  })
+})
+
+describe('applyDesiredFacets — source updates preserve overrides', () => {
+  test('changing a source keeps the entry expanded with its overrides', () => {
+    const raw = JSON.stringify({
+      manifestVersion: 0.1,
+      facets: { a: { source: '1.*', materialization: { commands: { deploy: { kind: 'omitted' } } } } },
+    })
+    const out = roundTrip(raw, {
+      a: entry('2.*', { commands: { deploy: { kind: 'omitted' } } }),
+    })
+    expect(JSON.parse(out).facets.a).toEqual({
+      source: '2.*',
+      materialization: { commands: { deploy: { kind: 'omitted' } } },
+    })
+  })
+})
+
+describe('applyDesiredFacets — comment preservation', () => {
+  const commented = `{
+  // file header
   "facets": {
-    // before viper-plans
-    "viper-plans": "github:x/y#main"
-  }
-}`
-    const parsed = parseFacetsJson(raw)
-    expect(parsed.ok).toBe(true)
-    if (parsed.ok) {
-      const serialized = serializeFacetsJson(parsed.data)
-      expect(serialized).toContain('top-level comment')
-      expect(serialized).toContain('before viper-plans')
-    }
-  })
-})
-
-describe('emptyFacetsJson', () => {
-  test('returns a valid skeleton', () => {
-    const empty = emptyFacetsJson()
-    expect(empty).toEqual({ facets: {} })
-  })
-})
-
-describe('upsertFacetInManifest', () => {
-  test('adds a new facet entry', () => {
-    const json = emptyFacetsJson()
-    upsertFacetInManifest(json, 'viper-plans', 'github:a/b#main')
-    expect(json.facets['viper-plans']).toBe('github:a/b#main')
-  })
-
-  test('replaces an existing facet entry', () => {
-    const parsed = parseFacetsJson('{"facets": {"viper-plans": "github:old/source#main"}}')
-    expect(parsed.ok).toBe(true)
-    if (parsed.ok) {
-      upsertFacetInManifest(parsed.data, 'viper-plans', 'github:new/source#v2')
-      expect(parsed.data.facets['viper-plans']).toBe('github:new/source#v2')
-    }
-  })
-
-  test('preserves comments on sibling entries after upsert', () => {
-    const raw = `{
-  "facets": {
-    // keep this comment
-    "alpha": "github:a/alpha#main"
-  }
-}`
-    const parsed = parseFacetsJson(raw)
-    expect(parsed.ok).toBe(true)
-    if (parsed.ok) {
-      upsertFacetInManifest(parsed.data, 'beta', 'github:b/beta#main')
-      const serialized = serializeFacetsJson(parsed.data)
-      expect(serialized).toContain('keep this comment')
-      expect(serialized).toContain('"beta"')
-    }
-  })
-})
-
-describe('removeFacetFromManifest', () => {
-  test('removes an existing facet entry', () => {
-    const parsed = parseFacetsJson('{"facets": {"viper-plans": "github:a/b#main"}}')
-    expect(parsed.ok).toBe(true)
-    if (parsed.ok) {
-      removeFacetFromManifest(parsed.data, 'viper-plans')
-      expect(parsed.data.facets['viper-plans']).toBeUndefined()
-    }
-  })
-
-  test('is idempotent when entry is absent', () => {
-    const json = emptyFacetsJson()
-    removeFacetFromManifest(json, 'nonexistent')
-    expect(json.facets).toEqual({})
-  })
-
-  test('preserves comments on sibling entries after removal', () => {
-    const raw = `{
-  "facets": {
-    // keep this comment
+    // about alpha
     "alpha": "github:a/alpha#main",
+    // about beta
     "beta": "github:b/beta#main"
   }
 }`
-    const parsed = parseFacetsJson(raw)
-    expect(parsed.ok).toBe(true)
-    if (parsed.ok) {
-      removeFacetFromManifest(parsed.data, 'beta')
-      const serialized = serializeFacetsJson(parsed.data)
-      expect(serialized).toContain('keep this comment')
-      expect(serialized).not.toContain('"beta"')
-    }
+
+  test('comments survive an unrelated addition', () => {
+    const out = roundTrip(commented, {
+      alpha: entry('github:a/alpha#main'),
+      beta: entry('github:b/beta#main'),
+      gamma: entry('github:g/gamma#main'),
+    })
+    expect(out).toContain('file header')
+    expect(out).toContain('about alpha')
+    expect(out).toContain('about beta')
+    expect(out).toContain('gamma')
+  })
+
+  test('comments survive a source update to another entry', () => {
+    const out = roundTrip(commented, {
+      alpha: entry('github:a/alpha#v2'),
+      beta: entry('github:b/beta#main'),
+    })
+    expect(out).toContain('file header')
+    expect(out).toContain('about beta')
+    expect(out).toContain('github:a/alpha#v2')
+  })
+
+  test('comments survive migration of a legacy document', () => {
+    const out = roundTrip(commented, {
+      alpha: entry('github:a/alpha#main'),
+      beta: entry('github:b/beta#main'),
+    })
+    expect(out).toContain('file header')
+    expect(JSON.parse(stripJsonComments(out)).manifestVersion).toBe(0.1)
+  })
+
+  test('comments survive an entry becoming expanded', () => {
+    const out = roundTrip(commented, {
+      alpha: entry('github:a/alpha#main', { skills: { review: { kind: 'aliased', as: 'a-review' } } }),
+      beta: entry('github:b/beta#main'),
+    })
+    expect(out).toContain('about alpha')
+    expect(out).toContain('about beta')
+    expect(JSON.parse(stripJsonComments(out)).facets.alpha.materialization.skills.review).toEqual({
+      kind: 'aliased',
+      as: 'a-review',
+    })
   })
 })

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -189,18 +189,25 @@ export type {
 // avoid two import paths for the same value.
 export { loadManifest, resolvePrompts } from './loaders/facet.ts'
 export { loadServerManifest } from './loaders/server.ts'
-// manifest mutations
+// project manifest — the normalized view the install pipeline reasons about,
+// plus the comment-preserving document that is the only thing serialized.
+export type {
+  LoadedManifestVersion,
+  ManifestDocument,
+  NormalizedFacetEntry,
+  NormalizedProjectManifest,
+} from './manifest/mutations.ts'
 export {
-  emptyFacetsJson,
+  applyDesiredFacets,
+  countOverrides,
+  emptyProjectManifest,
   FACETS_JSON_FILE,
-  parseFacetsJson,
-  removeFacetFromManifest,
-  serializeFacetsJson,
-  upsertFacetInManifest,
+  parseProjectManifest,
+  serializeProjectManifest,
 } from './manifest/mutations.ts'
 // manifest project files (I/O bridge)
-export type { LoadFacetsJsonResult } from './manifest/project-files.ts'
-export { loadFacetsJson, writeFacetsJson } from './manifest/project-files.ts'
+export type { LoadProjectManifestResult } from './manifest/project-files.ts'
+export { describeManifestFailure, loadProjectManifest, writeProjectManifest } from './manifest/project-files.ts'
 // readme (shared by scaffold + edit)
 export type { ReadmePath } from './readme.ts'
 export { isReadmePath, README_EXTENSIONLESS, README_MD, README_PATHS, readmeTemplate } from './readme.ts'

--- a/packages/engine/src/install/__tests__/detect-lockfile-drift.test.ts
+++ b/packages/engine/src/install/__tests__/detect-lockfile-drift.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test'
-import type { FacetsJson, Lockfile, LockfileFacet, LockfileSource } from '@agent-facets/protocol'
+import type { Lockfile, LockfileFacet, LockfileSource } from '@agent-facets/protocol'
 import { LOCKFILE_VERSION } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { detectLockfileDrift } from '../detect-lockfile-drift.ts'
 
-const manifest = (facets: Record<string, string>): FacetsJson => ({ facets })
+/** Build the normalized facet map from a plain name → specifier record. */
+const manifest = (facets: Record<string, string>): Record<string, NormalizedFacetEntry> =>
+  Object.fromEntries(Object.entries(facets).map(([name, source]) => [name, { source, overrides: undefined }]))
 
 /** Convert an OLD flat `source` string into the NEW tagged lockfile source. */
 const taggedSource = (source: string): LockfileSource => {

--- a/packages/engine/src/install/__tests__/manifest-transaction.test.ts
+++ b/packages/engine/src/install/__tests__/manifest-transaction.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+import { loadInstalledAdapters } from '../../adapters/loader.ts'
+import { parseFacetSource } from '../../sources/facet/parse-source.ts'
+import { runAdd } from '../add/index.ts'
+import { runRemove } from '../remove/index.ts'
+import { runInstall } from '../run-install.ts'
+
+/**
+ * Transactional guarantees for `facets.json`.
+ *
+ * These run the REAL install pipeline against local-source fixtures. That
+ * matters: the previous generation of manifest tests exercised the pure
+ * mutation helpers, which the pipeline stopped calling during the
+ * plan/commit refactor — so they kept passing while production silently
+ * destroyed every comment in the file. Anything asserted here is asserted
+ * against the bytes an actual `facet add` / `install` / `remove` writes.
+ */
+
+let projectRoot: string
+let originalCwd: string
+let fakeHome: string
+let originalHome: string | undefined
+let originalFacetDir: string | undefined
+let adaptersDir: string
+
+/** A local facet fixture inside the project tree, with one skill. */
+function buildFixture(name: string, version: string): string {
+  const dir = join(projectRoot, 'vendor', name)
+  mkdirSync(join(dir, 'skills/planning'), { recursive: true })
+  writeFileSync(
+    join(dir, 'facet.json'),
+    JSON.stringify({ name, version, skills: { planning: { description: 'planning skill' } } }),
+  )
+  writeFileSync(join(dir, 'skills/planning/SKILL.md'), `# planning ${version}\n`)
+  return `./vendor/${name}`
+}
+
+/** A working adapter, or one whose `installAsset` always fails. */
+function installFakeAdapter(baseDir: string, name: string, opts: { failInstall?: boolean } = {}): void {
+  const dir = join(baseDir, name)
+  mkdirSync(dir, { recursive: true })
+  const assetFsImport = require.resolve('@agent-facets/adapter')
+  const installBody = opts.failInstall
+    ? `return { ok: false, failure: { code: 'io-error', message: 'forced failure' } }`
+    : `const file = path(req.assetType, req.name)
+    await installAssetFile({ file }, req.content, req.metadata)
+    return { ok: true, primaryPath: file }`
+  writeFileSync(
+    join(dir, 'adapter.js'),
+    `
+import { installAssetFile, readAssetFile, deleteAssetFile } from '${assetFsImport}'
+import { join } from 'node:path'
+function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
+export default {
+  name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
+  supportsInstall: true,
+  buildAssetMetadata(data) { return { ok: true, data: data || {} } },
+  async installAsset(req) {
+    ${installBody}
+  },
+  async readAsset(req) {
+    try {
+      const r = await readAssetFile({ file: path(req.assetType, req.name) })
+      return {
+        ok: true,
+        asset: req.assetType === 'skill'
+          ? { assetType: 'skill', content: r.content, metadata: r.metadata, companions: {} }
+          : { assetType: req.assetType, content: r.content, metadata: r.metadata },
+      }
+    } catch {
+      return { ok: false, failure: { code: 'not-found' } }
+    }
+  },
+  async deleteAsset(req) {
+    const file = path(req.assetType, req.name)
+    await deleteAssetFile({ file })
+    return { ok: true, existed: true, deletedPaths: [file] }
+  },
+}
+`,
+  )
+}
+
+async function adapters() {
+  const loaded = await loadInstalledAdapters()
+  if (!loaded.ok) expect.unreachable('test bug: fixture adapters failed to load')
+  return loaded.adapters.filter((a) => a.supportsInstall === true)
+}
+
+async function add(specifier: string) {
+  const parsed = parseFacetSource(specifier)
+  if (!parsed.ok) throw new Error(`test bug: unparseable specifier ${specifier}`)
+  return runAdd({ projectRoot, sources: [{ specifier, source: parsed.value }], adapters: await adapters() })
+}
+
+async function install(opts: { frozenLockfile?: boolean } = {}) {
+  return runInstall({ projectRoot, adapters: await adapters(), ...opts })
+}
+
+async function remove(name: string) {
+  return runRemove({ projectRoot, names: [name], adapters: await adapters() })
+}
+
+const manifestPath = () => join(projectRoot, 'facets.json')
+const readManifest = () => readFileSync(manifestPath(), 'utf8')
+const parseManifest = () => JSON.parse(readManifest().replace(/^\s*\/\/.*$/gm, ''))
+
+function writeManifest(text: string): string {
+  writeFileSync(manifestPath(), text)
+  return text
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mtx-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-home-')))
+  const facetDir = join(fakeHome, '.facet')
+  adaptersDir = join(facetDir, 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+  process.env.HOME = fakeHome
+  process.env.FACET_DIR = facetDir
+  process.chdir(projectRoot)
+  installFakeAdapter(adaptersDir, 'test-adapter')
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('legacy migration is transactional', () => {
+  test('a successful install migrates an unversioned manifest and preserves every entry', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    writeManifest(`${JSON.stringify({ facets: { alpha: a, beta: b } }, null, 2)}\n`)
+
+    const result = await install()
+    expect(result.ok).toBe(true)
+
+    const written = parseManifest()
+    expect(written.manifestVersion).toBe(0.1)
+    expect(written.facets).toEqual({ alpha: a, beta: b })
+  })
+
+  test('a new project starts at the current version', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const result = await add(a)
+    expect(result.ok).toBe(true)
+    expect(parseManifest().manifestVersion).toBe(0.1)
+  })
+
+  // A failed operation must leave the file exactly as it was — not a
+  // half-migrated document.
+  test('a failed install leaves an unversioned manifest byte-for-byte unchanged', async () => {
+    installFakeAdapter(adaptersDir, 'test-adapter', { failInstall: true })
+    const a = buildFixture('alpha', '1.0.0')
+    const before = writeManifest(`${JSON.stringify({ facets: { alpha: a } }, null, 2)}\n`)
+
+    const result = await install()
+    if (result.ok) expect.unreachable()
+    // Pin the cause: the point is that a MATERIALIZATION failure leaves the
+    // manifest alone, not that the manifest was rejected up front.
+    expect(result.failure.code).toBe('ADAPTER_INSTALL_FAILED')
+    expect(readManifest()).toBe(before)
+  })
+
+  test('a frozen install retains legacy bytes', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    writeManifest(`${JSON.stringify({ facets: { alpha: a } }, null, 2)}\n`)
+    // Populate the lockfile with a normal install, then restore the legacy
+    // manifest so frozen mode sees covered-but-unversioned input.
+    expect((await install()).ok).toBe(true)
+    const legacy = writeManifest(`${JSON.stringify({ facets: { alpha: a } }, null, 2)}\n`)
+
+    const result = await install({ frozenLockfile: true })
+    expect(result.ok).toBe(true)
+    expect(readManifest()).toBe(legacy)
+  })
+})
+
+describe('malformed manifests fail before any mutation', () => {
+  test('duplicate members are rejected and nothing is written', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const before = writeManifest(`{"facets":{"alpha":"${a}"},"facets":{"alpha":"${a}"}}`)
+
+    const result = await install()
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('FACETS_JSON_INVALID')
+    expect(readManifest()).toBe(before)
+  })
+
+  test('an unsupported manifestVersion reports observed and supported versions', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const before = writeManifest(`${JSON.stringify({ manifestVersion: 0.9, facets: { alpha: a } }, null, 2)}\n`)
+
+    const result = await install()
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'FACETS_JSON_UNSUPPORTED_VERSION') expect.unreachable()
+    expect(result.failure.observed).toBe(0.9)
+    expect(result.failure.supported).toEqual([0.1])
+    expect(readManifest()).toBe(before)
+  })
+
+  test('an expanded entry in an unversioned manifest is rejected', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const before = writeManifest(
+      JSON.stringify({
+        facets: { alpha: { source: a, materialization: { skills: { planning: { kind: 'omitted' } } } } },
+      }),
+    )
+
+    const result = await install()
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('FACETS_JSON_INVALID')
+    expect(readManifest()).toBe(before)
+  })
+})
+
+describe('expanded entries survive unrelated operations', () => {
+  /** A current manifest where `alpha` carries an override and `beta` does not. */
+  function seedExpanded(a: string, b: string): void {
+    writeManifest(
+      `${JSON.stringify(
+        {
+          manifestVersion: 0.1,
+          facets: {
+            alpha: { source: a, materialization: { skills: { planning: { kind: 'aliased', as: 'alpha-planning' } } } },
+            beta: b,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+  }
+
+  test('an install preserves an untouched expanded entry', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    seedExpanded(a, b)
+
+    expect((await install()).ok).toBe(true)
+
+    expect(parseManifest().facets.alpha).toEqual({
+      source: a,
+      materialization: { skills: { planning: { kind: 'aliased', as: 'alpha-planning' } } },
+    })
+  })
+
+  test('removing another facet preserves an expanded entry', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    seedExpanded(a, b)
+    expect((await install()).ok).toBe(true)
+
+    const result = await remove('beta')
+    expect(result.ok).toBe(true)
+
+    const written = parseManifest()
+    expect(written.facets.beta).toBeUndefined()
+    expect(written.facets.alpha.materialization.skills.planning).toEqual({
+      kind: 'aliased',
+      as: 'alpha-planning',
+    })
+  })
+
+  // Changing where a facet comes from is not a statement about how its
+  // assets should be named, so a source update must carry overrides through.
+  test('re-adding a facet updates its source and keeps its overrides', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    seedExpanded(a, b)
+    expect((await install()).ok).toBe(true)
+
+    const result = await add(a)
+    expect(result.ok).toBe(true)
+
+    expect(parseManifest().facets.alpha).toEqual({
+      source: a,
+      materialization: { skills: { planning: { kind: 'aliased', as: 'alpha-planning' } } },
+    })
+  })
+})
+
+describe('comments survive the real install pipeline', () => {
+  test('an install preserves file, top-level, and per-entry comments', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    writeManifest(`{
+  // file header
+  "facets": {
+    // about alpha
+    "alpha": "${a}",
+    // about beta
+    "beta": "${b}"
+  }
+}
+`)
+
+    const result = await install()
+    expect(result.ok).toBe(true)
+
+    const raw = readManifest()
+    expect(raw).toContain('file header')
+    expect(raw).toContain('about alpha')
+    expect(raw).toContain('about beta')
+    expect(parseManifest().manifestVersion).toBe(0.1)
+  })
+
+  test('an add preserves comments on untouched entries', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    writeManifest(`{
+  "facets": {
+    // about alpha
+    "alpha": "${a}"
+  }
+}
+`)
+    expect((await install()).ok).toBe(true)
+
+    const result = await add(b)
+    expect(result.ok).toBe(true)
+
+    const raw = readManifest()
+    expect(raw).toContain('about alpha')
+    expect(parseManifest().facets.beta).toBe(b)
+  })
+
+  test('a remove preserves comments on surviving entries', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    const b = buildFixture('beta', '2.0.0')
+    writeManifest(`{
+  "facets": {
+    // about alpha
+    "alpha": "${a}",
+    // about beta
+    "beta": "${b}"
+  }
+}
+`)
+    expect((await install()).ok).toBe(true)
+
+    const result = await remove('beta')
+    expect(result.ok).toBe(true)
+
+    const raw = readManifest()
+    expect(raw).toContain('about alpha')
+    expect(raw).not.toContain('"beta"')
+  })
+})

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -329,7 +329,7 @@ describe('prepareRemove — read-only validation', () => {
     const result = prepareRemove({ projectRoot, names: ['cowsay'] })
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(result.json.facets.cowsay).toBe('0.1.1')
+    expect(result.manifest.facets.cowsay?.source).toBe('0.1.1')
     // Filtered names contains every requested name (all declared).
     expect(result.names).toEqual(['cowsay'])
   })

--- a/packages/engine/src/install/add/prepare.ts
+++ b/packages/engine/src/install/add/prepare.ts
@@ -1,5 +1,5 @@
-import type { FacetsJson } from '@agent-facets/protocol'
-import { loadFacetsJson } from '../../manifest/project-files.ts'
+import type { NormalizedProjectManifest } from '../../manifest/mutations.ts'
+import { describeManifestFailure, loadProjectManifest } from '../../manifest/project-files.ts'
 import type { Source } from '../../sources/facet/types.ts'
 import type { Addition, OnLog } from '../types.ts'
 import { type ResolveNameFailure, resolveFacetName } from './resolve-name.ts'
@@ -19,7 +19,7 @@ export interface AddSource {
 export type AddPrepareFailure = ResolveNameFailure | { reason: 'manifest-read'; error: string }
 
 export type PrepareAddResult =
-  | { ok: true; additions: ReadonlyArray<Addition>; json: FacetsJson; existed: boolean }
+  | { ok: true; additions: ReadonlyArray<Addition>; manifest: NormalizedProjectManifest; existed: boolean }
   | { ok: false; failure: AddPrepareFailure }
 
 /**
@@ -42,11 +42,16 @@ export async function prepareAdd(
   onLog?: OnLog,
 ): Promise<PrepareAddResult> {
   // 1. Load the manifest (or note it doesn't exist yet).
-  const loaded = loadFacetsJson(projectRoot)
+  const loaded = loadProjectManifest(projectRoot)
   if (!loaded.ok) {
-    return { ok: false, failure: { reason: 'manifest-read', error: loaded.error } }
+    return {
+      ok: false,
+      failure: {
+        reason: 'manifest-read',
+        error: loaded.reason === 'read' ? loaded.error : describeManifestFailure(loaded.failure),
+      },
+    }
   }
-  const json: FacetsJson = loaded.existed ? loaded.data : { facets: {} }
 
   // 2. Resolve names for every source.
   const additions: Addition[] = []
@@ -62,5 +67,5 @@ export async function prepareAdd(
     })
   }
 
-  return { ok: true, additions, json, existed: loaded.existed }
+  return { ok: true, additions, manifest: loaded.manifest, existed: loaded.existed }
 }

--- a/packages/engine/src/install/commit/delta.ts
+++ b/packages/engine/src/install/commit/delta.ts
@@ -1,4 +1,5 @@
 import type { LockfileFacet } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { describeVersionSpec } from '../../registry/describe.ts'
 import type { Addition, InstallDelta } from '../types.ts'
 
@@ -7,8 +8,8 @@ import type { Addition, InstallDelta } from '../types.ts'
  * delta — the commit phase's working "desired set".
  */
 export interface MergedDelta {
-  /** Manifest map (name → specifier) with additions upserted and removals deleted. */
-  desiredFacets: Record<string, string>
+  /** Normalized entries with additions upserted and removals deleted. */
+  desiredFacets: Record<string, NormalizedFacetEntry>
   /** Names arriving through `delta.additions` — the structural discriminator's input channel. */
   additionNames: ReadonlySet<string>
   hasDelta: boolean
@@ -23,13 +24,27 @@ export interface MergedDelta {
  * values are stored specifier-shaped (e.g. `1.2.3`, `latest`) so
  * `resolveFacet` can parse them; the final manifest value is computed
  * by `applyManifestWritePolicy` after resolution succeeds.
+ *
+ * Re-adding or updating a facet changes only its SOURCE. Materialization
+ * overrides are durable project intent, so an existing entry's overrides are
+ * carried through untouched — changing where a facet comes from is not a
+ * statement about how its assets should be named.
  */
-export function mergeDeltaIntoManifest(facets: Readonly<Record<string, string>>, delta: InstallDelta): MergedDelta {
-  const desiredFacets: Record<string, string> = { ...facets }
+export function mergeDeltaIntoManifest(
+  facets: Readonly<Record<string, NormalizedFacetEntry>>,
+  delta: InstallDelta,
+): MergedDelta {
+  const desiredFacets: Record<string, NormalizedFacetEntry> = {}
+  for (const [name, entry] of Object.entries(facets)) {
+    desiredFacets[name] = { source: entry.source, overrides: entry.overrides }
+  }
   for (const addition of delta.additions) {
-    const manifestValue =
+    const source =
       addition.source.kind === 'registry' ? describeVersionSpec(addition.source.version) : addition.specifier
-    desiredFacets[addition.facetName] = manifestValue
+    desiredFacets[addition.facetName] = {
+      source,
+      overrides: desiredFacets[addition.facetName]?.overrides,
+    }
   }
   for (const removal of delta.removals) {
     delete desiredFacets[removal.facetName]
@@ -62,7 +77,7 @@ export function mergeDeltaIntoManifest(facets: Readonly<Record<string, string>>,
  * Mutates `desiredFacets` in place.
  */
 export function applyManifestWritePolicy(
-  desiredFacets: Record<string, string>,
+  desiredFacets: Record<string, NormalizedFacetEntry>,
   additions: ReadonlyArray<Addition>,
   newFacetEntries: Readonly<Record<string, LockfileFacet>>,
 ): void {
@@ -74,7 +89,12 @@ export function applyManifestWritePolicy(
       addition.source.version.kind === 'latest' &&
       addition.specifier === addition.facetName
     if (isBareAdd) {
-      desiredFacets[addition.facetName] = lockEntry.version
+      const entry = desiredFacets[addition.facetName]
+      if (entry !== undefined) {
+        // Pin the source only. Overrides are untouched for the same reason
+        // they survive a source update.
+        entry.source = lockEntry.version
+      }
     }
   }
 }

--- a/packages/engine/src/install/commit/drift-removal.ts
+++ b/packages/engine/src/install/commit/drift-removal.ts
@@ -1,5 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import type { Lockfile } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import type { InstallJournal } from '../journal.ts'
 import { materialize } from '../materialize.ts'
 import { materializeFailureToRunInstall } from '../materialize-failure.ts'
@@ -16,7 +17,7 @@ export interface DriftRemovalSuccess {
 export type DriftRemovalResult = { ok: true; value: DriftRemovalSuccess } | { ok: false; failure: RunInstallFailure }
 
 export interface DriftRemovalArgs {
-  desiredFacets: Readonly<Record<string, string>>
+  desiredFacets: Readonly<Record<string, NormalizedFacetEntry>>
   receipt: Receipt
   previousLockfile: Lockfile
   adapters: ReadonlyArray<Adapter>

--- a/packages/engine/src/install/commit/install-loop.ts
+++ b/packages/engine/src/install/commit/install-loop.ts
@@ -1,5 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import type { Lockfile, LockfileFacet } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { classifyOutcome } from '../classify-outcome.ts'
 import type { InstallJournal } from '../journal.ts'
 import { materialize } from '../materialize.ts'
@@ -20,7 +21,7 @@ export interface InstallLoopSuccess {
 export type InstallLoopResult = { ok: true; value: InstallLoopSuccess } | { ok: false; failure: RunInstallFailure }
 
 export interface InstallLoopArgs {
-  desiredFacets: Readonly<Record<string, string>>
+  desiredFacets: Readonly<Record<string, NormalizedFacetEntry>>
   additionNames: ReadonlySet<string>
   previousLockfile: Lockfile
   projectRoot: string
@@ -48,7 +49,8 @@ export async function installFacets(args: InstallLoopArgs): Promise<InstallLoopR
   const serverWarnings: { facet: string; servers: ReadonlyArray<string> }[] = []
   let totalAssets = 0
 
-  for (const [facetName, specifier] of Object.entries(desiredFacets)) {
+  for (const [facetName, desired] of Object.entries(desiredFacets)) {
+    const specifier = desired.source
     if (signal?.aborted) {
       return { ok: false, failure: { code: 'ABORTED' } }
     }

--- a/packages/engine/src/install/commit/tri-write.ts
+++ b/packages/engine/src/install/commit/tri-write.ts
@@ -1,7 +1,8 @@
 import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import type { FacetsJson, Lockfile, LockfileFacet } from '@agent-facets/protocol'
-import { writeFacetsJson } from '../../manifest/project-files.ts'
+import type { Lockfile, LockfileFacet } from '@agent-facets/protocol'
+import { applyDesiredFacets, type ManifestDocument, type NormalizedFacetEntry } from '../../manifest/mutations.ts'
+import { writeProjectManifest } from '../../manifest/project-files.ts'
 import { FACETS_LOCK_FILE, writeLockfile } from '../lockfile-io.ts'
 import {
   ownedPathsForLockedAsset,
@@ -43,8 +44,12 @@ export type TriWriteResult = { ok: true } | { ok: false; failure: RunInstallFail
 
 export interface TriWriteArgs {
   projectRoot: string
-  facetsJson: FacetsJson
-  desiredFacets: Readonly<Record<string, string>>
+  /**
+   * The live comment-preserving manifest document. Mutated in place here —
+   * never rebuilt — so comments survive the write.
+   */
+  manifestDocument: ManifestDocument
+  desiredFacets: Readonly<Record<string, NormalizedFacetEntry>>
   newLockfile: Lockfile
   newReceipt: Receipt
   frozenLockfile: boolean
@@ -99,8 +104,12 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
       file: 'manifest',
       path: join(projectRoot, 'facets.json'),
       fn: () => {
-        const newManifest: FacetsJson = { ...args.facetsJson, facets: { ...args.desiredFacets } }
-        writeFacetsJson(projectRoot, newManifest)
+        // In-place mutation, not reconstruction: comment-json keeps comment
+        // metadata on non-enumerable symbols that an object spread would
+        // silently drop. This also stamps the current `manifestVersion`,
+        // migrating a legacy document as part of the same transaction.
+        applyDesiredFacets(args.manifestDocument, args.desiredFacets)
+        writeProjectManifest(projectRoot, args.manifestDocument)
       },
     },
     {

--- a/packages/engine/src/install/detect-lockfile-drift.ts
+++ b/packages/engine/src/install/detect-lockfile-drift.ts
@@ -1,5 +1,6 @@
-import type { FacetsJson, Lockfile } from '@agent-facets/protocol'
+import type { Lockfile } from '@agent-facets/protocol'
 import { satisfies } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../manifest/mutations.ts'
 import { parseFacetSource } from '../sources/facet/parse-source.ts'
 import { parseVersionSpec } from '../sources/facet/parse-version.ts'
 import { parseLockedVersion } from './parse-locked-version.ts'
@@ -13,12 +14,13 @@ import type { LockfileDriftEntry } from './types.ts'
  * satisfied by the locked version; git/local entries need only exist.
  */
 export function detectLockfileDrift(
-  facetsJson: FacetsJson,
+  facets: Readonly<Record<string, NormalizedFacetEntry>>,
   previousLockfile: Lockfile,
   lockfileExisted: boolean,
 ): LockfileDriftEntry[] {
   const drift: LockfileDriftEntry[] = []
-  for (const [name, specifier] of Object.entries(facetsJson.facets)) {
+  for (const [name, entry] of Object.entries(facets)) {
+    const specifier = entry.source
     if (!lockfileExisted) {
       drift.push({ name, reason: 'missing-lockfile', manifestSpec: specifier })
       continue
@@ -64,7 +66,7 @@ export function detectLockfileDrift(
   // when a lockfile exists (a missing lockfile is already reported above).
   if (lockfileExisted) {
     for (const [name, locked] of Object.entries(previousLockfile.facets)) {
-      if (facetsJson.facets[name] === undefined) {
+      if (facets[name] === undefined) {
         drift.push({ name, reason: 'orphaned', lockedVersion: locked.version })
       }
     }

--- a/packages/engine/src/install/remove/prepare.ts
+++ b/packages/engine/src/install/remove/prepare.ts
@@ -1,6 +1,5 @@
-import type { FacetsJson } from '@agent-facets/protocol'
-import { FACETS_JSON_FILE } from '../../manifest/mutations.ts'
-import { loadFacetsJson } from '../../manifest/project-files.ts'
+import { FACETS_JSON_FILE, type NormalizedProjectManifest } from '../../manifest/mutations.ts'
+import { describeManifestFailure, loadProjectManifest } from '../../manifest/project-files.ts'
 
 /**
  * Structured failure for the pre-install phase of `runRemove`.
@@ -12,7 +11,7 @@ export type RemovePrepareFailure = { reason: 'manifest-read'; error: string }
  * On success carries the filtered names of facets to remove.
  */
 export type RemovePrepareResult =
-  | { ok: true; json: FacetsJson; names: ReadonlyArray<string> }
+  | { ok: true; manifest: NormalizedProjectManifest; names: ReadonlyArray<string> }
   | { ok: false; failure: RemovePrepareFailure }
 
 /**
@@ -25,15 +24,20 @@ export type RemovePrepareResult =
 export function prepareRemove(opts: { projectRoot: string; names: ReadonlyArray<string> }): RemovePrepareResult {
   const { projectRoot, names } = opts
 
-  const loaded = loadFacetsJson(projectRoot)
+  const loaded = loadProjectManifest(projectRoot)
   if (!loaded.ok) {
-    return { ok: false, failure: { reason: 'manifest-read', error: loaded.error } }
+    return {
+      ok: false,
+      failure: {
+        reason: 'manifest-read',
+        error: loaded.reason === 'read' ? loaded.error : describeManifestFailure(loaded.failure),
+      },
+    }
   }
   if (!loaded.existed) {
     return { ok: false, failure: { reason: 'manifest-read', error: `no ${FACETS_JSON_FILE} found` } }
   }
-  const json = loaded.data
 
-  const present = names.filter((name) => Object.hasOwn(json.facets, name))
-  return { ok: true, json, names: present }
+  const present = names.filter((name) => Object.hasOwn(loaded.manifest.facets, name))
+  return { ok: true, manifest: loaded.manifest, names: present }
 }

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -1,7 +1,8 @@
 import { join } from 'node:path'
-import { CURRENT_LOCKFILE_VERSION, type FacetsJson, type Lockfile } from '@agent-facets/protocol'
+import { CURRENT_LOCKFILE_VERSION, type Lockfile } from '@agent-facets/protocol'
 import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
-import { loadFacetsJson } from '../manifest/project-files.ts'
+import type { NormalizedProjectManifest } from '../manifest/mutations.ts'
+import { describeManifestFailure, loadProjectManifest } from '../manifest/project-files.ts'
 import { applyManifestWritePolicy, mergeDeltaIntoManifest } from './commit/delta.ts'
 import { removeDriftedFacets } from './commit/drift-removal.ts'
 import { installFacets } from './commit/install-loop.ts'
@@ -38,21 +39,29 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
   //    created as part of the transactional write. Without a delta, a
   //    missing manifest is still a hard error (plain `facet install` with
   //    nothing to install).
-  const facetsJsonResult = loadFacetsJson(projectRoot)
-  if (!facetsJsonResult.ok) {
+  const manifestResult = loadProjectManifest(projectRoot)
+  if (!manifestResult.ok) {
+    if (manifestResult.reason === 'invalid' && manifestResult.failure.code === 'unsupported-manifest-version') {
+      return failureWithoutRollback({
+        code: 'FACETS_JSON_UNSUPPORTED_VERSION',
+        path: join(projectRoot, 'facets.json'),
+        observed: manifestResult.failure.observed,
+        supported: manifestResult.failure.supported,
+      })
+    }
     return failureWithoutRollback({
       code: 'FACETS_JSON_INVALID',
       path: join(projectRoot, 'facets.json'),
-      error: facetsJsonResult.error,
+      error: manifestResult.reason === 'read' ? manifestResult.error : describeManifestFailure(manifestResult.failure),
     })
   }
-  if (!facetsJsonResult.existed && delta.additions.length === 0) {
+  if (!manifestResult.existed && delta.additions.length === 0) {
     return failureWithoutRollback({
       code: 'FACETS_JSON_NOT_FOUND',
       path: join(projectRoot, 'facets.json'),
     })
   }
-  const facetsJson: FacetsJson = facetsJsonResult.existed ? facetsJsonResult.data : { facets: {} }
+  const projectManifest: NormalizedProjectManifest = manifestResult.manifest
 
   // 2. Acquire install lock.
   const lockResult = acquireInstallLock(projectRoot)
@@ -131,12 +140,12 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     //    the stale entry on disk. Receipt-only orphans (present in the
     //    receipt but not the lockfile) are not lockfile drift and are cleaned
     //    up normally under frozen — only the receipt is rewritten.
-    const merged = mergeDeltaIntoManifest(facetsJson.facets, delta)
+    const merged = mergeDeltaIntoManifest(projectManifest.facets, delta)
     if (frozenLockfile && merged.hasDelta) {
       return failureNoMutation({ code: 'FROZEN_WITH_DELTA' })
     }
     if (frozenLockfile) {
-      const drift = detectLockfileDrift(facetsJson, previousLockfile, lockfileResult.existed)
+      const drift = detectLockfileDrift(projectManifest.facets, previousLockfile, lockfileResult.existed)
       if (drift.length > 0) {
         return failureNoMutation({ code: 'LOCKFILE_DRIFT', facets: drift })
       }
@@ -203,7 +212,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     }
     const written = commitProjectFiles({
       projectRoot,
-      facetsJson,
+      manifestDocument: projectManifest.document,
       desiredFacets: merged.desiredFacets,
       newLockfile,
       newReceipt,

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -120,6 +120,18 @@ export type LockfileDriftEntry =
 export type RunInstallFailure =
   | { code: 'FACETS_JSON_NOT_FOUND'; path: string }
   | { code: 'FACETS_JSON_INVALID'; path: string; error: string }
+  /**
+   * The manifest declares a `manifestVersion` this CLI cannot read. Kept
+   * distinct from `FACETS_JSON_INVALID` because the remedy is different —
+   * upgrade the CLI, rather than fix the document — and because the observed
+   * and supported versions must reach the view as data, not prose.
+   */
+  | {
+      code: 'FACETS_JSON_UNSUPPORTED_VERSION'
+      path: string
+      observed: number | undefined
+      supported: readonly number[]
+    }
   | { code: 'LOCKFILE_INVALID'; path: string; error: string }
   | { code: 'LOCKFILE_WRITE_FAILED'; path: string; cause: string }
   | { code: 'LOCK_HELD'; path: string; heldByPid: number }

--- a/packages/engine/src/manifest/__tests__/project-files.test.ts
+++ b/packages/engine/src/manifest/__tests__/project-files.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { upsertFacetInManifest } from '../mutations.ts'
-import { loadFacetsJson, writeFacetsJson } from '../project-files.ts'
+import { applyDesiredFacets, emptyProjectManifest, type NormalizedFacetEntry } from '../mutations.ts'
+import { loadProjectManifest, writeProjectManifest } from '../project-files.ts'
 
 let projectRoot: string
 
@@ -15,71 +15,208 @@ afterEach(() => {
   rmSync(projectRoot, { recursive: true, force: true })
 })
 
-describe('loadFacetsJson', () => {
-  test('returns an empty skeleton when facets.json is absent', () => {
-    const result = loadFacetsJson(projectRoot)
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.existed).toBe(false)
-      expect(result.data).toEqual({ facets: {} })
-    }
+const entry = (source: string): NormalizedFacetEntry => ({ source, overrides: undefined })
+
+const read = (): string => readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+
+describe('loadProjectManifest', () => {
+  test('returns an empty current-version skeleton when facets.json is absent', () => {
+    const result = loadProjectManifest(projectRoot)
+    if (!result.ok) expect.unreachable()
+    expect(result.existed).toBe(false)
+    expect(result.manifest.facets).toEqual({})
+    // A manifest this system creates is never legacy.
+    expect(result.manifest.document.manifestVersion).toBe(0.1)
   })
 
-  test('reads and validates an existing facets.json', () => {
+  test('reads and normalizes a legacy unversioned manifest', () => {
     writeFileSync(join(projectRoot, 'facets.json'), '{"facets":{"v":"github:a/b#main"}}')
-    const result = loadFacetsJson(projectRoot)
-    expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.existed).toBe(true)
-      expect(result.data.facets.v).toBe('github:a/b#main')
-    }
+    const result = loadProjectManifest(projectRoot)
+    if (!result.ok) expect.unreachable()
+    expect(result.existed).toBe(true)
+    expect(result.manifest.loadedVersion).toBe('legacy-unversioned')
+    expect(result.manifest.facets.v).toEqual({ source: 'github:a/b#main', overrides: undefined })
   })
 
-  test('returns an error on malformed JSON', () => {
+  test('reads a current manifest with an expanded entry', () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        manifestVersion: 0.1,
+        facets: {
+          a: '1.*',
+          b: { source: 'github:a/b#main', materialization: { skills: { review: { kind: 'omitted' } } } },
+        },
+      }),
+    )
+    const result = loadProjectManifest(projectRoot)
+    if (!result.ok) expect.unreachable()
+    expect(result.manifest.loadedVersion).toBe(0.1)
+    expect(result.manifest.facets.a).toEqual({ source: '1.*', overrides: undefined })
+    expect(result.manifest.facets.b?.source).toBe('github:a/b#main')
+    expect(result.manifest.facets.b?.overrides?.skills?.review).toEqual({ kind: 'omitted' })
+  })
+
+  test('returns a structured failure on malformed JSON', () => {
     writeFileSync(join(projectRoot, 'facets.json'), '{not json')
-    const result = loadFacetsJson(projectRoot)
-    expect(result.ok).toBe(false)
+    const result = loadProjectManifest(projectRoot)
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid') expect.unreachable()
+    expect(result.failure.code).toBe('invalid-json')
   })
 
-  test('returns an error on shape mismatch', () => {
+  test('returns a structured failure on shape mismatch', () => {
     writeFileSync(join(projectRoot, 'facets.json'), '{"other":{}}')
-    const result = loadFacetsJson(projectRoot)
-    expect(result.ok).toBe(false)
+    const result = loadProjectManifest(projectRoot)
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('invalid')
+  })
+
+  // An unsupported version must reach the caller as data, not prose: the
+  // remedy (upgrade the CLI) differs from a malformed document's.
+  test('an unsupported manifestVersion carries the observed and supported versions', () => {
+    writeFileSync(join(projectRoot, 'facets.json'), '{"manifestVersion":0.2,"facets":{}}')
+    const result = loadProjectManifest(projectRoot)
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid') expect.unreachable()
+    if (result.failure.code !== 'unsupported-manifest-version') expect.unreachable()
+    expect(result.failure.observed).toBe(0.2)
+    expect(result.failure.supported).toEqual([0.1])
+  })
+
+  test('an expanded entry in an unversioned manifest is rejected, not promoted', () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      '{"facets":{"b":{"source":"github:a/b","materialization":{"skills":{"x":{"kind":"omitted"}}}}}}',
+    )
+    const result = loadProjectManifest(projectRoot)
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid') expect.unreachable()
+    if (result.failure.code !== 'schema-violation') expect.unreachable()
+    expect(result.failure.manifestVersion).toBe('legacy-unversioned')
+  })
+
+  test('duplicate members are rejected', () => {
+    writeFileSync(join(projectRoot, 'facets.json'), '{"facets":{"a":"1.*"},"facets":{"b":"2.*"}}')
+    const result = loadProjectManifest(projectRoot)
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid') expect.unreachable()
+    expect(result.failure.code).toBe('duplicate-members')
+  })
+
+  // Comments are a supported input form and must not defeat validation.
+  test('a commented manifest still validates and normalizes', () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      `{
+  // a note
+  "facets": {
+    // about alpha
+    "alpha": "github:a/alpha#main"
+  }
+}`,
+    )
+    const result = loadProjectManifest(projectRoot)
+    if (!result.ok) expect.unreachable()
+    expect(result.manifest.facets.alpha?.source).toBe('github:a/alpha#main')
+  })
+
+  // Comment stripping preserves member structure, so a duplicate hidden in a
+  // commented document is still caught rather than silently last-wins.
+  test('duplicate members are caught even in a commented manifest', () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      `{
+  // a note
+  "facets": { "a": "1.*" },
+  "facets": { "b": "2.*" }
+}`,
+    )
+    const result = loadProjectManifest(projectRoot)
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid') expect.unreachable()
+    expect(result.failure.code).toBe('duplicate-members')
+  })
+
+  // A comment must not be mistaken for document structure.
+  test('a key mentioned only inside a comment is not a duplicate', () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      `{
+  "facets": {
+    // "alpha": "old-value",
+    "alpha": "github:a/alpha#main"
+  }
+}`,
+    )
+    const result = loadProjectManifest(projectRoot)
+    if (!result.ok) expect.unreachable()
+    expect(result.manifest.facets.alpha?.source).toBe('github:a/alpha#main')
   })
 })
 
-describe('writeFacetsJson', () => {
+describe('writeProjectManifest', () => {
   test('writes valid JSON with 2-space indentation', () => {
-    writeFacetsJson(projectRoot, { facets: { v: 'github:a/b#main' } })
-    const raw = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
-    const reparsed = JSON.parse(raw)
-    expect(reparsed).toEqual({ facets: { v: 'github:a/b#main' } })
+    const manifest = emptyProjectManifest()
+    applyDesiredFacets(manifest.document, { v: entry('github:a/b#main') })
+    writeProjectManifest(projectRoot, manifest.document)
+    const raw = read()
+    expect(JSON.parse(raw)).toEqual({ manifestVersion: 0.1, facets: { v: 'github:a/b#main' } })
     expect(raw).toContain('  "facets"')
   })
 
   test('does not leave the .tmp file around on success', () => {
-    writeFacetsJson(projectRoot, { facets: {} })
+    writeProjectManifest(projectRoot, emptyProjectManifest().document)
     expect(existsSync(join(projectRoot, 'facets.json.tmp'))).toBe(false)
   })
 
-  test('round-trips through load + upsert + write preserving comments', () => {
+  // The regression this guards: the install pipeline used to rebuild the
+  // document with object spreads, which silently dropped comment-json's
+  // non-enumerable comment symbols.
+  test('round-trips through load + apply + write preserving comments', () => {
     writeFileSync(
       join(projectRoot, 'facets.json'),
       `{
   // keep me
   "facets": {
+    // about alpha
     "alpha": "github:a/alpha#main"
   }
 }`,
     )
-    const loaded = loadFacetsJson(projectRoot)
-    expect(loaded.ok).toBe(true)
-    if (loaded.ok) {
-      upsertFacetInManifest(loaded.data, 'beta', 'github:b/beta#main')
-      writeFacetsJson(projectRoot, loaded.data)
-    }
-    const raw = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+    const loaded = loadProjectManifest(projectRoot)
+    if (!loaded.ok) expect.unreachable()
+    applyDesiredFacets(loaded.manifest.document, {
+      alpha: entry('github:a/alpha#main'),
+      beta: entry('github:b/beta#main'),
+    })
+    writeProjectManifest(projectRoot, loaded.manifest.document)
+
+    const raw = read()
     expect(raw).toContain('keep me')
+    expect(raw).toContain('about alpha')
     expect(raw).toContain('beta')
+  })
+
+  test('a comment on a removed entry disappears with it, siblings survive', () => {
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      `{
+  "facets": {
+    // about alpha
+    "alpha": "github:a/alpha#main",
+    // about beta
+    "beta": "github:b/beta#main"
+  }
+}`,
+    )
+    const loaded = loadProjectManifest(projectRoot)
+    if (!loaded.ok) expect.unreachable()
+    applyDesiredFacets(loaded.manifest.document, { alpha: entry('github:a/alpha#main') })
+    writeProjectManifest(projectRoot, loaded.manifest.document)
+
+    const raw = read()
+    expect(raw).toContain('about alpha')
+    expect(raw).not.toContain('"beta"')
   })
 })

--- a/packages/engine/src/manifest/mutations.ts
+++ b/packages/engine/src/manifest/mutations.ts
@@ -1,94 +1,292 @@
-import type { Validated } from '@agent-facets/common'
-import { type FacetsJson, FacetsJsonSchema, mapArkErrors } from '@agent-facets/protocol'
-import { type } from 'arktype'
+import {
+  CURRENT_PROJECT_MANIFEST_VERSION,
+  type FacetMaterializationOverrides,
+  facetEntryOverrides,
+  facetEntrySource,
+  type LEGACY_PROJECT_MANIFEST_VERSION,
+  type ProjectManifestParseFailure,
+  parseProjectManifestDocument,
+} from '@agent-facets/protocol'
 import { parse as parseCommentJson, stringify as stringifyCommentJson } from 'comment-json'
 
 export const FACETS_JSON_FILE = 'facets.json'
 
 /**
- * Pure manifest mutations for facets.json.
+ * Pure manifest handling for facets.json.
  *
- * Core owns all JSON reading/writing logic (Adjustment M). CLI is presentation
- * + OS I/O only and never imports comment-json or touches the parsed shape.
+ * Engine owns all JSON reading/writing logic (Adjustment M). CLI is
+ * presentation + OS I/O only and never imports comment-json or touches the
+ * parsed shape.
  *
- * Comments in hand-edited facets.json files survive round-trips: comment-json
- * stores comment metadata on Symbol-keyed properties that persist through
- * direct key assignment and deletion. We never clone via spread — that would
- * drop the comment symbols.
+ * Two representations exist side by side, deliberately:
+ *
+ *   - **The normalized view** ({@link NormalizedProjectManifest.facets}) is
+ *     what the install pipeline reasons about: one uniform entry shape
+ *     regardless of whether the document spelled it compact or expanded, and
+ *     regardless of format version.
+ *   - **The document** ({@link ManifestDocument}) is the live comment-json
+ *     value. It is the only thing ever serialized, and it is mutated IN
+ *     PLACE — never rebuilt — because comment-json stores comment metadata
+ *     on non-enumerable Symbol-keyed properties that object spread silently
+ *     drops. Direct key assignment and deletion preserve them; `{ ...doc }`
+ *     does not.
+ *
+ * The protocol package owns the schema. Engine never re-implements version
+ * dispatch or entry validation; it delegates to `parseProjectManifestDocument`
+ * and normalizes the validated result.
  */
 
+/** The normalized form of one facet entry, whichever form declared it. */
+export interface NormalizedFacetEntry {
+  /** The source specifier as written. */
+  source: string
+  /** Materialization overrides, or undefined when the facet declares none. */
+  overrides: FacetMaterializationOverrides | undefined
+}
+
+/** The exact schema a manifest's bytes validated under. */
+export type LoadedManifestVersion = typeof LEGACY_PROJECT_MANIFEST_VERSION | typeof CURRENT_PROJECT_MANIFEST_VERSION
+
 /**
- * Parse facets.json bytes and validate against FacetsJsonSchema.
- *
- * Returns the parsed value with comment metadata preserved (safe to mutate
- * in place and re-serialize with {@link serializeFacetsJson}).
+ * The live comment-json document. Structurally typed rather than imported
+ * from comment-json because the comment metadata rides on symbols the type
+ * system cannot see — which is precisely why this value must be mutated
+ * rather than reconstructed.
  */
-export function parseFacetsJson(raw: string): Validated<FacetsJson> {
-  let parsed: unknown
+export interface ManifestDocument {
+  manifestVersion?: number
+  facets: Record<string, unknown>
+}
+
+export interface NormalizedProjectManifest {
+  /**
+   * Which schema the bytes validated under. Drives migration policy: a
+   * successful non-frozen write always emits the current version, but frozen
+   * mode must retain whatever was loaded.
+   */
+  loadedVersion: LoadedManifestVersion
+  /** Every declared facet in one uniform shape. */
+  facets: Record<string, NormalizedFacetEntry>
+  /** The writable, comment-preserving document. */
+  document: ManifestDocument
+}
+
+export type ParseProjectManifestResult =
+  | { ok: true; manifest: NormalizedProjectManifest }
+  | { ok: false; failure: ProjectManifestParseFailure }
+
+/**
+ * Replace every `//` and block-comment span with spaces, preserving all other
+ * bytes and every offset.
+ *
+ * This exists because the two requirements on this file pull in opposite
+ * directions. Comments must survive a round trip, so the document is parsed
+ * with a comment-tolerant parser. But validation, exact version dispatch, and
+ * duplicate-member rejection belong to protocol's loader, which uses
+ * `JSON.parse` and would reject a commented document outright.
+ *
+ * Stripping to spaces rather than deleting is what makes this safe: the
+ * member structure is byte-for-byte preserved, so a duplicate member survives
+ * into the stripped text and protocol's scanner still catches it. Removing
+ * the spans, or round-tripping through a parser, would collapse duplicates
+ * through last-member-wins and defeat that check.
+ */
+export function stripJsonComments(text: string): string {
+  let out = ''
+  let i = 0
+  let inString = false
+
+  while (i < text.length) {
+    const ch = text[i] as string
+
+    if (inString) {
+      out += ch
+      if (ch === '\\') {
+        // Copy the escaped character verbatim so an escaped quote does not
+        // look like the end of the string.
+        out += text[i + 1] ?? ''
+        i += 2
+        continue
+      }
+      if (ch === '"') inString = false
+      i++
+      continue
+    }
+
+    if (ch === '"') {
+      inString = true
+      out += ch
+      i++
+      continue
+    }
+
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') {
+        out += ' '
+        i++
+      }
+      continue
+    }
+
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2)
+      const stop = end === -1 ? text.length : end + 2
+      while (i < stop) {
+        // Newlines are kept so reported line numbers stay accurate.
+        out += text[i] === '\n' ? '\n' : ' '
+        i++
+      }
+      continue
+    }
+
+    out += ch
+    i++
+  }
+
+  return out
+}
+
+/**
+ * Parse and validate facets.json bytes into a normalized manifest.
+ *
+ * Validation, exact `manifestVersion` dispatch, and duplicate-member
+ * rejection are delegated to protocol. The comment-preserving document is
+ * parsed separately from the same bytes and carried on the result so a later
+ * write can mutate it in place.
+ */
+export function parseProjectManifest(raw: string): ParseProjectManifestResult {
+  const validated = parseProjectManifestDocument(stripJsonComments(raw))
+  if (!validated.ok) {
+    return { ok: false, failure: validated.failure }
+  }
+
+  // Protocol already accepted these bytes, so the comment-tolerant parser
+  // cannot fail on them — it accepts a strict superset of JSON. The guard is
+  // defense in depth at a trust boundary, converted to a value rather than
+  // allowed to escape as a throw.
+  let document: ManifestDocument
   try {
-    parsed = parseCommentJson(raw)
+    document = parseCommentJson(raw) as unknown as ManifestDocument
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown JSON parse error'
     return {
       ok: false,
-      errors: [
-        {
-          path: '',
-          message: `facets.json syntax error: ${message}`,
-          expected: 'valid JSON',
-          actual: 'malformed JSON',
-        },
-      ],
+      failure: {
+        code: 'invalid-json',
+        errors: [
+          {
+            path: '',
+            message: `${FACETS_JSON_FILE} syntax error: ${message}`,
+            expected: 'valid JSON',
+            actual: 'malformed JSON',
+          },
+        ],
+      },
     }
   }
 
-  const validated = FacetsJsonSchema(parsed)
-  if (validated instanceof type.errors) {
-    return { ok: false, errors: mapArkErrors(validated) }
+  const facets: Record<string, NormalizedFacetEntry> = {}
+  for (const [name, entry] of Object.entries(validated.data.manifest.facets)) {
+    facets[name] = { source: facetEntrySource(entry), overrides: facetEntryOverrides(entry) }
   }
 
-  return { ok: true, data: validated as FacetsJson }
+  return {
+    ok: true,
+    manifest: { loadedVersion: validated.data.manifestVersion, facets, document },
+  }
 }
 
 /**
- * Serialize a FacetsJson value back to bytes, preserving any comment metadata
- * the value carries. Uses 2-space indentation to match ADR-006.
+ * Serialize a manifest document, preserving its comment metadata. Uses
+ * 2-space indentation to match ADR-006.
  *
  * Deliberately does NOT go through engine's `jsonFileText` helper: it must
  * serialize via comment-json to preserve comments, so it upholds the same
  * invariant (2-space indent, trailing newline) independently.
  */
-export function serializeFacetsJson(json: FacetsJson): string {
-  return `${stringifyCommentJson(json, null, 2)}\n`
+export function serializeProjectManifest(document: ManifestDocument): string {
+  return `${stringifyCommentJson(document, null, 2)}\n`
 }
 
 /**
- * Return an empty FacetsJson skeleton. Used when `facet add` runs against a
- * directory with no existing facets.json.
+ * An empty manifest at the current format version. Used when `facet add`
+ * runs against a directory with no existing facets.json — a manifest this
+ * system creates is never legacy.
  */
-export function emptyFacetsJson(): FacetsJson {
-  return { facets: {} }
+export function emptyProjectManifest(): NormalizedProjectManifest {
+  return {
+    loadedVersion: CURRENT_PROJECT_MANIFEST_VERSION,
+    facets: {},
+    document: { manifestVersion: CURRENT_PROJECT_MANIFEST_VERSION, facets: {} },
+  }
+}
+
+/** How many overrides an entry declares across every asset type. */
+export function countOverrides(overrides: FacetMaterializationOverrides | undefined): number {
+  if (overrides === undefined) return 0
+  return (
+    Object.keys(overrides.skills ?? {}).length +
+    Object.keys(overrides.agents ?? {}).length +
+    Object.keys(overrides.commands ?? {}).length
+  )
 }
 
 /**
- * Insert or replace a facet entry in facets.json.
+ * Apply the desired facet set to the document, IN PLACE.
  *
- * Mutates `json` in place so any comments attached to other keys are
- * preserved. Returns the same object for convenience.
+ * Every mutation is a direct key assignment or deletion so comment metadata
+ * on untouched keys survives. An entry whose normalized value is unchanged is
+ * not reassigned at all, which additionally preserves the exact spelling and
+ * inner comments of expanded entries the operation did not touch.
+ *
+ * Canonical form: a facet with no overrides is written as its compact source
+ * string. An expanded entry whose final override was pruned therefore
+ * collapses back to a string rather than lingering as an empty object.
+ *
+ * The document is stamped with the current `manifestVersion`. On a legacy
+ * document the field is absent, so assignment appends it after `facets` —
+ * valid JSON that re-parses identically, and cheaper than rebuilding the
+ * object and hand-copying every comment symbol across.
  */
-export function upsertFacetInManifest(json: FacetsJson, name: string, source: string): FacetsJson {
-  json.facets[name] = source
-  return json
+export function applyDesiredFacets(
+  document: ManifestDocument,
+  desired: Readonly<Record<string, NormalizedFacetEntry>>,
+): void {
+  document.manifestVersion = CURRENT_PROJECT_MANIFEST_VERSION
+
+  for (const name of Object.keys(document.facets)) {
+    if (!Object.hasOwn(desired, name)) {
+      delete document.facets[name]
+    }
+  }
+
+  for (const [name, entry] of Object.entries(desired)) {
+    writeEntry(document.facets, name, entry)
+  }
 }
 
-/**
- * Remove a facet entry from facets.json.
- *
- * Mutates `json` in place. Returns the same object for convenience. No-op if
- * the entry is absent (idempotent by design — `facet remove` should be safe
- * to re-run).
- */
-export function removeFacetFromManifest(json: FacetsJson, name: string): FacetsJson {
-  delete json.facets[name]
-  return json
+/** Write one entry in canonical form, touching the document as little as possible. */
+function writeEntry(facets: Record<string, unknown>, name: string, entry: NormalizedFacetEntry): void {
+  const existing = facets[name]
+
+  if (countOverrides(entry.overrides) === 0) {
+    // Canonical compact form. Skip the assignment when it is already correct
+    // so a facet the operation did not touch keeps its comments verbatim.
+    if (existing !== entry.source) {
+      facets[name] = entry.source
+    }
+    return
+  }
+
+  if (typeof existing === 'object' && existing !== null && !Array.isArray(existing)) {
+    // Mutate the existing expanded entry so its own comments survive.
+    const expanded = existing as { source?: unknown; materialization?: unknown }
+    if (expanded.source !== entry.source) {
+      expanded.source = entry.source
+    }
+    expanded.materialization = entry.overrides
+    return
+  }
+
+  facets[name] = { source: entry.source, materialization: entry.overrides }
 }

--- a/packages/engine/src/manifest/project-files.ts
+++ b/packages/engine/src/manifest/project-files.ts
@@ -1,26 +1,40 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { atomicWriteFileSync } from '@agent-facets/common'
-import type { FacetsJson } from '@agent-facets/protocol'
-import { emptyFacetsJson, FACETS_JSON_FILE, parseFacetsJson, serializeFacetsJson } from './mutations.ts'
+import type { ProjectManifestParseFailure } from '@agent-facets/protocol'
+import {
+  emptyProjectManifest,
+  FACETS_JSON_FILE,
+  type ManifestDocument,
+  type NormalizedProjectManifest,
+  parseProjectManifest,
+  serializeProjectManifest,
+} from './mutations.ts'
 
 /**
- * Bridge between OS file I/O and the pure JSON mutation helpers in
- * `manifest/mutations.ts`. Reads bytes, hands them to the parsers,
- * then writes bytes back — never mutating parsed JSON directly.
+ * Bridge between OS file I/O and the pure manifest helpers in
+ * `manifest/mutations.ts`. Reads bytes, hands them to the parser, then writes
+ * bytes back — never mutating parsed JSON directly.
  */
 
-export type LoadFacetsJsonResult = { ok: true; data: FacetsJson; existed: boolean } | { ok: false; error: string }
+export type LoadProjectManifestResult =
+  | { ok: true; manifest: NormalizedProjectManifest; existed: boolean }
+  | { ok: false; reason: 'read'; error: string }
+  | { ok: false; reason: 'invalid'; failure: ProjectManifestParseFailure }
 
 /**
- * Read facets.json from a project root. Returns an empty skeleton when the
- * file is absent (first `facet add` in a new project). Validation failures
- * bubble up as error messages.
+ * Read facets.json from a project root. Returns an empty current-version
+ * skeleton when the file is absent (first `facet add` in a new project).
+ *
+ * Failures are split by cause rather than flattened into one message string:
+ * a filesystem read error and a schema/version rejection call for different
+ * guidance, and an unsupported `manifestVersion` must reach the caller as
+ * structured data so it can report the observed and supported versions.
  */
-export function loadFacetsJson(projectRoot: string): LoadFacetsJsonResult {
+export function loadProjectManifest(projectRoot: string): LoadProjectManifestResult {
   const path = join(projectRoot, FACETS_JSON_FILE)
   if (!existsSync(path)) {
-    return { ok: true, data: emptyFacetsJson(), existed: false }
+    return { ok: true, manifest: emptyProjectManifest(), existed: false }
   }
 
   let raw: string
@@ -29,24 +43,48 @@ export function loadFacetsJson(projectRoot: string): LoadFacetsJsonResult {
   } catch (err) {
     return {
       ok: false,
+      reason: 'read',
       error: `failed to read ${FACETS_JSON_FILE}: ${err instanceof Error ? err.message : String(err)}`,
     }
   }
 
-  const parsed = parseFacetsJson(raw)
+  const parsed = parseProjectManifest(raw)
   if (!parsed.ok) {
-    const details = parsed.errors.map((e) => e.message).join('; ')
-    return { ok: false, error: `${FACETS_JSON_FILE} is invalid: ${details}` }
+    return { ok: false, reason: 'invalid', failure: parsed.failure }
   }
-  return { ok: true, data: parsed.data, existed: true }
+  return { ok: true, manifest: parsed.manifest, existed: true }
 }
 
 /**
- * Write facets.json to disk atomically (tmp file + rename). Comments in the
- * parsed value survive the round-trip because core's serializer uses
- * comment-json.
+ * Write facets.json to disk atomically (tmp file + rename).
+ *
+ * Takes the document rather than the normalized view: the document is the
+ * thing that carries comment metadata, and serializing anything else would
+ * silently drop it.
  */
-export function writeFacetsJson(projectRoot: string, json: FacetsJson): void {
+export function writeProjectManifest(projectRoot: string, document: ManifestDocument): void {
   const path = join(projectRoot, FACETS_JSON_FILE)
-  atomicWriteFileSync(path, serializeFacetsJson(json))
+  atomicWriteFileSync(path, serializeProjectManifest(document))
+}
+
+/** Render a parse failure as a single actionable line for callers that need a string. */
+export function describeManifestFailure(failure: ProjectManifestParseFailure): string {
+  switch (failure.code) {
+    case 'invalid-json':
+      return `${FACETS_JSON_FILE} is malformed JSON: ${summarize(failure.errors)}`
+    case 'duplicate-members':
+      return `${FACETS_JSON_FILE} contains duplicate object member names: ${summarize(failure.errors)}`
+    case 'unsupported-manifest-version':
+      return (
+        `${FACETS_JSON_FILE} declares an unsupported manifestVersion ` +
+        `(${failure.observed ?? 'missing'}, this CLI supports ${failure.supported.join(', ')}). ` +
+        `Upgrade the CLI, or remove the field to use the legacy unversioned format.`
+      )
+    case 'schema-violation':
+      return `${FACETS_JSON_FILE} is invalid (manifestVersion ${failure.manifestVersion}): ${summarize(failure.errors)}`
+  }
+}
+
+function summarize(errors: ReadonlyArray<{ message: string }>): string {
+  return errors.map((e) => e.message).join('; ')
 }


### PR DESCRIPTION
### Why

Materialization aliasing requires facet entries to carry more than a source specifier — they need to declare overrides that control how assets are named and exposed. The previous manifest format only supported compact string entries (`"facet-name": "source"`), so there was nowhere to store that intent. This change introduces expanded entries (`{ source, materialization }`) and a `manifestVersion` field to distinguish the two formats, while keeping the install pipeline and CLI unaware of which form any given entry uses.

### Details

Two representations now coexist deliberately. The **normalized view** (`NormalizedProjectManifest.facets`) is what the install pipeline reasons about: every entry has a uniform `{ source, overrides }` shape regardless of whether the document spelled it compact or expanded. The **document** (`ManifestDocument`) is the live comment-json value and the only thing ever serialized. It is mutated in place — never rebuilt via object spread — because comment-json stores comment metadata on non-enumerable Symbol-keyed properties that spread silently drops.

Validation, version dispatch, and duplicate-member rejection are delegated entirely to the protocol package's `parseProjectManifestDocument`. Engine strips comments to spaces (not deletions) before handing bytes to protocol, which preserves member structure so duplicate detection still fires on commented documents. The comment-tolerant parser then runs separately on the original bytes to produce the writable document.

Key behavioral guarantees enforced by the new transactional test suite:

- A successful non-frozen write always stamps `manifestVersion: 0.1`, migrating a legacy document as part of the same atomic transaction.
- A failed operation leaves the file byte-for-byte unchanged — no half-migrated documents.
- Frozen installs retain whatever bytes were on disk.
- Re-adding or updating a facet changes only its source; materialization overrides are carried through untouched, because changing where a facet comes from is not a statement about how its assets should be named.
- An expanded entry whose last override is pruned collapses back to a compact string rather than leaving an empty object.
- An unsupported `manifestVersion` is a distinct failure code (`FACETS_JSON_UNSUPPORTED_VERSION`) with structured `observed` and `supported` fields, because the remedy (upgrade the CLI) differs from a malformed document's, and the view layer needs the version numbers as data.

The previous manifest test suite exercised pure mutation helpers that the pipeline had stopped calling during the plan/commit refactor — they kept passing while production silently destroyed every comment. The new `manifest-transaction.test.ts` runs the real install pipeline against local-source fixtures to close that gap.

### Verification

New and updated tests cover: legacy migration, frozen retention, failed-operation rollback, duplicate-member rejection, unsupported-version structured errors, expanded-entry round-trips, comment preservation through add/remove/install, and source updates carrying overrides. CI runs the full engine and CLI typecheck alongside these tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core install commit path and on-disk `facets.json` format/migration behavior; risk is mitigated by transactional tests and fail-closed validation before mutation, but any bug could corrupt user manifests or drop overrides/comments.
> 
> **Overview**
> **Project manifest handling** moves from `FacetsJson` / `loadFacetsJson` to a **normalized** `{ source, overrides }` view plus a **comment-json document** that is the only serialized form. Parsing delegates to protocol (`parseProjectManifestDocument`) after `stripJsonComments` so validation and duplicate-member checks work on commented files; commits call **`applyDesiredFacets` in place** (no object spread) so comments and untouched expanded entries survive.
> 
> The **install pipeline** (`mergeDeltaIntoManifest`, `applyManifestWritePolicy`, tri-write, drift detection) now works on `NormalizedFacetEntry` maps: re-adds/updates change **source only** and keep materialization overrides; successful non-frozen writes stamp **`manifestVersion: 0.1`**; frozen installs leave manifest bytes unchanged. **`FACETS_JSON_UNSUPPORTED_VERSION`** is a separate failure with structured `observed` / `supported` versions (CLI `facet list` and install failure UI updated).
> 
> **Tests** expand mutation/project-files coverage and add **`manifest-transaction.test.ts`**, which runs real `facet add` / `install` / `remove` to assert migration, rollback, comment preservation, and expanded-entry survival. Public engine exports switch to `loadProjectManifest`, `writeProjectManifest`, and related types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4fb6d46a4612f9586bfffed33ae80551fb662d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->