### PR TITLE
Implement CLI collision resolution workspace with interactive Keep/Alias/Omit controls

### DIFF
--- a/openspec/changes/add-materialization-aliasing/tasks.md
+++ b/openspec/changes/add-materialization-aliasing/tasks.md
@@ -79,19 +79,19 @@
 
 ## 9. CLI Collision Resolution Experience — Research
 
-- [ ] 9.1 Explore: Inspect `packages/cli/src/tui/views/install/`, existing overview/focused-item editors, focus/navigation hooks, inline input validation, cancellation handling, semantic colors/icons, and Ink test helpers.
-- [ ] 9.2 Explore: Inspect add/install/remove command wiring, stdin/stdout TTY and raw-mode capability checks, SIGINT behavior, install stage events, exhaustive failure rendering, stderr formatting, and final summary construction.
-- [ ] 9.3 Propose: Define the single-mount progress-to-workspace phase machine, global draft state, accessible status vocabulary, linked-conflict navigation, resolver bridge, and non-interactive error presentation.
+- [x] 9.1 Explore: Inspect `packages/cli/src/tui/views/install/`, existing overview/focused-item editors, focus/navigation hooks, inline input validation, cancellation handling, semantic colors/icons, and Ink test helpers.
+- [x] 9.2 Explore: Inspect add/install/remove command wiring, stdin/stdout TTY and raw-mode capability checks, SIGINT behavior, install stage events, exhaustive failure rendering, stderr formatting, and final summary construction.
+- [x] 9.3 Propose: Define the single-mount progress-to-workspace phase machine, global draft state, accessible status vocabulary, linked-conflict navigation, resolver bridge, and non-interactive error presentation.
 
 ## 10. CLI Collision Resolution Experience — Implementation
 
-- [ ] 10.1 Implement: Add one shared interactive-capability check for stdin/stdout/raw-mode support and an accessible unresolved/draft-conflict/resolved presentation whose labels or icons remain distinguishable without color.
-- [ ] 10.2 Implement: Implement the global collision draft and focused resolution workspace under `packages/cli/src/tui/views/install/`, with an all-groups overview, Keep/Alias/Omit controls, validated alias input, linked conflict navigation, and confirmation only when every item is resolved.
-- [ ] 10.3 Implement: Integrate the workspace into the existing `InstallView` mount as progress → resolution → progress → result, wire the typed engine callback only for interactive non-frozen commands, and make cancellation/SIGINT return a cancellation value with accurate no-change messaging.
-- [ ] 10.4 Implement: Render non-interactive collision failures to stderr with every group and claimant, exact expanded `facets.json` locations, parseable alias/omit snippets, no generated winner, a non-zero exit, and an explicit no-mutation statement.
-- [ ] 10.5 Implement: Render stale-override pruning without `--verbose`, frozen stale-override drift, the visible collision-checking stage, disposition-only updates, authored-to-effective alias summaries, and omitted assets without counting them as materialized.
-- [ ] 10.6 Implement: Add status/draft/component keyboard tests, InstallView phase/cancellation tests, stderr formatter tests, command tests, and collision e2e coverage for interactive, non-interactive, frozen, and adapter-precedence behavior.
-- [ ] 10.7 Verify: Run CLI unit tests, typechecking, build-dependent e2e tests, and adapter conformance tests using aliased names.
+- [x] 10.1 Implement: Add one shared interactive-capability check for stdin/stdout/raw-mode support and an accessible unresolved/draft-conflict/resolved presentation whose labels or icons remain distinguishable without color.
+- [x] 10.2 Implement: Implement the global collision draft and focused resolution workspace under `packages/cli/src/tui/views/install/`, with an all-groups overview, Keep/Alias/Omit controls, validated alias input, linked conflict navigation, and confirmation only when every item is resolved.
+- [x] 10.3 Implement: Integrate the workspace into the existing `InstallView` mount as progress → resolution → progress → result, wire the typed engine callback only for interactive non-frozen commands, and make cancellation/SIGINT return a cancellation value with accurate no-change messaging.
+- [x] 10.4 Implement: Render non-interactive collision failures to stderr with every group and claimant, exact expanded `facets.json` locations, parseable alias/omit snippets, no generated winner, a non-zero exit, and an explicit no-mutation statement.
+- [x] 10.5 Implement: Render stale-override pruning without `--verbose`, frozen stale-override drift, the visible collision-checking stage, disposition-only updates, authored-to-effective alias summaries, and omitted assets without counting them as materialized.
+- [x] 10.6 Implement: Add status/draft/component keyboard tests, InstallView phase/cancellation tests, stderr formatter tests, command tests, and collision e2e coverage for interactive, non-interactive, frozen, and adapter-precedence behavior.
+- [x] 10.7 Verify: Run CLI unit tests, typechecking, build-dependent e2e tests, and adapter conformance tests using aliased names.
 
 ## 11. User and Specification Documentation — Research
 

--- a/packages/brand/src/theme.ts
+++ b/packages/brand/src/theme.ts
@@ -15,6 +15,13 @@ export const THEME = {
   // Semantic aliases (can diverge from brand later)
   success: BRAND.green,
   warning: BRAND.coral,
+  /**
+   * The middle rung of a three-state scale, between `warning` (something
+   * is wrong) and `success` (it isn't). Distinct from `warning` because a
+   * red/amber/green status set needs three colors, and coral against
+   * green alone cannot express "not yet settled".
+   */
+  caution: ACCENTS_DARK.amber,
   focus: ACCENTS_DARK.pink,
 
   // Text — structural

--- a/packages/cli/src/__tests__/collision.e2e.test.ts
+++ b/packages/cli/src/__tests__/collision.e2e.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+
+/**
+ * End-to-end coverage for cross-facet name collisions, driving the
+ * compiled binary with piped stdio.
+ *
+ * The in-process command tests fake TTY-ness by redefining stream
+ * properties. That proves the branch, but not the thing that actually
+ * matters here: a real subprocess with pipes has no TTY on either
+ * stream, so this is the only place the true non-interactive path — the
+ * one CI hits — is exercised end to end. It is also where a regression
+ * would be most damaging, because the failure mode is a hang rather than
+ * an error.
+ */
+
+const CLI_PATH = resolve(import.meta.dir, '../../dist/facet')
+
+if (!existsSync(CLI_PATH)) {
+  throw new Error(
+    `[e2e] dist/facet not found at ${CLI_PATH}.\n` +
+      `Build the CLI first:\n` +
+      `  bun run --cwd packages/cli build\n` +
+      `Or run the full check pipeline:\n` +
+      `  bun check`,
+  )
+}
+
+type ExecResult = { stdout: string; stderr: string; exitCode: number }
+
+let projectRoot: string
+let fakeHome: string
+let adaptersDir: string
+
+async function runCli(args: string[]): Promise<ExecResult> {
+  const proc = Bun.spawn([CLI_PATH, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    // Closed stdin: nothing can answer a prompt, so a command that tried
+    // to open one would hang here rather than fail.
+    stdin: 'ignore',
+    cwd: projectRoot,
+    env: { ...process.env, HOME: fakeHome, FACET_DIR: join(fakeHome, '.facet') },
+  })
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode: await proc.exited }
+}
+
+function buildFixture(name: string, skill: string): string {
+  const repo = realpathSync(mkdtempSync(join(projectRoot, 'fixture-')))
+  writeFileSync(
+    join(repo, 'facet.json'),
+    JSON.stringify({ name, version: '0.1.0', skills: { [skill]: { description: `${skill} skill` } } }),
+  )
+  mkdirSync(join(repo, `skills/${skill}`), { recursive: true })
+  writeFileSync(join(repo, `skills/${skill}/SKILL.md`), `# ${skill}\n`)
+  return `./${repo.split('/').pop()}`
+}
+
+/**
+ * A dependency-free adapter bundle.
+ *
+ * The in-process command tests import the real `@agent-facets/adapter`
+ * helpers, but a bundle written into a temp directory and loaded by the
+ * compiled binary has no workspace `node_modules` to resolve them from.
+ * Since these tests are about which assets get written under which
+ * names — not about front-matter assembly, which the adapter suite
+ * covers — plain `node:fs` is the honest dependency here.
+ */
+function installFakeAdapter(name: string): void {
+  const dir = join(adaptersDir, name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'adapter.js'),
+    `
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
+
+export default {
+  name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
+  supportsInstall: true,
+  buildAssetMetadata(data) { return { ok: true, data: data || {} } },
+  async installAsset(req) {
+    const file = path(req.assetType, req.name)
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, req.content)
+    return { ok: true, primaryPath: file }
+  },
+  async readAsset(req) {
+    const file = path(req.assetType, req.name)
+    if (!existsSync(file)) return { ok: false, failure: { code: 'not-found' } }
+    const content = readFileSync(file, 'utf8')
+    return { ok: true, asset: req.assetType === 'skill'
+      ? { assetType: 'skill', content, metadata: {}, companions: {} }
+      : { assetType: req.assetType, content, metadata: {} } }
+  },
+  async deleteAsset(req) {
+    const file = path(req.assetType, req.name)
+    const existed = existsSync(file)
+    rmSync(file, { force: true })
+    return { ok: true, existed, deletedPaths: existed ? [file] : [] }
+  },
+}
+`,
+  )
+}
+
+function writeManifest(value: unknown): void {
+  writeFileSync(join(projectRoot, 'facets.json'), JSON.stringify(value, null, 2))
+}
+
+beforeEach(() => {
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-collision-e2e-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-collision-home-')))
+  adaptersDir = join(fakeHome, '.facet', 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('collisions — non-interactive install', () => {
+  test('fails with the full report, a non-zero exit, and no writes', async () => {
+    installFakeAdapter('test-adapter')
+    const alpha = buildFixture('alpha', 'planning')
+    const beta = buildFixture('beta', 'planning')
+    writeManifest({ facets: { alpha, beta } })
+    const before = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+
+    const result = await runCli(['install'])
+
+    expect(result.exitCode).toBe(1)
+    // The complete report reaches stderr, which is what survives `2>&1`
+    // into a CI log when stdout is a discarded live region.
+    expect(result.stderr).toContain('facets["alpha"].materialization.skills["planning"]')
+    expect(result.stderr).toContain('facets["beta"].materialization.skills["planning"]')
+    expect(result.stderr).toContain('"kind": "aliased"')
+    expect(result.stderr).toContain('"kind": "omitted"')
+    expect(result.stderr).toContain('NOT changed')
+    expect(result.stderr).toContain('code=MATERIALIZATION_COLLISION')
+
+    // No winner anywhere in the output.
+    expect(result.stderr.toLowerCase()).not.toContain('winner')
+    expect(result.stderr.toLowerCase()).not.toContain('preferred')
+
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(before)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    expect(existsSync(join(projectRoot, '.test-adapter'))).toBe(false)
+  })
+
+  test('recorded intent installs both assets without any prompt', async () => {
+    installFakeAdapter('test-adapter')
+    const alpha = buildFixture('alpha', 'planning')
+    const beta = buildFixture('beta', 'planning')
+    writeManifest({
+      manifestVersion: 0.1,
+      facets: {
+        alpha,
+        beta: { source: beta, materialization: { skills: { planning: { kind: 'aliased', as: 'beta-planning' } } } },
+      },
+    })
+
+    const result = await runCli(['install'])
+
+    expect(result.exitCode).toBe(0)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/planning.md'))).toBe(true)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/beta-planning.md'))).toBe(true)
+  })
+
+  test('an omitted asset is never written but stays in the lockfile', async () => {
+    installFakeAdapter('test-adapter')
+    const alpha = buildFixture('alpha', 'planning')
+    const beta = buildFixture('beta', 'planning')
+    writeManifest({
+      manifestVersion: 0.1,
+      facets: {
+        alpha,
+        beta: { source: beta, materialization: { skills: { planning: { kind: 'omitted' } } } },
+      },
+    })
+
+    const result = await runCli(['install'])
+
+    expect(result.exitCode).toBe(0)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/planning.md'))).toBe(true)
+    const lockfile = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    expect(lockfile.facets.beta.assets[0].materialization).toEqual({ kind: 'omitted' })
+  })
+})
+
+describe('collisions — frozen install', () => {
+  test('reports rather than prompting, and writes nothing', async () => {
+    installFakeAdapter('test-adapter')
+    const alpha = buildFixture('alpha', 'planning')
+    const beta = buildFixture('beta', 'planning')
+    writeManifest({ facets: { alpha, beta } })
+
+    const result = await runCli(['install', '--frozen-lockfile'])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('install failed')
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    expect(existsSync(join(projectRoot, '.test-adapter'))).toBe(false)
+  })
+})
+
+describe('collisions — failure ordering', () => {
+  test('an unusable adapter is reported before any collision choice is requested', async () => {
+    // Adapter compatibility is a precondition of materializing anything,
+    // so asking a user to arbitrate names first would be asking them to
+    // decide something that cannot be applied either way.
+    const dir = join(adaptersDir, 'broken-adapter')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'adapter.js'), 'export default { name: "broken-adapter", apiVersion: "0.0" }\n')
+
+    const alpha = buildFixture('alpha', 'planning')
+    const beta = buildFixture('beta', 'planning')
+    writeManifest({ facets: { alpha, beta } })
+
+    const result = await runCli(['install'])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).not.toContain('MATERIALIZATION_COLLISION')
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+})

--- a/packages/cli/src/__tests__/helpers/with-tty.ts
+++ b/packages/cli/src/__tests__/helpers/with-tty.ts
@@ -1,27 +1,73 @@
 /**
- * Test helper that forces `process.stdout.isTTY` to a specific value
- * for the duration of a block, then restores it.
+ * Force the process to look fully interactive (or fully non-interactive)
+ * for the duration of a block, then restore every property it touched.
  *
- * Why this exists: production code in the CLI (e.g. the adapter picker
- * gate, the "no adapters installed" hint copy) branches on
- * `process.stdout.isTTY`. Tests that exercise either branch must NOT
- * inherit the runner's TTY-ness — otherwise a test labelled
- * "non-TTY" will spuriously hang or pass depending on whether
- * `bun test` was launched from a real terminal vs a CI subprocess.
+ * Why this exists: production code branches on whether a real human is
+ * attached — the adapter picker, the login prompt, the publish build
+ * offer, the collision workspace. A test that inherits the runner's own
+ * terminal state is not testing a branch, it is testing where `bun test`
+ * happened to be launched from.
  *
- * Tests should always wrap TTY-sensitive assertions in `withTTY(true,
- * ...)` or `withTTY(false, ...)` to make the intent and the
- * environment explicit.
+ * Why it sets four things rather than `stdout.isTTY` alone: that is the
+ * complete input to `isInteractive` in `util/interactive.ts`. An earlier
+ * version of this helper set only stdout, which meant a test could assert
+ * "the interactive path runs" while the real interactive path — the one
+ * that calls `stdin.setRawMode` — would have thrown for a user with a
+ * piped stdin. The helper now expresses the same four facts the
+ * production check reads, so the two cannot drift apart.
  *
- * The property is restored in a `finally` block so a thrown assertion
- * doesn't leak the override into the next test.
+ * Everything is restored in `finally`, including deleting env vars that
+ * were absent to begin with, so a thrown assertion cannot leak state into
+ * the next test.
  */
+const CI_VARS = ['CI', 'CONTINUOUS_INTEGRATION'] as const
+
 export async function withTTY<T>(value: boolean, fn: () => Promise<T> | T): Promise<T> {
-  const original = process.stdout.isTTY
-  Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true, writable: true })
+  const originalStdin = process.stdin.isTTY
+  const originalStdout = process.stdout.isTTY
+  const originalSetRawMode = process.stdin.setRawMode
+  const hadSetRawMode = 'setRawMode' in process.stdin
+  const originalCi = CI_VARS.map((name) => [name, process.env[name]] as const)
+
+  setTTY(process.stdin, value)
+  setTTY(process.stdout, value)
+
+  if (value) {
+    // A TTY stdin always has `setRawMode`. Supplying a no-op keeps Ink's
+    // raw-mode path from throwing on the runner's real (piped) stdin.
+    if (typeof process.stdin.setRawMode !== 'function') {
+      Object.defineProperty(process.stdin, 'setRawMode', {
+        value: () => process.stdin,
+        configurable: true,
+        writable: true,
+      })
+    }
+    // CI is non-interactive by definition, so an interactive test must
+    // not silently become a non-interactive one on a build machine.
+    for (const name of CI_VARS) delete process.env[name]
+  }
+
   try {
     return await fn()
   } finally {
-    Object.defineProperty(process.stdout, 'isTTY', { value: original, configurable: true, writable: true })
+    setTTY(process.stdin, originalStdin)
+    setTTY(process.stdout, originalStdout)
+    if (hadSetRawMode) {
+      Object.defineProperty(process.stdin, 'setRawMode', {
+        value: originalSetRawMode,
+        configurable: true,
+        writable: true,
+      })
+    } else {
+      Reflect.deleteProperty(process.stdin, 'setRawMode')
+    }
+    for (const [name, original] of originalCi) {
+      if (original === undefined) delete process.env[name]
+      else process.env[name] = original
+    }
   }
+}
+
+function setTTY(stream: NodeJS.ReadStream | NodeJS.WriteStream, value: boolean | undefined): void {
+  Object.defineProperty(stream, 'isTTY', { value, configurable: true, writable: true })
 }

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import type { RunInstallFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
-import type { IntegrityFailure } from '@agent-facets/protocol'
+import type {
+  CollisionResolution,
+  CollisionResolutionRequest,
+  CollisionResolver,
+  RunInstallFailure,
+  RunInstallResult,
+  StageEvent,
+} from '@agent-facets/engine'
+import type { FacetContribution, IntegrityFailure } from '@agent-facets/protocol'
+import { planMaterialization } from '@agent-facets/protocol'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
 import { InstallView } from '../tui/views/install/install-view.tsx'
@@ -715,6 +723,288 @@ describe('InstallView — frozen-lockfile drift', () => {
     expect(frame).toContain('in lockfile but not in facets.json (locked 4.5.6)')
     expect(frame).toContain('source changed: locked github:agent-facets/planner')
     expect(frame).toContain('without --frozen-lockfile')
+    instance.unmount()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Collision resolution: the workspace phase inside the same Ink mount
+// ---------------------------------------------------------------------------
+
+const KEY = { down: '\u001B[B', right: '\u001B[C', enter: '\r', escape: '\u001B' } as const
+
+function collisionRequest(): CollisionResolutionRequest {
+  const contributions: FacetContribution[] = [
+    { facet: 'alpha', assets: [{ scope: 'project', type: 'skill', name: 'review' }] },
+    { facet: 'beta', assets: [{ scope: 'project', type: 'skill', name: 'review' }] },
+  ]
+  const planned = planMaterialization(contributions)
+  if (planned.ok || planned.reason !== 'collision') expect.unreachable()
+  return { groups: planned.groups, contributions, staleOverrides: [] }
+}
+
+const CANCELLED_RESULT: RunInstallResult = {
+  ok: false,
+  failure: { code: 'MATERIALIZATION_CANCELLED' },
+  rollback: { kind: 'not-needed', reason: 'no journal was created' },
+}
+
+/**
+ * A driver that behaves like the engine around a collision: emit
+ * progress, block on the resolver, then continue or fail based on what
+ * came back. Records the resolution so tests can assert on the exact
+ * value the engine would have received.
+ */
+function makeResolvingRun(
+  request: CollisionResolutionRequest,
+  onResolution: (resolution: CollisionResolution) => void,
+  resolvedResult: RunInstallResult = successResultSingle,
+) {
+  return async (
+    onStage: (e: StageEvent) => void,
+    _onLog: ((build: () => string) => void) | undefined,
+    resolveCollisions: CollisionResolver,
+  ): Promise<RunInstallResult> => {
+    onStage({ kind: 'install-start', totalFacets: 2 })
+    onStage({ kind: 'collision-check' })
+    const resolution = await resolveCollisions(request)
+    onResolution(resolution)
+    if (resolution.kind === 'cancelled') return CANCELLED_RESULT
+    onStage({ kind: 'facet-start', facet: 'alpha', specifier: './alpha' })
+    onStage({ kind: 'facet-stage', facet: 'alpha', stage: 'materialize' })
+    return resolvedResult
+  }
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 25))
+}
+
+describe('InstallView — collision phase machine', () => {
+  test('the collision check is a visible stage, not a stall', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: async (onStage) => {
+          onStage({ kind: 'install-start', totalFacets: 2 })
+          onStage({ kind: 'collision-check' })
+          await tick()
+          return successResultSingle
+        },
+      }),
+    )
+    await tick()
+    expect(instance.lastFrame() ?? '').toContain('Checking for name collisions')
+    await settle()
+    instance.unmount()
+  })
+
+  test('progress gives way to the workspace and comes back, in one mount', async () => {
+    const resolutions: CollisionResolution[] = []
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeResolvingRun(collisionRequest(), (r) => resolutions.push(r)),
+      }),
+    )
+    await tick()
+
+    // Phase 2: the workspace has the screen.
+    expect(instance.lastFrame() ?? '').toContain('Installation is paused')
+
+    // Resolve by omitting both claimants, then confirm.
+    for (const key of [
+      KEY.enter,
+      KEY.right,
+      KEY.right,
+      KEY.enter,
+      KEY.down,
+      KEY.right,
+      KEY.right,
+      KEY.enter,
+      KEY.escape,
+      KEY.down,
+      KEY.enter,
+    ]) {
+      instance.stdin.write(key)
+      await tick()
+    }
+
+    expect(resolutions).toHaveLength(1)
+    expect(resolutions[0]?.kind).toBe('resolved')
+
+    // Phase 3 and 4: progress resumed and the result rendered — no
+    // second Ink renderer, so the whole run is one continuous frame
+    // stream.
+    await settle()
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('Install complete.')
+    expect(frame).toContain('1 installed')
+    instance.unmount()
+  })
+
+  test('cancelling shows the cancellation block and no success summary', async () => {
+    const resolutions: CollisionResolution[] = []
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeResolvingRun(collisionRequest(), (r) => resolutions.push(r)),
+      }),
+    )
+    await tick()
+    instance.stdin.write(KEY.escape)
+    await settle()
+
+    expect(resolutions).toEqual([{ kind: 'cancelled' }])
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('Cancelled')
+    expect(frame).toContain('Nothing was changed')
+    expect(frame).not.toContain('Install complete.')
+    instance.unmount()
+  })
+
+  test('an interrupt while the workspace is open settles the pending prompt', async () => {
+    // The engine is holding the project lock and awaiting this promise.
+    // If an interrupt left it unsettled, the lock would never be
+    // released and the process would hang instead of exiting.
+    const controller = new AbortController()
+    const resolutions: CollisionResolution[] = []
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        signal: controller.signal,
+        run: makeResolvingRun(collisionRequest(), (r) => resolutions.push(r)),
+      }),
+    )
+    await tick()
+    expect(instance.lastFrame() ?? '').toContain('Installation is paused')
+
+    controller.abort()
+    await settle()
+
+    expect(resolutions).toEqual([{ kind: 'cancelled' }])
+    instance.unmount()
+  })
+})
+
+describe('InstallView — materialization reporting', () => {
+  const lockfileWithDispositions: RunInstallResult = {
+    ok: true,
+    lockfile: {
+      lockfileVersion: 0.3,
+      facets: {
+        alpha: {
+          source: { kind: 'local', path: './alpha' },
+          version: '1.0.0',
+          integrity: 'sha256:aaaa',
+          assets: [
+            {
+              scope: 'project',
+              type: 'skill',
+              name: 'review',
+              materialization: { kind: 'aliased', as: 'vendor-review' },
+              files: [{ path: 'skills/review/SKILL.md', integrity: 'sha256:bbbb' }],
+            },
+            {
+              scope: 'project',
+              type: 'command',
+              name: 'deploy',
+              materialization: { kind: 'omitted' },
+              files: [{ path: 'commands/deploy.md', integrity: 'sha256:cccc' }],
+            },
+          ],
+        },
+      },
+    },
+    summary: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0, totalAssets: 1, removedAssets: 0 },
+    perFacet: [{ kind: 'installed', name: 'alpha', version: '1.0.0' }],
+    serverWarnings: [],
+  }
+
+  test('shows the authored name beside the effective name, and marks omissions', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], lockfileWithDispositions),
+      }),
+    )
+    await settle()
+
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('review')
+    expect(frame).toContain('vendor-review')
+    expect(frame).toContain('deploy')
+    expect(frame).toContain('omitted')
+    instance.unmount()
+  })
+
+  test('an omitted asset is not counted as materialized', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], lockfileWithDispositions),
+      }),
+    )
+    await settle()
+
+    // The omitted command stays in the lockfile — it is part of the
+    // resolved set — but claiming it in the bundle would advertise a
+    // file that was never written.
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('1 skill')
+    expect(frame).not.toContain('1 command')
+    instance.unmount()
+  })
+
+  test('a pruned stale override is reported without --verbose', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun(
+          [
+            { kind: 'install-start', totalFacets: 1 },
+            { kind: 'stale-override-pruned', facet: 'alpha', assetType: 'skill', authoredName: 'gone' },
+          ],
+          successResultSingle,
+        ),
+      }),
+    )
+    await settle()
+
+    // No `onLog` was supplied — this has to be visible anyway, because
+    // it silently changed what facets.json says.
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('gone')
+    expect(frame).toContain('alpha')
+    expect(frame).toContain('no longer contains')
+    instance.unmount()
+  })
+})
+
+describe('InstallView — disposition-only change', () => {
+  test('is summarised as an update, without a version-to-itself arrow', async () => {
+    // The facet did not move; its materialization did. Reporting a
+    // repair would claim the disk had drifted, and printing
+    // "was 1.0.0 → 1.0.0" would read as a bug in the version resolver.
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: { lockfileVersion: 1, facets: {} },
+      summary: { installed: 0, updated: 1, repaired: 0, unchanged: 0, removed: 0, totalAssets: 1, removedAssets: 0 },
+      perFacet: [{ kind: 'updated', name: 'alpha', oldVersion: '1.0.0', newVersion: '1.0.0' }],
+      serverWarnings: [],
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], result),
+      }),
+    )
+    await settle()
+
+    const frame = findContentFrame(instance.frames)
+    expect(frame).toContain('1 updated')
+    expect(frame).not.toContain('repaired')
+    expect(frame).not.toContain('1.0.0 → 1.0.0')
     instance.unmount()
   })
 })

--- a/packages/cli/src/commands/adapter/pick-and-install.ts
+++ b/packages/cli/src/commands/adapter/pick-and-install.ts
@@ -14,6 +14,7 @@ import {
   formatPlacementWarning,
 } from '../../util/adapter-install-errors.ts'
 import { writeCliError } from '../../util/errors.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
 import { InstallPicker } from './install-picker.tsx'
 
 /**
@@ -44,7 +45,7 @@ export type PickAndInstallResult =
  * reclaim raw mode cleanly.
  */
 export async function pickAndInstallAdapters(): Promise<PickAndInstallResult> {
-  if (!process.stdout.isTTY) {
+  if (!canPromptInteractively()) {
     return { ok: false, reason: 'non-tty' }
   }
 

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -291,3 +291,36 @@ describe('facet add — incompatible installed adapter gate', () => {
     expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
   })
 })
+
+describe('facet add — collision with an already-installed facet', () => {
+  test('reports both claimants and leaves the manifest untouched', async () => {
+    installFakeAdapter(adaptersDir, 'test-adapter')
+    const installed = buildLocalFixture('alpha', '0.1.0', 'planning')
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({ facets: { alpha: `./${installed.split('/').pop()}` } }),
+    )
+    expect(await withTTY(false, () => addCommand.run([`./${installed.split('/').pop()}`], {}))).toBe(0)
+
+    // A second facet publishing the same skill name.
+    const incoming = buildLocalFixture('beta', '0.1.0', 'planning')
+    const manifestBefore = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+    const lockBefore = readFileSync(join(projectRoot, 'facets.lock'), 'utf8')
+
+    const { result: code, stderr } = await withTTY(false, () =>
+      captureStderr(() => addCommand.run([`./${incoming.split('/').pop()}`], {})),
+    )
+
+    expect(code).toBe(1)
+    expect(stderr).toContain('add failed')
+    expect(stderr).toContain('code=MATERIALIZATION_COLLISION')
+    // The already-installed claimant is named too: the fix may well be
+    // to alias the one that was there first.
+    expect(stderr).toContain('facets["alpha"].materialization.skills["planning"]')
+    expect(stderr).toContain('facets["beta"].materialization.skills["planning"]')
+
+    // `add` writes nothing ahead of install, so a refused add is a no-op.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+  })
+})

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -10,8 +10,11 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
+import { writeMaterializationDetail } from '../../util/collision-report.ts'
 import { writeCliError } from '../../util/errors.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { installFailureFix } from '../shared/install-failure.ts'
 
 /**
  * `facet add <source> [more sources...]` — adds one or more facets to
@@ -72,22 +75,26 @@ export const addCommand: Command = {
     // ensures the rollback render lands before unmount.
     const controller = new AbortController()
     const sigintHandler = () => {
-      process.stderr.write('\nInterrupted. Rolling back...\n')
+      process.stderr.write('\nInterrupted. Stopping safely...\n')
       controller.abort()
     }
     process.on('SIGINT', sigintHandler)
+
+    const mayPrompt = canPromptInteractively()
 
     let captured: RunAddResult | undefined
     const instance = render(
       createElement(InstallView, {
         mode: 'add',
-        run: async (onStage, onLog) => {
+        signal: controller.signal,
+        run: async (onStage, onLog, resolveCollisions) => {
           const result = await runAdd({
             projectRoot,
             sources,
             adapters,
             onStage,
             ...(verbose && onLog ? { onLog } : {}),
+            ...(mayPrompt ? { resolveCollisions } : {}),
             signal: controller.signal,
           })
           captured = result
@@ -105,6 +112,9 @@ export const addCommand: Command = {
           void r
         },
       }),
+      // See `install`: Ctrl-C has to reach the workspace so the engine's
+      // pending resolver call is settled and the lock released.
+      { exitOnCtrlC: false },
     )
 
     try {
@@ -133,17 +143,12 @@ export const addCommand: Command = {
 
     // Install-phase failure. The delta-based flow never writes the manifest
     // ahead of install, so there's nothing to restore — the journal rollback
-    // handles asset cleanup. Branch the guidance on whether the rollback
-    // was partial.
-    const rollback = captured.install.rollback
-    const partialFailureCount = rollback.kind === 'partial-failure' ? rollback.failures : 0
+    // handles asset cleanup.
+    writeMaterializationDetail(captured.install.failure)
     writeCliError({
       what: 'add failed',
       detail: `code=${captured.install.failure.code}`,
-      fix:
-        partialFailureCount > 0
-          ? "partial rollback: some state may remain. Inspect and clean manually before re-running 'facet add'."
-          : "rollback complete; project state unchanged. Fix the underlying issue and re-run 'facet add'.",
+      fix: installFailureFix(captured.install.failure, captured.install.rollback, 'add'),
     })
     return 1
   },

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -209,3 +209,236 @@ describe('facet install — incompatible installed adapter gate', () => {
     expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
   })
 })
+
+describe('facet install — unresolved collisions', () => {
+  /** Two facets that both publish the project-scoped skill `planning`. */
+  function twoCollidingFacets(): void {
+    installFakeAdapter(adaptersDir, 'test-adapter')
+    const alpha = buildLocalFixture('alpha')
+    const beta = buildLocalFixture('beta')
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        facets: {
+          alpha: `./${alpha.split('/').pop()}`,
+          beta: `./${beta.split('/').pop()}`,
+        },
+      }),
+    )
+  }
+
+  test('non-interactive install fails with the complete report and changes nothing', async () => {
+    twoCollidingFacets()
+    const before = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+
+    const { result: code, stderr } = await withTTY(false, () => captureStderr(() => installCommand.run([], {})))
+
+    expect(code).toBe(1)
+
+    // Every group and every claimant, on stderr — the stream that
+    // survives being piped, which is exactly the situation that produces
+    // a collision with no resolver.
+    expect(stderr).toContain('alpha')
+    expect(stderr).toContain('beta')
+    expect(stderr).toContain('"planning"')
+    expect(stderr).toContain('facets["alpha"].materialization.skills["planning"]')
+    expect(stderr).toContain('facets["beta"].materialization.skills["planning"]')
+    expect(stderr).toContain('"kind": "aliased"')
+    expect(stderr).toContain('"kind": "omitted"')
+    expect(stderr).toContain('NOT changed')
+    expect(stderr).toContain('code=MATERIALIZATION_COLLISION')
+
+    // And nothing on disk moved.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(before)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    expect(existsSync(join(projectRoot, '.test-adapter'))).toBe(false)
+  })
+
+  test('a recorded alias resolves the collision without prompting', async () => {
+    twoCollidingFacets()
+    const manifest = JSON.parse(readFileSync(join(projectRoot, 'facets.json'), 'utf8'))
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        manifestVersion: 0.1,
+        facets: {
+          alpha: manifest.facets.alpha,
+          beta: {
+            source: manifest.facets.beta,
+            materialization: { skills: { planning: { kind: 'aliased', as: 'beta-planning' } } },
+          },
+        },
+      }),
+    )
+
+    const code = await withTTY(false, () => installCommand.run([], {}))
+    expect(code).toBe(0)
+
+    // Both assets land, under names that differ.
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/planning.md'))).toBe(true)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/beta-planning.md'))).toBe(true)
+  })
+
+  test('a recorded omission keeps the asset out of the adapter', async () => {
+    twoCollidingFacets()
+    const manifest = JSON.parse(readFileSync(join(projectRoot, 'facets.json'), 'utf8'))
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        manifestVersion: 0.1,
+        facets: {
+          alpha: manifest.facets.alpha,
+          beta: { source: manifest.facets.beta, materialization: { skills: { planning: { kind: 'omitted' } } } },
+        },
+      }),
+    )
+
+    const code = await withTTY(false, () => installCommand.run([], {}))
+    expect(code).toBe(0)
+
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/planning.md'))).toBe(true)
+    // Omitted, but still recorded as part of the resolved set.
+    const lockfile = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    expect(lockfile.facets.beta.assets[0].materialization).toEqual({ kind: 'omitted' })
+  })
+
+  test('frozen mode reports the collision instead of opening a workspace', async () => {
+    twoCollidingFacets()
+
+    // Interactive terminal, but frozen: reproducing recorded intent must
+    // never collect a new decision, so this must not hang on a prompt.
+    const { result: code, stderr } = await withTTY(true, () =>
+      captureStderr(() => installCommand.run([], { 'frozen-lockfile': true })),
+    )
+
+    expect(code).toBe(1)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    expect(stderr).toContain('install failed')
+  })
+})
+
+describe('facet install — what an adapter is asked to write', () => {
+  /**
+   * An adapter that records every request it receives. The adapter API
+   * does not change for aliasing, so the only way to show that the
+   * effective name reaches the adapter — and that authored content does
+   * not get rewritten along with it — is to look at the requests.
+   */
+  function installRecordingAdapter(name: string, logPath: string): void {
+    const dir = join(adaptersDir, name)
+    mkdirSync(dir, { recursive: true })
+    const assetFsImport = require.resolve('@agent-facets/adapter')
+    writeFileSync(
+      join(dir, 'adapter.js'),
+      `
+import { installAssetFile, readAssetFile, deleteAssetFile } from '${assetFsImport}'
+import { appendFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
+function record(kind, req) {
+  appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({
+    kind, assetType: req.assetType, name: req.name, content: req.content ?? null,
+  }) + '\\n')
+}
+
+export default {
+  name: '${name}',
+  apiVersion: '${ADAPTER_API_VERSION}',
+  supportsInstall: true,
+  buildAssetMetadata(data) { return { ok: true, data: data || {} } },
+  async installAsset(req) {
+    record('install', req)
+    const file = path(req.assetType, req.name)
+    await installAssetFile({ file }, req.content, req.metadata)
+    return { ok: true, primaryPath: file }
+  },
+  async readAsset(req) {
+    record('read', req)
+    try {
+      const r = await readAssetFile({ file: path(req.assetType, req.name) })
+      return { ok: true, asset: { assetType: 'skill', content: r.content, metadata: r.metadata, companions: {} } }
+    } catch { return { ok: false, failure: { code: 'not-found' } } }
+  },
+  async deleteAsset(req) {
+    record('delete', req)
+    const file = path(req.assetType, req.name)
+    await deleteAssetFile({ file })
+    return { ok: true, existed: true, deletedPaths: [file] }
+  },
+}
+`,
+    )
+  }
+
+  test('an aliased asset is requested under its effective name, with authored content', async () => {
+    const logPath = join(projectRoot, 'adapter-requests.log')
+    installRecordingAdapter('test-adapter', logPath)
+    const fixture = buildLocalFixture('viper-plans')
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        manifestVersion: 0.1,
+        facets: {
+          'viper-plans': {
+            source: `./${fixture.split('/').pop()}`,
+            materialization: { skills: { planning: { kind: 'aliased', as: 'vendor-planning' } } },
+          },
+        },
+      }),
+    )
+
+    expect(await installCommand.run([], {})).toBe(0)
+
+    const requests = readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { kind: string; name: string; content: string | null })
+    const install = requests.find((r) => r.kind === 'install')
+    if (install === undefined) expect.unreachable()
+
+    // The adapter sees the alias...
+    expect(install.name).toBe('vendor-planning')
+    // ...but the bytes are the publisher's, unmodified. Aliasing is a
+    // placement decision; rewriting content would corrupt the very hash
+    // the lockfile just verified.
+    expect(install.content).toContain('# planning 0.1.0')
+
+    // And the file lands under the alias.
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/vendor-planning.md'))).toBe(true)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/planning.md'))).toBe(false)
+
+    // Integrity stays anchored to the authored path.
+    const lockfile = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    expect(lockfile.facets['viper-plans'].assets[0]).toMatchObject({
+      name: 'planning',
+      materialization: { kind: 'aliased', as: 'vendor-planning' },
+      files: [{ path: 'skills/planning/SKILL.md' }],
+    })
+  })
+
+  test('changing an alias deletes the old name and writes the new one', async () => {
+    const logPath = join(projectRoot, 'adapter-requests.log')
+    installRecordingAdapter('test-adapter', logPath)
+    const fixture = buildLocalFixture('viper-plans')
+    const source = `./${fixture.split('/').pop()}`
+    const manifest = (as: string) =>
+      JSON.stringify({
+        manifestVersion: 0.1,
+        facets: {
+          'viper-plans': { source, materialization: { skills: { planning: { kind: 'aliased', as } } } },
+        },
+      })
+
+    writeFileSync(join(projectRoot, 'facets.json'), manifest('first-name'))
+    expect(await installCommand.run([], {})).toBe(0)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/first-name.md'))).toBe(true)
+
+    writeFileSync(join(projectRoot, 'facets.json'), manifest('second-name'))
+    expect(await installCommand.run([], {})).toBe(0)
+
+    // The rename is a delete plus a write, not an orphaned copy.
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/second-name.md'))).toBe(true)
+    expect(existsSync(join(projectRoot, '.test-adapter/skills/first-name.md'))).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -1,10 +1,13 @@
-import { type RollbackOutcome, type RunInstallFailure, type RunInstallResult, runInstall } from '@agent-facets/engine'
+import { type RunInstallFailure, type RunInstallResult, runInstall } from '@agent-facets/engine'
 import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
+import { writeMaterializationDetail } from '../../util/collision-report.ts'
 import { writeCliError } from '../../util/errors.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { installFailureFix } from '../shared/install-failure.ts'
 
 /**
  * `facet install` — bring the project on disk into agreement with
@@ -50,23 +53,34 @@ export const installCommand: Command = {
     // Wire SIGINT to an AbortController so core never installs a
     // process-global signal handler. The view's deferred-exit pattern
     // ensures the rollback render lands before unmount.
+    //
+    // The copy is deliberately vague about rollback: an interrupt during
+    // resolution has nothing to undo, and promising a rollback that never
+    // happened sends people looking for damage that isn't there. The
+    // structured result says what actually occurred.
     const controller = new AbortController()
     const sigintHandler = () => {
-      process.stderr.write('\nInterrupted. Rolling back...\n')
+      process.stderr.write('\nInterrupted. Stopping safely...\n')
       controller.abort()
     }
     process.on('SIGINT', sigintHandler)
+
+    // Frozen mode reproduces recorded intent, so it must never collect a
+    // new decision — not even from a human sitting at a terminal.
+    const mayPrompt = !frozenLockfile && canPromptInteractively()
 
     let captured: RunInstallResult | undefined
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
-        run: async (onStage, onLog) => {
+        signal: controller.signal,
+        run: async (onStage, onLog, resolveCollisions) => {
           const result = await runInstall({
             projectRoot,
             adapters,
             onStage,
             ...(verbose && onLog ? { onLog } : {}),
+            ...(mayPrompt ? { resolveCollisions } : {}),
             signal: controller.signal,
             frozenLockfile,
           })
@@ -81,6 +95,11 @@ export const installCommand: Command = {
           if (!('prepareFailure' in r) && !('removePrepareFailure' in r)) captured = r
         },
       }),
+      // Ctrl-C must reach the collision workspace, which is the only
+      // thing that can settle the engine's pending resolver call and let
+      // it release the project lock. Ink's built-in handler would exit
+      // the render without ever settling that promise.
+      { exitOnCtrlC: false },
     )
 
     try {
@@ -106,10 +125,16 @@ export const installCommand: Command = {
       // The view rendered the structured failure block on stdout. Emit
       // the canonical CLI error block on stderr so scripts and existing
       // tests that grep stderr for 'install failed' continue to work.
+      //
+      // A collision needs more than three lines to act on, and the
+      // contexts that produce one without a prompt are exactly the ones
+      // where stdout is discarded — so the full report goes to stderr
+      // first, leaving `fix:` as the last line.
+      writeMaterializationDetail(captured.failure)
       writeCliError({
         what: 'install failed',
         detail: failureDetail(captured.failure),
-        fix: failureFix(captured.failure, captured.rollback),
+        fix: installFailureFix(captured.failure, captured.rollback, 'install'),
       })
       return 1
     }
@@ -125,17 +150,4 @@ export const installCommand: Command = {
  */
 function failureDetail(failure: RunInstallFailure): string {
   return `code=${failure.code}`
-}
-
-function failureFix(failure: RunInstallFailure, rollback: RollbackOutcome): string {
-  if (rollback.kind === 'partial-failure') {
-    return `partial state on disk after ${rollback.failures} rollback failure(s); re-run 'facet install' to attempt reconciliation`
-  }
-  if (failure.code === 'ABORTED') {
-    return 'rollback complete; project state unchanged'
-  }
-  if (failure.code === 'LOCKFILE_DRIFT') {
-    return "lockfile is out of date; run 'facet install' (without --frozen-lockfile) or 'facet add' to update it"
-  }
-  return "rollback complete; fix the underlying issue and re-run 'facet install'"
 }

--- a/packages/cli/src/commands/login/index.ts
+++ b/packages/cli/src/commands/login/index.ts
@@ -4,6 +4,7 @@ import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { LoginMenu } from '../../tui/components/login-menu.tsx'
 import { writeCliError } from '../../util/errors.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
 import { translateEngineRegistryError } from '../../util/registry-errors.ts'
 
 /**
@@ -22,7 +23,7 @@ export const loginCommand: Command = {
   implemented: true,
   run: async (_args, _flags) => {
     // The menu and masked prompt require an interactive terminal.
-    if (!process.stdout.isTTY) {
+    if (!canPromptInteractively()) {
       writeCliError({
         what: 'facet login requires an interactive terminal',
         detail: 'this is a non-interactive environment; the sign-in prompt cannot run here',

--- a/packages/cli/src/commands/publish/build-offer.ts
+++ b/packages/cli/src/commands/publish/build-offer.ts
@@ -9,9 +9,9 @@ import { SelectPrompt } from '../../tui/components/select-prompt.tsx'
  * branch and one for the source-drift branch — over the same
  * `ConfirmPrompt` machinery the rest of the CLI uses for y/n questions.
  *
- * Caller MUST gate on `process.stdout.isTTY` before calling either of
- * these. The mount is unconditional: in a non-TTY context Ink would
- * still try to attach to stdin and the behavior is undefined.
+ * Caller MUST gate on `canPromptInteractively()` before calling either
+ * of these. The mount is unconditional: without a raw-mode-capable stdin
+ * Ink throws rather than degrading.
  *
  * Returns the user's boolean answer; the Ink unmount yields a clean
  * stdin state so a follow-up `<BuildView>` mount on the "yes" branch
@@ -101,8 +101,8 @@ export type IdentityDriftDecision = 'build-new' | 'ship-existing' | 'cancel'
  * Renders via the arrow-key `SelectPrompt` to match the
  * single-select pattern already used elsewhere in the CLI.
  *
- * Caller MUST gate on `process.stdout.isTTY` before calling this — the
- * mount is unconditional.
+ * Caller MUST gate on `canPromptInteractively()` before calling this —
+ * the mount is unconditional.
  */
 export async function askIdentityDriftDecision(
   sourceIdentity: { name: string; version: string },

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -10,6 +10,7 @@ import {
 import { type ArchiveVerificationFailure, type FacetManifest, validateFacetArchive } from '@agent-facets/protocol'
 import type { Command } from '../../commands.ts'
 import { writeCliError } from '../../util/errors.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
 import { translateEngineRegistryError } from '../../util/registry-errors.ts'
 import { resolveTargetDir } from '../resolve-dir.ts'
 import { askIdentityDriftDecision, askToBuildMissing, askToRebuildDrifted } from './build-offer.ts'
@@ -203,7 +204,7 @@ async function pickBytesToPublish(
 ): Promise<Uint8Array | null> {
   // === No artifact present ===
   if (discovery.state === 'none') {
-    if (!process.stdout.isTTY) {
+    if (!canPromptInteractively()) {
       writeCliError({
         what: 'no built artifact in dist/',
         fix: 'run `facet build` first, then `facet publish`',
@@ -244,7 +245,7 @@ async function pickBytesToPublish(
   const isIdentityDrift = drift.reason === 'name' || drift.reason === 'version'
 
   // Non-interactive: warn to stderr, ship existing.
-  if (!process.stdout.isTTY) {
+  if (!canPromptInteractively()) {
     const summary = isIdentityDrift
       ? `built artifact is ${embedded.name}@${embedded.version}; source is ${sourceManifest.name}@${sourceManifest.version}`
       : `built artifact is out of date (manifest content differs from source)`

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -4,8 +4,11 @@ import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { THEME } from '../../tui/theme.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
+import { writeMaterializationDetail } from '../../util/collision-report.ts'
 import { writeCliError } from '../../util/errors.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { installFailureFix } from '../shared/install-failure.ts'
 
 /**
  * `facet remove <facet> [more facets...]` — removes one or more facets
@@ -96,16 +99,19 @@ export const removeCommand: Command = {
     // ensures the rollback render lands before unmount.
     const controller = new AbortController()
     const sigintHandler = () => {
-      process.stderr.write('\nInterrupted. Rolling back...\n')
+      process.stderr.write('\nInterrupted. Stopping safely...\n')
       controller.abort()
     }
     process.on('SIGINT', sigintHandler)
+
+    const mayPrompt = canPromptInteractively()
 
     let captured: RunRemoveResult | undefined
     const instance = render(
       createElement(InstallView, {
         mode: 'remove',
-        run: async (onStage, onLog) => {
+        signal: controller.signal,
+        run: async (onStage, onLog, resolveCollisions) => {
           const result = await runRemove({
             projectRoot,
             names,
@@ -113,6 +119,7 @@ export const removeCommand: Command = {
             prepared,
             onStage,
             ...(verbose && onLog ? { onLog } : {}),
+            ...(mayPrompt ? { resolveCollisions } : {}),
             signal: controller.signal,
           })
           captured = result
@@ -130,6 +137,9 @@ export const removeCommand: Command = {
           void r
         },
       }),
+      // See `install`: Ctrl-C has to reach the workspace so the engine's
+      // pending resolver call is settled and the lock released.
+      { exitOnCtrlC: false },
     )
 
     try {
@@ -158,15 +168,11 @@ export const removeCommand: Command = {
 
     // Install-phase failure. The delta-based flow never writes the manifest
     // ahead of install — the journal rollback handles asset cleanup.
-    const rollback = captured.install.rollback
-    const partialFailureCount = rollback.kind === 'partial-failure' ? rollback.failures : 0
+    writeMaterializationDetail(captured.install.failure)
     writeCliError({
       what: 'remove failed',
       detail: `code=${captured.install.failure.code}`,
-      fix:
-        partialFailureCount > 0
-          ? "partial rollback: some state may remain. Inspect and clean manually before re-running 'facet remove'."
-          : "rollback complete; project state unchanged. Fix the underlying issue and re-run 'facet remove'.",
+      fix: installFailureFix(captured.install.failure, captured.install.rollback, 'remove'),
     })
     return 1
   },

--- a/packages/cli/src/commands/shared/install-failure.ts
+++ b/packages/cli/src/commands/shared/install-failure.ts
@@ -1,0 +1,38 @@
+import type { RollbackOutcome, RunInstallFailure } from '@agent-facets/engine'
+
+/**
+ * The `fix:` line for a failed install-pipeline run, shared by `add`,
+ * `install`, and `remove`.
+ *
+ * These three commands are the same pipeline behind different front
+ * doors, so their guidance drifted apart for no reason: three copies of
+ * the rollback branch with three different phrasings of the same fact.
+ * The only genuine variation is which command to re-run.
+ */
+export function installFailureFix(
+  failure: RunInstallFailure,
+  rollback: RollbackOutcome,
+  command: 'add' | 'install' | 'remove',
+): string {
+  // Partial rollback outranks everything: whatever caused the failure
+  // matters less than the fact that undoing it did not fully succeed.
+  if (rollback.kind === 'partial-failure') {
+    return `partial state may remain on disk after ${rollback.failures} rollback failure(s); inspect the project tree before re-running 'facet ${command}'`
+  }
+
+  switch (failure.code) {
+    case 'MATERIALIZATION_COLLISION':
+    case 'MATERIALIZATION_RESOLUTION_INVALID':
+      return `record an alias or omission for each asset listed above in facets.json, then re-run 'facet ${command}'`
+    case 'MATERIALIZATION_ALIAS_INVALID':
+      return 'correct the invalid alias in facets.json, then re-run'
+    case 'MATERIALIZATION_CANCELLED':
+      return `cancelled; nothing was written. Re-run 'facet ${command}' to make the choices again`
+    case 'ABORTED':
+      return 'nothing was written; project state unchanged'
+    case 'LOCKFILE_DRIFT':
+      return "lockfile is out of date; run 'facet install' (without --frozen-lockfile) or 'facet add' to update it"
+    default:
+      return `rollback complete; fix the underlying issue and re-run 'facet ${command}'`
+  }
+}

--- a/packages/cli/src/tui/views/install/__tests__/collision-status.test.ts
+++ b/packages/cli/src/tui/views/install/__tests__/collision-status.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { COLLISION_STATUS, type CollisionStatus, describeStatus } from '../collision-status.ts'
+
+const ALL: CollisionStatus[] = ['unresolved', 'draft-conflict', 'resolved']
+
+describe('collision status presentation', () => {
+  test('every state has a distinct icon', () => {
+    const icons = ALL.map((status) => COLLISION_STATUS[status].icon)
+    expect(new Set(icons).size).toBe(ALL.length)
+  })
+
+  test('every state has a distinct word', () => {
+    const labels = ALL.map((status) => COLLISION_STATUS[status].label)
+    expect(new Set(labels).size).toBe(ALL.length)
+  })
+
+  test('every state has a distinct color', () => {
+    // Color is the redundant channel, not the only one — but two states
+    // sharing a color would still be a bug.
+    const colors = ALL.map((status) => COLLISION_STATUS[status].color)
+    expect(new Set(colors).size).toBe(ALL.length)
+  })
+
+  test('states stay distinguishable with color stripped', () => {
+    // This is the actual accessibility promise: under NO_COLOR, in a
+    // pipe, or for a red/green-colorblind reader, the rendered text
+    // alone must still separate the three states.
+    const rendered = ALL.map((status) => describeStatus(status))
+    expect(new Set(rendered).size).toBe(ALL.length)
+    expect(rendered).toEqual(['✕ unresolved', '⚠ conflict', '✓ resolved'])
+  })
+})

--- a/packages/cli/src/tui/views/install/collision-status.ts
+++ b/packages/cli/src/tui/views/install/collision-status.ts
@@ -1,0 +1,48 @@
+import { THEME } from '../../theme.ts'
+
+/**
+ * The three states a claimant can be in while collisions are being
+ * resolved, and how each one is shown.
+ *
+ * Color alone cannot carry this. Roughly one in twelve men cannot
+ * reliably separate the red and green ends of the scale, `NO_COLOR` is a
+ * supported environment, and piped output drops styling entirely. So
+ * every state ships an icon AND a word, and the color is decoration on
+ * top of an already-complete signal.
+ */
+export type CollisionStatus =
+  /** The set still collides here and no in-session edit has addressed it. */
+  | 'unresolved'
+  /** This claimant collides with a name the current draft proposes. */
+  | 'draft-conflict'
+  /** This claimant's effective identity is unique across the whole draft. */
+  | 'resolved'
+
+export interface CollisionStatusPresentation {
+  /** Distinct at a glance without reading. */
+  icon: string
+  /** Distinct when the icon does not render (or is read aloud). */
+  label: string
+  color: string
+}
+
+/**
+ * Keyed exhaustively on purpose: adding a fourth state to
+ * {@link CollisionStatus} fails to compile until it is given a
+ * presentation, rather than rendering as a blank cell.
+ */
+export const COLLISION_STATUS: Record<CollisionStatus, CollisionStatusPresentation> = {
+  unresolved: { icon: '✕', label: 'unresolved', color: THEME.warning },
+  'draft-conflict': { icon: '⚠', label: 'conflict', color: THEME.caution },
+  resolved: { icon: '✓', label: 'resolved', color: THEME.success },
+}
+
+/**
+ * The color-free rendering of a status, e.g. `✕ unresolved`. Used by the
+ * views and asserted directly by the accessibility tests, so the promise
+ * the tests check is the same string users see.
+ */
+export function describeStatus(status: CollisionStatus): string {
+  const { icon, label } = COLLISION_STATUS[status]
+  return `${icon} ${label}`
+}

--- a/packages/cli/src/tui/views/install/collision/__tests__/draft.test.ts
+++ b/packages/cli/src/tui/views/install/collision/__tests__/draft.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from 'bun:test'
+import type { CollisionResolutionRequest } from '@agent-facets/engine'
+import type { FacetContribution } from '@agent-facets/protocol'
+import { planMaterialization } from '@agent-facets/protocol'
+import {
+  type ClaimantModel,
+  createDraft,
+  evaluateDraft,
+  reviseDraft,
+  validateAlias,
+  type WorkspaceModel,
+} from '../draft.ts'
+
+/**
+ * Build the request the engine would hand a resolver: the planner's own
+ * collision report over these contributions, never a hand-written one.
+ * A fixture that disagreed with the planner would let these tests pass
+ * while the real workspace showed something else.
+ */
+function requestFor(contributions: FacetContribution[]): CollisionResolutionRequest {
+  const planned = planMaterialization(contributions)
+  if (planned.ok) expect.unreachable()
+  if (planned.reason !== 'collision') expect.unreachable()
+  return { groups: planned.groups, contributions, staleOverrides: planned.staleOverrides }
+}
+
+function skill(facet: string, ...names: string[]): FacetContribution {
+  return { facet, assets: names.map((name) => ({ scope: 'project', type: 'skill', name })) }
+}
+
+function memberOf(model: WorkspaceModel, facet: string, authoredName: string): ClaimantModel {
+  for (const group of model.groups) {
+    const found = group.members.find((m) => m.facet === facet && m.authoredName === authoredName)
+    if (found) return found
+  }
+  expect.unreachable()
+}
+
+function statusOf(model: WorkspaceModel, facet: string, authoredName: string): string {
+  return memberOf(model, facet, authoredName).status
+}
+
+const TWO_WAY = [skill('alpha', 'review'), skill('beta', 'review')]
+
+describe('collision draft — initial state', () => {
+  test('an inherited collision is unresolved, not a draft conflict', () => {
+    const request = requestFor(TWO_WAY)
+    const model = evaluateDraft(request, createDraft(request))
+
+    expect(model.confirmable).toBe(false)
+    expect(model.groups).toHaveLength(1)
+    expect(statusOf(model, 'alpha', 'review')).toBe('unresolved')
+    expect(statusOf(model, 'beta', 'review')).toBe('unresolved')
+  })
+
+  test('seeds from existing project overrides rather than discarding them', () => {
+    // `gamma` already has an alias recorded. It is not part of the
+    // collision, so nothing in the workspace will touch it — but it must
+    // survive into what gets submitted.
+    const contributions: FacetContribution[] = [
+      ...TWO_WAY,
+      { ...skill('gamma', 'audit'), overrides: { skills: { audit: { kind: 'aliased', as: 'gamma-audit' } } } },
+    ]
+    const request = requestFor(contributions)
+    const draft = createDraft(request)
+
+    expect(draft.overrides.gamma).toEqual({ skills: { audit: { kind: 'aliased', as: 'gamma-audit' } } })
+  })
+})
+
+describe('collision draft — resolving', () => {
+  test('aliasing one claimant resolves the group and keeps both assets', () => {
+    const request = requestFor(TWO_WAY)
+    let draft = createDraft(request)
+    const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
+
+    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(true)
+    expect(statusOf(model, 'alpha', 'review')).toBe('resolved')
+    expect(statusOf(model, 'beta', 'review')).toBe('resolved')
+    expect(memberOf(model, 'alpha', 'review').effectiveName).toBe('alpha-review')
+    expect(memberOf(model, 'beta', 'review').effectiveName).toBe('review')
+  })
+
+  test('omitting every claimant is a legal resolution', () => {
+    const request = requestFor(TWO_WAY)
+    let draft = createDraft(request)
+    for (const member of evaluateDraft(request, draft).groups[0]?.members ?? []) {
+      draft = reviseDraft(request, draft, member, { kind: 'omitted' })
+    }
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(true)
+    expect(memberOf(model, 'alpha', 'review').effectiveName).toBeNull()
+    expect(memberOf(model, 'beta', 'review').effectiveName).toBeNull()
+  })
+
+  test('aliasing both claimants apart is accepted', () => {
+    const request = requestFor(TWO_WAY)
+    let draft = createDraft(request)
+    const model0 = evaluateDraft(request, draft)
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'a-review' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'beta', 'review'), { kind: 'aliased', as: 'b-review' })
+
+    expect(evaluateDraft(request, draft).confirmable).toBe(true)
+  })
+
+  test('two claimants aliased to the same name still collide', () => {
+    const request = requestFor(TWO_WAY)
+    let draft = createDraft(request)
+    const model0 = evaluateDraft(request, draft)
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'shared' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'beta', 'review'), { kind: 'aliased', as: 'shared' })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(false)
+    expect(statusOf(model, 'alpha', 'review')).toBe('draft-conflict')
+    expect(statusOf(model, 'beta', 'review')).toBe('draft-conflict')
+  })
+
+  test('Keep removes the override instead of recording an explicit authored arm', () => {
+    const request = requestFor(TWO_WAY)
+    let draft = createDraft(request)
+    const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
+
+    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    expect(draft.overrides.alpha).toBeDefined()
+
+    draft = reviseDraft(request, draft, alpha, { kind: 'authored' })
+    // The project schema rejects an explicit `authored` override, so the
+    // only correct spelling of "use the authored name" is absence.
+    expect(draft.overrides.alpha).toBeUndefined()
+  })
+})
+
+describe('collision draft — conflicts the user creates', () => {
+  const THREE = [skill('alpha', 'review'), skill('beta', 'review'), skill('gamma', 'audit')]
+
+  test('aliasing onto an uninvolved asset pulls that asset into the workspace', () => {
+    const request = requestFor(THREE)
+    let draft = createDraft(request)
+    const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
+
+    // `gamma/audit` was never colliding and is not in the initial report.
+    expect(request.groups.flatMap((g) => g.members).some((m) => m.facet === 'gamma')).toBe(false)
+
+    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'audit' })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(false)
+    // Reachable, and reachable from the same group — the user can fix
+    // either side without hunting for the other one.
+    expect(statusOf(model, 'gamma', 'audit')).toBe('draft-conflict')
+    expect(statusOf(model, 'alpha', 'review')).toBe('draft-conflict')
+    const group = model.groups.find((g) => g.members.some((m) => m.facet === 'gamma'))
+    expect(group?.members.map((m) => m.facet).sort()).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  test('a resolved claimant becomes conflicting when a later edit targets its name', () => {
+    const request = requestFor(THREE)
+    let draft = createDraft(request)
+    const model0 = evaluateDraft(request, draft)
+
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'alpha-review' })
+    const model1 = evaluateDraft(request, draft)
+    expect(statusOf(model1, 'beta', 'review')).toBe('resolved')
+
+    draft = reviseDraft(request, draft, memberOf(model1, 'alpha', 'review'), { kind: 'aliased', as: 'review' })
+    const model2 = evaluateDraft(request, draft)
+    expect(statusOf(model2, 'alpha', 'review')).toBe('draft-conflict')
+    expect(statusOf(model2, 'beta', 'review')).toBe('draft-conflict')
+  })
+
+  test('a claimant dragged in by an alias stays visible after the alias is withdrawn', () => {
+    const request = requestFor(THREE)
+    let draft = createDraft(request)
+    const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
+
+    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'audit' })
+    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    const model = evaluateDraft(request, draft)
+
+    // If `gamma` vanished here, the list would reflow under the cursor
+    // the moment a user corrected a typo.
+    expect(statusOf(model, 'gamma', 'audit')).toBe('resolved')
+    expect(model.confirmable).toBe(true)
+  })
+
+  test('two assets may exchange effective names', () => {
+    const request = requestFor([skill('alpha', 'one', 'two'), skill('beta', 'one')])
+    let draft = createDraft(request)
+
+    // Point alpha's `one` at `two`. That drags alpha's own `two` in.
+    draft = reviseDraft(request, draft, memberOf(evaluateDraft(request, draft), 'alpha', 'one'), {
+      kind: 'aliased',
+      as: 'two',
+    })
+    // Now send `two` the other way. Mid-swap the set is still colliding,
+    // which is exactly the state the workspace has to tolerate.
+    draft = reviseDraft(request, draft, memberOf(evaluateDraft(request, draft), 'alpha', 'two'), {
+      kind: 'aliased',
+      as: 'one',
+    })
+    expect(evaluateDraft(request, draft).confirmable).toBe(false)
+
+    // Free the name beta was holding, and the swap lands.
+    draft = reviseDraft(request, draft, memberOf(evaluateDraft(request, draft), 'beta', 'one'), {
+      kind: 'aliased',
+      as: 'beta-one',
+    })
+
+    const model = evaluateDraft(request, draft)
+    expect(model.confirmable).toBe(true)
+    expect(memberOf(model, 'alpha', 'one').effectiveName).toBe('two')
+    expect(memberOf(model, 'alpha', 'two').effectiveName).toBe('one')
+  })
+})
+
+describe('collision draft — grouping', () => {
+  test('separate collisions stay separate groups', () => {
+    const request = requestFor([skill('alpha', 'review', 'deploy'), skill('beta', 'review', 'deploy')])
+    const model = evaluateDraft(request, createDraft(request))
+
+    expect(model.groups).toHaveLength(2)
+    expect(model.groups.map((g) => g.origin)).toEqual(['deploy', 'review'])
+  })
+
+  test('merging two collisions with one alias produces one decision surface', () => {
+    const request = requestFor([skill('alpha', 'review', 'deploy'), skill('beta', 'review', 'deploy')])
+    let draft = createDraft(request)
+    const model0 = evaluateDraft(request, draft)
+
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'deploy' })
+    const model = evaluateDraft(request, draft)
+
+    // Three assets now want `deploy`. Splitting them across two screens
+    // would hide part of the problem from whoever is solving it.
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.members).toHaveLength(4)
+  })
+})
+
+describe('alias validation', () => {
+  test('accepts a legal single-segment name', () => {
+    expect(validateAlias('vendor-review')).toBeNull()
+  })
+
+  test.each([
+    ['Review', 'uppercase'],
+    ['review/code', 'a slash'],
+    ['-review', 'a leading dash'],
+    ['', 'empty'],
+  ])('rejects %s (%s) with a reason', (value) => {
+    expect(validateAlias(value)).not.toBeNull()
+  })
+
+  test('reports the published reason rather than a local paraphrase', () => {
+    // The message a user reads while typing must be the message the
+    // engine would have produced for the same string. Asserting they are
+    // equal is what stops the UI from growing its own friendlier — and
+    // eventually divergent — description of the grammar.
+    const planned = planMaterialization([
+      {
+        facet: 'alpha',
+        assets: [{ scope: 'project', type: 'skill', name: 'review' }],
+        overrides: { skills: { review: { kind: 'aliased', as: 'Review' } } },
+      },
+    ])
+    if (planned.ok || planned.reason !== 'invalid-alias') expect.unreachable()
+
+    expect(validateAlias('Review')).toBe(planned.problems[0]?.reason ?? '')
+  })
+})

--- a/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
+++ b/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'bun:test'
+import type { CollisionResolution, CollisionResolutionRequest } from '@agent-facets/engine'
+import type { FacetContribution } from '@agent-facets/protocol'
+import { planMaterialization } from '@agent-facets/protocol'
+import { render } from 'ink-testing-library'
+import { createElement } from 'react'
+import { CollisionWorkspace } from '../workspace.tsx'
+
+const KEY = {
+  up: '\u001B[A',
+  down: '\u001B[B',
+  right: '\u001B[C',
+  left: '\u001B[D',
+  enter: '\r',
+  escape: '\u001B',
+  ctrlC: '\u0003',
+} as const
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+function skill(facet: string, ...names: string[]): FacetContribution {
+  return { facet, assets: names.map((name) => ({ scope: 'project', type: 'skill', name })) }
+}
+
+function requestFor(contributions: FacetContribution[]): CollisionResolutionRequest {
+  const planned = planMaterialization(contributions)
+  if (planned.ok) expect.unreachable()
+  if (planned.reason !== 'collision') expect.unreachable()
+  return { groups: planned.groups, contributions, staleOverrides: planned.staleOverrides }
+}
+
+function mount(contributions: FacetContribution[]) {
+  const resolutions: CollisionResolution[] = []
+  const request = requestFor(contributions)
+  const app = render(
+    createElement(CollisionWorkspace, {
+      request,
+      onComplete: (resolution: CollisionResolution) => resolutions.push(resolution),
+    }),
+  )
+  return { app, resolutions, request }
+}
+
+async function press(app: ReturnType<typeof render>, ...keys: string[]): Promise<void> {
+  for (const key of keys) {
+    app.stdin.write(key)
+    await nextTick()
+  }
+}
+
+const TWO_WAY = [skill('alpha', 'review'), skill('beta', 'review')]
+
+describe('CollisionWorkspace — overview', () => {
+  test('shows every group, every claimant, and that nothing is written yet', async () => {
+    const { app } = mount([skill('alpha', 'review', 'deploy'), skill('beta', 'review', 'deploy')])
+    await nextTick()
+
+    const frame = app.lastFrame() ?? ''
+    expect(frame).toContain('review')
+    expect(frame).toContain('deploy')
+    expect(frame).toContain('alpha')
+    expect(frame).toContain('beta')
+    expect(frame).toContain('nothing has been written yet')
+    app.unmount()
+  })
+
+  test('confirm is refused while any group is unresolved', async () => {
+    const { app, resolutions } = mount(TWO_WAY)
+    await nextTick()
+
+    expect(app.lastFrame() ?? '').toContain('resolve every group first')
+
+    // Walk to the confirm row and press it anyway.
+    await press(app, KEY.down, KEY.enter)
+    expect(resolutions).toHaveLength(0)
+    app.unmount()
+  })
+
+  test('escape cancels without submitting a draft', async () => {
+    const { app, resolutions } = mount(TWO_WAY)
+    await nextTick()
+    await press(app, KEY.escape)
+
+    expect(resolutions).toEqual([{ kind: 'cancelled' }])
+    app.unmount()
+  })
+
+  test('ctrl-c cancels', async () => {
+    // Ink's own ctrl-C handling is disabled by the commands precisely so
+    // this path runs: it is the only one that settles the engine's
+    // pending promise and lets it release the project lock.
+    const { app, resolutions } = mount(TWO_WAY)
+    await nextTick()
+    await press(app, KEY.ctrlC)
+
+    expect(resolutions).toEqual([{ kind: 'cancelled' }])
+    app.unmount()
+  })
+})
+
+describe('CollisionWorkspace — resolving a group', () => {
+  test('omitting every claimant resolves the group and confirms', async () => {
+    const { app, resolutions } = mount(TWO_WAY)
+    await nextTick()
+
+    // Open the group, then put both claimants on Omit. Arrows only
+    // move the cursor; Enter applies.
+    await press(app, KEY.enter, KEY.right, KEY.right, KEY.enter, KEY.down, KEY.right, KEY.right, KEY.enter)
+    expect(app.lastFrame() ?? '').toContain('not materialized')
+
+    // Back to the overview, onto the confirm row, submit.
+    await press(app, KEY.escape, KEY.down, KEY.enter)
+
+    expect(resolutions).toHaveLength(1)
+    const resolution = resolutions[0]
+    if (resolution?.kind !== 'resolved') expect.unreachable()
+    expect(resolution.overrides.alpha).toEqual({ skills: { review: { kind: 'omitted' } } })
+    expect(resolution.overrides.beta).toEqual({ skills: { review: { kind: 'omitted' } } })
+    app.unmount()
+  })
+
+  test('choosing Alias opens an editor without committing a choice yet', async () => {
+    const { app } = mount(TWO_WAY)
+    await nextTick()
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+
+    // An alias is not a decision until it has a name, so nothing is
+    // recorded until the editor is submitted.
+    expect(app.lastFrame() ?? '').toContain('Enter')
+    expect(app.lastFrame() ?? '').toContain('apply')
+    app.unmount()
+  })
+
+  test('an invalid alias explains itself and refuses to apply', async () => {
+    const { app, resolutions } = mount(TWO_WAY)
+    await nextTick()
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+
+    // Clear the seeded value and type something illegal.
+    await press(app, ...'\u007f'.repeat(10).split(''), 'R')
+    const frame = app.lastFrame() ?? ''
+    expect(frame.toLowerCase()).toContain('lowercase')
+
+    // Enter is inert while invalid.
+    await press(app, KEY.enter)
+    expect(app.lastFrame() ?? '').toContain('lowercase')
+    expect(resolutions).toHaveLength(0)
+    app.unmount()
+  })
+
+  test('a valid alias resolves the group and can be confirmed', async () => {
+    const { app, resolutions } = mount(TWO_WAY)
+    await nextTick()
+
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+    await press(app, ...'\u007f'.repeat(10).split(''))
+    await press(app, ...'vendor-review'.split(''))
+    await press(app, KEY.enter)
+
+    expect(app.lastFrame() ?? '').toContain('vendor-review')
+
+    await press(app, KEY.escape, KEY.down, KEY.enter)
+
+    const resolution = resolutions[0]
+    if (resolution?.kind !== 'resolved') expect.unreachable()
+    expect(resolution.overrides.alpha).toEqual({ skills: { review: { kind: 'aliased', as: 'vendor-review' } } })
+    // The untouched claimant keeps its authored name, recorded by absence.
+    expect(resolution.overrides.beta).toBeUndefined()
+    app.unmount()
+  })
+
+  test('escape abandons an alias edit without changing the choice', async () => {
+    const { app } = mount(TWO_WAY)
+    await nextTick()
+
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+    await press(app, ...'zzz'.split(''))
+    await press(app, KEY.escape)
+
+    const frame = app.lastFrame() ?? ''
+    expect(frame).not.toContain('zzz')
+    // Still the group view, still on Keep.
+    expect(frame).toContain('(Keep)')
+    app.unmount()
+  })
+})
+
+describe('CollisionWorkspace — conflicts the user creates', () => {
+  test('aliasing onto another asset marks both sides and keeps confirm shut', async () => {
+    const { app, resolutions } = mount([skill('alpha', 'review'), skill('beta', 'review'), skill('gamma', 'audit')])
+    await nextTick()
+
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+    await press(app, ...'\u007f'.repeat(10).split(''))
+    await press(app, ...'audit'.split(''))
+    await press(app, KEY.enter)
+
+    const frame = app.lastFrame() ?? ''
+    // The dragged-in asset is now on screen, in the same group, so the
+    // user can fix either side without hunting for the other.
+    expect(frame).toContain('gamma')
+    expect(frame).toContain('conflict')
+    expect(frame).toContain('still contested with')
+
+    await press(app, KEY.escape, KEY.down, KEY.enter)
+    expect(resolutions).toHaveLength(0)
+    app.unmount()
+  })
+})

--- a/packages/cli/src/tui/views/install/collision/alias-input.tsx
+++ b/packages/cli/src/tui/views/install/collision/alias-input.tsx
@@ -1,0 +1,62 @@
+import { Box, Text, useInput } from 'ink'
+import TextInput from 'ink-text-input'
+import { THEME } from '../../../theme.ts'
+import { validateAlias } from './draft.ts'
+
+/**
+ * The alias editor for one claimant.
+ *
+ * Validation runs on every keystroke rather than on Enter. The spec
+ * requires the reason to be visible while the alias is invalid, and
+ * on-commit validation cannot do that — the user would type a name,
+ * press Enter, and only then learn that capitals are illegal.
+ *
+ * It calls the same published validator the planner uses, so the message
+ * shown here is the message the engine would produce. A second,
+ * friendlier copy of the grammar would be a second source of truth and
+ * would eventually disagree.
+ */
+export function AliasInput({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+}: {
+  value: string
+  onChange: (value: string) => void
+  onSubmit: (alias: string) => void
+  onCancel: () => void
+}) {
+  const error = value.length === 0 ? 'an alias cannot be empty' : validateAlias(value)
+
+  useInput((_input, key) => {
+    if (key.return) {
+      // Enter is inert while invalid: refusing here is what stops an
+      // unusable name from reaching the draft at all, which is why the
+      // draft never has to represent one.
+      if (error === null) onSubmit(value)
+      return
+    }
+    if (key.escape) onCancel()
+  })
+
+  return (
+    <Box flexDirection="column">
+      <Box gap={1}>
+        <Text color={THEME.focus}>{'   >'}</Text>
+        <TextInput value={value} onChange={onChange} focus />
+      </Box>
+      {error === null ? (
+        <Text color={THEME.hint}>
+          {'     '}
+          <Text color={THEME.keyword}>Enter</Text> apply · <Text color={THEME.keyword}>Esc</Text> cancel
+        </Text>
+      ) : (
+        <Text color={THEME.warning}>
+          {'     '}
+          {error}
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/packages/cli/src/tui/views/install/collision/claimant-row.tsx
+++ b/packages/cli/src/tui/views/install/collision/claimant-row.tsx
@@ -1,0 +1,115 @@
+import { Box, Text } from 'ink'
+import { THEME } from '../../../theme.ts'
+import { COLLISION_STATUS } from '../collision-status.ts'
+import { AliasInput } from './alias-input.tsx'
+import type { ClaimantModel } from './draft.ts'
+
+/**
+ * The three resolutions, in the order they appear on screen.
+ *
+ * Ordered Keep → Alias → Omit deliberately: least to most destructive,
+ * so arrowing rightwards never skips past a milder option, and the
+ * default (Keep) sits where the cursor starts.
+ */
+export const CHOICES = ['keep', 'alias', 'omit'] as const
+export type ChoiceKind = (typeof CHOICES)[number]
+
+const CHOICE_LABELS: Record<ChoiceKind, string> = {
+  keep: 'Keep',
+  alias: 'Alias',
+  omit: 'Omit',
+}
+
+/** Which control a claimant's current disposition corresponds to. */
+export function choiceOf(claimant: ClaimantModel): ChoiceKind {
+  switch (claimant.disposition.kind) {
+    case 'authored':
+      return 'keep'
+    case 'aliased':
+      return 'alias'
+    case 'omitted':
+      return 'omit'
+  }
+}
+
+export function StatusTag({ claimant }: { claimant: ClaimantModel }) {
+  const presentation = COLLISION_STATUS[claimant.status]
+  return (
+    <Text color={presentation.color}>
+      {presentation.icon} {presentation.label}
+    </Text>
+  )
+}
+
+/** How this claimant's asset will land on disk, in one phrase. */
+function outcomeOf(claimant: ClaimantModel): string {
+  if (claimant.effectiveName === null) return 'not materialized'
+  if (claimant.effectiveName === claimant.authoredName) return claimant.authoredName
+  return `${claimant.authoredName} → ${claimant.effectiveName}`
+}
+
+export function ClaimantRow({
+  claimant,
+  focused,
+  highlight,
+  editing,
+  aliasValue,
+  onAliasChange,
+  onAliasSubmit,
+  onAliasCancel,
+}: {
+  claimant: ClaimantModel
+  focused: boolean
+  /**
+   * The option the arrow keys are currently sitting on, for the focused
+   * row only. Separate from the applied choice because moving across the
+   * options must not change anything: landing on Alias would otherwise
+   * open the editor, and the editor would swallow the next arrow key —
+   * making Omit unreachable from Keep.
+   */
+  highlight: ChoiceKind | null
+  editing: boolean
+  aliasValue: string
+  onAliasChange: (value: string) => void
+  onAliasSubmit: (alias: string) => void
+  onAliasCancel: () => void
+}) {
+  const applied = choiceOf(claimant)
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text color={focused ? THEME.focus : THEME.hint}>{focused ? '▸ ' : '  '}</Text>
+        <Text bold>{claimant.facet}</Text>
+        <Text color={THEME.hint}>
+          {' '}
+          {claimant.scope} {claimant.type} {claimant.authoredName}
+        </Text>
+      </Text>
+
+      <Box marginLeft={4} gap={1}>
+        {CHOICES.map((choice) => (
+          <Text
+            key={choice}
+            color={choice === highlight ? THEME.focus : choice === applied ? THEME.success : THEME.hint}
+            bold={choice === applied || choice === highlight}
+            dimColor={choice !== applied && choice !== highlight}
+          >
+            {choice === applied ? `(${CHOICE_LABELS[choice]})` : ` ${CHOICE_LABELS[choice]} `}
+          </Text>
+        ))}
+        <StatusTag claimant={claimant} />
+      </Box>
+
+      {editing ? (
+        <AliasInput value={aliasValue} onChange={onAliasChange} onSubmit={onAliasSubmit} onCancel={onAliasCancel} />
+      ) : (
+        <Text color={THEME.hint}>
+          {'    '}
+          {outcomeOf(claimant)}
+          {claimant.aliasError !== null && <Text color={THEME.warning}> · {claimant.aliasError}</Text>}
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/packages/cli/src/tui/views/install/collision/draft.ts
+++ b/packages/cli/src/tui/views/install/collision/draft.ts
@@ -1,0 +1,469 @@
+import type { AssetType, Scope } from '@agent-facets/common'
+import type { CollisionResolutionRequest } from '@agent-facets/engine'
+import type {
+  CollisionGroup,
+  FacetMaterializationOverrides,
+  MaterializationDisposition,
+  StaleOverride,
+} from '@agent-facets/protocol'
+import {
+  isMaterialized,
+  materializedNameOf,
+  overrideGroupKey,
+  planMaterialization,
+  validateAssetNameSegment,
+} from '@agent-facets/protocol'
+import type { CollisionStatus } from '../collision-status.ts'
+
+/**
+ * The collision workspace's state, and the pure rule that turns it into
+ * something renderable.
+ *
+ * Two properties drive the whole design:
+ *
+ *  1. **There is exactly one draft, and it is the same shape the engine
+ *     consumes.** The draft IS a `Record<facet, overrides>` — the same
+ *     durable project intent a user could have typed into `facets.json`.
+ *     There is no parallel "UI choice" model to keep in sync, so the
+ *     thing shown and the thing submitted cannot disagree.
+ *
+ *  2. **Collision truth comes from the protocol planner, always.** This
+ *     module never decides what collides. It arranges the planner's
+ *     answer for display. That is what keeps the live preview and the
+ *     engine's final validation from ever disagreeing — a disagreement
+ *     would show a green confirm button that then fails the install.
+ */
+
+/** One asset a facet contributes, addressed by its authored identity. */
+export interface ClaimantRef {
+  facet: string
+  scope: Scope
+  type: AssetType
+  authoredName: string
+}
+
+/**
+ * Stable identity for a claimant. NUL-joined because it cannot occur in a
+ * facet name, an asset name, or a scope, so no combination of legal
+ * values can forge another claimant's key.
+ */
+export function claimantKey(ref: ClaimantRef): string {
+  return `${ref.facet}\u0000${ref.scope}\u0000${ref.type}\u0000${ref.authoredName}`
+}
+
+export interface CollisionDraft {
+  /**
+   * Complete project intent. Handed to the engine verbatim, so facets and
+   * assets the workspace never displays keep the overrides they arrived
+   * with.
+   */
+  readonly overrides: Readonly<Record<string, FacetMaterializationOverrides>>
+  /**
+   * Claimants the user changed in this session. Purely presentational:
+   * it separates "this collided when you got here" (unresolved) from
+   * "your edits caused this" (draft conflict). It is never submitted.
+   */
+  readonly edited: ReadonlySet<string>
+  /**
+   * Every claimant ever surfaced, so the workspace only ever grows.
+   *
+   * Without this, un-doing an alias would delete the row the user was
+   * standing on — the list would reflow under the cursor mid-edit.
+   */
+  readonly claimants: ReadonlyMap<string, ClaimantRef>
+}
+
+/** A claimant as displayed: its current choice, name, and standing. */
+export interface ClaimantModel extends ClaimantRef {
+  key: string
+  disposition: MaterializationDisposition
+  /** Empty when omitted — there is no effective name to show. */
+  effectiveName: string | null
+  status: CollisionStatus
+  /** Other claimants contesting this name right now, for navigation. */
+  conflictsWith: readonly string[]
+  /** Why the current alias is not a legal asset name, if it isn't. */
+  aliasError: string | null
+}
+
+export interface DisplayGroup {
+  key: string
+  /** The name(s) that first brought these claimants together. */
+  origin: string
+  /** Names contested right now. Empty once the group is resolved. */
+  contested: readonly string[]
+  status: CollisionStatus
+  members: readonly ClaimantModel[]
+}
+
+export interface WorkspaceModel {
+  groups: readonly DisplayGroup[]
+  /**
+   * Whether the complete draft plans cleanly. This is the planner's
+   * verdict, not a count of green rows: the confirm gate and the engine's
+   * final check then answer the same question the same way.
+   */
+  confirmable: boolean
+  staleOverrides: readonly StaleOverride[]
+}
+
+/** Seed a draft from the overrides the project already has. */
+export function createDraft(request: CollisionResolutionRequest): CollisionDraft {
+  const overrides: Record<string, FacetMaterializationOverrides> = {}
+  for (const contribution of request.contributions) {
+    if (contribution.overrides !== undefined) overrides[contribution.facet] = contribution.overrides
+  }
+  return {
+    overrides,
+    edited: new Set(),
+    claimants: claimantsOf(request.groups),
+  }
+}
+
+/**
+ * Record one Keep / Alias / Omit choice.
+ *
+ * Keep DELETES the override rather than writing `{ kind: 'authored' }`.
+ * Absence already means "use the authored name", and the project schema
+ * rejects an explicit `authored` override precisely so the same state
+ * cannot be spelled two ways.
+ */
+export function reviseDraft(
+  request: CollisionResolutionRequest,
+  draft: CollisionDraft,
+  ref: ClaimantRef,
+  disposition: MaterializationDisposition,
+): CollisionDraft {
+  const overrides = withOverride(draft.overrides, ref, disposition)
+  const edited = new Set(draft.edited)
+  edited.add(claimantKey(ref))
+
+  // An alias can pull in an asset that was never colliding. Surface it
+  // immediately: the user has to be able to reach the other side of a
+  // conflict they just created.
+  const claimants = new Map(draft.claimants)
+  const planned = planMaterialization(contributionsWith(request, overrides))
+  if (!planned.ok && planned.reason === 'collision') {
+    for (const [key, value] of claimantsOf(planned.groups)) {
+      if (!claimants.has(key)) claimants.set(key, value)
+    }
+  }
+
+  return { overrides, edited, claimants }
+}
+
+/** Arrange the planner's current verdict for display. */
+export function evaluateDraft(request: CollisionResolutionRequest, draft: CollisionDraft): WorkspaceModel {
+  const planned = planMaterialization(contributionsWith(request, draft.overrides))
+
+  const currentGroups = !planned.ok && planned.reason === 'collision' ? planned.groups : []
+
+  // Defensive, not expected: the workspace commits an alias only after
+  // the same validator accepts it, and the engine rejects an unparseable
+  // persisted alias before ever opening a resolver. Kept so that a draft
+  // holding a bad alias explains itself instead of showing a green row
+  // beside a disabled confirm button.
+  const aliasErrors = new Map<string, string>()
+  if (!planned.ok && planned.reason === 'invalid-alias') {
+    for (const problem of planned.problems) {
+      const scope = scopeOf(request, problem.facet, problem.type, problem.authoredName)
+      if (scope === null) continue
+      aliasErrors.set(
+        claimantKey({ facet: problem.facet, scope, type: problem.type, authoredName: problem.authoredName }),
+        problem.reason,
+      )
+    }
+  }
+
+  // Which claimants are contesting a name right now, and with whom.
+  const conflictsWith = new Map<string, string[]>()
+  const contestedNameOf = new Map<string, string>()
+  for (const group of currentGroups) {
+    const keys = group.members.map((member) => claimantKey(member))
+    for (const key of keys) {
+      conflictsWith.set(
+        key,
+        keys.filter((other) => other !== key),
+      )
+      contestedNameOf.set(key, group.effectiveName)
+    }
+  }
+
+  const components = groupClaimants(request.groups, currentGroups, draft.claimants)
+
+  const groups: DisplayGroup[] = components.map((component) => {
+    const members = component.members
+      .map((ref) => modelFor(ref, draft, conflictsWith, aliasErrors))
+      .sort(compareClaimants)
+    const contested = unique(
+      members.flatMap((member) => {
+        const name = contestedNameOf.get(member.key)
+        return name === undefined ? [] : [name]
+      }),
+    )
+    return {
+      key: component.key,
+      origin: component.origin.join(', '),
+      contested,
+      status: worstStatus(members.map((member) => member.status)),
+      members,
+    }
+  })
+
+  return {
+    groups,
+    confirmable: planned.ok,
+    staleOverrides: planned.ok ? planned.staleOverrides : request.staleOverrides,
+  }
+}
+
+/** The value handed back to the engine. */
+export function draftOverrides(draft: CollisionDraft): Readonly<Record<string, FacetMaterializationOverrides>> {
+  return draft.overrides
+}
+
+/** The current choice for one claimant. */
+export function choiceFor(draft: CollisionDraft, ref: ClaimantRef): MaterializationDisposition {
+  return overrideFor(draft.overrides, ref) ?? { kind: 'authored' }
+}
+
+// ---------------------------------------------------------------------------
+// internals
+// ---------------------------------------------------------------------------
+
+function modelFor(
+  ref: ClaimantRef,
+  draft: CollisionDraft,
+  conflictsWith: ReadonlyMap<string, readonly string[]>,
+  aliasErrors: ReadonlyMap<string, string>,
+): ClaimantModel {
+  const key = claimantKey(ref)
+  const disposition = choiceFor(draft, ref)
+  const conflicts = conflictsWith.get(key) ?? []
+  const aliasError = aliasErrors.get(key) ?? null
+
+  return {
+    ...ref,
+    key,
+    disposition,
+    effectiveName: isMaterialized(disposition) ? materializedNameOf(ref.authoredName, disposition) : null,
+    status: statusFor({ key, conflicts, aliasError, draft, conflictsWith }),
+    conflictsWith: conflicts,
+    aliasError,
+  }
+}
+
+/**
+ * The three-state rule.
+ *
+ * The distinction that matters is between a collision the user inherited
+ * and one their own edits produced: the first says "you must decide
+ * something", the second says "your decision isn't finished". A group
+ * counts as edited if ANY of its claimants was touched — otherwise the
+ * asset someone else's alias landed on would stay red and read as an
+ * unrelated pre-existing problem.
+ */
+function statusFor(args: {
+  key: string
+  conflicts: readonly string[]
+  aliasError: string | null
+  draft: CollisionDraft
+  conflictsWith: ReadonlyMap<string, readonly string[]>
+}): CollisionStatus {
+  const { key, conflicts, aliasError, draft } = args
+  // An alias that isn't a legal name blocks confirmation, so it can never
+  // read as settled — even though the planner reports no group for it.
+  if (aliasError !== null) return 'unresolved'
+  if (conflicts.length === 0) return 'resolved'
+  const touched = [key, ...conflicts].some((member) => draft.edited.has(member))
+  return touched ? 'draft-conflict' : 'unresolved'
+}
+
+const STATUS_SEVERITY: Record<CollisionStatus, number> = {
+  unresolved: 2,
+  'draft-conflict': 1,
+  resolved: 0,
+}
+
+function worstStatus(statuses: readonly CollisionStatus[]): CollisionStatus {
+  let worst: CollisionStatus = 'resolved'
+  for (const status of statuses) {
+    if (STATUS_SEVERITY[status] > STATUS_SEVERITY[worst]) worst = status
+  }
+  return worst
+}
+
+/**
+ * Partition claimants into the groups the user works through.
+ *
+ * Membership is the transitive closure of "was originally grouped with"
+ * and "collides with right now". Union-find rather than a simple index by
+ * contested name, because both relations move: aliasing one claimant onto
+ * another group's name genuinely merges two problems into one decision,
+ * and the user has to see them together to solve either.
+ */
+function groupClaimants(
+  originalGroups: readonly CollisionGroup[],
+  currentGroups: readonly CollisionGroup[],
+  claimants: ReadonlyMap<string, ClaimantRef>,
+): ReadonlyArray<{ key: string; origin: string[]; members: ClaimantRef[] }> {
+  const parent = new Map<string, string>()
+  const find = (key: string): string => {
+    let root = key
+    while (parent.get(root) !== undefined && parent.get(root) !== root) root = parent.get(root) as string
+    return root
+  }
+  const union = (a: string, b: string): void => {
+    const rootA = find(a)
+    const rootB = find(b)
+    if (rootA !== rootB) parent.set(rootB, rootA)
+  }
+
+  for (const key of claimants.keys()) parent.set(key, key)
+
+  const originNames = new Map<string, Set<string>>()
+  for (const group of [...originalGroups, ...currentGroups]) {
+    const keys = group.members.map((member) => claimantKey(member))
+    const first = keys[0]
+    if (first === undefined) continue
+    for (const key of keys) {
+      if (!parent.has(key)) parent.set(key, key)
+      union(first, key)
+    }
+  }
+  for (const group of originalGroups) {
+    const first = group.members[0]
+    if (first === undefined) continue
+    const root = find(claimantKey(first))
+    const names = originNames.get(root) ?? new Set<string>()
+    names.add(group.effectiveName)
+    originNames.set(root, names)
+  }
+
+  const byRoot = new Map<string, ClaimantRef[]>()
+  for (const [key, ref] of claimants) {
+    const root = find(key)
+    const members = byRoot.get(root) ?? []
+    members.push(ref)
+    byRoot.set(root, members)
+  }
+
+  // Origin names were indexed before the final unions settled, so fold
+  // them onto the roots that actually survived.
+  const foldedOrigins = new Map<string, Set<string>>()
+  for (const [root, names] of originNames) {
+    const settled = find(root)
+    const target = foldedOrigins.get(settled) ?? new Set<string>()
+    for (const name of names) target.add(name)
+    foldedOrigins.set(settled, target)
+  }
+
+  return [...byRoot.entries()]
+    .map(([root, members]) => ({
+      key: root,
+      origin: [...(foldedOrigins.get(root) ?? new Set<string>())].sort(compareStrings),
+      members,
+    }))
+    .sort((a, b) => compareStrings(a.origin.join(', '), b.origin.join(', ')) || compareStrings(a.key, b.key))
+}
+
+function claimantsOf(groups: readonly CollisionGroup[]): Map<string, ClaimantRef> {
+  const claimants = new Map<string, ClaimantRef>()
+  for (const group of groups) {
+    for (const member of group.members) {
+      const ref: ClaimantRef = {
+        facet: member.facet,
+        scope: member.scope,
+        type: member.type,
+        authoredName: member.authoredName,
+      }
+      claimants.set(claimantKey(ref), ref)
+    }
+  }
+  return claimants
+}
+
+function contributionsWith(
+  request: CollisionResolutionRequest,
+  overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
+) {
+  return request.contributions.map((contribution) => ({
+    ...contribution,
+    overrides: overrides[contribution.facet],
+  }))
+}
+
+function overrideFor(
+  overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
+  ref: ClaimantRef,
+): MaterializationDisposition | undefined {
+  return overrides[ref.facet]?.[overrideGroupKey(ref.type)]?.[ref.authoredName]
+}
+
+function withOverride(
+  overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
+  ref: ClaimantRef,
+  disposition: MaterializationDisposition,
+): Record<string, FacetMaterializationOverrides> {
+  const group = overrideGroupKey(ref.type)
+  const next: Record<string, FacetMaterializationOverrides> = { ...overrides }
+  const facet: FacetMaterializationOverrides = { ...(next[ref.facet] ?? {}) }
+  const assets = { ...(facet[group] ?? {}) }
+
+  if (disposition.kind === 'authored') {
+    delete assets[ref.authoredName]
+  } else {
+    assets[ref.authoredName] = disposition
+  }
+
+  if (Object.keys(assets).length === 0) delete facet[group]
+  else facet[group] = assets
+
+  if (Object.keys(facet).length === 0) delete next[ref.facet]
+  else next[ref.facet] = facet
+
+  return next
+}
+
+/**
+ * Recover a claimant's scope from the authored contributions.
+ *
+ * `InvalidAlias` carries no scope — it is a complaint about a string, not
+ * about a placement — so the scope is looked up rather than assumed.
+ * Returns null instead of defaulting: silently guessing `project` would
+ * attach the error to a different claimant the day a second scope exists.
+ */
+function scopeOf(
+  request: CollisionResolutionRequest,
+  facet: string,
+  type: AssetType,
+  authoredName: string,
+): Scope | null {
+  for (const contribution of request.contributions) {
+    if (contribution.facet !== facet) continue
+    for (const asset of contribution.assets) {
+      if (asset.type === type && asset.name === authoredName) return asset.scope
+    }
+  }
+  return null
+}
+
+function compareClaimants(a: ClaimantModel, b: ClaimantModel): number {
+  return (
+    compareStrings(a.facet, b.facet) || compareStrings(a.type, b.type) || compareStrings(a.authoredName, b.authoredName)
+  )
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort(compareStrings)
+}
+
+/** Validate an alias exactly as the planner will. */
+export function validateAlias(value: string): string | null {
+  const result = validateAssetNameSegment(value)
+  return result.ok ? null : result.reason
+}

--- a/packages/cli/src/tui/views/install/collision/workspace.tsx
+++ b/packages/cli/src/tui/views/install/collision/workspace.tsx
@@ -1,0 +1,349 @@
+import type { CollisionResolution, CollisionResolutionRequest } from '@agent-facets/engine'
+import type { MaterializationDisposition } from '@agent-facets/protocol'
+import { Box, Text, useInput } from 'ink'
+import { useCallback, useMemo, useState } from 'react'
+import { THEME } from '../../../theme.ts'
+import { COLLISION_STATUS } from '../collision-status.ts'
+import { CHOICES, type ChoiceKind, ClaimantRow, choiceOf, StatusTag } from './claimant-row.tsx'
+import {
+  type ClaimantModel,
+  type CollisionDraft,
+  createDraft,
+  type DisplayGroup,
+  draftOverrides,
+  evaluateDraft,
+  reviseDraft,
+} from './draft.ts'
+
+/**
+ * The interactive collision workspace: an overview of every group, and a
+ * focused editor for one group at a time.
+ *
+ * Two decisions shape it.
+ *
+ * **One draft, always global.** Every edit re-plans the COMPLETE desired
+ * set, not just the group on screen. That is what lets a user alias onto
+ * a name nothing was fighting over, and see instantly that they have
+ * merely moved the conflict. A per-group model would have accepted that
+ * edit and failed at install time.
+ *
+ * **Temporary conflict is a legal state.** The user may leave a group
+ * yellow, walk to the other claimant, and fix it from that side instead.
+ * Refusing to record a conflicting choice would force people to solve
+ * conflicts in the one order the tool happened to prefer.
+ */
+export function CollisionWorkspace({
+  request,
+  onComplete,
+}: {
+  request: CollisionResolutionRequest
+  /** Settles the engine's pending resolver call. Called exactly once. */
+  onComplete: (resolution: CollisionResolution) => void
+}) {
+  const [draft, setDraft] = useState<CollisionDraft>(() => createDraft(request))
+  const [view, setView] = useState<View>({ kind: 'overview', index: 0 })
+  const [editing, setEditing] = useState<{ key: string; value: string } | null>(null)
+
+  const model = useMemo(() => evaluateDraft(request, draft), [request, draft])
+  const { groups, confirmable } = model
+
+  const activeGroup = view.kind === 'group' ? findGroup(groups, view.anchor) : null
+  // A group always has at least two members, but the index signature
+  // cannot say so; normalize to null so the narrowing below is real.
+  const focusedMember: ClaimantModel | null = activeGroup
+    ? (findMember(activeGroup, view) ?? activeGroup.members[0] ?? null)
+    : null
+
+  const revise = useCallback(
+    (claimant: ClaimantModel, disposition: MaterializationDisposition) => {
+      setDraft((current) => reviseDraft(request, current, claimant, disposition))
+    },
+    [request],
+  )
+
+  const openAlias = useCallback((claimant: ClaimantModel) => {
+    setEditing({
+      key: claimant.key,
+      // Seed from the current alias so a small correction is a small
+      // edit, and from the authored name otherwise so the user starts
+      // from the thing they are renaming.
+      value: claimant.disposition.kind === 'aliased' ? claimant.disposition.as : claimant.authoredName,
+    })
+  }, [])
+
+  const chooseFor = useCallback(
+    (claimant: ClaimantModel, choice: ChoiceKind) => {
+      switch (choice) {
+        case 'keep':
+          revise(claimant, { kind: 'authored' })
+          return
+        case 'omit':
+          revise(claimant, { kind: 'omitted' })
+          return
+        case 'alias':
+          // Deliberately does NOT write the draft yet: an alias is not a
+          // decision until it has a name, and committing the authored
+          // name as an "alias" would be a lie the lockfile would record.
+          openAlias(claimant)
+          return
+      }
+    },
+    [revise, openAlias],
+  )
+
+  useInput(
+    (input, key) => {
+      if (key.ctrl && input === 'c') {
+        onComplete({ kind: 'cancelled' })
+        return
+      }
+
+      if (view.kind === 'overview') {
+        const rows = groups.length + 1 // groups, then the confirm row
+        if (key.escape) {
+          onComplete({ kind: 'cancelled' })
+          return
+        }
+        if (key.downArrow || (key.tab && !key.shift)) {
+          setView({ kind: 'overview', index: Math.min(view.index + 1, rows - 1) })
+          return
+        }
+        if (key.upArrow || (key.tab && key.shift)) {
+          setView({ kind: 'overview', index: Math.max(view.index - 1, 0) })
+          return
+        }
+        if (key.return) {
+          const group = groups[view.index]
+          if (group !== undefined) {
+            const first = group.members[0]
+            if (first !== undefined) {
+              setView({ kind: 'group', anchor: first.key, focus: first.key, highlight: choiceOf(first) })
+            }
+            return
+          }
+          if (confirmable) onComplete({ kind: 'resolved', overrides: draftOverrides(draft) })
+        }
+        return
+      }
+
+      if (activeGroup === null || focusedMember === null) return
+
+      if (key.escape) {
+        setView({ kind: 'overview', index: indexOfGroup(groups, activeGroup) })
+        return
+      }
+      if (key.downArrow || (key.tab && !key.shift)) {
+        setView(moveFocus(view, activeGroup, 1))
+        return
+      }
+      if (key.upArrow || (key.tab && key.shift)) {
+        setView(moveFocus(view, activeGroup, -1))
+        return
+      }
+      if (key.leftArrow || key.rightArrow) {
+        // Move the cursor only. Applying on arrow would open the alias
+        // editor the instant the cursor passed over Alias, and the
+        // editor captures every subsequent key — so Omit, which sits
+        // beyond it, could never be reached.
+        const current = CHOICES.indexOf(view.highlight)
+        const next = CHOICES[clamp(current + (key.rightArrow ? 1 : -1), 0, CHOICES.length - 1)]
+        if (next !== undefined) setView({ ...view, highlight: next })
+        return
+      }
+      if (key.return) {
+        chooseFor(focusedMember, view.highlight)
+      }
+    },
+    { isActive: editing === null },
+  )
+
+  if (activeGroup !== null && focusedMember !== null) {
+    return (
+      <GroupView
+        group={activeGroup}
+        focused={focusedMember}
+        highlight={view.kind === 'group' ? view.highlight : choiceOf(focusedMember)}
+        editing={editing}
+        onAliasChange={(value) => setEditing((current) => (current === null ? null : { ...current, value }))}
+        onAliasSubmit={(alias) => {
+          revise(focusedMember, { kind: 'aliased', as: alias })
+          setEditing(null)
+        }}
+        onAliasCancel={() => setEditing(null)}
+      />
+    )
+  }
+
+  return <Overview model={model} index={view.kind === 'overview' ? view.index : 0} />
+}
+
+type View =
+  | { kind: 'overview'; index: number }
+  /**
+   * `anchor` selects the group by a claimant rather than a group id,
+   * because group identity is not stable: aliasing across groups merges
+   * two of them, and a merge would otherwise strand the user on a group
+   * that no longer exists. A claimant, once surfaced, never disappears.
+   */
+  | { kind: 'group'; anchor: string; focus: string; highlight: ChoiceKind }
+
+function Overview({ model, index }: { model: ReturnType<typeof evaluateDraft>; index: number }) {
+  const { groups, confirmable, staleOverrides } = model
+  const unresolved = groups.filter((group) => group.status !== 'resolved').length
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={THEME.brand}>
+        Installation is paused: two or more facets want the same name.
+      </Text>
+      <Text color={THEME.hint}>
+        {groups.length} group{groups.length === 1 ? '' : 's'} · {unresolved} still to resolve · nothing has been written
+        yet
+      </Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        {groups.map((group, groupIndex) => (
+          <Box key={group.key} flexDirection="column">
+            <Text>
+              <Text color={groupIndex === index ? THEME.focus : THEME.hint}>{groupIndex === index ? '▸ ' : '  '}</Text>
+              <StatusTagFor status={group.status} />
+              <Text bold> {group.contested.length > 0 ? group.contested.join(', ') : group.origin}</Text>
+              <Text color={THEME.hint}>
+                {' '}
+                ({group.members.length} asset{group.members.length === 1 ? '' : 's'})
+              </Text>
+            </Text>
+            {group.members.map((member) => (
+              <Text key={member.key} color={THEME.hint}>
+                {'      '}
+                {member.facet} {member.type} {member.authoredName}
+                {member.effectiveName === null ? ' — omitted' : ` → ${member.effectiveName}`}
+              </Text>
+            ))}
+          </Box>
+        ))}
+      </Box>
+
+      {staleOverrides.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          {staleOverrides.map((stale) => (
+            <Text key={`${stale.facet}:${stale.type}:${stale.authoredName}`} color={THEME.caution}>
+              ⚠ {stale.facet} has a leftover choice for {stale.type} {stale.authoredName}, which this version no longer
+              contains.
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      <Box marginTop={1}>
+        <Text color={index === model.groups.length ? THEME.focus : THEME.hint}>
+          {index === model.groups.length ? '▸ ' : '  '}
+        </Text>
+        <Text color={confirmable ? THEME.success : THEME.hint} bold={confirmable} dimColor={!confirmable}>
+          [ Confirm and continue installing ]
+        </Text>
+        {!confirmable && <Text color={THEME.hint}> — resolve every group first</Text>}
+      </Box>
+
+      <Text color={THEME.hint}>↑↓ move · Enter open · Esc cancel</Text>
+    </Box>
+  )
+}
+
+function GroupView({
+  group,
+  focused,
+  highlight,
+  editing,
+  onAliasChange,
+  onAliasSubmit,
+  onAliasCancel,
+}: {
+  group: DisplayGroup
+  focused: ClaimantModel
+  highlight: ChoiceKind
+  editing: { key: string; value: string } | null
+  onAliasChange: (value: string) => void
+  onAliasSubmit: (alias: string) => void
+  onAliasCancel: () => void
+}) {
+  return (
+    <Box flexDirection="column">
+      <Text bold color={THEME.brand}>
+        {group.contested.length > 0 ? group.contested.join(', ') : group.origin}
+      </Text>
+      <Text color={THEME.hint}>
+        {group.members.length} assets want this name. Give each one an outcome; they only have to differ from each
+        other.
+      </Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        {group.members.map((member) => (
+          <Box key={member.key} flexDirection="column" marginBottom={1}>
+            <ClaimantRow
+              claimant={member}
+              focused={member.key === focused.key}
+              highlight={member.key === focused.key ? highlight : null}
+              editing={editing !== null && editing.key === member.key}
+              aliasValue={editing !== null && editing.key === member.key ? editing.value : ''}
+              onAliasChange={onAliasChange}
+              onAliasSubmit={onAliasSubmit}
+              onAliasCancel={onAliasCancel}
+            />
+            {member.conflictsWith.length > 0 && (
+              <Text color={THEME.hint}>
+                {'    '}still contested with{' '}
+                {group.members
+                  .filter((other) => member.conflictsWith.includes(other.key))
+                  .map((other) => `${other.facet} ${other.authoredName}`)
+                  .join(', ')}
+              </Text>
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      <Text color={THEME.hint}>
+        {editing === null ? '↑↓ move · ←→ choose · Enter apply · Esc back' : 'type a name · Esc cancel'}
+      </Text>
+    </Box>
+  )
+}
+
+function StatusTagFor({ status }: { status: ClaimantModel['status'] }) {
+  const presentation = COLLISION_STATUS[status]
+  return (
+    <Text color={presentation.color}>
+      {presentation.icon} {presentation.label}
+    </Text>
+  )
+}
+
+function findGroup(groups: readonly DisplayGroup[], anchor: string): DisplayGroup | null {
+  return groups.find((group) => group.members.some((member) => member.key === anchor)) ?? null
+}
+
+function findMember(group: DisplayGroup, view: View): ClaimantModel | undefined {
+  if (view.kind !== 'group') return undefined
+  return group.members.find((member) => member.key === view.focus)
+}
+
+function indexOfGroup(groups: readonly DisplayGroup[], group: DisplayGroup): number {
+  const index = groups.findIndex((candidate) => candidate.key === group.key)
+  return index === -1 ? 0 : index
+}
+
+function moveFocus(view: View, group: DisplayGroup, delta: number): View {
+  if (view.kind !== 'group') return view
+  const current = group.members.findIndex((member) => member.key === view.focus)
+  const next = group.members[clamp(current + delta, 0, group.members.length - 1)]
+  // The cursor follows the row it lands on, so arrowing down and back up
+  // never silently re-points an option at a different claimant.
+  return next === undefined ? view : { kind: 'group', anchor: view.anchor, focus: next.key, highlight: choiceOf(next) }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+export { StatusTag }

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -2,6 +2,7 @@ import type { LockfileDriftEntry, RunInstallFailure } from '@agent-facets/engine
 import { Box, Text } from 'ink'
 import type React from 'react'
 import { describeCompatibilityFailure } from '../../../util/adapter-install-errors.ts'
+import { describeNamespace, manifestLocation } from '../../../util/collision-report.ts'
 import { THEME } from '../../theme.ts'
 
 /** How a materialization disposition reads in a one-line drift report. */
@@ -491,17 +492,28 @@ export function FailureBlock({ failure }: { failure: RunInstallFailure }): React
             <Box key={`${group.scope}:${group.namespace}:${group.effectiveName}`} flexDirection="column">
               <Text>
                 {' '}
-                {group.namespace} “{group.effectiveName}” is claimed by:
+                {describeNamespace(group.namespace, group.scope)} — “{group.effectiveName}” is claimed by:
               </Text>
               {group.members.map((member) => (
-                <Text key={`${member.facet}:${member.type}:${member.authoredName}`} color={THEME.hint}>
-                  {'   '}
-                  {member.facet} ({member.type} {member.authoredName})
-                </Text>
+                <Box key={`${member.facet}:${member.type}:${member.authoredName}`} flexDirection="column">
+                  <Text color={THEME.hint}>
+                    {'   '}
+                    {member.facet} ({member.type} {member.authoredName})
+                  </Text>
+                  {/* The exact edit site, derived from the published
+                      group mapping so it cannot drift from the schema. */}
+                  <Text color={THEME.hint}>
+                    {'     '}
+                    {manifestLocation(member.facet, member.type, member.authoredName)}
+                  </Text>
+                </Box>
               ))}
             </Box>
           ))}
-          <Text color={THEME.hint}> Nothing was changed. Record a choice per asset in facets.json, then re-run.</Text>
+          <Text color={THEME.hint}>
+            {' '}
+            Nothing was changed. Record an alias or omission per asset in facets.json, then re-run.
+          </Text>
         </Box>
       )
     case 'MATERIALIZATION_ALIAS_INVALID':

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -1,9 +1,20 @@
-import type { AddPrepareFailure, RemovePrepareFailure, RunInstallResult, StageEvent } from '@agent-facets/engine'
+import type { AssetType } from '@agent-facets/common'
+import type {
+  AddPrepareFailure,
+  CollisionResolution,
+  CollisionResolutionRequest,
+  CollisionResolver,
+  RemovePrepareFailure,
+  RunInstallResult,
+  StageEvent,
+} from '@agent-facets/engine'
+import { LOCKFILE_VERSION_0_3 } from '@agent-facets/protocol'
 import { Box, Text, useApp, useStderr } from 'ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ProgressBar } from '../../components/progress-bar.tsx'
 import { ASSET_TYPE_COLORS, THEME } from '../../theme.ts'
 import { AddPrepareFailureBlock } from './add-prepare-failure-block.tsx'
+import { CollisionWorkspace } from './collision/workspace.tsx'
 import { type FacetState, STAGE_LABELS } from './facet-row.tsx'
 import { FailureBlock } from './failure-block.tsx'
 import { RemovePrepareFailureBlock } from './remove-prepare-failure-block.tsx'
@@ -23,14 +34,25 @@ export type InstallViewResult =
 
 export interface InstallViewProps {
   /**
-   * Driver: caller supplies `runInstall`-equivalent closure that takes
-   * an `onStage` callback and an optional `onLog` callback, and returns
-   * the result. The view runs it once on mount and surfaces its events /
-   * outcome. When verbose output is enabled, the caller should thread
-   * `onLog` into the engine call; the view routes it through Ink's
-   * stderr writer so it doesn't race the progress bar repaint.
+   * Driver: caller supplies a `runInstall`-equivalent closure that takes
+   * an `onStage` callback, an optional `onLog` callback, and a collision
+   * resolver, and returns the result. The view runs it once on mount and
+   * surfaces its events / outcome. When verbose output is enabled, the
+   * caller should thread `onLog` into the engine call; the view routes it
+   * through Ink's stderr writer so it doesn't race the progress bar
+   * repaint.
+   *
+   * The resolver is OFFERED, not imposed. The view can always drive a
+   * workspace — it owns the mount — but only the command knows whether
+   * this invocation may prompt at all (an interactive terminal, and not
+   * frozen mode). So the command decides whether to forward it to the
+   * engine; a resolver that is never passed on is simply never called.
    */
-  run: (onStage: (event: StageEvent) => void, onLog?: (build: () => string) => void) => Promise<InstallViewResult>
+  run: (
+    onStage: (event: StageEvent) => void,
+    onLog: ((build: () => string) => void) | undefined,
+    resolveCollisions: CollisionResolver,
+  ) => Promise<InstallViewResult>
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
    * renders "Installing facets..."; `'remove'` renders "Removing
@@ -42,6 +64,13 @@ export interface InstallViewProps {
    * the caller capture the result for exit-code mapping.
    */
   onComplete?: (result: InstallViewResult) => void
+  /**
+   * The command's interrupt signal. Watched only to settle a pending
+   * collision prompt: an interrupt raised while the engine is blocked on
+   * the resolver would otherwise leave the promise unsettled forever,
+   * holding the project lock with nothing left to release it.
+   */
+  signal?: AbortSignal
 }
 
 /** Type guard: a driver result that is an add prepare-phase failure. */
@@ -73,7 +102,36 @@ interface DriftRemoval {
   oldVersion: string
 }
 
-export function InstallView({ run, mode, onComplete }: InstallViewProps) {
+/** A materialization choice dropped because its asset no longer exists. */
+interface PrunedOverride {
+  facet: string
+  assetType: AssetType
+  authoredName: string
+}
+
+/**
+ * What the single Ink mount is currently showing.
+ *
+ * Tagged rather than a set of booleans because the resolution phase
+ * carries data nothing else does — the request being answered and the
+ * function that answers it — and those must not be reachable while the
+ * view is drawing progress or a result. Before this, "am I finished?"
+ * was `result === null` and "what do I tell Ink?" was a second
+ * `exitState`; the two could disagree.
+ */
+type ViewPhase =
+  | { kind: 'progress' }
+  | {
+      kind: 'resolution'
+      request: CollisionResolutionRequest
+      /** Settles the engine's pending call. Idempotent. */
+      settle: (resolution: CollisionResolution) => void
+    }
+  | { kind: 'result'; result: InstallViewResult }
+  /** The driver threw rather than returning a structured failure. */
+  | { kind: 'crashed'; error: Error }
+
+export function InstallView({ run, mode, onComplete, signal }: InstallViewProps) {
   const { exit } = useApp()
   const { write: writeToStderr } = useStderr()
   const [totalFacets, setTotalFacets] = useState(0)
@@ -83,18 +141,33 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   const [_driftRemovals, setDriftRemovals] = useState<DriftRemoval[]>([])
   /** Per-facet adapter completions: facetName → list of adapter names done. */
   const [adaptersByFacet, setAdaptersByFacet] = useState<Record<string, string[]>>({})
-  const [result, setResult] = useState<InstallViewResult | null>(null)
+  const [phase, setPhase] = useState<ViewPhase>({ kind: 'progress' })
+  const [checkingCollisions, setCheckingCollisions] = useState(false)
+  const [prunedOverrides, setPrunedOverrides] = useState<PrunedOverride[]>([])
   const [elapsedMs, setElapsedMs] = useState(0)
-  const [exitState, setExitState] = useState<
-    { kind: 'idle' } | { kind: 'success' } | { kind: 'failure'; error: Error }
-  >({ kind: 'idle' })
   const startedRef = useRef(false)
   const startTimeRef = useRef(Date.now())
+
+  const result = phase.kind === 'result' ? phase.result : null
 
   const onStage = useCallback((event: StageEvent) => {
     switch (event.kind) {
       case 'install-start':
         setTotalFacets(event.totalFacets)
+        return
+      case 'collision-check':
+        // Composition happens between the last fetch and the first write.
+        // On a large project it is the one step with no per-facet event,
+        // so without this it reads as a stall.
+        setCheckingCollisions(true)
+        return
+      case 'stale-override-pruned':
+        // A silent change to what `facets.json` says. It has to be
+        // visible without `--verbose`, so it is state, not a log line.
+        setPrunedOverrides((prev) => [
+          ...prev,
+          { facet: event.facet, assetType: event.assetType, authoredName: event.authoredName },
+        ])
         return
       case 'facet-start':
         setFacetOrder((prev) => (prev.includes(event.facet) ? prev : [...prev, event.facet]))
@@ -110,6 +183,7 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
         }))
         return
       case 'facet-stage':
+        setCheckingCollisions(false)
         setFacets((prev) => {
           const existing = prev[event.facet]
           if (!existing) return prev
@@ -159,11 +233,17 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
       case 'asset-deleted':
       case 'lockfile-write':
       case 'receipt-invalid-asset':
-      case 'collision-check':
       case 'install-complete':
         // No per-event UI for these; the final result render (or the
         // verbose log, for rejected receipt entries) covers them.
         return
+      default: {
+        // Exhaustiveness guard. Without it a newly added stage event
+        // compiles as silently ignored — which is exactly how
+        // `stale-override-pruned` reached the view unrendered.
+        const _exhaustive: never = event
+        return _exhaustive
+      }
     }
   }, [])
 
@@ -181,33 +261,73 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
     [writeToStderr],
   )
 
+  /**
+   * Hand the engine a way to ask the user, without leaving this mount.
+   *
+   * The engine is holding the project lock and awaiting this promise, so
+   * the promise MUST settle on every path — confirm, cancel, Ctrl-C, or
+   * an interrupt. `settled` guards that it settles exactly once: a second
+   * resolve would be ignored by the promise but would also flip the view
+   * back to progress a second time, out from under whatever came next.
+   */
+  const resolveCollisions = useCallback<CollisionResolver>((request) => {
+    return new Promise<CollisionResolution>((resolve) => {
+      let settled = false
+      const settle = (resolution: CollisionResolution) => {
+        if (settled) return
+        settled = true
+        setCheckingCollisions(false)
+        setPhase({ kind: 'progress' })
+        resolve(resolution)
+      }
+      setPhase({ kind: 'resolution', request, settle })
+    })
+  }, [])
+
   const start = useCallback(async () => {
     if (startedRef.current) return
     startedRef.current = true
     try {
-      const r = await run(onStage, onLog)
+      const r = await run(onStage, onLog, resolveCollisions)
       setElapsedMs(Date.now() - startTimeRef.current)
-      setResult(r)
       onComplete?.(r)
       // Defer exit so React paints the result state before Ink unmounts.
-      setExitState(r.ok ? { kind: 'success' } : { kind: 'failure', error: new Error('Install failed') })
+      setPhase({ kind: 'result', result: r })
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error))
-      setExitState({ kind: 'failure', error: err })
+      setPhase({ kind: 'crashed', error: error instanceof Error ? error : new Error(String(error)) })
     }
-  }, [run, onStage, onLog, onComplete])
+  }, [run, onStage, onLog, onComplete, resolveCollisions])
 
   useEffect(() => {
-    if (exitState.kind === 'success') {
-      exit()
+    if (phase.kind === 'result') {
+      if (phase.result.ok) exit()
+      else exit(new Error('Install failed'))
       return
     }
-    if (exitState.kind === 'failure') {
-      exit(exitState.error)
+    if (phase.kind === 'crashed') {
+      exit(phase.error)
       return
     }
     void start()
-  }, [exitState, exit, start])
+  }, [phase, exit, start])
+
+  /**
+   * An interrupt while the workspace is open cancels the prompt rather
+   * than killing the process. The engine then returns a structured
+   * cancellation, unwinds, and releases the lock through its own
+   * `finally` — which a hard exit here would have skipped.
+   */
+  useEffect(() => {
+    if (signal === undefined || phase.kind !== 'resolution') return
+    const { settle } = phase
+    const onAbort = () => settle({ kind: 'cancelled' })
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    return () => signal.removeEventListener('abort', onAbort)
+  }, [signal, phase])
 
   const headerLabel = mode === 'add' ? 'Adding facets:' : mode === 'remove' ? 'Removing facets:' : 'Installing facets:'
 
@@ -253,6 +373,13 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
   // Stage label for the progress bar line.
   const stageLabel = currentFacet ? (currentFacet.stage ? STAGE_LABELS[currentFacet.stage] : 'starting') : null
 
+  // The workspace owns the screen while it is open: mixing a live
+  // progress bar into a form the user is typing into repaints under the
+  // cursor. Progress resumes, in this same mount, once it closes.
+  if (phase.kind === 'resolution') {
+    return <CollisionWorkspace request={phase.request} onComplete={phase.settle} />
+  }
+
   return (
     <Box flexDirection="column">
       {result === null && (
@@ -263,7 +390,9 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
 
       {result === null && (
         <Box flexDirection="column" marginLeft={2}>
-          {currentFacetInfo ? (
+          {checkingCollisions ? (
+            <Text color={THEME.hint}>Checking for name collisions across all facets</Text>
+          ) : currentFacetInfo ? (
             <Text>
               {currentFacetInfo}
               {stageLabel && <Text color={THEME.hint}> · {stageLabel}</Text>}
@@ -295,6 +424,17 @@ export function InstallView({ run, mode, onComplete }: InstallViewProps) {
             <Text key={w.facet} color={THEME.warning}>
               ⚠ {w.facet}: {w.servers.length} server{w.servers.length === 1 ? '' : 's'} declared ({w.servers.join(', ')}
               ) — server installation not yet supported, skipping.
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      {prunedOverrides.length > 0 && (
+        <Box flexDirection="column" marginLeft={2}>
+          {prunedOverrides.map((pruned) => (
+            <Text key={`${pruned.facet}:${pruned.assetType}:${pruned.authoredName}`} color={THEME.caution}>
+              ⚠ dropped the materialization choice for {pruned.assetType} “{pruned.authoredName}” in {pruned.facet} —
+              this version no longer contains that asset.
             </Text>
           ))}
         </Box>
@@ -353,6 +493,7 @@ function SuccessSummary({
   const touched = touchedFacetNames(result)
   const counts = countAssetsByType(result)
   const bundleVizNode = formatColoredBundleViz(counts)
+  const notes = materializationNotes(result)
 
   const removedNames = result.perFacet.filter((o) => o.kind === 'removed').map((o) => o.name)
 
@@ -386,6 +527,23 @@ function SuccessSummary({
       <Box flexDirection="column" marginLeft={2}>
         <Text color={THEME.hint}>{summaryLine(summary)}</Text>
         {bundleVizNode}
+        {/* Aliases and omissions are the one thing a user cannot infer
+            from the file tree: an asset is missing, or present under a
+            name they did not publish. Naming both sides makes the
+            outcome checkable. */}
+        {notes.map((note) => (
+          <Text key={`${note.facet}:${note.type}:${note.authoredName}`} color={THEME.hint}>
+            {note.facet} {note.type} {note.authoredName}
+            {note.effectiveName === null ? (
+              <Text color={THEME.caution}> — omitted</Text>
+            ) : (
+              <Text>
+                {' → '}
+                <Text color={THEME.success}>{note.effectiveName}</Text>
+              </Text>
+            )}
+          </Text>
+        ))}
       </Box>
       <Text>
         {timerVerb} <Text color={THEME.success}>{timerCount}</Text> facet
@@ -402,12 +560,57 @@ interface AssetCounts {
   command: number
 }
 
+/**
+ * How one asset was materialized, for the summary.
+ *
+ * `effectiveName: null` means omitted. Only a current lockfile records
+ * dispositions at all; a legacy one is authored by definition, which is
+ * why this is derived from the lockfile rather than carried separately.
+ */
+interface MaterializationNote {
+  facet: string
+  type: AssetType
+  authoredName: string
+  effectiveName: string | null
+}
+
+function materializationNotes(result: RunInstallResult & { ok: true }): MaterializationNote[] {
+  // Legacy lockfiles cannot express an alias or an omission, so there is
+  // nothing to report — not "nothing happened", but "this format has no
+  // opinion". Frozen mode returns the lockfile it read, so this branch is
+  // reachable in normal use, not just during migration.
+  if (result.lockfile.lockfileVersion !== LOCKFILE_VERSION_0_3) return []
+
+  const notes: MaterializationNote[] = []
+  for (const [facet, entry] of Object.entries(result.lockfile.facets)) {
+    for (const asset of entry.assets) {
+      if (asset.materialization.kind === 'authored') continue
+      notes.push({
+        facet,
+        type: asset.type,
+        authoredName: asset.name,
+        effectiveName: asset.materialization.kind === 'aliased' ? asset.materialization.as : null,
+      })
+    }
+  }
+  return notes
+}
+
 function countAssetsByType(result: RunInstallResult & { ok: true }): AssetCounts {
   const counts: AssetCounts = { skill: 0, agent: 0, command: 0 }
+  const omitted = new Set(
+    materializationNotes(result)
+      .filter((note) => note.effectiveName === null)
+      .map((note) => `${note.facet}\u0000${note.type}\u0000${note.authoredName}`),
+  )
   for (const name of touchedFacetNames(result)) {
     const facet = result.lockfile.facets[name]
     if (facet === undefined) continue
     for (const asset of facet.assets) {
+      // An omitted asset stays in the lockfile — it is part of the
+      // resolved set — but nothing was written for it, so counting it
+      // here would claim a file that does not exist on disk.
+      if (omitted.has(`${name}\u0000${asset.type}\u0000${asset.name}`)) continue
       counts[asset.type]++
     }
   }

--- a/packages/cli/src/util/__tests__/collision-report.test.ts
+++ b/packages/cli/src/util/__tests__/collision-report.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+import type { CollisionGroup, StaleOverride } from '@agent-facets/protocol'
+import { formatCollisionReport, manifestLocation, PLACEHOLDER_ALIAS } from '../collision-report.ts'
+
+const TWO_WAY: CollisionGroup[] = [
+  {
+    scope: 'project',
+    namespace: 'skill-command',
+    effectiveName: 'review',
+    members: [
+      {
+        facet: 'alpha',
+        scope: 'project',
+        type: 'skill',
+        authoredName: 'review',
+        effectiveName: 'review',
+        disposition: { kind: 'authored' },
+      },
+      {
+        facet: 'beta',
+        scope: 'project',
+        type: 'command',
+        authoredName: 'review',
+        effectiveName: 'review',
+        disposition: { kind: 'authored' },
+      },
+    ],
+  },
+]
+
+const SECOND_GROUP: CollisionGroup = {
+  scope: 'project',
+  namespace: 'agent',
+  effectiveName: 'auditor',
+  members: [
+    {
+      facet: 'alpha',
+      scope: 'project',
+      type: 'agent',
+      authoredName: 'auditor',
+      effectiveName: 'auditor',
+      disposition: { kind: 'authored' },
+    },
+    {
+      facet: 'gamma',
+      scope: 'project',
+      type: 'agent',
+      authoredName: 'checker',
+      effectiveName: 'auditor',
+      disposition: { kind: 'aliased', as: 'auditor' },
+    },
+  ],
+}
+
+describe('manifestLocation', () => {
+  test('points at the typed override map for the asset', () => {
+    expect(manifestLocation('alpha', 'skill', 'review')).toBe('facets["alpha"].materialization.skills["review"]')
+    expect(manifestLocation('alpha', 'command', 'deploy')).toBe('facets["alpha"].materialization.commands["deploy"]')
+    expect(manifestLocation('alpha', 'agent', 'auditor')).toBe('facets["alpha"].materialization.agents["auditor"]')
+  })
+
+  test('quotes names that would otherwise break the path', () => {
+    // Legacy asset names are path-safe but not necessarily
+    // identifier-safe; JSON quoting keeps the location copy-pasteable.
+    expect(manifestLocation('my.facet', 'skill', 'a-b.c')).toBe('facets["my.facet"].materialization.skills["a-b.c"]')
+  })
+})
+
+describe('formatCollisionReport', () => {
+  test('names every group and every claimant', () => {
+    const report = formatCollisionReport([...TWO_WAY, SECOND_GROUP], [])
+
+    expect(report).toContain('"review"')
+    expect(report).toContain('"auditor"')
+    for (const facet of ['alpha', 'beta', 'gamma']) expect(report).toContain(facet)
+    // Both sides of both groups, including the already-aliased claimant.
+    expect(report).toContain('checker')
+    expect(report).toContain('already aliased from "checker"')
+  })
+
+  test('gives every claimant its own manifest location', () => {
+    const report = formatCollisionReport(TWO_WAY, [])
+
+    expect(report).toContain('facets["alpha"].materialization.skills["review"]')
+    expect(report).toContain('facets["beta"].materialization.commands["review"]')
+  })
+
+  test('offers an alias and an omission snippet for each claimant', () => {
+    const report = formatCollisionReport(TWO_WAY, [])
+    const aliasLines = report.split('\n').filter((line) => line.includes('"kind": "aliased"'))
+    const omitLines = report.split('\n').filter((line) => line.includes('"kind": "omitted"'))
+
+    expect(aliasLines.length).toBeGreaterThanOrEqual(2)
+    expect(omitLines.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('the snippets it prints are parseable JSON', () => {
+    const report = formatCollisionReport(TWO_WAY, [])
+    const snippets = report
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('alias:') || line.startsWith('omit:'))
+      .map((line) => line.replace(/^(alias|omit):\s*/, ''))
+
+    expect(snippets.length).toBeGreaterThanOrEqual(4)
+    for (const snippet of snippets) {
+      // A snippet a user cannot paste is worse than no snippet: it looks
+      // authoritative and then fails schema validation.
+      expect(() => JSON.parse(`{ ${snippet} }`)).not.toThrow()
+    }
+  })
+
+  test('the example alias satisfies the asset-name grammar', () => {
+    // The spec requires syntactically valid examples, so the placeholder
+    // cannot be something like `<your-name>`.
+    expect(PLACEHOLDER_ALIAS).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+    expect(formatCollisionReport(TWO_WAY, [])).toContain(PLACEHOLDER_ALIAS)
+  })
+
+  test('does not prefer a claimant or invent a resolution', () => {
+    const report = formatCollisionReport(TWO_WAY, []).toLowerCase()
+
+    for (const word of ['winner', 'preferred', 'takes precedence', 'wins', 'recommend']) {
+      expect(report).not.toContain(word)
+    }
+    // Both claimants get exactly the same two options, so nothing in the
+    // text implies which one should yield.
+    const alphaOffers = report.split('\n').filter((l) => l.includes('alpha') && l.includes('kind')).length
+    const betaOffers = report.split('\n').filter((l) => l.includes('beta') && l.includes('kind')).length
+    expect(alphaOffers).toBe(betaOffers)
+  })
+
+  test('states that nothing was changed', () => {
+    const report = formatCollisionReport(TWO_WAY, [])
+
+    expect(report).toContain('facets.json')
+    expect(report).toContain('facets.lock')
+    expect(report).toContain('receipt')
+    expect(report).toContain('NOT changed')
+  })
+
+  test('explains that skills and commands share one namespace', () => {
+    // Without this, a skill colliding with a command reads as a bug.
+    expect(formatCollisionReport(TWO_WAY, [])).toContain('skills and commands')
+    expect(formatCollisionReport([SECOND_GROUP], [])).toContain('project agents')
+  })
+
+  test('lists stale overrides when there are any', () => {
+    const stale: StaleOverride[] = [
+      { facet: 'alpha', type: 'skill', authoredName: 'gone', disposition: { kind: 'omitted' } },
+    ]
+    const report = formatCollisionReport(TWO_WAY, stale)
+
+    expect(report).toContain('no longer contain')
+    expect(report).toContain('"gone"')
+  })
+
+  test('omits the stale-override section entirely when there are none', () => {
+    expect(formatCollisionReport(TWO_WAY, [])).not.toContain('no longer contain')
+  })
+})

--- a/packages/cli/src/util/__tests__/interactive.test.ts
+++ b/packages/cli/src/util/__tests__/interactive.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+import { isInteractive, type TerminalCapabilities } from '../interactive.ts'
+
+const FULLY_INTERACTIVE: TerminalCapabilities = {
+  stdinIsTTY: true,
+  stdoutIsTTY: true,
+  rawModeSupported: true,
+  ci: false,
+}
+
+describe('isInteractive', () => {
+  test('a real terminal with a human at it can be prompted', () => {
+    expect(isInteractive(FULLY_INTERACTIVE)).toBe(true)
+  })
+
+  test('a piped stdin is not interactive even when stdout is a terminal', () => {
+    // `facet add < /dev/null` from a terminal. The old stdout-only check
+    // passed this and then crashed inside Ink's setRawMode.
+    expect(isInteractive({ ...FULLY_INTERACTIVE, stdinIsTTY: false })).toBe(false)
+  })
+
+  test('a redirected stdout is not interactive even when stdin is a terminal', () => {
+    // `facet add > log.txt` — there is nowhere to draw the workspace.
+    expect(isInteractive({ ...FULLY_INTERACTIVE, stdoutIsTTY: false })).toBe(false)
+  })
+
+  test('a stdin without raw-mode support is not interactive', () => {
+    expect(isInteractive({ ...FULLY_INTERACTIVE, rawModeSupported: false })).toBe(false)
+  })
+
+  test('CI is never interactive, even with a pseudo-terminal on both streams', () => {
+    // Runners commonly allocate a PTY with nobody attached. Prompting
+    // there does not fail — it hangs until the job times out.
+    expect(isInteractive({ ...FULLY_INTERACTIVE, ci: true })).toBe(false)
+  })
+})

--- a/packages/cli/src/util/collision-report.ts
+++ b/packages/cli/src/util/collision-report.ts
@@ -1,0 +1,165 @@
+import type { AssetType, Scope } from '@agent-facets/common'
+import type { RunInstallFailure } from '@agent-facets/engine'
+import type { CollisionGroup, MaterializationNamespace, StaleOverride } from '@agent-facets/protocol'
+import { overrideGroupKey } from '@agent-facets/protocol'
+
+/**
+ * The complete, copy-pasteable account of a materialization collision.
+ *
+ * This exists because the rich Ink block is written to stdout, and the
+ * situations that produce a collision without a resolver are exactly the
+ * situations where stdout is a log file nobody reads: CI, a piped
+ * command, `--frozen-lockfile`. Leaving `code=MATERIALIZATION_COLLISION`
+ * on stderr as the only machine-visible signal tells an engineer that
+ * something named a constant went wrong, and nothing about which two
+ * facets to reconcile.
+ *
+ * Three rules govern the wording, all of them from the spec and all of
+ * them easy to violate by accident:
+ *
+ *   - **No winner.** Every claimant is described identically. The tool
+ *     has no basis for preferring one publisher over another, and a
+ *     hint that looked like a recommendation would become one.
+ *   - **No invented alias.** The examples use a fixed placeholder, not a
+ *     name derived from the facet. `alpha-review` would look like the
+ *     answer rather than a slot.
+ *   - **State the absence of damage.** After a wall of error text, the
+ *     first thing a reader wants to know is whether their project is now
+ *     half-installed.
+ */
+
+/**
+ * The alias used in examples. Grammar-valid on purpose — the spec
+ * requires the snippets to be syntactically valid, so a metasyntactic
+ * `<name>` would not do — and obviously a placeholder, so it cannot be
+ * mistaken for advice.
+ */
+export const PLACEHOLDER_ALIAS = 'choose-a-name'
+
+/**
+ * Where in `facets.json` a choice for this asset is written.
+ *
+ * Derived through the published `overrideGroupKey` rather than a local
+ * type-to-group switch, so a rename in the schema cannot leave this
+ * error pointing at a path that no longer exists.
+ */
+export function manifestLocation(facet: string, type: AssetType, authoredName: string): string {
+  return `facets[${JSON.stringify(facet)}].materialization.${overrideGroupKey(type)}[${JSON.stringify(authoredName)}]`
+}
+
+/** Human phrasing for the namespace two assets are contesting. */
+export function describeNamespace(namespace: MaterializationNamespace, scope: Scope): string {
+  switch (namespace) {
+    case 'skill-command':
+      // Worth spelling out: a skill colliding with a command surprises
+      // people who assume the two are separate.
+      return `${scope} skills and commands`
+    case 'agent':
+      return `${scope} agents`
+  }
+}
+
+/** The full stderr report for an unresolved collision. */
+export function formatCollisionReport(
+  groups: readonly CollisionGroup[],
+  staleOverrides: readonly StaleOverride[],
+): string {
+  const lines: string[] = []
+
+  lines.push(
+    `Two or more facets want the same name, so installation stopped before writing anything.`,
+    `Every asset below needs one choice: keep its name, give it a different one, or leave it out.`,
+    ``,
+  )
+
+  for (const group of groups) {
+    lines.push(`  ${describeNamespace(group.namespace, group.scope)} — "${group.effectiveName}" is claimed by:`)
+    for (const member of group.members) {
+      const via = member.disposition.kind === 'aliased' ? ` (already aliased from "${member.authoredName}")` : ''
+      lines.push(`    • ${member.facet}: ${member.type} "${member.authoredName}" → "${member.effectiveName}"${via}`)
+      lines.push(`        edit ${manifestLocation(member.facet, member.type, member.authoredName)}`)
+      lines.push(`          alias:  ${aliasSnippet(member.authoredName)}`)
+      lines.push(`          omit:   ${omitSnippet(member.authoredName)}`)
+    }
+    lines.push(``)
+  }
+
+  lines.push(
+    `  Replace ${JSON.stringify(PLACEHOLDER_ALIAS)} with whatever name you want; it only has to`,
+    `  differ from the other claimants. A facet entry carrying a choice looks like:`,
+    ``,
+    `    "${exampleFacet(groups)}": {`,
+    `      "source": "<the source string already in facets.json>",`,
+    `      "materialization": { ${exampleOverrideBody(groups)} }`,
+    `    }`,
+    ``,
+  )
+
+  if (staleOverrides.length > 0) {
+    lines.push(`  Also note — these recorded choices name assets the resolved versions no longer contain:`)
+    for (const stale of staleOverrides) {
+      lines.push(`    • ${stale.facet}: ${stale.type} "${stale.authoredName}"`)
+    }
+    lines.push(``)
+  }
+
+  lines.push(`  facets.json, facets.lock, the install receipt, and your materialized assets were NOT changed.`)
+
+  return lines.join('\n')
+}
+
+function aliasSnippet(authoredName: string): string {
+  return `${JSON.stringify(authoredName)}: { "kind": "aliased", "as": ${JSON.stringify(PLACEHOLDER_ALIAS)} }`
+}
+
+function omitSnippet(authoredName: string): string {
+  return `${JSON.stringify(authoredName)}: { "kind": "omitted" }`
+}
+
+/**
+ * A facet name for the shape example.
+ *
+ * Uses the first claimant of the first group only so the example is
+ * concrete. It is not a suggestion about which facet should yield —
+ * every claimant already got the identical pair of snippets above.
+ */
+function exampleFacet(groups: readonly CollisionGroup[]): string {
+  return groups[0]?.members[0]?.facet ?? 'your-facet'
+}
+
+function exampleOverrideBody(groups: readonly CollisionGroup[]): string {
+  const member = groups[0]?.members[0]
+  if (member === undefined) return `"skills": { ${aliasSnippet('asset-name')} }`
+  return `"${overrideGroupKey(member.type)}": { ${aliasSnippet(member.authoredName)} }`
+}
+
+/**
+ * Write the long-form stderr detail for a materialization failure, if it
+ * has one. Returns whether anything was written.
+ *
+ * Called before the canonical three-line block so the `fix:` line stays
+ * the last thing on the stream, where people look for it.
+ */
+export function writeMaterializationDetail(failure: RunInstallFailure): boolean {
+  switch (failure.code) {
+    case 'MATERIALIZATION_COLLISION':
+      process.stderr.write(`${formatCollisionReport(failure.groups, failure.staleOverrides)}\n`)
+      return true
+    case 'MATERIALIZATION_RESOLUTION_INVALID':
+      process.stderr.write(
+        `${formatCollisionReport(failure.groups, [])}\n${failure.problems
+          .map((problem) => `  • ${problem.facet}: alias "${problem.alias}" ${problem.reason}`)
+          .join('\n')}\n`,
+      )
+      return true
+    case 'MATERIALIZATION_ALIAS_INVALID':
+      process.stderr.write(
+        `A materialization alias in facets.json is not a legal asset name. Nothing was changed.\n${failure.problems
+          .map((problem) => `  • ${problem.facet}: "${problem.alias}" ${problem.reason}`)
+          .join('\n')}\n`,
+      )
+      return true
+    default:
+      return false
+  }
+}

--- a/packages/cli/src/util/interactive.ts
+++ b/packages/cli/src/util/interactive.ts
@@ -1,0 +1,79 @@
+/**
+ * One decision, in one place: may this process open an interactive,
+ * raw-mode terminal UI?
+ *
+ * Before this existed, four call sites each tested `process.stdout.isTTY`
+ * alone. That test is not sufficient for anything that reads keys. Ink
+ * calls `stdin.setRawMode()` the moment any mounted component uses
+ * `useInput`, and `setRawMode` throws outright when stdin is not a TTY.
+ * A command that checks only stdout therefore passes its own gate and
+ * then crashes inside the renderer — `facet add > log.txt` in a terminal
+ * is exactly that shape.
+ *
+ * The capability set is a plain record so the rule is a pure function of
+ * data. Tests state the four facts directly instead of monkey-patching
+ * global streams and hoping the patch is torn down.
+ */
+
+/** The four facts that decide interactivity. */
+export interface TerminalCapabilities {
+  /** Reading keystrokes at all requires stdin to be a terminal. */
+  stdinIsTTY: boolean
+  /** Drawing and repainting a live region requires stdout to be a terminal. */
+  stdoutIsTTY: boolean
+  /**
+   * Whether stdin actually exposes `setRawMode`. A piped or synthetic
+   * stdin can be missing it entirely, and Ink does not degrade — it
+   * throws.
+   */
+  rawModeSupported: boolean
+  /**
+   * CI runners commonly allocate a pseudo-TTY with no human attached.
+   * Prompting there does not fail fast; it hangs until the job times
+   * out, which is the worst available outcome. Treated as
+   * non-interactive so automation gets the structured failure instead.
+   */
+  ci: boolean
+}
+
+/**
+ * The interactivity rule. Every condition is necessary: dropping any one
+ * of them reintroduces either a crash inside Ink or a hung pipeline.
+ */
+export function isInteractive(capabilities: TerminalCapabilities): boolean {
+  const { stdinIsTTY, stdoutIsTTY, rawModeSupported, ci } = capabilities
+  return stdinIsTTY && stdoutIsTTY && rawModeSupported && !ci
+}
+
+/**
+ * CI detection, deliberately identical to the `is-in-ci` check Ink itself
+ * uses to decide whether a terminal is interactive. Agreeing with Ink
+ * matters more than being clever here: if the two disagreed, we would
+ * mount a workspace Ink has already decided not to drive.
+ */
+function detectCi(env: Record<string, string | undefined>): boolean {
+  const set = (key: string): boolean => key in env && env[key] !== '0' && env[key] !== 'false'
+  return set('CI') || set('CONTINUOUS_INTEGRATION')
+}
+
+/** Read the current process's capabilities. The only impure part. */
+export function currentTerminalCapabilities(): TerminalCapabilities {
+  return {
+    stdinIsTTY: Boolean(process.stdin.isTTY),
+    stdoutIsTTY: Boolean(process.stdout.isTTY),
+    rawModeSupported: typeof process.stdin.setRawMode === 'function',
+    ci: detectCi(process.env),
+  }
+}
+
+/**
+ * Convenience for call sites that just want the answer for this process.
+ *
+ * Note what this does NOT decide: frozen-lockfile mode never prompts even
+ * on a fully interactive terminal, because reproducing recorded intent
+ * must not collect new decisions. That is a policy question, so it stays
+ * at the call site rather than being folded in here.
+ */
+export function canPromptInteractively(): boolean {
+  return isInteractive(currentTerminalCapabilities())
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -147,6 +147,15 @@ export {
   resolveFacetDir,
 } from './facet-dir.ts'
 // install machinery
+// The collision-resolver contract. Exported because the interactive
+// workspace lives in the CLI (TTY detection and prompting are display
+// concerns) while the rule it must satisfy lives here: return complete
+// project overrides, or cancel. Nothing else crosses the boundary.
+export type {
+  CollisionResolution,
+  CollisionResolutionRequest,
+  CollisionResolver,
+} from './install/commit/compose.ts'
 export type { JournalEntry, JournalRollbackOptions, JournalRollbackResult } from './install/journal.ts'
 export { InstallJournal } from './install/journal.ts'
 export type { AcquireLockError, AcquireLockResult, InstallLock } from './install/lockfile-guard.ts'

--- a/packages/engine/src/install/add/index.ts
+++ b/packages/engine/src/install/add/index.ts
@@ -1,4 +1,5 @@
 import type { Adapter } from '@agent-facets/adapter'
+import type { CollisionResolver } from '../commit/compose.ts'
 import { runInstall } from '../run-install.ts'
 import type { OnLog, RunInstallResult, StageEvent } from '../types.ts'
 import { type AddPrepareFailure, type AddSource, type PrepareAddResult, prepareAdd } from './prepare.ts'
@@ -16,6 +17,15 @@ export interface RunAddOptions {
   onStage?: (event: StageEvent) => void
   onLog?: OnLog
   signal?: AbortSignal
+  /**
+   * Interactive collision resolver, forwarded to `runInstall`.
+   *
+   * `add` is the command most likely to introduce a collision — it is
+   * the one that brings a new facet into the set — so omitting this
+   * would leave the interactive path unreachable exactly where it is
+   * most needed.
+   */
+  resolveCollisions?: CollisionResolver
 }
 
 /**
@@ -62,6 +72,7 @@ export async function runAdd(opts: RunAddOptions): Promise<RunAddResult> {
     ...(onStage ? { onStage } : {}),
     ...(onLog ? { onLog } : {}),
     ...(signal ? { signal } : {}),
+    ...(opts.resolveCollisions ? { resolveCollisions: opts.resolveCollisions } : {}),
   })
 
   if (!install.ok) {

--- a/packages/engine/src/install/remove/index.ts
+++ b/packages/engine/src/install/remove/index.ts
@@ -1,4 +1,5 @@
 import type { Adapter } from '@agent-facets/adapter'
+import type { CollisionResolver } from '../commit/compose.ts'
 import { runInstall } from '../run-install.ts'
 import type { OnLog, Removal, RunInstallResult, StageEvent } from '../types.ts'
 import { prepareRemove, type RemovePrepareFailure, type RemovePrepareResult } from './prepare.ts'
@@ -16,6 +17,15 @@ export interface RunRemoveOptions {
   onStage?: (event: StageEvent) => void
   onLog?: OnLog
   signal?: AbortSignal
+  /**
+   * Interactive collision resolver, forwarded to `runInstall`.
+   *
+   * Removal only shrinks the desired set, so it cannot introduce a new
+   * collision — but it CAN surface one that was already recorded and
+   * never resolved. Forwarding keeps that recoverable instead of
+   * dead-ending the user in a command that can only report.
+   */
+  resolveCollisions?: CollisionResolver
 }
 
 /**
@@ -67,6 +77,7 @@ export async function runRemove(opts: RunRemoveOptions): Promise<RunRemoveResult
     ...(onStage ? { onStage } : {}),
     ...(onLog ? { onLog } : {}),
     ...(signal ? { signal } : {}),
+    ...(opts.resolveCollisions ? { resolveCollisions: opts.resolveCollisions } : {}),
   })
 
   if (!install.ok) {

--- a/packages/protocol/src/materialization/planner.ts
+++ b/packages/protocol/src/materialization/planner.ts
@@ -353,7 +353,13 @@ export function planMaterialization(contributions: readonly FacetContribution[])
  * `skills`, `agents`, or `commands`. Exposed so failure renderers can point
  * a user at the exact `facets.json` location to edit without restating the
  * type-to-group mapping.
+ *
+ * The literal return type is load-bearing: callers that BUILD an override
+ * map (rather than just printing a location) index
+ * {@link FacetMaterializationOverrides} with it, and a widened `string`
+ * would force those call sites into a cast that the type system could no
+ * longer check against the schema.
  */
-export function overrideGroupKey(type: AssetType): string {
+export function overrideGroupKey(type: AssetType): (typeof ASSET_DIRECTORY)[AssetType] {
   return ASSET_DIRECTORY[type]
 }


### PR DESCRIPTION
### Why

When two facets publish an asset under the same name, the engine has no basis for choosing a winner. Previously the only outcome was a structured failure with a terse error block — useful in CI, but a dead end for a developer sitting at a terminal who just wants to finish the install. This change adds an interactive collision workspace that pauses the install, lets the user assign Keep / Alias / Omit to each claimant, and then resumes the install in the same Ink mount without a second render cycle.

### Details

**Interactive capability check (`util/interactive.ts`)**
The old call sites each tested `process.stdout.isTTY` alone. That is not sufficient: Ink calls `stdin.setRawMode()` the moment any component uses `useInput`, and `setRawMode` throws when stdin is not a TTY. `canPromptInteractively()` now checks all four necessary conditions — stdin is a TTY, stdout is a TTY, `setRawMode` is present, and the process is not running in CI. CI runners commonly allocate a pseudo-TTY with no human attached; prompting there hangs until the job times out.

**Collision workspace (`tui/views/install/collision/`)**
The workspace is a pure function of a `CollisionDraft`, which is itself a `Record<facet, overrides>` — the same shape the engine consumes. There is no parallel UI model to keep in sync, so what is shown and what is submitted cannot disagree. Collision truth always comes from the protocol planner: the workspace never decides what collides, it only arranges the planner's answer for display. This means the live preview and the engine's final validation answer the same question the same way, so a green Confirm button cannot precede a failed install.

Temporary conflict is a legal draft state. A user may alias one claimant onto a name that is still contested, walk to the other side, and fix it from there. Refusing to record a conflicting intermediate choice would force a specific resolution order the tool has no basis for imposing.

**Single-mount phase machine (`install-view.tsx`)**
`InstallView` now tracks a `ViewPhase` — `progress`, `resolution`, or `result` — rather than a pair of booleans that could disagree. The workspace replaces the progress bar while it is open and hands control back when it closes; the whole run is one continuous frame stream with no second Ink renderer. The `CollisionResolver` is offered to the view but not imposed: the command decides whether to forward it to the engine based on whether the terminal is interactive and whether `--frozen-lockfile` is set.

An `AbortSignal` is threaded into `InstallView` so that a Ctrl-C while the workspace is open cancels the prompt rather than killing the process. The engine is holding the project lock and awaiting the resolver promise; a hard exit would skip the `finally` block that releases it. `exitOnCtrlC: false` is passed to Ink's `render` for the same reason.

**Non-interactive stderr report (`util/collision-report.ts`)**
The Ink failure block is written to stdout, which is discarded in the contexts that produce a collision without a resolver (CI, piped commands, `--frozen-lockfile`). `formatCollisionReport` writes the complete account to stderr: every group, every claimant, the exact `facets.json` edit location for each one, parseable alias and omit snippets, and an explicit statement that nothing was changed. Three rules from the spec govern the wording: no winner, no invented alias (a fixed `choose-a-name` placeholder is used), and an explicit no-damage statement.

**`installFailureFix` (`commands/shared/install-failure.ts`)**
The three commands (`add`, `install`, `remove`) each had their own copy of the rollback guidance with slightly different phrasing. They are now unified, and the new collision and cancellation codes are handled.

**`overrideGroupKey` return type**
The return type is narrowed from `string` to the literal union of directory names. Callers that build override maps index `FacetMaterializationOverrides` with it, and a widened `string` forced those sites into casts the type system could not check.

**`THEME.caution`**
A three-state status vocabulary (unresolved / draft-conflict / resolved) needs three colors. Coral against green alone cannot express "not yet settled", so an amber `caution` token is added between `warning` and `success`.

**Accessibility**
Every collision status ships an icon, a word, and a color. Color is the redundant channel: under `NO_COLOR`, in a pipe, or for a red/green-colorblind reader, the text alone still separates the three states. This is asserted directly in `collision-status.test.ts`.

### Verification

- Unit tests cover the draft state machine (all resolution paths, group merging, name-swap, alias validation), the workspace component (keyboard navigation, alias editor, cancellation, user-created conflicts), the status presentation (distinct icon/label/color per state, color-free distinguishability), the stderr formatter (no winner language, parseable snippets, stale-override section), and the `isInteractive` rule.
- `InstallView` tests cover the collision-check stage label, the progress → resolution → progress → result phase sequence, cancellation messaging, interrupt handling, materialization notes in the success summary, omitted-asset counting, stale-override pruning visibility, and disposition-only update reporting.
- Command-level tests cover non-interactive collision failure output, recorded alias and omission resolution, frozen-lockfile behavior, adapter request content for aliased assets, and alias rename (delete old name, write new name).
- End-to-end tests drive the compiled binary with piped stdio — the only place the true non-interactive path is exercised — covering the full failure report, recorded-intent installs, omitted-asset lockfile entries, frozen-lockfile collision reporting, and adapter-error precedence over collision prompting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install/add/remove control flow, lock interaction during prompts, and failure output; regressions could hang CI or leave locks held, though behavior is heavily tested and non-interactive paths fail closed.
> 
> **Overview**
> When facets fight over the same asset name, **install/add/remove** can now pause in a single **Ink** mount and walk the user through **Keep / Alias / Omit** for every claimant, then resume the same run instead of failing with only a terse error.
> 
> **`canPromptInteractively()`** replaces scattered `stdout.isTTY` checks with one gate (stdin/stdout TTY, raw mode, not CI) so piped or redirected stdio and CI get structured failures instead of **Ink** crashes or hangs. **`--frozen-lockfile`** still never prompts.
> 
> **`CollisionWorkspace`** keeps draft state as the same `facets.json` override map the engine consumes and re-plans via the protocol planner so confirmability matches what install will accept. **`InstallView`** uses a **progress → resolution → progress → result** phase machine, disables Ink’s default Ctrl-C exit while resolving, and settles the engine resolver on cancel/SIGINT so the project lock is released.
> 
> **Non-interactive** collisions get a full **`stderr`** report (`collision-report.ts`) with manifest paths, copy-pasteable snippets, and an explicit no-mutation statement. Success summaries show alias/omit notes, prune stale overrides without `--verbose`, and omit omitted assets from materialized counts. Shared **`installFailureFix`**, **`THEME.caution`** for three-state status, and a narrowed **`overrideGroupKey`** return type round out the UX/type tweaks; engine **`add`/`remove`** forward **`resolveCollisions`** and re-export collision types for the CLI.
> 
> Coverage spans draft/workspace/status unit tests, command tests, and compiled-binary e2e with piped stdio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d206b31a5fa9672afb5039d1284298796b349200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive workspace for resolving installation name collisions by keeping, aliasing, or omitting assets.
  * Installation summaries now show aliases, omissions, and effective asset names.
  * Added clearer collision reports with affected assets, manifest locations, and copy-ready configuration examples.

* **Bug Fixes**
  * Non-interactive and frozen-lockfile installs now fail safely without prompting or modifying files.
  * Improved cancellation handling and install-failure guidance.
  * Prevented stale aliased files from remaining after alias changes.

* **Documentation**
  * Clarified theme caution semantics and interactive prompt requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->