### PR TITLE
Add cross-facet name collision resolution, asset aliasing/omission, manifest 0.1, lockfile 0.3, and Resolve-all → Compose → Apply pipeline

### DIFF
--- a/.changeset/materialization-aliasing-cli.md
+++ b/.changeset/materialization-aliasing-cli.md
@@ -1,0 +1,77 @@
+---
+'agent-facets': minor
+---
+
+**Cross-facet name collision resolution and asset aliasing (pre-1.0 breaking minor).**
+
+Two facets can now publish an asset with the same name without one silently
+overwriting the other. `facet add`, `facet install`, and `facet remove` detect
+every cross-facet collision across the complete desired asset set before
+writing anything, and stop.
+
+**Interactive resolution.** When the terminal can prompt — stdin and stdout are
+both TTYs, raw mode is available, and the process is not in CI — the install
+pauses and opens a resolution workspace inside the existing install view. Each
+contested asset gets one of three outcomes: keep the authored name, alias it to
+a name you type, or omit it entirely. Arrow keys move a cursor and `Enter`
+applies, so the alias editor cannot trap focus and make `Omit` unreachable.
+Status is three-state and readable without color (`✕ unresolved`, `⚠ conflict`,
+`✓ resolved`). Confirmation unlocks only when the planner — not a count of green
+rows — reports the whole draft collision-free. `Esc` or `Ctrl-C` cancels the
+install with nothing written; Ink's built-in Ctrl-C handling is disabled so the
+cancellation settles the engine's pending resolver and releases the project
+lock.
+
+**Non-interactive resolution.** In CI, with piped output, or under
+`--frozen-lockfile`, nothing is prompted. The command exits non-zero and writes
+a full report to stderr: every group, every claimant, the exact
+`facets.json` location to edit, and parseable alias/omit snippets. It chooses no
+winner and invents no alias — the placeholder is literally `choose-a-name` and is
+offered identically to every claimant — and states explicitly that
+`facets.json`, `facets.lock`, the receipt, and materialized assets were not
+changed. Frozen mode never prompts even on a full TTY, because it reproduces
+recorded intent rather than collecting new decisions.
+
+**BREAKING: `facets.json` gains `manifestVersion: 0.1` and expanded entries.** A
+facet entry is now either a source string or `{ source, materialization }`. Any
+tool reading `facets.json` must handle both forms; code assuming a flat
+`Record<string, string>` will discard recorded aliases when it rewrites the
+file. A manifest with no `manifestVersion` is read as legacy and migrated in
+place inside the same transaction that writes the lockfile and receipt. An
+entry whose last override is removed collapses back to a compact string, and
+`//` and `/* */` comments survive a write.
+
+**BREAKING: `facets.lock` moves to `0.3` and the receipt to `0.3`.** Every
+lockfile asset entry carries a required `materialization` disposition; omitted
+assets stay listed with their complete authored file records. `name` and `files`
+remain authored even when aliased, so integrity is unaffected. Legacy `1` and
+`0.2` lockfiles remain readable and are migrated by any non-frozen install.
+A frozen install fails with `materialization-unrepresentable` when the manifest
+declares overrides against a pre-`0.3` lockfile.
+
+**The install pipeline is now Resolve-all → Compose → Apply.** The previous
+interleaved per-facet loop could not detect a collision between the first and
+last facet, because the first was already on disk. Resolve-all and Compose are
+read-only, so a collision, invalid alias, or cancellation leaves the project
+byte-identical with no rollback needed. Apply deletes obsolete assets in one
+global pass keyed by effective adapter identity *before* writing, which makes
+ownership transfer between facets correct and stops a duplicate historical claim
+from double-deleting.
+
+**Other user-visible changes.**
+
+- A version-unchanged disposition change classifies as `updated`, not
+  `unchanged` or `repaired`.
+- The install summary names every asset whose materialized name differs from its
+  authored one (`planning → team-planning`, `scratch — omitted`), and omitted
+  assets are excluded from asset counts.
+- Stale overrides — naming an asset the resolved version no longer contains —
+  are pruned on a successful commit and reported without `--verbose`. Frozen
+  mode treats them as blocking drift.
+- `facet list` reports an unsupported `manifestVersion` distinctly from a
+  malformed manifest.
+- Adapters receive the **effective** asset name in every install, read, and
+  delete request. The adapter API version is unchanged and no adapter needs
+  rebuilding.
+- `facet instructions` now teaches agents both `facets.json` entry forms and the
+  hand-edit path for resolving a collision without a TTY.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ facet install
 facet self-update
 ```
 
-The public registry index (used by `facet add <name>` without a source) is open-beta — see [docs.agentfacets.io/roadmap](https://docs.agentfacets.io/roadmap). Today, bare-name resolution errors out against the stub; use `github:owner/repo`, an `https://...git` URL, an SCP-style git URL, or a local path.
+The public registry is open-beta — see [docs.agentfacets.io/roadmap](https://docs.agentfacets.io/roadmap). A bare name (`facet add cowsay`) resolves against it; you can also install from `github:owner/repo`, an `https://...git` URL, an SCP-style git URL, or a local path.
 
 Please see https://docs.agentfacets.io for detailed guidance and documentation for the `facet` CLI tool.
 
@@ -38,11 +38,11 @@ Please see https://docs.agentfacets.io for detailed guidance and documentation f
 
 | Package                                   | NPM                       | Description                                                          |
 |-------------------------------------------|---------------------------|----------------------------------------------------------------------|
-| [CLI](packages/cli/README.md)             | `agent-facets`            | CLI tool for managing facets                                         |
+| [CLI](packages/cli/AGENTS.md)             | `agent-facets`            | CLI tool for managing facets                                         |
 | [Protocol](packages/protocol/AGENTS.md)   | `@agent-facets/protocol`  | TypeScript reference implementation of the facet artifact spec — Node-native, public, consumed by registries and other third-party tools |
-| [Brand](packages/brand/README.md)         | `@agent-facets/brand`     | Agent Facets branding and styles                                     |
+| [Brand](packages/brand)                   | `@agent-facets/brand`     | Agent Facets branding and styles                                     |
 
-> The legacy `@agent-facets/core` package was split into `@agent-facets/protocol` (the published spec implementation) and `@agent-facets/engine` (Bun-native CLI machinery, private to this monorepo). The `@agent-facets/core` package is no longer published; it is frozen at v0.9.1 on npm. New consumers MUST use `@agent-facets/protocol`. See `docs/docs/contributing/architecture.md` for the full layer description.
+> The legacy `@agent-facets/core` package was split into `@agent-facets/protocol` (the published spec implementation) and `@agent-facets/engine` (Bun-native CLI machinery, private to this monorepo). The `@agent-facets/core` package is no longer published; it is frozen at v0.9.1 on npm. New consumers MUST use `@agent-facets/protocol`. See [`AGENTS.md`](AGENTS.md) for the full layer description.
 
 ## Development
 

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -5,6 +5,161 @@ description: What's new in Agent Facets
 rss: true
 ---
 
+<Update label="2026-07-27" description="Resolve name collisions between facets; manifest 0.1, lockfile 0.3, and asset aliasing" tags={["CLI", "Breaking", "New Feature"]} rss={{
+  title: "Asset aliasing, omission, and cross-facet collision resolution",
+  description: "Two facets can now publish an asset with the same name without one of them losing. facet add and facet install detect every cross-facet name collision before writing anything, and in a terminal they pause and let you keep, rename, or omit each contested asset. Your choices are saved into facets.json as a materialization block and replayed on every later install, so it happens once and your teammates get the same layout. Without a terminal -- CI, or piped output -- nothing is prompted: the install fails and prints every claimant with the exact facets.json edit to make, choosing no winner and inventing no name. Aliasing renames only the file on disk; archive paths, integrity hashes, and the lockfile keep the publisher's authored name, so an alias can never smuggle different content under a familiar name. Omitted assets are still resolved, verified, and recorded, they are simply not written. Breaking: facets.json now carries manifestVersion 0.1 and entries may be objects instead of strings, so any tool that reads it must handle both forms; facets.lock moves to 0.3 with a required materialization disposition on every asset. Both migrate automatically on the next successful install. A frozen install against a pre-0.3 lockfile fails if the manifest declares overrides -- run one normal install first. Commit is now three phases, Resolve-all then Compose then Apply, so nothing is written until the whole plan is known to be collision-free."
+}}>
+  ## Two facets, one name
+
+  Facets are published independently, so sooner or later two of them
+  ship an asset with the same name. Until now the second one quietly
+  overwrote the first. Now [`facet add`](/cli/add) and
+  [`facet install`](/cli/install) detect every collision across the
+  whole project **before writing anything**, and stop.
+
+  In a terminal, the install pauses and hands you the decision:
+
+  ```
+  Installation is paused: two or more facets want the same name.
+  1 group · 1 still to resolve · nothing has been written yet
+
+    project skills and commands — "planning"
+      ✕ unresolved   viper-plans  skill planning
+      ✕ unresolved   team-tools   skill planning
+  ```
+
+  Give each contested asset one of three outcomes -- **Keep** it under
+  the published name, **Alias** it to a name you choose, or **Omit** it
+  entirely. Only one of them has to change; the names just have to
+  differ from each other.
+
+  What this means for you:
+
+  - **Nothing is written until you decide.** A collision leaves
+    `facets.json`, `facets.lock`, the receipt, and your materialized
+    assets byte-identical. Cancelling with `Esc` is not an error state.
+  - **You decide once.** Your choices are saved into `facets.json`, so
+    the next install -- and every teammate's, and CI's -- replays them
+    without prompting.
+  - **No tool picks a winner.** Not the CLI, not the registry, not the
+    facet authors. A silent winner means a silently discarded asset.
+
+  ## Alias or omit any asset
+
+  The same mechanism works without a collision. A facet entry can carry
+  a `materialization` block naming, per asset, what you want:
+
+  ```json facets.json
+  "team-tools": {
+    "source": "1.*",
+    "materialization": {
+      "skills": {
+        "planning": { "kind": "aliased", "as": "team-planning" },
+        "scratch": { "kind": "omitted" }
+      }
+    }
+  }
+  ```
+
+  - **Aliasing renames the file, nothing else.** Archive paths,
+    per-file integrity, and the lockfile all keep the publisher's
+    **authored** name. That is what makes an alias safe: it can never
+    be used to smuggle different content in under a familiar name.
+  - **Omitted assets are still verified.** They are resolved, hashed,
+    and recorded in the lockfile -- they are just never written to
+    disk. Dropping them from the lockfile would make an omission
+    indistinguishable from a facet that never published the asset.
+  - **Skills and commands share one namespace**, agents have their
+    own. A skill `deploy` and a command `deploy` collide; an agent
+    `deploy` coexists with both.
+
+  See [Materialization](/specification/materialization) for the full
+  model.
+
+  ## **Breaking:** `facets.json` entries may be objects
+
+  `facets.json` now carries a `manifestVersion` (currently `0.1`), and
+  a facet entry is **either** a source string **or** an object with
+  `source` and `materialization`:
+
+  ```json facets.json
+  {
+    "manifestVersion": 0.1,
+    "facets": {
+      "cowsay": "1.*",
+      "team-tools": { "source": "1.*", "materialization": { "skills": { "planning": { "kind": "aliased", "as": "team-planning" } } } }
+    }
+  }
+  ```
+
+  **If you have tooling that reads `facets.json`, it must handle both
+  forms.** Code that assumes every value is a string will render an
+  expanded entry as `[object Object]` -- or, worse, destroy a recorded
+  alias when it rewrites the file.
+
+  A manifest with no `manifestVersion` is still read as the legacy
+  format and is migrated in place on the next successful install. There
+  is no separate migration command and nothing to run.
+
+  ## **Breaking:** lockfile `0.3`
+
+  Every asset entry in `facets.lock` now carries a required
+  `materialization` disposition -- `authored`, `aliased`, or `omitted`.
+  Versions `1` and `0.2` remain readable and are migrated to `0.3` by
+  any normal install.
+
+  ```json facets.lock
+  {
+    "scope": "project", "type": "skill", "name": "planning",
+    "materialization": { "kind": "aliased", "as": "team-planning" },
+    "files": [{ "path": "skills/planning/SKILL.md", "integrity": "sha256:…" }]
+  }
+  ```
+
+  Note `name` and `files` keep the authored name even when aliased.
+  Versions are matched exactly, never by ordering -- `0.3` is
+  numerically *less* than `0.2`, so comparison would rank the newest
+  schema as the oldest.
+
+  **In CI:** a [`--frozen-lockfile`](/cli/install) install fails if
+  `facets.json` declares any materialization override while
+  `facets.lock` predates `0.3`, since the older format has no field to
+  record it. Run one normal `facet install` locally and commit the
+  migrated lockfile. Frozen mode also treats a changed alias as drift,
+  exactly like a changed version, and never prompts.
+
+  ## The install pipeline resolves everything before writing anything
+
+  Commit used to be an interleaved loop -- resolve facet A, write it,
+  then start facet B. Detecting that A and Z want the same name is
+  impossible that way, because A is already on disk.
+
+  It now runs in three phases: **Resolve-all**, **Compose**, then
+  **Apply**. The first two are read-only, which is why a collision, an
+  invalid alias, or a cancelled resolution leaves the project untouched
+  rather than rolled back. Deletion also moved to the start of Apply,
+  before any write, so an asset name can transfer from one facet to
+  another in a single install without the new owner's file being
+  deleted behind it.
+
+  Two smaller consequences you may notice:
+
+  - **Disposition changes report as `updated`.** Aliasing an asset at
+    an unchanged version is a real change to what is on disk, not a
+    no-op and not a repair.
+  - **Stale choices are pruned and reported.** If you upgrade a facet
+    and the publisher removed an asset you had aliased, the override is
+    dropped on a successful install and the CLI tells you which one.
+
+  ## Adapter authors
+
+  The adapter contract is unchanged -- no rebuild, no version bump. But
+  `request.name` has always been, and now visibly is, the **effective**
+  name: the name the consuming project chose. Address files by
+  `request.name` and never re-derive a path from a facet's manifest.
+  See [Custom adapters](/guides/custom-adapters).
+</Update>
+
 <Update label="2026-07-23" description="Facets ship non-asset files; archive 0.2, per-file lockfiles, first-class README, and the 0.1 adapter contract" tags={["CLI", "Breaking", "New Feature"]} rss={{
   title: "Supplementary files, archive 0.2, and first-class README authoring",
   description: "Facets can now declare and ship non-asset files: skill companion files (references, scripts, templates beside SKILL.md) that install and remove atomically with their skill, and top-level archive-only files like README.md and LICENSE that ship in the archive but never materialize on disk. Declare them with exact paths in the manifest's top-level files array or a skill descriptor's files array. Builds emit the new 0.2 archive format with a complete per-entry hash map; lockfiles move to 0.2 with a per-file integrity record for every materialized file; install reports and repairs drift per file. facet create now writes and declares an editable README.md by default (skip with --no-readme), and facet edit has a dedicated README panel. Consumers still accept legacy 0.1 archives and legacy alpha lockfiles during the compatibility window; the two versions are dispatched by exact match. Asset names are single-segment Agent Skills names -- slash-namespaced names are no longer valid in new manifests -- and skills and commands now share one namespace. The adapter contract advances from positional 0.0 to the tagged 0.1 request/result shape: rebuild and reinstall any adapter that still declares 0.0. Rollout is consumer-first: protocol, then registry, then adapters, then the CLI."

--- a/docs/cli/add.mdx
+++ b/docs/cli/add.mdx
@@ -11,7 +11,7 @@ facet add <source> [more sources...]
 
 Adds the named facet(s) to `facets.json` and immediately installs them into every connected adapter. There is no separate "install after add" step  -- `facet add` is the single command for bringing a new facet into a project.
 
-If the project has no adapters installed, `facet add` will launch the adapter picker before doing any work (in an interactive terminal). In a non-interactive environment, it exits with an error pointing at `facet adapter install`.
+Every source specifier is validated first. If the project then has no adapters installed, `facet add` launches the adapter picker — but only when the terminal can prompt. Otherwise it exits with an error pointing at `facet adapter install`.
 
 ## Examples
 
@@ -37,7 +37,7 @@ Every accepted form — and what each writes to `facets.json` — is in the [sou
 | Code | Meaning                                                                              |
 | ---- | ------------------------------------------------------------------------------------ |
 | `0`  | Add and install succeeded.                                                           |
-| `1`  | Failed (parse error, no adapters in non-TTY, install failure, etc.). No files are modified on failure. |
+| `1`  | Failed — parse error, no usable adapter, an unresolved [name collision](/cli/install#name-collisions), a cancelled resolution, or an install failure. Nothing is written unless the failure happened mid-write, in which case the journal rolls it back. |
 
 ## What it does
 
@@ -46,18 +46,20 @@ Every accepted form — and what each writes to `facets.json` — is in the [sou
     Validate every source specifier up front. Invalid grammar exits before touching disk.
   </Step>
   <Step title="Discover adapters">
-    If none installed: launch the picker (TTY) or fail (non-TTY).
+    If none installed: launch the picker when the terminal can prompt, or fail with recovery guidance when it cannot.
   </Step>
   <Step title="Prepare">
     Read each source's `facet.json` to learn its name. Sources that declare a non-empty `facets: [...]` array are rejected. Load the project manifest if it exists.
   </Step>
   <Step title="Commit">
-    Delegate to the [install pipeline](/specification/install) with the additions delta. Version resolution, integrity verification, and the atomic write follow the [commit phase](/specification/commit) — additions always [re-resolve non-exact specifiers](/specification/commit#resolve), and new lockfile entries require [registry confirmation](/specification/commit#verify) (fails closed offline).
+    Delegate to the [install pipeline](/specification/install) with the additions delta. Version resolution, integrity verification, [global collision detection](/specification/commit#compose), and the atomic write follow the [commit phase](/specification/commit) — additions always [re-resolve non-exact specifiers](/specification/commit#resolve), and new lockfile entries require [registry confirmation](/specification/commit#verify) (fails closed offline).
+
+    Adding a facet is the most common way to hit a name collision: the new facet may want a name an installed facet already uses. See [Name collisions](/cli/install#name-collisions) for how that is resolved and what gets recorded.
   </Step>
 </Steps>
 
 <Tip>
-The manifest, lockfile, and receipt are **never written ahead** of success. On failure, the journal rolls back all materialization and the project is left unchanged.
+The manifest, lockfile, and receipt are **never written ahead** of success. A failure before the first write — including an unresolved collision — leaves the project byte-identical with nothing to undo; a failure after it rolls back through the journal.
 </Tip>
 
 ## Source grammar
@@ -142,10 +144,12 @@ facet add viper-plans@1.x            # x-style placeholders — use 1.* or 1.2.*
 
 Running `facet add` against a facet that's already in `facets.json` is supported:
 
-- Same source as before → no-op (lockfile may report `unchanged` or `repaired`).
+- Same source as before → no-op (lockfile may report `unchanged` or `repaired`). If you have since aliased or omitted one of its assets, it reports `updated` instead — the version did not move, but its materialization did.
 - Different version pin → updates the entry; the install summary shows `(was X → Y)`.
 - Bare re-add (no version) → resolves the newest published version and **pins** it in `facets.json`. A bare add always pins to the resolved exact version, even over an existing wildcard spec.
 - Explicit `@latest`/wildcard re-add → re-resolves to the newest match (the lockfile never pins an explicit non-exact add), but the specifier itself is written verbatim and keeps floating.
+
+In every case, any [materialization overrides](/specification/materialization#recording-intent) already recorded for the facet are preserved. Changing where a facet comes from is not a statement about how its assets should be named. An override naming an asset the new version no longer contains is dropped, and the install tells you which one.
 
 What gets written per specifier shape is defined by the [manifest-write policy](/specification/commit#manifest-write-policy).
 

--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -22,7 +22,11 @@ Reads `facets.json`, fetches and materializes every facet declared there, and wr
 <ResponseField name="--frozen-lockfile" type="boolean">
   Treat the lockfile as the source of truth; fail on any manifest/lockfile drift.
 
-  Setting this flag makes the **lockfile authoritative**: no re-resolution, no lockfile writes, and every facet — including local sources — must reproduce its locked integrity. The full preflight and behavior matrix are in the [Frozen lockfile specification](/specification/commit#frozen-lockfile).
+  Setting this flag makes the **lockfile authoritative**: no re-resolution, no lockfile writes, and every facet — including local sources — must reproduce its locked integrity. It also requires the lockfile's recorded [materialization](/specification/materialization) intent to match `facets.json` exactly. The full preflight and behavior matrix are in the [Frozen lockfile specification](/specification/commit#frozen-lockfile).
+
+  Frozen mode **never prompts**, even in a fully interactive terminal. It reproduces recorded intent, so it must not collect a new decision. A name collision under `--frozen-lockfile` is reported and fails.
+
+  A lockfile older than `0.3` cannot record a materialization disposition. If `facets.json` declares any override against one, the frozen install fails rather than silently ignoring it — run one non-frozen `facet install` to migrate the lockfile.
 
   <Tip>
   Use this in CI to guarantee `facets.json` and `facets.lock` are in agreement. Mirrors `--frozen-lockfile` from `npm` and `bun`.
@@ -34,21 +38,23 @@ Reads `facets.json`, fetches and materializes every facet declared there, and wr
 | Code | Meaning                                                              |
 | ---- | -------------------------------------------------------------------- |
 | `0`  | Install succeeded (including no-op when nothing has changed).        |
-| `1`  | Install failed. The view renders the structured failure inline; stderr carries an `install failed code=...` line for log-grepping. |
+| `1`  | Install failed. The view renders the structured failure inline; stderr carries a three-line block — `error:`, `code=...` for log-grepping, and a `fix:` action. A [name collision](#name-collisions) prints its full report above that block, so `fix:` stays the last line. |
 
 ## What it does
 
 <Steps>
   <Step title="Validate the project">
-    `facets.json` must exist; at least one adapter must be installed (the picker auto-launches on a TTY if none are).
+    `facets.json` must exist, and at least one **install-capable** adapter must be installed. If none are, the picker launches when the terminal can prompt; otherwise the command exits pointing at [`facet adapter install`](/cli/adapters/install). Installed-but-incompatible adapters fail here rather than falling through to the picker.
   </Step>
   <Step title="Run the install pipeline">
-    Runs the [install pipeline](/specification/install) with an empty delta: acquire the install lock, resolve each declared facet ([honoring satisfying lockfile pins](/specification/commit#resolve)), [verify integrity](/specification/commit#verify), materialize assets into every adapter, [remove drift](/specification/commit#drift-removal), and [write manifest + lockfile + receipt atomically](/specification/commit#transactional-tri-write).
+    Runs the [install pipeline](/specification/install) with an empty delta: acquire the install lock, resolve and [verify](/specification/commit#verify) *every* declared facet ([honoring satisfying lockfile pins](/specification/commit#resolve)), [compose one global plan](/specification/commit#compose) checking for name collisions, then [remove drift](/specification/commit#drift-removal) and materialize assets into every adapter, and finally [write manifest + lockfile + receipt atomically](/specification/commit#transactional-tri-write).
+
+    Deletion runs before any write, which is what lets an asset name move from one facet to another in a single install.
   </Step>
 </Steps>
 
 <Note>
-Every facet is verified before any asset is written; any integrity mismatch aborts the install with the project unchanged. The full semantics — lockfile trust, staleness, the verification chain — live in the [Commit specification](/specification/commit) and the [Integrity Model](/specification/integrity).
+Every facet is verified, and the whole plan composed, before any asset is written. An integrity mismatch, a name collision, or a cancelled resolution all abort with the project **byte-identical** — not rolled back, but never touched. The full semantics — lockfile trust, staleness, the verification chain — live in the [Commit specification](/specification/commit) and the [Integrity Model](/specification/integrity).
 </Note>
 
 ## Outcomes
@@ -59,16 +65,18 @@ The summary line classifies each facet by what happened on disk:
   Facet was not in the previous lockfile.
 </ResponseField>
 
-<ResponseField name="updated" type="version change">
+<ResponseField name="updated" type="state change">
   Facet was in the lockfile at a different version  -- including when a stale entry was re-resolved to match the manifest. The summary shows `(was X → Y)`.
+
+  Also reported when the version is unchanged but its [materialization](/specification/materialization) is not: aliasing or omitting an asset changes what is on disk and what the lockfile records, so it is an update rather than a no-op. It is not a *repair* either — nothing drifted, the project changed its mind.
 </ResponseField>
 
 <ResponseField name="repaired" type="self-heal">
-  Same lockfile entry, but at least one adapter file was missing or had drifted from the lockfile content. Restored.
+  Same version and same materialization intent, but at least one adapter file was missing or had drifted from the lockfile content. Restored. A skill is repaired by replacing its whole bundle atomically, so a single drifted companion pulls the primary with it.
 </ResponseField>
 
 <ResponseField name="unchanged" type="no-op">
-  Same lockfile entry, every asset already in its desired state. Nothing was written.
+  Same version, same materialization intent, every asset already in its desired state. Nothing was written.
 </ResponseField>
 
 <ResponseField name="removed" type="cleanup">
@@ -76,6 +84,48 @@ The summary line classifies each facet by what happened on disk:
 </ResponseField>
 
 If you delete a materialized asset by hand and re-run `facet install`, the affected facet shows up as `repaired`.
+
+Below the counts, the summary names every asset whose materialized name differs from its authored one — the one thing you cannot infer from the file tree:
+
+```
+  1 updated · 1 asset written
+  + 1 skill
+  viper-plans skill planning → team-planning
+  cowsay command scratch — omitted
+```
+
+Omitted assets are not counted as written.
+
+## Name collisions
+
+Two facets cannot materialize an asset under the same name. Skills and commands share one namespace; agents have their own — see [Namespaces](/specification/materialization#namespaces).
+
+Collisions are detected **globally, before anything is written**, so the install stops with the project untouched.
+
+**In an interactive terminal**, the install pauses and opens a resolver. Each contested asset gets one of three outcomes:
+
+| Key | Choice | Result |
+| --- | --- | --- |
+| `Keep` | keep the authored name | records nothing |
+| `Alias` | materialize under a name you type | `{ "kind": "aliased", "as": "..." }` |
+| `Omit` | do not materialize it at all | `{ "kind": "omitted" }` |
+
+Move with `↑↓`, pick with `←→`, apply with `Enter`, and `Esc` to go back. Arrow keys only move the cursor — nothing is applied until you press `Enter`. Each claimant shows a status that pairs an icon with a word, so it stays readable without color: `✕ unresolved`, `⚠ conflict` (your own edit created this one), `✓ resolved`. Confirmation unlocks only when every group is resolved.
+
+Your choices are written into `facets.json` as durable intent, so the next install runs without prompting:
+
+```json facets.json
+"viper-plans": {
+  "source": "1.*",
+  "materialization": {
+    "skills": { "planning": { "kind": "aliased", "as": "team-planning" } }
+  }
+}
+```
+
+`Esc` or `Ctrl-C` cancels the whole install. Nothing was written, and re-running lets you make the choices again.
+
+**Without a terminal** — CI, piped output, or `--frozen-lockfile` — nothing is prompted. Every group and every claimant is printed to stderr with the exact `facets.json` location to edit and copy-pasteable alias and omit snippets. No winner is chosen and no alias is invented for you: the placeholder is literally `choose-a-name`. The report ends by stating that `facets.json`, `facets.lock`, the receipt, and your materialized assets were **not** changed.
 
 ## Cache
 

--- a/docs/cli/instructions.mdx
+++ b/docs/cli/instructions.mdx
@@ -20,7 +20,7 @@ The default topic is `overview`. It opens with a generated index of every instru
 ## Topics
 
 <ResponseField name="overview" type="default">
-  What facets are, the three artifact files, the two workflows (authoring vs. using), and a generated index of every topic.
+  What facets are, the three artifact files, the two workflows (authoring vs. using), a command index, and a generated index of every topic.
 </ResponseField>
 
 <ResponseField name="manifest" type="topic">
@@ -32,7 +32,7 @@ The default topic is `overview`. It opens with a generated index of every instru
 </ResponseField>
 
 <ResponseField name="usage" type="topic">
-  Project management: add/update/remove facets (registry-first), and install adapter tooling (including adapter API `0.1` recovery).
+  Project management: add/update/remove facets (registry-first), the shape of `facets.json` including materialization overrides, how to resolve a name collision without a TTY, and installing adapter tooling (including adapter API `0.1` recovery).
 </ResponseField>
 
 ```sh

--- a/docs/cli/list.mdx
+++ b/docs/cli/list.mdx
@@ -15,8 +15,8 @@ Shows all facets declared in `facets.json` for the current project. No network c
 
 | Code | Meaning |
 | ---- | ------- |
-| `0`  | Listed successfully — including an empty project or no `facets.json` at all (a hint is printed). |
-| `1`  | Malformed `facets.json`. |
+| `0`  | Listed successfully — including an empty project or no `facets.json` at all (a hint is printed). A malformed `facets.lock` is a warning, not a failure: the listing falls back to source specifiers. |
+| `1`  | Positional arguments were given, `facets.json` is malformed, or its `manifestVersion` is one this CLI does not understand (upgrade the CLI). |
 
 ## What it does
 
@@ -28,9 +28,13 @@ Shows all facets declared in `facets.json` for the current project. No network c
     When a lockfile exists, resolved versions from the [lockfile](/specification/lockfile) are displayed instead of the raw manifest specifier.
   </Step>
   <Step title="Display entries">
-    Each facet is listed with its name and resolved version (or source specifier if not yet installed).
+    Each facet is listed with its name and resolved version (or source specifier if not yet installed). Entries carrying [materialization overrides](/specification/materialization#recording-intent) show their source the same way a plain entry does.
   </Step>
 </Steps>
+
+<Note>
+`facet list` reports declared facets and versions only. It does not yet show which assets a facet aliases or omits — read the `materialization` blocks in `facets.json`, or the per-asset dispositions in `facets.lock`, for that.
+</Note>
 
 ## See also
 

--- a/docs/cli/remove.mdx
+++ b/docs/cli/remove.mdx
@@ -9,7 +9,7 @@ description: Remove one or more facets from the project
 facet remove <facet> [more facets...]
 ```
 
-Removes one or more facets from `facets.json`, deletes their assets from every connected adapter, and rewrites `facets.lock` without them  -- in a single command. The inverse of [`facet add`](/cli/add). Aliased as `facet rm`.
+Removes one or more facets from `facets.json`, deletes the assets they still own from every connected adapter, and rewrites `facets.lock` without them  -- in a single command. The inverse of [`facet add`](/cli/add). Aliased as `facet rm`.
 
 ## Examples
 
@@ -35,7 +35,7 @@ facet remove viper-plans rezi
 | Code | Meaning                                                                              |
 | ---- | ------------------------------------------------------------------------------------ |
 | `0`  | Removal succeeded, or all requested names were already absent from `facets.json` (no-op). |
-| `1`  | Failed (no names given, install failure, etc.). No files are modified on failure. |
+| `1`  | Failed — no names given, no `facets.json`, an unresolved [name collision](/cli/install#name-collisions), or an install failure. Nothing is modified unless the failure happened mid-write, in which case the journal rolls it back. |
 
 ## What it does
 
@@ -47,12 +47,20 @@ facet remove viper-plans rezi
     Names not in `facets.json` are silently ignored. If every name is absent, the command exits successfully with no changes.
   </Step>
   <Step title="Commit">
-    Delegate to the [install pipeline](/specification/install) with the removals delta. Removal is [receipt-driven and offline](/specification/commit#drift-removal); the manifest, lockfile, and receipt are [written together](/specification/commit#transactional-tri-write). Every other facet is left untouched.
+    Delegate to the [install pipeline](/specification/install) with the removals delta. Removal is [receipt-driven and offline](/specification/commit#drift-removal); the manifest, lockfile, and receipt are [written together](/specification/commit#transactional-tri-write).
+
+    Deletion is keyed by the name each asset was **materialized** under, not by the facet that owned it. A name another declared facet still claims is kept, so removing a facet never deletes an asset that has since transferred to a different one. Assets you [omitted](/specification/materialization#dispositions) were never written, so there is nothing to delete for them.
   </Step>
   <Step title="On any failure">
     The journal rolls back all changes. Nothing is written ahead of success.
   </Step>
 </Steps>
+
+Removing a facet discards the materialization overrides recorded for it. Overrides on the facets that remain are durable and are **not** reverted, even if the removal frees the name they were working around — undoing them is a decision, so it stays yours. Delete the `materialization` block from `facets.json` and re-run [`facet install`](/cli/install) to go back to published names.
+
+<Note>
+Removal runs the full install pipeline, so it can surface a name collision that was already recorded and never resolved. In a terminal you get the same resolver [`facet install`](/cli/install#name-collisions) uses; in CI it fails with the report.
+</Note>
 
 ## See also
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,7 +131,12 @@
           },
           {
             "group": "Installation",
-            "pages": ["specification/install", "specification/planning", "specification/commit"]
+            "pages": [
+              "specification/install",
+              "specification/planning",
+              "specification/commit",
+              "specification/materialization"
+            ]
           },
           {
             "group": "Authoring",

--- a/docs/guides/custom-adapters.mdx
+++ b/docs/guides/custom-adapters.mdx
@@ -52,7 +52,11 @@ An adapter is a small TypeScript library. You write one file, build it, and inst
 
 ## How an adapter fits in
 
-When you run `facet install`, the CLI reads each facet's assets and hands them to every installed adapter. The adapter decides **where** on disk each asset goes and **how** it's formatted, so the target tool picks it up. That's the entire job: translate a facet asset into files your tool understands.
+When you run `facet install`, the CLI resolves each facet's assets and hands the ones the project wants materialized to every installed adapter. The adapter decides **where** on disk each asset goes and **how** it's formatted, so the target tool picks it up. That's the entire job: translate a facet asset into files your tool understands.
+
+<Warning>
+`request.name` is the asset's **effective** name — the name the consuming project chose, which is not necessarily the one the publisher declared. A project can [alias](/specification/materialization) any asset, so the same published skill may arrive as `planning` in one project and `team-planning` in another. Address the file by `request.name` and never re-derive it from a facet's manifest. Assets the project [omitted](/specification/materialization#dispositions) are never passed to you at all — their absence is a choice, not a bug.
+</Warning>
 
 An adapter implements a small contract from the SDK. Two methods matter most:
 
@@ -100,7 +104,7 @@ import { join } from 'node:path'
 
 const baseDir = join(homedir(), '.my-tool')
 
-// A skill lives in its own directory: skills/<name>/SKILL.md (+ companions).
+// A skill lives in its own directory: skills/<effective name>/SKILL.md (+ companions).
 function skillPaths(name: string): SkillBundlePaths {
   const root = join(baseDir, 'skills', name)
   return { root, primaryFile: join(root, 'SKILL.md'), pruneBoundary: baseDir }
@@ -110,8 +114,8 @@ export default defineAdapter({
   name: 'my-tool',
   supportsInstall: true,
 
-  // Validate + enrich the author's `adapters.my-tool` block. Return the
-  // metadata you want written as front-matter, or errors if it's invalid.
+  // Validate the author's `adapters.my-tool` block at build time.
+  // Returns errors if it's invalid; the CLI writes front matter itself.
   buildAssetMetadata(data: unknown): Validated<AdapterMetadata> {
     // Trivial pass-through; use arktype/zod here for a real schema.
     const meta = (data ?? {}) as AdapterMetadata
@@ -202,14 +206,14 @@ Everything an adapter can implement, from [`@agent-facets/adapter`](https://gith
 </ResponseField>
 
 <ResponseField name="readAsset(request: ReadAssetRequest)" type="Promise<ReadAssetResult>">
-  Read an asset back. The `skill` variant carries `ownedCompanionPaths` (read exactly those, never enumerate the directory). Return `{ ok: true, asset }` or `{ ok: false, failure }` (`failure.code === 'not-found'` when absent).
+  Read an asset back. The `skill` variant carries `ownedCompanionPaths` (read exactly those, never enumerate the directory). Your `readAsset` must be a byte-stable inverse of `installAsset` — the engine compares what it reads back against what it would write to decide whether a facet is unchanged, so any asymmetry reports phantom drift on every install. Return `{ ok: true, asset }` or `{ ok: false, failure }` (`failure.code === 'not-found'` when absent).
 </ResponseField>
 
 <ResponseField name="deleteAsset(request: DeleteAssetRequest)" type="Promise<DeleteAssetResult>">
-  Remove an asset. The `skill` variant carries `ownedCompanionPaths`; deletion removes the primary plus exactly those, preserving unowned files. Return `{ ok: true, existed, deletedPaths }` or `{ ok: false, failure }`.
+  Remove an asset. The `skill` variant carries `ownedCompanionPaths`; deletion removes the primary plus exactly those, preserving unowned files. That set is the union of every past claim on this name, so it may include files a *different* facet left behind when the name changed hands. Deletes run before writes in a single install, so expect to be asked to delete and then re-create the same name. Return `{ ok: true, existed, deletedPaths }` or `{ ok: false, failure }`.
 </ResponseField>
 
-Every request carries `scope` (`'system'`, `'user'`, or `'project'` — decide your on-disk layout per scope) and `name`, tagged by `assetType` (`'skill'`, `'agent'`, or `'command'`). Expected failures are structured values (`not-found`, `invalid-companion-path`, `unsupported-scope`, `not-implemented`, `io-failed`), never thrown errors.
+Every request carries `scope` (`'system'`, `'user'`, or `'project'` — decide your on-disk layout per scope) and `name`, tagged by `assetType` (`'skill'`, `'agent'`, or `'command'`). `name` is always the effective name (see above); by the time a request reaches you the effective set is guaranteed collision-free, so you never have to arbitrate between two assets wanting one path. Expected failures are structured values (`not-found`, `invalid-companion-path`, `unsupported-scope`, `not-implemented`, `io-failed`), never thrown errors.
 
 <Tip>
   You can ship a **metadata-only** adapter: implement just `name` and `buildAssetMetadata`, and omit `supportsInstall`. It validates manifest config during builds without materializing anything  -- useful while you're still figuring out a tool's on-disk layout.
@@ -264,7 +268,7 @@ facet adapter list          # your adapter should appear
 facet add cowsay            # installs into every connected adapter, yours included
 ```
 
-Check that files landed where your `assetPath` puts them. From here, harden `buildAssetMetadata` with a real schema and flesh out the on-disk layout your tool expects.
+Check that files landed where your path helpers put them. From here, harden `buildAssetMetadata` with a real schema and flesh out the on-disk layout your tool expects.
 
 `facet adapter list` also shows each adapter's declared adapter API and whether the CLI supports it. If a CLI update ever changes the supported API set, rebuild your adapter against a matching SDK release and reinstall it — the list output prints the exact reinstall command next to any incompatible entry.
 

--- a/docs/guides/install-facets.mdx
+++ b/docs/guides/install-facets.mdx
@@ -90,9 +90,9 @@ A bare name is pinned to its resolved version in `facets.json`; a wildcard like 
 
 ## What `facet add` writes
 
-Your project now has two files  -- commit both to version control so teammates and CI resolve identical versions.
+Your project now has two version-controlled files  -- commit both so teammates and CI resolve identical versions. (A third, the machine-local install receipt, lives outside your project and is not committed.)
 
-**`facets.json`**  -- the project manifest: which facets belong to the project, and at what version. It is the source of truth for your dependencies.
+**`facets.json`**  -- the project manifest: which facets belong to the project, at what version, and how you want their assets named. It is the source of truth for your dependencies.
 
 **`facets.lock`**  -- the lockfile: exact resolved versions, <Tooltip headline="Integrity hash" tip="A content hash of a facet's contents, checked on every install so you get exactly the bytes that were published — tampering or corruption fails the install." cta="How integrity works" href="/specification/integrity">integrity hashes</Tooltip>, and per-file asset records for reproducible installs. It is managed by the CLI; you never hand-edit it.
 
@@ -100,6 +100,7 @@ Your project now has two files  -- commit both to version control so teammates a
 
 ```json facets.json
 {
+  "manifestVersion": 0.1,
   "facets": {
     "cowsay": "1.*",
     "viper-plans": "1.0.0"
@@ -109,7 +110,7 @@ Your project now has two files  -- commit both to version control so teammates a
 
 ```json expandable facets.lock
 {
-  "lockfileVersion": 0.2,
+  "lockfileVersion": 0.3,
   "facets": {
     "cowsay": {
       "source": { "kind": "registry", "registry": "https://api.agentfacets.io" },
@@ -118,16 +119,20 @@ Your project now has two files  -- commit both to version control so teammates a
       "assets": [
         {
           "scope": "project", "type": "skill", "name": "cowsay-rules",
+          "materialization": { "kind": "authored" },
           "files": [
             { "path": "skills/cowsay-rules/SKILL.md", "integrity": "sha256:11aa22…" },
             { "path": "skills/cowsay-rules/references/moods.md", "integrity": "sha256:22bb33…" }
           ]
         },
         { "scope": "project", "type": "agent", "name": "cowsay",
+          "materialization": { "kind": "authored" },
           "files": [{ "path": "agents/cowsay.md", "integrity": "sha256:33cc44…" }] },
         { "scope": "project", "type": "command", "name": "cowchat",
+          "materialization": { "kind": "authored" },
           "files": [{ "path": "commands/cowchat.md", "integrity": "sha256:44dd55…" }] },
         { "scope": "project", "type": "command", "name": "cowsay",
+          "materialization": { "kind": "authored" },
           "files": [{ "path": "commands/cowsay.md", "integrity": "sha256:55ee66…" }] }
       ]
     }
@@ -139,13 +144,15 @@ Your project now has two files  -- commit both to version control so teammates a
 
 The full schema — every field, the tagged source kinds, and the exact-version rules — is specified in [Lockfile](/specification/lockfile).
 
+Note this facet ships an agent `cowsay` **and** a command `cowsay`. That is legal: skills and commands share one namespace, and agents have their own. What is *not* legal is two facets claiming the same name in the same namespace — see [Two facets, one name](#two-facets-one-name).
+
 <Note>
   The lockfile honors the manifest. A pinned entry is reused as long as it still satisfies `facets.json`; when you bump a version or widen a wildcard, `facet install` [re-resolves](/specification/commit#resolve) and updates the lock.
 </Note>
 
 ## Where assets land
 
-`facet add` also writes each asset into every connected adapter's **project-local** directory, so your tool picks them up immediately. With the `opencode` adapter, adding `cowsay` writes:
+`facet add` writes each materialized asset into every connected adapter's **project-local** directory, so your tool picks them up immediately. With the `opencode` adapter, adding `cowsay` writes:
 
 ```
 .opencode/
@@ -158,6 +165,61 @@ The full schema — every field, the tagged source kinds, and the exact-version 
 
 A skill's [companion files](/specification/manifest#supplementary-files) land beside its `SKILL.md`, and a skill installs and removes as one atomic bundle. [Archive-only files](/specification/commit#materialize) — a facet's top-level `README.md` or `LICENSE` — ship in the archive but are **never** written into your adapters. Other adapters use their own conventional location (Claude Code under `.claude/`, and so on). These files are `project`-scoped  -- the same `scope` you see in the lockfile  -- so they belong to the checkout, not your machine. `facet remove` deletes them again — including a skill's owned companions, while preserving any files you added into a skill directory yourself — and `facet install` recreates them from the lockfile after a clone.
 
+## Two facets, one name
+
+Sooner or later two facets will publish an asset with the same name. Facets cannot know about each other, so your project decides.
+
+Adding a second facet whose skill is also called `planning` pauses the install:
+
+```
+Installation is paused: two or more facets want the same name.
+1 group · 1 still to resolve · nothing has been written yet
+
+  project skills and commands — "planning"
+    ✕ unresolved   viper-plans  skill planning
+    ✕ unresolved   team-tools   skill planning
+```
+
+Press `Enter` on the group to open it, then give each one an outcome:
+
+- **Keep** — leave it under the published name.
+- **Alias** — type a different name for it.
+- **Omit** — do not install it at all.
+
+Move with `↑↓`, highlight a choice with `←→`, and press `Enter` to apply it. They only have to differ from each other, so aliasing *one* of them is enough. Once every group shows `✓ resolved`, confirm and the install continues.
+
+Your decision is saved to `facets.json`, so it happens once:
+
+```json facets.json
+{
+  "manifestVersion": 0.1,
+  "facets": {
+    "viper-plans": "1.0.0",
+    "team-tools": {
+      "source": "1.*",
+      "materialization": {
+        "skills": { "planning": { "kind": "aliased", "as": "team-planning" } }
+      }
+    }
+  }
+}
+```
+
+Both skills now install, and your teammates get the same layout from the same manifest:
+
+```
+.opencode/skills/planning/SKILL.md
+.opencode/skills/team-planning/SKILL.md
+```
+
+<Note>
+Aliasing renames the file, not the facet. `team-tools` is still `team-tools`, its published skill is still `planning`, and every integrity hash is unchanged — which is why an alias can never smuggle different content in under a familiar name. See [Materialization](/specification/materialization).
+</Note>
+
+<Warning>
+CI cannot prompt. If a collision reaches an automated run, the install fails and prints every claimant with the exact `facets.json` edit to make. Resolve collisions locally and commit `facets.json` so CI never sees one.
+</Warning>
+
 ## Reinstall after a git clone
 
 When you clone a project that already has `facets.json` and `facets.lock`, materialize into your adapters with:
@@ -169,7 +231,7 @@ facet install
 [`facet install`](/cli/install) fetches and installs every declared facet at the exact versions in the lockfile  -- so you get precisely what is pinned.
 
 <Tip>
-  For CI, add `--frozen-lockfile`. It never re-resolves or writes the lockfile and **fails** if `facets.json` and `facets.lock` disagree  -- catching a forgotten `facet add` or a hand-edited manifest instead of silently mutating the lock.
+  For CI, add `--frozen-lockfile`. It never re-resolves or writes the lockfile and **fails** if `facets.json` and `facets.lock` disagree  -- catching a forgotten `facet add` or a hand-edited manifest instead of silently mutating the lock. That includes disagreement about asset names: a recorded alias you changed by hand but never installed is drift, exactly like a changed version. Frozen mode also never prompts, so an unresolved name collision fails rather than waiting for input.
 </Tip>
 
 ## Manage what's installed

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -57,7 +57,54 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
   <Accordion title='"integrity mismatch" / companion drift on install'>
     **Cause:** a materialized file no longer matches the [per-file integrity](/specification/lockfile) recorded in `facets.lock` — a file was edited or corrupted on disk, or the cache was tampered with. Install reconciles every file (including each skill companion) before writing and reports the exact drifting path.
 
-    **Fix:** re-run [`facet install`](/cli/install) — it repairs a drifted file in place (reported as *repaired*) without touching files you added yourself. If a registry facet fails to reconcile against its lockfile integrity, the download is rejected rather than silently replaced; confirm the lockfile matches what you expect.
+    **Fix:** re-run [`facet install`](/cli/install) — it repairs a drifted file in place (reported as *repaired*) without touching files you added yourself. If a registry facet fails to reconcile against its lockfile integrity, the download is rejected rather than silently replaced; confirm the lockfile matches what you expect. A `RECONCILE_*` failure is different: the archive itself disagrees with the lockfile, so re-running will not fix it — delete `facets.lock` and re-run, or [`facet add`](/cli/add) the facet to update the entry.
+  </Accordion>
+
+  <Accordion title='"two or more facets want the same name"'>
+    **Cause:** two installed facets each publish an asset that would materialize under the same name. Skills and commands share one namespace, so a skill and a command can collide too. Nothing is written — the check runs before any file is touched.
+
+    **Fix:** in a terminal, [`facet install`](/cli/install#name-collisions) pauses and lets you keep, rename, or omit each one. In CI it fails and prints every claimant with the exact `facets.json` edit; make that edit locally, commit it, and CI will never see the collision again:
+
+    ```json facets.json
+    "team-tools": {
+      "source": "1.*",
+      "materialization": {
+        "skills": { "planning": { "kind": "aliased", "as": "team-planning" } }
+      }
+    }
+    ```
+
+    Only *one* claimant needs to change — the names just have to differ from each other. See [Materialization](/specification/materialization).
+  </Accordion>
+
+  <Accordion title='"invalid materialization alias"'>
+    **Cause:** an `as` value in a `materialization` block does not satisfy the [asset-name grammar](/specification/manifest#asset-names): 1–64 characters of lowercase letters, digits, and hyphens, no leading or trailing hyphen, no consecutive hyphens, and no `/`.
+
+    **Fix:** correct the alias in `facets.json` and re-run. Aliases are never auto-corrected — silently rewriting your chosen name would make the result unpredictable.
+  </Accordion>
+
+  <Accordion title='"lockfile cannot record materialization overrides" (frozen install)'>
+    **Cause:** `facets.json` declares an alias or omission, but `facets.lock` predates lockfile `0.3` and has no field to record it. [`--frozen-lockfile`](/cli/install) refuses rather than silently ignoring your intent.
+
+    **Fix:** run one plain `facet install` (without the flag) to migrate the lockfile to `0.3`, then commit it. CI will pass from then on.
+  </Accordion>
+
+  <Accordion title='"facets.json says X, lockfile says Y" (frozen install)'>
+    **Cause:** you changed an alias or omission in `facets.json` but never ran a normal install, so `facets.lock` still records the old disposition. Under [`--frozen-lockfile`](/cli/install) that is drift, exactly like an unrecorded version bump.
+
+    **Fix:** run `facet install` without the flag, then commit the updated `facets.lock`.
+  </Accordion>
+
+  <Accordion title='A materialization choice was dropped, or is rejected in CI'>
+    **Cause:** an override names an asset the resolved facet version no longer contains — usually the publisher renamed or removed it in an upgrade. A normal install prunes the stale override and tells you which one; a frozen install treats it as blocking drift, because it has no transaction in which to prune.
+
+    **Fix:** nothing, if you saw the pruning notice — it is already resolved and `facets.json` was updated. In CI, run `facet install` locally without `--frozen-lockfile` and commit the pruned manifest.
+  </Accordion>
+
+  <Accordion title='"facets.json declares an unsupported manifestVersion"'>
+    **Cause:** the manifest was written by a newer CLI. Versions are matched exactly, never by ordering, so a newer format is refused rather than guessed at.
+
+    **Fix:** update with [`facet self-update`](/cli/self-update). A manifest with **no** `manifestVersion` is not affected — that is the legacy format, and it is still read and migrated on the next successful install.
   </Accordion>
 
   <Accordion title='"not signed in — no registry credential found"'>

--- a/docs/specification/commit.mdx
+++ b/docs/specification/commit.mdx
@@ -5,7 +5,9 @@ description: Verify, materialize, write — atomically
 
 import { DeltaTip, InstallReceiptTip, CanonicalFingerprintTip, SidecarTip } from "/snippets/glossary.jsx";
 
-Commit is phase 2 of the [install pipeline](/specification/install): a single transaction that applies the <DeltaTip>delta</DeltaTip> from [Planning](/specification/planning). Its inputs are the on-disk `facets.json`, `facets.lock`, the <InstallReceiptTip>install receipt</InstallReceiptTip>, and the delta. It is never partial: a failure anywhere MUST roll back all materialization via the **journal** — a log in which every materialization write records its inverse operation, replayed in reverse on failure — and leave the project exactly as it was.
+Commit is phase 2 of the [install pipeline](/specification/install): a single transaction that applies the <DeltaTip>delta</DeltaTip> from [Planning](/specification/planning). Its inputs are the on-disk `facets.json` — including the [materialization](/specification/materialization) intent it records — `facets.lock`, the <InstallReceiptTip>install receipt</InstallReceiptTip>, and the delta.
+
+It is never partial. Commit runs in three phases, and the boundary between the second and third is where mutation begins: everything up to and including [Compose](#compose) is read-only, so a failure there leaves the project byte-identical without needing to undo anything. From the first write onward, every write records its inverse in the **journal**, and a failure MUST replay it in reverse to leave the project exactly as it was.
 
 <CardGroup cols={3}>
   <Card title="Verify" icon="shield-check">
@@ -23,16 +25,23 @@ Commit is phase 2 of the [install pipeline](/specification/install): a single tr
 
 <Steps>
   <Step title="Load state and gate">
-    The manifest is read, the **install lock** — a per-project advisory lock ensuring only one install operates on a project at a time — is acquired, and the lockfile and receipt are loaded (an invalid receipt is re-bootstrapped from the lockfile; receipt asset entries with crafted names are reported and skipped individually). A delta naming the same facet in both additions and removals MUST be rejected, the adapters selected for this operation MUST pass the adapter API compatibility preflight — a defense-in-depth re-check behind the command-level gate that already rejected any incompatible installed adapter before planning; a selected adapter whose declared adapter API the CLI does not support MUST fail the commit here, before the per-facet loop and therefore before any Git or local facet build can invoke adapter metadata methods — and the frozen gates run (see [Frozen lockfile](#frozen-lockfile)). Failures here touch nothing — no rollback is needed.
+    The manifest is read and the **install lock** — a per-project advisory lock ensuring only one install operates on a project at a time — is acquired. A frozen operation carrying a non-empty delta is rejected here, before the lockfile is even read, so `facet add --frozen-lockfile` against a corrupt lockfile reports the operation it cannot perform rather than a file it never needed to open.
+
+    The lockfile and receipt are then loaded (an invalid receipt is re-bootstrapped from the lockfile; receipt asset entries with crafted names are reported and skipped individually). A delta naming the same facet in both additions and removals MUST be rejected, and the adapters selected for this operation MUST pass the adapter API compatibility preflight — a defense-in-depth re-check behind the command-level gate that already rejected any incompatible installed adapter before planning. Every incompatible adapter is collected, not just the first. A selected adapter whose declared adapter API the CLI does not support MUST fail the commit here, before any Git or local facet build can invoke adapter metadata methods. Failures here touch nothing — no rollback is needed.
   </Step>
   <Step title="Merge delta in memory">
-    Additions are upserted, removals are deleted — all in memory. The on-disk `facets.json` MUST NOT be written ahead of the install.
+    Additions are upserted, removals are deleted — all in memory. The on-disk `facets.json` MUST NOT be written ahead of the install. Re-adding a facet preserves any materialization overrides already recorded for it: changing where a facet comes from is not a statement about how its assets should be named.
+
+    The frozen gates then run against the merged result (see [Frozen lockfile](#frozen-lockfile)).
   </Step>
-  <Step title="Per-facet loop">
-    Each facet in the **desired set** — the manifest's facets after the delta is merged in memory — passes four sub-stages: [parse → resolve → verify → materialize](#the-per-facet-loop). The loop stops at the first failure.
+  <Step title="Phase A — Resolve all">
+    Every facet in the **desired set** — the manifest's facets after the delta is merged in memory — is [parsed, resolved, and verified](#the-three-phases), in a deterministic order. Nothing is written. The phase stops at the first failure.
   </Step>
-  <Step title="Drift removal">
-    The receipt is compared against the desired set: any facet still on disk but no longer wanted has its assets deleted — entirely offline.
+  <Step title="Phase B — Compose">
+    The complete set of verified contributions, plus the project's recorded intent, becomes either one collision-free plan or the complete list of [collisions](#compose) blocking it. Still nothing written.
+  </Step>
+  <Step title="Phase C — Apply">
+    The journal opens. Obsolete assets are deleted in one global pass, then every desired asset is [materialized](#materialize) under its effective name. Deleting first is what lets a name move between facets safely.
   </Step>
   <Step title="Transactional tri-write">
     The [manifest-write policy](#manifest-write-policy) is applied just before the write, then `facets.json`, `facets.lock`, and the receipt are written together. A failure anywhere rolls back all materialization and leaves all three files unchanged.
@@ -55,9 +64,25 @@ These combine independently: a facet may need any combination, or none. The cach
 Registry versions are immutable — the bytes for a published `name@version` never change. Integrity confirmation and lockfile comparison enforce this invariant **client-side** rather than assuming it.
 </Info>
 
-## The per-facet loop
+## The three phases
 
-Every facet in the desired set passes the same four sub-stages, in order. The loop is interleaved — facet A is resolved and materialized before facet B starts — and stops at the first failure.
+Commit is **not** an interleaved per-facet loop. Every facet is fully resolved and verified before any facet is materialized, because cross-facet collision detection needs the complete desired asset set to exist before the first adapter write — which is impossible while facet N is materialized before facet N+1 is fetched.
+
+```mermaid
+flowchart LR
+    subgraph A["Phase A — Resolve all (read-only)"]
+        P["Parse"] --> R["Resolve"] --> V["Verify"]
+    end
+    subgraph B["Phase B — Compose (read-only)"]
+        C["Plan materialization"]
+    end
+    subgraph C2["Phase C — Apply (journaled)"]
+        D["Delete obsolete"] --> M["Materialize"]
+    end
+    A --> B --> C2
+```
+
+Facets are processed in a deterministic order — sorted by name, not manifest key order — because which facet fails first is user-visible.
 
 ### Parse
 
@@ -128,7 +153,9 @@ flowchart TD
 
 On a miss, the downloaded content's canonical fingerprint MUST be **genuinely recomputed** from the extracted bytes (per-entry hashes plus the canonical-archive hash) — never taken from the build manifest's self-declared claim. The recomputed value MUST be verified against the registry's published `content_integrity` and, when the lockfile pins this version, against the locked integrity, before the verified content populates the cache.
 
-Before any file is written, install also proves a four-way agreement per materialized file: the recomputed archive-entry hash, the [lockfile `0.2`](/specification/lockfile) per-file integrity, the verified build-manifest hash, and the complete owned-file set MUST all agree. A mismatch fails the commit with the exact drifting path. This gate — and, in frozen mode, the bidirectional-consistency gate — completes before any receipt-driven cleanup begins. Archive-only supplementary files (like `README.md`) are verified as archive entries but are **never written to disk**.
+**On reproduction**, install also proves a four-way agreement per file: the recomputed archive-entry hash, the [lockfile](/specification/lockfile) per-file integrity, the verified build-manifest hash, and the complete owned-file set MUST all agree. A mismatch fails the commit with the exact drifting path.
+
+This reconciliation applies only when the facet resolves to the integrity already locked. A legitimate change — a new version, an edited local facet, a removed asset — resolves to a *different* integrity, so there is nothing to reconcile against. It is also skipped for a legacy identity-only lockfile entry, which records no per-file hashes, and in frozen mode, where the drift preflight substitutes for it. Archive-only supplementary files (like `README.md`) are verified as archive entries but are **never written to disk**.
 
 #### Git and local sources
 
@@ -138,17 +165,37 @@ Git and local facets are **built from source** during commit rather than downloa
 
 **Local** — trust-by-path: the source is containment-checked, rebuilt from disk on every install, and the lockfile follows what is on disk (no integrity confirmation, no caching). The exception is frozen mode, which promises bit-for-bit reproduction: the built content MUST hash to the locked integrity or the install fails, and the entry is never rewritten.
 
+### Compose
+
+Compose turns the complete set of verified authored contributions, plus the project's persisted intent, into either one collision-free global plan or the complete list of collisions blocking it. **Nothing here writes.**
+
+This is the only place current lockfile entries are constructed. Resolution deliberately produces no disposition, so a provisional `authored` can never masquerade as a real decision.
+
+Compose applies the [materialization planner](/specification/materialization#planning-rules) — the same pure rule the CLI uses to recompute status while you edit a collision interactively. Three outcomes are possible:
+
+- **Collision-free** — the plan proceeds to Apply.
+- **Invalid alias** — an override's alias does not satisfy the asset-name grammar. No effective set can be derived from it, so no collision report is possible either; the commit fails.
+- **Collisions** — two or more assets claim one logical identity. Every group and every claimant is reported, never truncated and never resolved by picking a winner.
+
+When a collision is found, an interactive caller MAY be offered the chance to resolve it. The resolver returns **overrides, not a winner** — exactly the durable intent a user could have written by hand — and its answer is re-planned as defense in depth before being accepted. There is no automatic retry loop: a resolver that returns a still-colliding answer fails the commit rather than being re-invoked. Cancelling produces a distinct outcome, not an error, because nothing has been written.
+
+A frozen or non-interactive commit MUST report rather than resolve. Frozen mode reproduces recorded intent, so it must never collect a new decision — not even from a human sitting at a terminal.
+
 ### Materialize
 
-Materialization writes assets from verified content into each selected adapter's storage. A skill is written as an **atomic bundle**: its `SKILL.md` and every owned companion file are staged, committed, and rolled back as one all-or-nothing adapter operation carrying the validated owned-file set — the adapter never infers ownership from disk. Writes are skip-if-identical at per-file granularity — a facet whose lockfile entry is unchanged but whose on-disk files needed rewriting is reported as *repaired*, and a single drifted companion is repaired without touching the rest (the full outcome taxonomy is documented at [`facet install`](/cli/install#outcomes)). An interrupted install converges on re-run through the same per-file reconciliation without deleting unowned files. Every write MUST journal its inverse operation for rollback.
+Materialization writes assets from verified content into each selected adapter's storage, under each asset's **effective** name. Every adapter request, journal label, and failure report addresses the file on disk, which is named by the project's disposition — not by the publisher. Content lookup, canonical paths, and integrity stay anchored to the authored name; see [Two identities](/specification/materialization#two-identities). An omitted asset never reaches an adapter at all.
+
+A skill is written as an **atomic bundle**: its `SKILL.md` and every owned companion file are staged, committed, and rolled back as one all-or-nothing adapter operation carrying the validated owned-file set — the adapter never infers ownership from disk. Writes are skip-if-identical **per asset**: the write is skipped only when the primary *and* every companion already match on disk, so a single drifted companion (or a changed companion set) forces a repair through the same atomic bundle replacement. A facet whose lockfile entry is unchanged but whose on-disk files needed rewriting is reported as *repaired* (the full outcome taxonomy is documented at [`facet install`](/cli/install#outcomes)). An interrupted install converges on re-run without deleting unowned files. Every write MUST journal its inverse operation for rollback.
 
 ## Lockfile shape
 
-Commit writes `facets.lock` as part of the tri-write: per facet, the tagged source provenance, the exact resolved version, the verified integrity, and the contributed assets — each asset carrying a per-file `{ path, integrity }` ownership record. The full schema is specified in [Lockfile](/specification/lockfile).
+Commit writes `facets.lock` as part of the tri-write: per facet, the tagged source provenance, the exact resolved version, the verified integrity, and the contributed assets — each asset carrying its resolved materialization disposition and a per-file `{ path, integrity }` ownership record. Omitted assets are listed too: the lockfile records the resolved asset **set**, not the on-disk set. The full schema is specified in [Lockfile](/specification/lockfile).
 
 ## Machine-local install receipt
 
-Receipts are per-project, machine-local records (schema `0.2`) stored outside the project's version-controlled tree ([`$FACET_DIR`](/cli/env)`/receipts/`). They mirror the committed lockfile's asset and per-file ownership so drift removal can clean up correctly — including a skill's owned companions — even when the lockfile no longer mentions the facet, and entirely offline. A legacy primary-only receipt is safely refined rather than rejected. The receipt records ownership, not hashes.
+Receipts are per-project, machine-local records (schema `0.3`) stored outside the project's version-controlled tree ([`$FACET_DIR`](/cli/env)`/receipts/`). They record, for each asset actually present on disk, its authored identity, the authored inner-archive paths it owns, and the disposition it was materialized under — both names are needed to delete an aliased asset offline. Omitted assets never appear.
+
+This lets drift removal clean up correctly — including a skill's owned companions — even when the lockfile no longer mentions the facet, and entirely offline. A legacy primary-only receipt is safely refined rather than rejected, and a pre-`0.3` receipt reads as `authored`. The receipt records ownership, not hashes, and carries its own version axis independent of the lockfile's.
 
 <CardGroup cols={2}>
   <Card title="Per-project isolation" icon="folder">
@@ -161,21 +208,29 @@ Receipts are per-project, machine-local records (schema `0.2`) stored outside th
     Asset entries and per-file ownership paths with crafted names (path traversal, backslashes) are **reported and skipped individually** — each owned path is containment-validated before use, and the rest of the receipt still loads and is processed.
   </Card>
   <Card title="Contained deletion" icon="box">
-    Deletion goes through adapters using validated **asset tuples** — `(scope, type, name)` triples, the adapter-agnostic identity of a materialized asset — never raw filesystem paths taken from the receipt. For a skill, the delete request also carries the validated owned-companion path set, so only owned files are removed, unowned files survive, and emptied directories are pruned.
+    Deletion goes through adapters using validated **asset tuples** — `(scope, type, effective name)` triples, the addressable identity of a materialized asset — never raw filesystem paths taken from the receipt. For a skill, the delete request also carries the validated owned-companion path set, so only owned files are removed, unowned files survive, and emptied directories are pruned.
   </Card>
 </CardGroup>
 
 ## Drift removal
 
-After the loop, the receipt is compared against the desired set. Any facet the receipt shows as installed — but that is no longer wanted — has its assets deleted, including each skill's owned companion files. The comparison runs against the **receipt**, not the on-disk lockfile; this is what makes **orphan-on-pull** recoverable (a facet whose lockfile entry vanished because a teammate removed it and you pulled — the receipt still remembers the local materialization). Lockfile entries missing from a freshly-bootstrapped receipt are caught too. And because the asset tuples and owned-file sets to delete come from the receipt itself, removal needs no cache and no network.
+Drift removal is a **single global pass keyed by effective identity**, and it runs at the start of Apply — *before* any asset is written, not after.
 
-Drift removal runs **before** the tri-write, but its deletions MUST be journaled like every other write — if the commit fails afterward, rollback restores them.
+The receipt supplies the previous ownership set, with the lockfile as a fallback for facets the receipt does not mention. Every historical claim on one effective identity is unioned, and each claim's owned companion paths are stripped using its **own** authored name, because an aliased skill's recorded paths are authored while its bundle lives under the effective name. The desired set is the composed plan's effective identities. The difference is deleted.
+
+The question asked is *"is this effective identity still claimed by any desired asset?"* — not *"is this facet still wanted?"* An identity is retained even when the facet that used to own it is gone, which is what makes **ownership transfer** work: facet A gives up the name `deploy`, facet B claims it, and B's file survives. A per-facet decision would have deleted it.
+
+Deleting before writing is load-bearing for the same reason. If writes came first, transferring a name would write B's asset and then delete it as part of cleaning up A.
+
+The comparison runs against the **receipt**, not the on-disk lockfile; this is what makes **orphan-on-pull** recoverable (a facet whose lockfile entry vanished because a teammate removed it and you pulled — the receipt still remembers the local materialization). Lockfile entries missing from a freshly-bootstrapped receipt are caught too. And because the asset tuples and owned-file sets to delete come from the receipt itself, removal needs no cache and no network.
+
+Deletions MUST be journaled like every other write — if the commit fails afterward, rollback restores them.
 
 ```mermaid
 flowchart TD
-    REC["Each facet in receipt"] --> W{"Still wanted?"}
-    W -->|yes| KEEP["Materialize as above"]
-    W -->|no| DROP["Delete its assets offline"]
+    PREV["Every effective identity<br/>previously owned"] --> W{"Claimed by any<br/>desired asset?"}
+    W -->|yes| KEEP["Retain — possibly<br/>under a new owner"]
+    W -->|no| DROP["Delete offline<br/>(primary + owned companions)"]
     DROP --> RM["Drop from lockfile + receipt"]
 ```
 
@@ -202,8 +257,9 @@ sequenceDiagram
     participant Commit as commit()
     participant FS as filesystem
     Commit->>Commit: merge delta in memory
-    Commit->>Commit: parse + resolve + verify + materialize each facet
-    Commit->>Commit: drift removal via receipt
+    Commit->>Commit: Phase A — parse + resolve + verify every facet
+    Commit->>Commit: Phase B — compose the global plan
+    Commit->>Commit: Phase C — delete obsolete, then materialize
     alt all succeeded
         Commit->>FS: write facets.json + facets.lock + receipt
     else failed
@@ -221,7 +277,25 @@ Frozen mode (the [`--frozen-lockfile`](/cli/install#param-frozen-lockfile) flag)
 A frozen commit with a non-empty delta (any addition or removal) MUST be rejected immediately. Only a plain `facet install` can run frozen.
 </Warning>
 
-The system MUST check bidirectional consistency before touching anything: every manifest facet MUST have a satisfying lockfile entry, the lockfile MUST NOT pin anything the manifest dropped, and git/local sources MUST match their locked provenance.
+Five gates run before anything is touched, and all of them run **before any network access** — a frozen install can refuse without fetching a byte:
+
+<Steps>
+  <Step title="Coverage">
+    Every manifest facet MUST have a satisfying lockfile entry, the lockfile MUST NOT pin anything the manifest dropped, and git/local sources MUST match their locked provenance.
+  </Step>
+  <Step title="Format capability">
+    A lockfile older than `0.3` cannot record a disposition. If the manifest declares any materialization override against one, the install MUST fail rather than silently ignore the intent. The fix is one non-frozen install to migrate the lockfile.
+  </Step>
+  <Step title="Materialization plan over the locked set">
+    The [planner](/specification/materialization#planning-rules) runs against the lockfile's recorded assets, so a collision or invalid alias in recorded state is reported before anything is downloaded. Frozen mode never prompts to resolve it.
+  </Step>
+  <Step title="Stale intent">
+    An override naming an asset the locked version does not contain is blocking drift. A normal install prunes it inside the transaction; frozen mode has no transaction to prune in.
+  </Step>
+  <Step title="Intent vs. recorded disposition">
+    For every locked asset, what `facets.json` asks for MUST equal what `facets.lock` records. Editing an alias without re-running a normal install is drift, exactly like editing a version.
+  </Step>
+</Steps>
 
 | Behavior                         | Frozen mode                                          |
 |----------------------------------|------------------------------------------------------|
@@ -231,6 +305,9 @@ The system MUST check bidirectional consistency before touching anything: every 
 | Archive resolution               | Allowed (downloading locked content is reproduction) |
 | Bidirectional consistency        | Required (manifest ↔ lockfile)                       |
 | Integrity before materialization | Required for every facet (including local sources)   |
+| Collision resolution             | Never prompted — reported                            |
+| Materialization drift            | Rejected (manifest intent ↔ locked disposition)      |
+| Stale overrides                  | Rejected, not pruned                                 |
 | Drift removal                    | Runs; receipt is rewritten                           |
 | Lockfile write                   | Never                                                |
 | Manifest write                   | Never                                                |

--- a/docs/specification/index.mdx
+++ b/docs/specification/index.mdx
@@ -89,7 +89,10 @@ Implementors MUST address:
       Phase 1 -- turn a command into a delta.
    </Card>
    <Card title="Commit" icon="check" href="/specification/commit">
-      Phase 2 -- verify, materialize, write atomically.
+      Phase 2 -- resolve, compose, materialize, write atomically.
+   </Card>
+   <Card title="Materialization" icon="tag" href="/specification/materialization">
+      Authored vs. effective names, aliasing, omission, collisions.
    </Card>
    <Card title="Build" icon="hammer" href="/specification/build">
       Produce the canonical `.facet` archive.

--- a/docs/specification/install.mdx
+++ b/docs/specification/install.mdx
@@ -6,20 +6,22 @@ description: The two-phase install pipeline
 
 import { DeltaTip } from "/snippets/glossary.jsx";
 
-Installation is a single pipeline with two phases. **[Planning](/specification/planning)** builds a <DeltaTip>delta</DeltaTip> — what should change. **[Commit](/specification/commit)** applies it — resolving versions, verifying [integrity](/specification/integrity), materializing assets, and writing `facets.json`, `facets.lock`, and the install receipt together.
+Installation is a single pipeline with two phases. **[Planning](/specification/planning)** builds a <DeltaTip>delta</DeltaTip> — what should change. **[Commit](/specification/commit)** applies it — resolving versions, verifying [integrity](/specification/integrity), composing one global [materialization](/specification/materialization) plan, writing assets, and writing `facets.json`, `facets.lock`, and the install receipt together.
 
 [`facet add`](/cli/add), [`facet remove`](/cli/remove), and [`facet install`](/cli/install) all run this same pipeline — they differ only in the delta they produce.
 
-Before the pipeline runs, **every installed adapter's** declared adapter API MUST be inspected against the CLI's supported set. An incompatible or broken installed adapter MUST fail the operation before planning begins — before any adapter method is invoked and before any project write — with per-adapter diagnostics and the best available reinstall command for each entry. The commit phase then re-checks the adapters selected for the operation as defense-in-depth: the same incompatibility MUST fail at [Load state and gate](/specification/commit), before the per-facet loop and therefore before any Git or local facet build can invoke adapter metadata methods.
+Before the pipeline runs, **every installed adapter's** declared adapter API MUST be inspected against the CLI's supported set. An incompatible or broken installed adapter MUST fail the operation before planning begins — before any adapter method is invoked and before any project write — with per-adapter diagnostics and the best available reinstall command for each entry. The commit phase then re-checks the adapters selected for the operation as defense-in-depth: the same incompatibility MUST fail at [Load state and gate](/specification/commit), before any facet is resolved and therefore before any Git or local facet build can invoke adapter metadata methods.
 
-The [adapter API](/guides/custom-adapters), the [archive `facetVersion`](/specification/archive), and the [lockfile version](/specification/lockfile) are three independent version axes, each classified separately. The adapter-compatibility preflight runs **before** archive-version dispatch, so a positional `0.0` adapter fails on the adapter axis — with reinstall guidance — before a facet's `facetVersion` is even examined.
+The [adapter API](/guides/custom-adapters), the [archive `facetVersion`](/specification/archive), the [project manifest version](/specification/project-manifest), and the [lockfile version](/specification/lockfile) are four independent version axes, each classified separately by exact match. They happen to share release trains; they are not one version in four places. The adapter-compatibility preflight runs **before** archive-version dispatch, so a positional `0.0` adapter fails on the adapter axis — with reinstall guidance — before a facet's `facetVersion` is even examined.
 
-Project state MUST NOT be written unless every check passes: a failure anywhere in commit MUST roll back all materialization via the journal and leave the project exactly as it was.
+Project state MUST NOT be written unless every check passes. Commit's first two phases are read-only, so a failure there — including an unresolved name collision or a cancelled resolution — leaves the project byte-identical with nothing to undo. From the first write onward, a failure MUST roll back all materialization via the journal and leave the project exactly as it was.
 
 What install materializes — and what it does not — is a first-class part of the contract:
 
 - **Materialization boundary.** Skill companion files materialize atomically with their skill; every other supplementary file (top-level `README.md`, `LICENSE`, extras beside agents or commands) ships in the archive but is **never written to disk**. Detail in [Commit — Materialize](/specification/commit#materialize).
-- **Per-file integrity and drift.** Install reconciles each materialized file against its [lockfile `0.2`](/specification/lockfile) integrity before writing and reports the exact drifting path; a single drifted companion is repaired without touching the rest.
+- **Project-chosen names.** A project MAY materialize an asset under a different name, or not at all. The asset is still resolved, verified, and recorded either way — only the file on disk changes. See [Materialization](/specification/materialization).
+- **Global collision detection.** Two facets cannot claim one name. The complete desired asset set is checked before the first write, so a collision stops the install with nothing changed. See [Commit — Compose](/specification/commit#compose).
+- **Per-file integrity and drift.** On reproduction, install reconciles each file against its [lockfile](/specification/lockfile) integrity before writing and reports the exact drifting path; a drifted companion is repaired by replacing its skill's bundle atomically.
 - **Unsupported archive versions.** An archive whose `facetVersion` the CLI does not support fails with a structured error the CLI renders as upgrade guidance — a known newer format names the minimum supporting release, an unknown format says update to the latest.
 
 <CardGroup cols={2}>
@@ -27,14 +29,14 @@ What install materializes — and what it does not — is a first-class part of 
     Phase 1 — build the delta. No version resolution, no lockfile reads, no project mutation.
   </Card>
   <Card title="Commit" icon="check" href="/specification/commit">
-    Phase 2 — the transaction. Parse, resolve, verify, and materialize each facet; remove drift; write atomically.
+    Phase 2 — the transaction. Resolve every facet, compose one global plan, then delete drift and materialize; write atomically.
   </Card>
 </CardGroup>
 
 ```mermaid
 flowchart LR
     CMD["Command<br/>(add / remove / install)"] --> PLAN["Phase 1: Planning<br/>build the delta"]
-    PLAN --> COMMIT["Phase 2: Commit<br/>parse · resolve · verify · materialize<br/>+ drift removal"]
+    PLAN --> COMMIT["Phase 2: Commit<br/>resolve all · compose · apply"]
     COMMIT -->|all checks pass| OK["Tri-write:<br/>facets.json + facets.lock + receipt"]
     COMMIT -->|any failure| RB["Journal rollback<br/>project unchanged"]
 ```

--- a/docs/specification/integrity.mdx
+++ b/docs/specification/integrity.mdx
@@ -48,7 +48,7 @@ These are not interchangeable: gzip is a delivery concern outside the hash contr
     The cached content MUST be re-hashed against its sidecar (self-audit). Tampered content MUST be evicted and re-fetched.
   </Step>
   <Step title="Lockfile comparison">
-    When the lockfile pins a version, the audited integrity MUST equal the locked integrity. Before any file is written, install also reconciles the recomputed archive-entry hash against each [lockfile `0.2` per-file record](/specification/lockfile) and the verified build-manifest hash; a mismatch fails with the exact drifting path.
+    When the lockfile pins a version, the audited integrity MUST equal the locked integrity. **On reproduction** — when the facet resolves to the integrity already locked — install additionally reconciles the recomputed archive-entry hash against each [lockfile per-file record](/specification/lockfile) and the verified build-manifest hash before any file is written; a mismatch fails with the exact drifting path. A legitimate change resolves to a different integrity and has nothing to reconcile against.
   </Step>
   <Step title="Integrity confirmation">
     When a lockfile entry is being created or replaced, the audited integrity MUST match the registry's published `content_integrity`. An unreachable registry MUST fail the operation.
@@ -58,7 +58,11 @@ These are not interchangeable: gzip is a delivery concern outside the hash contr
   </Step>
 </Steps>
 
-Two variants sit outside this lifecycle: **git installs** MUST verify built content against the lockfile integrity (the [one-check reproduction guard](/specification/commit#git-and-local-sources)), and **frozen installs** MUST require every facet — including local sources — to reproduce its locked integrity. The pipeline mechanics for all of these live in [Commit — Verify](/specification/commit#verify).
+Two variants sit outside this lifecycle, and they are distinct checks rather than one: **git installs** MUST verify built content against the lockfile integrity (the [one-check reproduction guard](/specification/commit#git-and-local-sources)), and **frozen installs** MUST require every facet — including local sources — to reproduce its locked integrity. Each reports under its own check label, so a frozen local-source failure is never mislabeled as a git failure. The pipeline mechanics for all of these live in [Commit — Verify](/specification/commit#verify).
+
+<Note>
+Integrity is entirely **authored-domain** and, in fact, name-agnostic. Archive paths and every hash derive from the name the publisher declared, so [aliasing an asset](/specification/materialization) changes nothing here — and an alias can never be used to smuggle different content under a familiar name. An **omitted** asset is fully verified too: verification covers the resolved set, not the subset written to disk.
+</Note>
 
 ### What it guarantees
 
@@ -71,7 +75,7 @@ Two variants sit outside this lifecycle: **git installs** MUST verify built cont
 
 <CardGroup cols={2}>
   <Card title="Lockfile" icon="lock" href="/specification/lockfile">
-    Canonical fingerprint (`content_integrity`) per facet, plus a per-materialized-file `{ path, integrity }` record inside each asset entry.
+    Canonical fingerprint (`content_integrity`) per facet, plus a `{ path, integrity }` record per authored file inside each asset entry — present even for an omitted asset, which materializes nothing.
   </Card>
   <Card title="Cache sidecar" icon="folder" href="/specification/commit#verify">
     Canonical fingerprint + per-entry hash map (`cache-integrity.json`) per cache slot. Written at cache-populate time; re-verified on every cache hit.
@@ -80,6 +84,6 @@ Two variants sit outside this lifecycle: **git installs** MUST verify built cont
     Canonical fingerprint + complete `files` hash map (one entry per inner-tar file). Embedded in the `.facet` archive.
   </Card>
   <Card title="Install receipt" icon="receipt" href="/specification/commit#machine-local-install-receipt">
-    Per-facet asset and owned-file ownership records (not hashes — used for offline drift removal).
+    Per-asset authored identity, owned authored paths, and the disposition each asset was materialized under (not hashes — used for offline drift removal). Omitted assets never appear.
   </Card>
 </CardGroup>

--- a/docs/specification/lockfile.mdx
+++ b/docs/specification/lockfile.mdx
@@ -5,7 +5,7 @@ tag: facets.lock
 description: The facets.lock schema and entry semantics
 ---
 
-The lockfile (`facets.lock`) records resolved installation state: for every declared facet, the exact version, the verified integrity, the provenance it was resolved from, and the assets it contributed — each with a per-file integrity record for every materialized file. It is the **resolution** counterpart to the [project manifest](/specification/project-manifest)'s **intent** — the manifest records what the user asked for, the lockfile records what that resolved to.
+The lockfile (`facets.lock`) records resolved installation state: for every declared facet, the exact version, the verified integrity, the provenance it was resolved from, and the assets it contributed — each with the [disposition](/specification/materialization#dispositions) it resolved to and a per-file integrity record for every file it owns. It is the **resolution** counterpart to the [project manifest](/specification/project-manifest)'s **intent** — the manifest records what the user asked for, the lockfile records what that resolved to.
 
 Both files are version-controlled. The lockfile is written **only** by the install pipeline, as part of the [tri-write](/specification/commit#transactional-tri-write) — never ahead of success, and never by hand. A hand-edited or merge-conflicted lockfile fails validation at load rather than surfacing as a failure deep inside an install.
 
@@ -13,7 +13,7 @@ Both files are version-controlled. The lockfile is written **only** by the insta
 
 ```json expandable facets.lock
 {
-  "lockfileVersion": 0.2,
+  "lockfileVersion": 0.3,
   "facets": {
     "cowsay": {
       "source": { "kind": "registry", "registry": "https://api.agentfacets.io" },
@@ -24,6 +24,7 @@ Both files are version-controlled. The lockfile is written **only** by the insta
           "scope": "project",
           "type": "command",
           "name": "cowsay",
+          "materialization": { "kind": "authored" },
           "files": [
             { "path": "commands/cowsay.md", "integrity": "sha256:11aa22…" }
           ]
@@ -39,9 +40,19 @@ Both files are version-controlled. The lockfile is written **only** by the insta
           "scope": "project",
           "type": "skill",
           "name": "viper-planning",
+          "materialization": { "kind": "aliased", "as": "team-planning" },
           "files": [
             { "path": "skills/viper-planning/SKILL.md", "integrity": "sha256:33cc44…" },
             { "path": "skills/viper-planning/references/api.md", "integrity": "sha256:55ee66…" }
+          ]
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "scratch",
+          "materialization": { "kind": "omitted" },
+          "files": [
+            { "path": "commands/scratch.md", "integrity": "sha256:77ff88…" }
           ]
         }
       ]
@@ -50,10 +61,20 @@ Both files are version-controlled. The lockfile is written **only** by the insta
 }
 ```
 
+Note what aliasing does **not** move: `name` is still `viper-planning` and its `files` still live under `skills/viper-planning/`. Only the file on disk is named `team-planning`.
+
 ## Fields
 
 <ResponseField name="lockfileVersion" type="number" required>
-  The lockfile schema version. The current schema is `0.2`; the numeric `1` names the earlier legacy-alpha schema. Versions are dispatched by **exact match**, never by numeric ordering (`0.2` is numerically less than `1`, so ordering would be wrong): a loader recognizes exactly the versions it supports and fails on any other rather than guessing. A normal install MAY migrate a verified legacy `1` lockfile to `0.2`; a [frozen install](/specification/commit#frozen-lockfile) never rewrites it, and a `0.2` archive requires a `0.2` lockfile in frozen mode. The authoritative version is the `CURRENT_LOCKFILE_VERSION` constant in `@agent-facets/protocol`.
+  The lockfile schema version. The current schema — the one a normal install writes — is `0.3`. Two earlier schemas remain **readable**: `0.2`, and the numeric `1` naming the legacy-alpha schema.
+
+  Versions are dispatched by **exact match**, never by numeric ordering. Note that `0.3 < 0.2 < 1` numerically, so ordered comparison would rank the newest schema as the oldest; a loader recognizes exactly the versions it supports and fails on any other rather than guessing. There is no cross-version fallback.
+
+  A normal install migrates a verified `1` or `0.2` lockfile to `0.3` as part of the tri-write. A [frozen install](/specification/commit#frozen-lockfile) never rewrites it, and therefore retains whatever version it loaded. The authoritative version is the `CURRENT_LOCKFILE_VERSION` constant in `@agent-facets/protocol`.
+
+  <Note>
+  Readers are deliberately broader than the writer: reading three versions and writing one is a format-compatibility property, not a staged rollout.
+  </Note>
 
   <Note>
   Before the future stable lockfile v1 (which reuses the numeric `1`), legacy-alpha-`1` parsing is removed and replaced with delete-and-regenerate guidance for old-shape files.
@@ -61,7 +82,7 @@ Both files are version-controlled. The lockfile is written **only** by the insta
 </ResponseField>
 
 <ResponseField name="facets" type="map<name, entry>" required>
-  One entry per resolved facet, keyed by facet name. The name lives only in the key — entries do not repeat it.
+  One entry per resolved facet, keyed by facet name. The name lives only in the key — entries do not repeat it. Keys are written in sorted order, so add/remove/add produces byte-identical output.
 </ResponseField>
 
 ## Entry fields
@@ -83,14 +104,23 @@ Both files are version-controlled. The lockfile is written **only** by the insta
 </ResponseField>
 
 <ResponseField name="assets" type="array" required>
-  The assets this facet contributed. Each entry is `{ scope, type, name, files }` (`scope`: `system` | `user` | `project`; `type`: `skill` | `agent` | `command`). Names MUST pass asset-name validation — a crafted lockfile cannot smuggle path traversal into adapter I/O. Adapter-agnostic by design: the same asset set is applied to every selected adapter, and no per-adapter fields exist here.
+  The assets this facet contributed. Each entry is `{ scope, type, name, materialization, files }` (`scope`: `system` | `user` | `project`; `type`: `skill` | `agent` | `command`). Names MUST pass asset-name validation — a crafted lockfile cannot smuggle path traversal into adapter I/O. Adapter-agnostic by design: the same asset set is applied to every selected adapter, and no per-adapter fields exist here.
 
-  The `files` array records every **materialized** file inside the asset as a deterministically-sorted `{ path, integrity }` record: a skill lists its `SKILL.md` plus each companion; an agent or command lists its single primary file. The integrity is the recomputed [canonical per-entry hash](/specification/integrity#two-hashes-two-domains) of the verified file — never copied from a self-declared value. Archive-only supplementary files (like `README.md`) are **not** materialized and therefore never appear in any asset's `files`; they stay protected by facet-level integrity. Install reconciles these per-file records against recomputed archive hashes before writing and fails with the exact mismatching path.
+  `name` is the **authored** name and `files` are **canonical authored** archive paths, both unchanged by aliasing — they anchor integrity. See [Two identities](/specification/materialization#two-identities).
+
+  `materialization` is the resolved [disposition](/specification/materialization#dispositions), and all three arms are legal here: this array is the resolved asset **set**, not the on-disk set. An **omitted** asset therefore stays listed with its complete file records — dropping it would make an omission indistinguishable from a facet that never published the asset. (The [install receipt](/specification/commit#machine-local-install-receipt), which records what is actually on disk, admits only `authored` and `aliased`.)
+
+  The `files` array records every file the asset owns as a `{ path, integrity }` record: a skill lists its `SKILL.md` plus each companion; an agent or command lists its single primary file. Each `integrity` is `sha256:` followed by exactly 64 lowercase hex characters — the recomputed [canonical per-entry hash](/specification/integrity#two-hashes-two-domains) of the verified file, never copied from a self-declared value. Records are sorted strictly ascending by path, which also forbids duplicates. At least one record is required. Archive-only supplementary files (like `README.md`) are never materialized and never appear here; they stay protected by facet-level integrity.
 </ResponseField>
+
+<Note>
+An asset entry from a pre-`0.3` lockfile has no `materialization` field. It is read as equivalent to an explicit `{ "kind": "authored" }` — the only disposition those schemas could express.
+</Note>
 
 ## Role in the pipeline
 
 - **Trust anchor.** When the lockfile pins a version, the audited content MUST hash to the locked integrity — a mismatch is a hard failure, never a silent re-download. → [Commit — Verify](/specification/commit#verify)
 - **Lockfile trust for resolution.** Whether a satisfying entry short-circuits version resolution depends on how the facet was requested (addition vs reproduction). → [Commit — Resolve](/specification/commit#resolve)
-- **Drift-proof deletion.** The entry's `assets` array — with its per-file `files` records — is the OLD ownership set; the freshly extracted build manifest is the NEW set; the difference is deleted with no separate bookkeeping. Deletion supplies the validated owned-file set to the adapter, so a skill's companions are removed with it while unowned files are preserved. → [Drift removal](/specification/commit#drift-removal)
-- **Frozen mode.** With `--frozen-lockfile`, the lockfile is the complete, authoritative source of truth and is never written. → [Frozen lockfile](/specification/commit#frozen-lockfile)
+- **Per-file reconciliation on reproduction.** When a facet resolves to the integrity already locked, install proves the per-file records still agree with the recomputed archive before writing, and fails with the exact mismatching path. A legitimate change resolves to a *different* integrity, so reconciliation does not apply to it. → [Commit — Verify](/specification/commit#verify)
+- **Ownership fallback for deletion.** The install receipt is the authority on what is on disk; the lockfile's `assets` supply the previous ownership set for facets the receipt does not mention. Ownership is indexed by **effective** identity, so a name that transferred between facets is not deleted out from under its new owner. Omitted assets contribute nothing, having never been written. → [Drift removal](/specification/commit#drift-removal)
+- **Frozen mode.** With `--frozen-lockfile`, the lockfile is the complete, authoritative source of truth and is never written. A lockfile older than `0.3` cannot record a disposition, so a project that declares materialization overrides against one fails frozen validation rather than silently ignoring the intent. → [Frozen lockfile](/specification/commit#frozen-lockfile)

--- a/docs/specification/manifest.mdx
+++ b/docs/specification/manifest.mdx
@@ -7,10 +7,10 @@ description: The facet.json schema and name grammar
 
 import { AssetDescriptor } from "/snippets/asset-descriptor.mdx";
 
-The facet manifest (`facet.json`) is the source of truth for a facet's identity, the text assets it contains, and the [supplementary files](#supplementary-files) it ships. This page defines every field in the manifest schema and is the canonical reference for both the facet name grammar and the asset name grammar.
+The facet manifest (`facet.json`) is the source of truth for a facet's identity, the text assets it contains, and the [supplementary files](#supplementary-files) it ships. The names it declares are **authored** names: they fix every archive path and integrity value, and a consuming project may materialize an asset under a different name without changing any of that. This page defines every field in the manifest schema and is the canonical reference for both the facet name grammar and the asset name grammar.
 
 <Note>
-The facet manifest is distinct from the [project manifest](/specification/project-manifest) (`facets.json`) — the file in a consuming project that declares which facets are installed. Throughout this page, "the manifest" means the facet manifest.
+The facet manifest is distinct from the [project manifest](/specification/project-manifest) (`facets.json`) — the file in a consuming project that declares which facets are installed, and how it wants their assets named. Throughout this page, "the manifest" means the facet manifest.
 </Note>
 
 For conceptual guides to each asset type, see [Skills](/docs/learn/skills), [Commands](/docs/learn/commands), and [Agents](/docs/learn/agents).
@@ -153,6 +153,8 @@ Asset names — skill, command, and agent names — follow the [Agent Skills nam
 
 Skills and commands share **one namespace**: within a facet, a skill and a command MUST NOT use the same name. Agents are a separate namespace and may reuse a skill or command name.
 
+The manifest is validated against this rule within a single facet. The same rule is applied again **across every facet in a project** at install time, over the names assets are actually materialized under — see [Namespaces](/specification/materialization#namespaces).
+
 A companion file's path may contain `/` for directory depth (`references/api.md`), but those separators are part of the file path, not the skill name — the skill name itself is still a single segment.
 
 <Note>
@@ -176,7 +178,11 @@ A facet's content is carried by three text asset types: skills, agents, and comm
 - **Agent** — `agents/<name>.md`. A single markdown file whose content is the agent's system prompt.
 - **Command** — `commands/<name>.md`. A single markdown file whose content is the command's prompt.
 
-A primary asset file (a `SKILL.md`, agent, or command file) MUST NOT contain YAML front matter — the manifest is the single source of asset metadata. Authoring tools strip front matter before writing, and [`facet build`](/specification/build#steps) rejects a primary file that still carries it.
+A primary asset file (a `SKILL.md`, agent, or command file) MAY carry author-supplied YAML front matter. It ships verbatim in the archive and is reconciled with the manifest only at install time: materialization merges the manifest's `name` and `description`, plus any per-adapter extras, on top of whatever the author wrote. The manifest always wins, so a facet cannot override its own asset identity through front matter.
+
+<Note>
+The `name` written at install time is the asset's **effective** name — the one the consuming project chose. `description` stays as the publisher wrote it. See [Two identities](/specification/materialization#two-identities).
+</Note>
 
 An asset descriptor's `adapters` block is validated at [build time](/specification/build#steps) against each installed adapter's schema: unknown adapters produce a warning, and invalid metadata for an installed adapter is a build error.
 

--- a/docs/specification/materialization.mdx
+++ b/docs/specification/materialization.mdx
@@ -1,0 +1,161 @@
+---
+title: "Materialization"
+description: How authored assets become files on disk
+---
+
+Materialization is the rule that turns the assets facets publish into the files a tool actually reads. It sits inside [Commit](/specification/commit#compose), between verification and the first write.
+
+Most of the time it is invisible: a facet publishes a skill named `planning`, and a file named `planning` appears. It becomes visible the moment two facets publish the same name, or a project decides it wants a published asset under a different name — or not at all.
+
+<Info>
+Materialization decides **names**, never **content**. Every archive path, every integrity hash, and every byte of an asset is fixed by its publisher and unaffected by anything on this page.
+</Info>
+
+## Two identities
+
+Every asset has two names, and conflating them is the mistake this model exists to prevent.
+
+<ResponseField name="authored name" type="fixed by the publisher">
+  The name declared in the facet's [`facet.json`](/specification/manifest). It fixes the asset's canonical paths inside the [archive](/specification/archive) — `skills/<authored>/SKILL.md`, `agents/<authored>.md`, `commands/<authored>.md` — and therefore every [integrity](/specification/integrity) value recorded for it. It is what the [lockfile](/specification/lockfile) stores. Aliasing and omission never change it.
+</ResponseField>
+
+<ResponseField name="effective name" type="chosen by the project">
+  The name the asset is materialized under: the file an [adapter](/specification/terminology#core-concepts) reads, writes, and deletes. It equals the authored name unless the consuming project aliased it.
+</ResponseField>
+
+An aliased skill therefore lives on disk under its **effective** name while its recorded file paths remain **authored**:
+
+```
+facet.json          skills/planning/SKILL.md      (authored — anchors integrity)
+facets.lock         skills/planning/SKILL.md      (authored)
+on disk             skills/team-planning/SKILL.md (effective)
+```
+
+Front matter follows the same split: the `name` field written into a materialized asset is the **effective** name, while `description` stays as the publisher wrote it. Renaming an asset does not rewrite it.
+
+## Dispositions
+
+A project resolves each authored asset to exactly one of three outcomes.
+
+<ResponseField name="authored" type="the default">
+  Materialize under the publisher's name. Expressed by recording **nothing** — the absence of an override *is* the authored disposition. An explicit `authored` override in [`facets.json`](/specification/project-manifest) MUST be rejected, so that one state has exactly one spelling.
+</ResponseField>
+
+<ResponseField name="aliased" type="{ kind: 'aliased', as }">
+  Materialize under a different effective name. `as` is required and MUST satisfy the single-segment [asset-name grammar](/specification/manifest#asset-names). An invalid alias MUST be rejected, never normalized or sanitized — silently rewriting a chosen name would make the materialized identity unpredictable.
+</ResponseField>
+
+<ResponseField name="omitted" type="{ kind: 'omitted' }">
+  Do not materialize this asset, or any file it owns. The asset is still resolved, still verified, and still recorded in the lockfile — it simply never reaches an adapter.
+</ResponseField>
+
+Two narrower forms are derived from these three arms:
+
+- A **project override** admits only `aliased` and `omitted`, because `authored` is the absence of an override.
+- A **materialized disposition** — what the [install receipt](/specification/commit#machine-local-install-receipt) records for an asset present on disk — admits only `authored` and `aliased`, because an omitted asset is not on disk. "Omitted but present" is unrepresentable rather than merely invalid.
+
+<Note>
+An omitted asset stays listed in the lockfile with its complete authored file records. Dropping it would make an omission indistinguishable from a facet that never published the asset at all.
+</Note>
+
+## Recording intent
+
+Dispositions live in [`facets.json`](/specification/project-manifest) as durable project intent, keyed by asset type and then by **authored** name:
+
+```json facets.json
+{
+  "manifestVersion": 0.1,
+  "facets": {
+    "team-tools": {
+      "source": "1.*",
+      "materialization": {
+        "skills": {
+          "planning": { "kind": "aliased", "as": "team-planning" },
+          "scratch": { "kind": "omitted" }
+        }
+      }
+    }
+  }
+}
+```
+
+Overrides are keyed by authored name because that is the only stable identifier — an alias is the thing being declared, so it cannot also be the key.
+
+Intent is durable. It survives a failed install, a re-add, and a change of source: changing *where* a facet comes from is not a statement about *how* its assets should be named. It is discarded only when the facet is removed, or when the asset it names disappears (see [Stale overrides](#stale-overrides)).
+
+<Tip>
+You rarely write this block by hand. [`facet add`](/cli/add) and [`facet install`](/cli/install) open an interactive resolver when they hit a collision and write your choices here. Hand-editing is the path for CI, where nothing can prompt.
+</Tip>
+
+## Namespaces
+
+Two assets may share a name freely across namespaces, but never within one.
+
+- **`skill-command`** — skills and commands compete for the same names, because they materialize into a single flat command surface in the tools facets target.
+- **`agent`** — agents occupy their own namespace.
+
+So a skill `deploy` and a command `deploy` collide, while an agent `deploy` coexists with both. This is the same rule a single facet's [`facet.json`](/specification/manifest#constraints) is validated against; materialization applies it across every facet in the project at once.
+
+## Collisions
+
+Two assets collide when their **collision keys** are equal:
+
+```
+collisionKey = (scope, namespace, portable effective name)
+```
+
+Three properties of that key matter:
+
+- It uses the **effective** name, so aliasing can both cause and cure a collision.
+- It folds asset type into its **namespace**, giving the rule above.
+- It folds the name **portably** — Unicode NFC, then case — so two assets differing only by case or normalization collide rather than silently overwriting each other on a case-insensitive volume.
+
+A collision key is a *logical* identity and MUST NOT be handed to an adapter. The addressable identity is `(scope, type, effective name)`, keyed by asset type rather than namespace and by the verbatim effective name rather than a folded one: a skill `deploy` and a command `deploy` are two different files even though they may not legally coexist.
+
+### When collisions are detected
+
+Detection is **global and pre-write**. Every facet in the desired set is resolved and verified first; only then is the complete effective set checked, before any adapter is asked to write anything.
+
+```mermaid
+flowchart LR
+    RESOLVE["Resolve all<br/>every facet fetched + verified"]
+    PLAN["Plan materialization<br/>overrides applied, effective set checked"]
+    APPLY["Apply<br/>delete obsolete, then write"]
+    RESOLVE --> PLAN
+    PLAN -->|collision-free| APPLY
+    PLAN -->|collisions| STOP["Stop<br/>nothing written"]
+```
+
+This ordering is the reason the whole desired set must exist before the first write: a per-facet loop cannot detect that facet A and facet Z want the same name until it has already materialized A.
+
+When the effective set does collide, the result carries **every** group with **every** claimant — never a truncated report, and never a generated winner. A tool that picked a winner would silently discard someone's asset.
+
+## Planning rules
+
+Materialization planning is a **single pass**, not a fixed-point resolver. Overrides are applied once against authored identity, then the resulting effective set is checked once. Four consequences follow, and all four are normative:
+
+- **Alias swaps are legal.** If `A` aliases to `B` and `B` aliases to `A`, both land. Neither observes the other's result, because there is no second pass.
+- **Duplicate alias targets fail.** Two assets aliased to the same name collide like any other pair.
+- **A name freed by an omission is available.** Omitting one claimant removes it from the effective set entirely.
+- **Order does not matter.** The result never depends on the order facets were declared in.
+
+Determinism is a contract: every output list is sorted — by scope, then asset type in canonical order (`skill`, `agent`, `command`), then name by code unit. Identical inputs produce identical bytes, so lockfile diffs stay reviewable. Sorting is deliberately not locale-aware; locale-sensitive collation would make output depend on the machine's environment.
+
+## Stale overrides
+
+An override naming an asset the resolved facet version no longer contains is **stale** — typically because you upgraded a facet and the publisher renamed or dropped that asset.
+
+A stale override is reported, not fatal. Because intent is durable, it survives a failed operation and is pruned only as part of a successful commit — at which point the CLI tells you what it dropped. Under [`--frozen-lockfile`](/specification/commit#frozen-lockfile) the same report is blocking drift instead: frozen mode has no transaction to prune in, and silently ignoring recorded intent would defeat the flag's purpose.
+
+## What aliasing does not change
+
+Aliasing renames; it does not rewrite. Everything in this list is anchored to the **authored** name and is byte-identical whether or not an asset is aliased:
+
+- Canonical inner-archive paths, and therefore the archive's per-entry hashes.
+- The facet's canonical fingerprint (`content_integrity`).
+- The lockfile's `name` and `files` records for the asset.
+- The asset's content and its `description`.
+
+<Warning>
+Because integrity is anchored to authored paths, an alias can never be used to smuggle different content under a familiar name. Verification happens before materialization and never sees the effective name.
+</Warning>

--- a/docs/specification/planning.mdx
+++ b/docs/specification/planning.mdx
@@ -5,7 +5,7 @@ description: Build the install delta
 
 import { DeltaTip } from "/snippets/glossary.jsx";
 
-Planning is phase 1 of the [install pipeline](/specification/install): turn a command into a <DeltaTip>delta</DeltaTip>. It is thin by design — all resolution, verification, and mutation belong to [Commit](/specification/commit).
+Planning is phase 1 of the [install pipeline](/specification/install): turn a command into a <DeltaTip>delta</DeltaTip>. It is thin by design — all resolution, verification, composition, and mutation belong to [Commit](/specification/commit).
 
 <Info>
     Planning performs **no version resolution, no lockfile lookups, no project mutation, and takes no install lock.**
@@ -44,7 +44,7 @@ The specifier is passed through untouched. Plan does not decide what version a w
 
 **`facet add`** resolves each source's facet name and builds the additions list. For registry sources the name comes from the specifier itself. For git and local sources the name lives in the source's `facet.json`, so preparation MAY **clone the repository or read the local path** to discover it. Still no version resolution and no project writes.
 
-**`facet remove`** is read-only validation: it loads the manifest and filters the requested names against the facets it actually declares, producing the removals list.
+**`facet remove`** is read-only validation: it loads the manifest and filters the requested names against the facets it actually declares, producing the removals list. A missing `facets.json` is a hard failure; a name the manifest does not declare is silently ignored.
 
 **`facet install`** has no preparation at all — an empty delta. The commit phase reproduces the declared set.
 
@@ -55,6 +55,10 @@ Each addition specifier is parsed into one of three tagged source kinds before c
 - **`registry`** — `name@range`. A registry facet: `cowsay`, `cowsay@1.*`, `cowsay@latest`. The default when no other shape matches.
 - **`git`** — a full git URL (`https://…`, `git@…`) with an optional `#ref` (branch, tag, or commit). The shorthand `github:owner/repo#ref` is accepted and normalizes to this kind.
 - **`local`** — a directory path, resolved relative to the project.
+
+<Note>
+The delta carries **no materialization intent**. An addition is `{ name, specifier, source }` and nothing more: how a project wants an asset named is durable intent read from `facets.json` during [Compose](/specification/commit#compose), never something a command plans. This is also why planning cannot detect a name collision — a `facet add` that will collide is caught in Compose, after every facet has been fetched and verified.
+</Note>
 
 <Note>
 Caret, tilde, and comparator ranges (`^1.2.0`, `~1.2.0`, `>=1.2.0`) MUST be rejected. Only exact versions, bounded wildcards (`1.*`, `1.2.*`), the open wildcard (`*`), and `latest` are accepted. The user-facing grammar, including every accepted and rejected shape, is documented at [`facet add`](/cli/add#source-grammar).

--- a/docs/specification/project-manifest.mdx
+++ b/docs/specification/project-manifest.mdx
@@ -5,7 +5,7 @@ tag: facets.json
 description: The facets.json schema and entry semantics
 ---
 
-The project manifest (`facets.json`) is the file in a consuming project that declares which facets the project depends on. It is the input every install command reads and the declarative record a team commits to version control — a fresh clone plus [`facet install`](/cli/install) reproduces the full asset set.
+The project manifest (`facets.json`) is the file in a consuming project that declares which facets the project depends on, and how it wants their assets materialized. It is the input every install command reads and the declarative record a team commits to version control — a fresh clone plus [`facet install`](/cli/install) reproduces the full asset set.
 
 <Note>
 The project manifest is distinct from the [facet manifest](/specification/manifest) (`facet.json`) — the file *inside a facet* that declares its identity and assets. A consuming project has one `facets.json`; every facet ships its own `facet.json`.
@@ -15,38 +15,89 @@ The project manifest is distinct from the [facet manifest](/specification/manife
 
 ```json facets.json
 {
+  "manifestVersion": 0.1,
   "facets": {
     "cowsay": "1.*",
     "viper-plans": "github:agent-facets/viper-plans#main",
-    "my-local": "./facets/my-local"
+    "my-local": "./facets/my-local",
+    "team-tools": {
+      "source": "1.*",
+      "materialization": {
+        "skills": { "planning": { "kind": "aliased", "as": "team-planning" } }
+      }
+    }
   }
 }
 ```
 
 ## Fields
 
-<ResponseField name="facets" type="map<name, specifier>" required>
-  One entry per declared facet. The key is the facet name; the value is the source specifier **as the user wrote it**. Entries are added and removed by the install pipeline — or by hand, with `facet install` reconciling the result.
+<ResponseField name="manifestVersion" type="number" required>
+  The manifest schema version. The current version is `0.1`. A document that omits this field is a **legacy unversioned** manifest and is still read; see [Validation](#validation).
+
+  This axis is independent of the archive, lockfile, and adapter API versions — four separate compatibility axes that happen to share release trains.
+</ResponseField>
+
+<ResponseField name="facets" type="map<name, entry>" required>
+  One entry per declared facet. The key is the facet name. The value is either a **compact** source specifier string or an **expanded** object. Entries are added and removed by the install pipeline — or by hand, with `facet install` reconciling the result.
 </ResponseField>
 
 ## Entry value semantics
 
-The value's meaning depends on the source kind established when the entry was added (see [Accepted source kinds](/specification/planning#accepted-source-kinds)):
+An entry takes one of two forms. Both express the same source; the expanded form additionally carries the project's [materialization](/specification/materialization) intent.
 
-- **Registry** — the value is a bare version specifier (`1.2.3`, `1.*`, `1.2.*`, `*`, `latest`); the facet name lives in the key, and commit reconstructs the full source as `name@specifier`.
-- **Git / GitHub** — the value is a self-contained source string (a git URL or `github:` shorthand, with an optional `#ref`). The ref recorded here is what the user *requested*; the resolved commit lives in the [lockfile](/specification/lockfile).
-- **Local** — the value is a directory path that MUST resolve inside the project tree.
+<ResponseField name="compact" type="string">
+  The source specifier **as the user wrote it**. This is the canonical form for a facet with no materialization overrides.
+</ResponseField>
+
+<ResponseField name="expanded" type="{ source, materialization }">
+  `source` carries the same specifier string the compact form would. `materialization` records per-asset [dispositions](/specification/materialization#dispositions), grouped by asset type (`skills`, `agents`, `commands`) and keyed by **authored** asset name. It MUST declare at least one override — an expanded entry with none is invalid, because the compact form already expresses that.
+</ResponseField>
+
+A consumer reading `facets.json` MUST handle both forms. Treating the value as a string is the failure mode this schema is shaped to make obvious rather than silent.
+
+Whichever form the entry takes, the specifier's meaning depends on the source kind established when the entry was added (see [Accepted source kinds](/specification/planning#accepted-source-kinds)):
+
+- **Registry** — a bare version specifier (`1.2.3`, `1.*`, `1.2.*`, `*`, `latest`); the facet name lives in the key, and commit reconstructs the full source as `name@specifier`.
+- **Git / GitHub** — a self-contained source string (a git URL or `github:` shorthand, with an optional `#ref`). The ref recorded here is what the user *requested*; the resolved commit lives in the [lockfile](/specification/lockfile).
+- **Local** — a directory path that MUST resolve inside the project tree.
 
 ## Validation
 
-Only the shape is validated at load time: `facets` MUST be a map of string to string. Specifier grammar is validated when each entry is parsed during [commit](/specification/commit#parse) — a malformed specifier fails the install, not the load.
+**Version dispatch is by exact equality, never by shape.** A document is classified before its schema is chosen:
+
+- `manifestVersion` **absent** → legacy unversioned. Every entry value MUST be a string; an expanded entry here is rejected, not promoted.
+- `manifestVersion` **exactly** the number `0.1` → current schema. The string `"0.1"` is not the number `0.1` and MUST be rejected.
+- Anything else → an `unsupported manifestVersion` failure naming the observed and supported versions.
+
+There is no cross-version fallback. A `0.1` document that violates the current schema MUST NOT be retried as legacy — that would let a typo downgrade a manifest silently.
+
+**Duplicate JSON members are rejected before dispatch.** Two entries with the same key would otherwise collapse by last-member-wins, which could discard one of two conflicting materialization decisions for the same asset.
+
+Beyond shape, the load validates what it can prove locally:
+
+- Override **keys** are checked for path safety, so a project can address a legacy multi-segment authored name.
+- Alias **values** are checked against the current single-segment [asset-name grammar](/specification/manifest#asset-names) and are rejected rather than normalized.
+- An `{ "kind": "authored" }` override is rejected. Authored materialization is expressed by the absence of an override, and one state MUST have exactly one spelling.
+
+Specifier grammar is *not* validated at load. It is validated when each entry is parsed during [commit](/specification/commit#parse) — a malformed specifier fails the install, not the load.
 
 ## Write rules
 
 - The project manifest MUST NOT be written ahead of the install. A failed operation MUST leave it untouched. → [Installation](/specification/install)
+- Every successful non-frozen write stamps the current `manifestVersion`, migrating a legacy document **inside the same transaction** that writes the lockfile and receipt. There is no separate migration step and no standalone upgrade command.
 - What gets written per specifier shape (bare names pin, explicit specifiers are preserved verbatim, reproductions are unchanged) is defined by the [manifest-write policy](/specification/commit#manifest-write-policy).
+- Entry form follows content: an entry that has overrides is written expanded; an entry whose last override is removed **collapses back to a compact string**. An existing expanded entry is mutated in place.
+- Comments survive. `facets.json` may carry `//` and `/* */` comments; writes mutate the document in place rather than re-serializing it, so hand-written annotations are preserved.
+- [Stale overrides](/specification/materialization#stale-overrides) are pruned as part of a successful commit, and reported afterwards.
 - On success it is written atomically alongside `facets.lock` and the install receipt — the [tri-write](/specification/commit#transactional-tri-write).
+
+<Note>
+Frozen mode never writes the manifest. A legacy document therefore stays legacy under [`--frozen-lockfile`](/specification/commit#frozen-lockfile), and stale overrides are neither pruned nor reported — they are blocking drift instead.
+</Note>
 
 ## Relationship to the lockfile
 
-The project manifest records **intent** (what the user asked for, in the shape they asked for it); the [lockfile](/specification/lockfile) records **resolution** (exact versions, integrity, provenance). Both are version-controlled; the install receipt is not. The two MUST stay consistent — [frozen mode](/specification/commit#frozen-lockfile) checks that consistency bidirectionally before touching anything.
+The project manifest records **intent** (what the user asked for, in the shape they asked for it, and how they want it named); the [lockfile](/specification/lockfile) records **resolution** (exact versions, integrity, provenance, and the disposition each asset was resolved to). Both are version-controlled; the install receipt is not.
+
+The two MUST stay consistent — [frozen mode](/specification/commit#frozen-lockfile) checks that consistency bidirectionally before touching anything, including whether the lockfile's format can express the intent the manifest declares.

--- a/docs/specification/terminology.mdx
+++ b/docs/specification/terminology.mdx
@@ -12,7 +12,7 @@ Canonical terms used throughout the specification. Implementations SHOULD use th
     A named, versioned collection of text assets defined by a manifest. What the author creates, what gets published, and what gets installed.
   </Card>
   <Card title="Project manifest" icon="files" href="/specification/project-manifest">
-      `facets.json` — the file in a consuming project that declares which facets are installed. Distinct from the facet manifest.
+      `facets.json` — the versioned file in a consuming project that declares which facets are installed and how it wants their assets materialized. Distinct from the facet manifest.
     </Card>
   <Card title="Facet manifest" icon="file-code" href="/specification/manifest">
     `facet.json` — the source of truth for a facet's identity and the text assets it contains.
@@ -44,13 +44,15 @@ Canonical terms used throughout the specification. Implementations SHOULD use th
 
 | Term | Definition | Reference |
 | --- | --- | --- |
-| **Asset tuple** | A `(scope, type, name)` triple — the adapter-agnostic identity of a materialized asset. Skill ownership also carries a validated owned-companion path set. | [Install receipt](/specification/commit#machine-local-install-receipt) |
+| **Asset tuple** | A `(scope, type, effective name)` triple — the addressable identity an adapter reads, writes, or deletes. Skill ownership also carries a validated owned-companion path set. | [Install receipt](/specification/commit#machine-local-install-receipt) |
+| **Authored name** | The name the publisher declared. Fixes the asset's canonical archive paths and every integrity value; aliasing never changes it. | [Two identities](/specification/materialization#two-identities) |
+| **Effective name** | The name an asset is materialized under. Equals the authored name unless the project aliased it. | [Two identities](/specification/materialization#two-identities) |
 | **Managed asset** | Installed by a facet; tracked in the lockfile and install receipt. | [`facet edit`](/cli/authoring/edit) |
 | **Unmanaged asset** | In an adapter directory but not connected to any facet: user-created, or kept from an uninstalled facet. | [`facet edit`](/cli/authoring/edit) |
 | **Supplementary file** | A manifest-declared non-asset file shipped in the archive and integrity-protected, but never an independently installable asset. | [Supplementary files](/specification/manifest#supplementary-files) |
 | **Companion file** | A per-skill supplementary file that materializes atomically with its owning skill. | [Supplementary files](/specification/manifest#supplementary-files) |
 | **Archive-only file** | A top-level supplementary file (e.g. `README.md`) that ships in the archive but is never written to disk at install. | [Materialize](/specification/commit#materialize) |
-| **Owned companion path set** | The engine-supplied, containment-validated set of a skill's companion paths handed to the adapter for install, read, and delete. | [Materialize](/specification/commit#materialize) |
+| **Owned companion path set** | The engine-supplied, containment-validated set of a skill's companion paths handed to the adapter for install, read, and delete. Unioned across every historical claim on one effective identity, so a name taken over from another facet still cleans up that facet's leftovers. | [Materialize](/specification/commit#materialize) |
 
 ## Identity & versioning
 
@@ -69,11 +71,11 @@ Canonical terms used throughout the specification. Implementations SHOULD use th
 | **Transport hash** | `content_hash` — SHA-256 of the uploaded `.facet` tarball; a download-time transit check only, never persisted. | [Two hashes, two domains](/specification/integrity#two-hashes-two-domains) |
 | **Build manifest** | `build-manifest.json`, embedded in the archive's outer layer; the integrity claim and the complete per-entry `files` hash map. | [Archive format](/specification/archive) |
 | **Cache sidecar** | `cache-integrity.json`, stored alongside cached content; the canonical fingerprint plus per-entry hashes. | [Where hashes live](/specification/integrity#where-hashes-live) |
-| **Adapter API version** | The identifier for the adapter contract shape (currently `0.1`); classified by exact match, independent of the archive and lockfile versions. | [Custom adapters](/guides/custom-adapters) |
+| **Adapter API version** | The identifier for the adapter contract shape (currently `0.1`); classified by exact match. One of four independent version axes, alongside the archive `facetVersion`, the project manifest version, and the lockfile version. | [Custom adapters](/guides/custom-adapters) |
 | **Cache self-audit** | Re-verification of cached content against its sidecar on every materialization; a mismatch evicts the slot. | [Commit — Verify](/specification/commit#verify) |
 | **Integrity confirmation** | The registry metadata check required whenever a lockfile entry is created or replaced; fails offline. | [Registry interactions](/specification/commit#registry-interactions) |
-| **One-check reproduction guard** | The git-source defense: built content must hash to the locked integrity (the tag-move defense). | [Git and local sources](/specification/commit#git-and-local-sources) |
-| **Frozen mode** | `--frozen-lockfile` — the lockfile is the complete, authoritative source of truth; every facet must reproduce its locked integrity. | [Frozen lockfile](/specification/commit#frozen-lockfile) |
+| **One-check reproduction guard** | The single-anchor defense used where no registry confirmation applies: built content must hash to the locked integrity. Reported under a `git` check for git sources (the tag-move defense) and a `lockfile` check elsewhere, e.g. a frozen local source. | [Git and local sources](/specification/commit#git-and-local-sources) |
+| **Frozen mode** | `--frozen-lockfile` — the lockfile is the complete, authoritative source of truth; every facet must reproduce its locked integrity, and its recorded materialization intent must match the manifest exactly. Never prompts. | [Frozen lockfile](/specification/commit#frozen-lockfile) |
 
 ## Install pipeline
 
@@ -81,18 +83,26 @@ Canonical terms used throughout the specification. Implementations SHOULD use th
 | --- | --- | --- |
 | **Install pipeline** | The two-phase flow every install command runs: planning, then commit. | [Installation](/specification/install) |
 | **Planning** | Phase 1: turn a command into a delta; no resolution, no lockfile reads, no writes. | [Planning](/specification/planning) |
-| **Commit** | Phase 2: the transaction that resolves, verifies, materializes, and writes atomically. | [Commit](/specification/commit) |
+| **Commit** | Phase 2: the transaction that resolves, composes, materializes, and writes atomically. | [Commit](/specification/commit) |
+| **Resolve-all / Compose / Apply** | Commit's three phases. The first two are read-only; the journal opens at Apply. | [The three phases](/specification/commit#the-three-phases) |
 | **Delta** | Additions (the user's specifier verbatim) plus removals (bare names); `facet install` produces an empty delta. | [The delta](/specification/planning#the-delta) |
 | **Addition / reproduction** | The structural discriminator: non-exact additions never trust the lockfile for version resolution; reproductions and exact additions do. | [The delta](/specification/planning#the-delta) |
 | **Desired set** | The manifest's facets after the delta is merged in memory. | [Sequence](/specification/commit#sequence) |
 | **Install lock** | The per-project advisory lock ensuring one install at a time. | [Sequence](/specification/commit#sequence) |
 | **Journal** | The log in which every materialization write records its inverse operation, replayed in reverse on failure. | [Commit](/specification/commit) |
-| **Materialization** | Writing assets from verified content into each selected adapter's storage. | [Materialize](/specification/commit#materialize) |
-| **Install receipt** | The machine-local, per-project record (schema `0.2`) under `$FACET_DIR/receipts/` mirroring committed asset and per-file ownership for offline removal. | [Install receipt](/specification/commit#machine-local-install-receipt) |
-| **Drift removal** | Deleting assets of facets no longer wanted, computed from the receipt, entirely offline. | [Drift removal](/specification/commit#drift-removal) |
+| **Materialization** | Deciding each asset's effective identity, then writing the result into each selected adapter's storage. | [Materialization](/specification/materialization) |
+| **Disposition** | How a project materializes one authored asset: `authored`, `aliased`, or `omitted`. | [Dispositions](/specification/materialization#dispositions) |
+| **Materialization override** | A project's recorded `aliased` or `omitted` intent for one authored asset, stored in `facets.json`. Authored is the absence of an override. | [Recording intent](/specification/materialization#recording-intent) |
+| **Materialization namespace** | The logical space asset types compete for names in: skills and commands share one, agents have their own. | [Namespaces](/specification/materialization#namespaces) |
+| **Collision group** | Two or more assets claiming one logical identity `(scope, namespace, folded effective name)`. | [Collisions](/specification/materialization#collisions) |
+| **Claimant** | One member of a collision group — the facet, asset, and disposition that arrived at the contested name. | [Collisions](/specification/materialization#collisions) |
+| **Stale override** | An override naming an asset the resolved version no longer contains. Pruned on a successful commit; blocking drift under frozen mode. | [Stale overrides](/specification/materialization#stale-overrides) |
+| **Ownership transfer** | A name moving between facets across one install. Deletion is keyed by effective identity, so the new owner's file survives. | [Drift removal](/specification/commit#drift-removal) |
+| **Install receipt** | The machine-local, per-project record (schema `0.3`) under `$FACET_DIR/receipts/` recording asset ownership, owned authored paths, and each asset's disposition for offline removal. Omitted assets never appear. | [Install receipt](/specification/commit#machine-local-install-receipt) |
+| **Drift removal** | Deleting every effective identity no longer claimed by any desired asset, computed from the receipt, entirely offline. Runs before any write. | [Drift removal](/specification/commit#drift-removal) |
 | **Orphan-on-pull** | The recoverable state where a teammate's removal reaches you via `git pull`; the receipt still remembers. | [Drift removal](/specification/commit#drift-removal) |
 | **Tri-write** | The atomic commit of `facets.json`, `facets.lock`, and the receipt together; failure leaves all three unchanged. | [Transactional tri-write](/specification/commit#transactional-tri-write) |
-| **Lockfile** | `facets.lock` — resolved installation state: tagged source, exact version, integrity, and per-asset entries with per-file `{ path, integrity }` records. | [Lockfile](/specification/lockfile) |
+| **Lockfile** | `facets.lock` — resolved installation state: tagged source, exact version, integrity, and per-asset entries carrying a disposition plus per-file `{ path, integrity }` records. | [Lockfile](/specification/lockfile) |
 | **Cache** | The machine-local content-addressed store for fetched facet payloads under `$FACET_DIR/cache/`. | [`facet install`](/cli/install#cache) |
 
 ## Authoring & publishing

--- a/openspec/changes/add-materialization-aliasing/tasks.md
+++ b/openspec/changes/add-materialization-aliasing/tasks.md
@@ -95,20 +95,32 @@
 
 ## 11. User and Specification Documentation — Research
 
-- [ ] 11.1 Explore: Re-audit `docs/specification/project-manifest.mdx`, `lockfile.mdx`, `install.mdx`, `planning.mdx`, `commit.mdx`, `manifest.mdx`, `integrity.mdx`, and `terminology.mdx` against the implemented schemas and phase boundaries, preserving existing inbound anchors.
-- [ ] 11.2 Explore: Re-audit `docs/cli/add.mdx`, `install.mdx`, `instructions.mdx`, `remove.mdx`, and `list.mdx` plus `docs/guides/install-facets.mdx`, `custom-adapters.mdx`, and `troubleshooting.mdx` against final CLI output and recovery behavior.
-- [ ] 11.3 Explore: Inspect `docs/changelog/index.mdx`, documentation conventions, navigation/link requirements, and root `README.md`; confirm whether the reviewed README quickstart remains accurate.
-- [ ] 11.4 Propose: Define one non-duplicative documentation update plan covering schema references, install behavior, CLI workflows, guides, recovery, changelog, links, and the README disposition.
+- [x] 11.1 Explore: Re-audit `docs/specification/project-manifest.mdx`, `lockfile.mdx`, `install.mdx`, `planning.mdx`, `commit.mdx`, `manifest.mdx`, `integrity.mdx`, and `terminology.mdx` against the implemented schemas and phase boundaries, preserving existing inbound anchors.
+- [x] 11.2 Explore: Re-audit `docs/cli/add.mdx`, `install.mdx`, `instructions.mdx`, `remove.mdx`, and `list.mdx` plus `docs/guides/install-facets.mdx`, `custom-adapters.mdx`, and `troubleshooting.mdx` against final CLI output and recovery behavior.
+- [x] 11.3 Explore: Inspect `docs/changelog/index.mdx`, documentation conventions, navigation/link requirements, and root `README.md`; confirm whether the reviewed README quickstart remains accurate.
+- [x] 11.4 Propose: Define one non-duplicative documentation update plan covering schema references, install behavior, CLI workflows, guides, recovery, changelog, links, and the README disposition.
 
 ## 12. User and Specification Documentation — Implementation
 
-- [ ] 12.1 Implement: Update `docs/specification/project-manifest.mdx` for `manifestVersion: 0.1`, exact dispatch, legacy migration, compact/expanded entries, typed overrides, preservation/collapse rules, duplicate rejection, and frozen behavior.
-- [ ] 12.2 Implement: Update `docs/specification/lockfile.mdx` for lockfile `0.3`, required dispositions, authored paths, omitted records, exact legacy dispatch, migration policy, and receipt/effective-ownership implications.
-- [ ] 12.3 Implement: Update install pipeline documentation in `docs/specification/install.mdx`, `planning.mdx`, `commit.mdx`, `manifest.mdx`, `integrity.mdx`, and `terminology.mdx` for authored/effective identities, Resolve-all/Compose/Apply, global ownership, frozen behavior, and the four independent version axes while preserving existing anchors.
-- [ ] 12.4 Implement: Update `docs/cli/add.mdx`, `docs/cli/install.mdx`, and `docs/guides/install-facets.mdx` with the interactive resolution workflow, red/yellow/green status model with non-color cues, persisted examples, non-interactive/frozen behavior, cancellation, summaries, and resulting on-disk layout.
-- [ ] 12.5 Implement: Update `docs/cli/instructions.mdx`, `remove.mdx`, `list.mdx`, `docs/guides/custom-adapters.mdx`, and `troubleshooting.mdx` for manual CI intent, effective adapter names, expanded-entry reading, ownership-safe removal, unsupported versions, stale overrides, and recovery.
-- [ ] 12.6 Implement: Add the newest-first changelog entry for the breaking manifest/lockfile/receipt formats and collision workflow, including required RSS metadata and links, without rewriting historical entries; leave README unchanged unless final behavior invalidates the reviewed quickstart.
-- [ ] 12.7 Verify: Run documentation formatting/link checks and stale-text searches for lockfile/receipt `0.2`, three-version-axis claims, string-only manifests, and the interleaved install loop.
+> Approved plan additions from 11.4, beyond the original file list: (a) a new
+> `docs/specification/materialization.mdx` owning the identity/disposition model,
+> registered in the `Installation` nav group, so the model is stated once rather
+> than restated on nine pages; (b) correcting the `facet instructions` prompt
+> source, which currently tells agents `facets.json` is a flat string map and
+> should not be hand-edited — both false, and the second steers agents away from
+> the only non-TTY remedy; (c) fixing four pre-existing `README.md` defects found
+> during the audit. `facet list` cannot show aliased or omitted assets; that gap
+> is documented, not closed, in this change.
+
+- [x] 12.0 Implement: Add `docs/specification/materialization.mdx` defining authored vs. effective identity, the three dispositions, the override schema, collision/adapter keys and portable folding, the skill-command namespace rule, and the planner's determinism guarantees; register it in the `Installation` nav group in `docs/docs.json`.
+- [x] 12.1 Implement: Update `docs/specification/project-manifest.mdx` for `manifestVersion: 0.1`, exact dispatch, legacy migration, compact/expanded entries, typed overrides, preservation/collapse rules, duplicate rejection, and frozen behavior.
+- [x] 12.2 Implement: Update `docs/specification/lockfile.mdx` for lockfile `0.3`, required dispositions, authored paths, omitted records, exact legacy dispatch, migration policy, and receipt/effective-ownership implications.
+- [x] 12.3 Implement: Update install pipeline documentation in `docs/specification/install.mdx`, `planning.mdx`, `commit.mdx`, `manifest.mdx`, `integrity.mdx`, and `terminology.mdx` for authored/effective identities, Resolve-all/Compose/Apply, global ownership, frozen behavior, and the four independent version axes while preserving existing anchors.
+- [x] 12.4 Implement: Update `docs/cli/add.mdx`, `docs/cli/install.mdx`, and `docs/guides/install-facets.mdx` with the interactive resolution workflow, red/yellow/green status model with non-color cues, persisted examples, non-interactive/frozen behavior, cancellation, summaries, and resulting on-disk layout.
+- [x] 12.5 Implement: Update `docs/cli/instructions.mdx`, `remove.mdx`, `list.mdx`, `docs/guides/custom-adapters.mdx`, and `troubleshooting.mdx` for manual CI intent, effective adapter names, expanded-entry reading, ownership-safe removal, unsupported versions, stale overrides, and recovery.
+- [x] 12.5a Implement: Correct the `facet instructions` prompt source (`packages/cli/src/prompts/`) so emitted agent guidance describes compact and expanded `facets.json` entries and the hand-edit recovery path for collisions, and add tests asserting that guidance.
+- [x] 12.6 Implement: Add the newest-first changelog entry for the breaking manifest/lockfile/receipt formats and collision workflow, including required RSS metadata and links, without rewriting historical entries; leave README's quickstart unchanged, and repair the four pre-existing README defects found in 11.3 (three dead relative links, stale bare-name resolution claim).
+- [x] 12.7 Verify: Run documentation formatting/link checks and stale-text searches for lockfile/receipt `0.2`, three-version-axis claims, string-only manifests, and the interleaved install loop.
 
 ## 13. Migration and Cross-Layer Validation — Research
 

--- a/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
+++ b/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
@@ -84,6 +84,52 @@ describe('0.29 guidance is present in the prompts', () => {
   })
 })
 
+describe('materialization guidance is present in the prompts', () => {
+  // An agent that believes facets.json is a flat name -> string map will
+  // silently destroy any recorded alias or omission the moment it rewrites
+  // the file. The prompt is the only thing standing between that belief and
+  // a user's project, so assert it teaches both entry forms.
+  test('usage documents the expanded facets.json entry form', () => {
+    const usage = TOPICS.usage.prompt
+    expect(usage).toContain('manifestVersion')
+    expect(usage).toContain('"materialization"')
+    expect(usage).toContain('handle BOTH forms')
+  })
+
+  test('usage teaches the non-TTY collision remedy', () => {
+    const usage = TOPICS.usage.prompt
+    expect(usage).toContain('"kind": "aliased"')
+    expect(usage).toContain('"kind": "omitted"')
+    // Recording an explicit authored disposition is rejected by the schema,
+    // so the prompt must not present it as an option.
+    expect(usage).toContain('Do NOT write')
+    expect(usage).toContain('"skills", "agents", and "commands"')
+  })
+
+  test('usage does not claim facets.json is a flat string map', () => {
+    expect(TOPICS.usage.prompt).not.toContain('map of facet name to source specifier')
+  })
+
+  test('usage does not steer agents away from the only non-TTY remedy', () => {
+    // Hand-editing facets.json is the sole way to record an alias without a
+    // TTY -- there is no --as or --omit flag on any command.
+    expect(TOPICS.usage.prompt).not.toContain('You generally do not hand-edit it')
+  })
+
+  test('authoring warns that authored names may not land verbatim', () => {
+    const authoring = TOPICS.authoring.prompt
+    expect(authoring).toContain('AUTHORED name')
+    expect(authoring).toContain('omit it entirely')
+  })
+
+  test('overview command index covers the project-management commands', () => {
+    const overview = TOPICS.overview.prompt
+    for (const command of ['facet install', 'facet remove', 'facet list', 'facet publish']) {
+      expect(overview).toContain(command)
+    }
+  })
+})
+
 describe('manifest schema generation', () => {
   test('toJsonSchema with the predicate fallback does not throw and drops the predicate', () => {
     let schema: unknown

--- a/packages/cli/src/prompts/authoring.txt
+++ b/packages/cli/src/prompts/authoring.txt
@@ -13,6 +13,14 @@ Asset names are a single segment: 1-64 chars, lowercase letters/digits/hyphens,
 no leading/trailing/consecutive hyphens, and no slashes. A skill and a command
 must NOT share a name (agents are a separate namespace).
 
+The name you declare is the AUTHORED name. It fixes the asset's archive paths
+and every integrity hash, and it is what facets.lock records. A consuming
+project may install the asset under a different name, or omit it entirely, if
+it collides with another facet — so do not assume your names land verbatim on
+a user's disk. Nothing about authoring changes because of this; pick names that
+are unlikely to collide (a distinctive prefix helps) and you make it a non-issue
+for your users.
+
 1) SCAFFOLD a new facet — `facet create`
    Pass headless flags to skip the interactive wizard:
      facet create ./my-facet \

--- a/packages/cli/src/prompts/overview.txt
+++ b/packages/cli/src/prompts/overview.txt
@@ -22,17 +22,28 @@ The three artifact files
                descriptions and optional per-adapter config, and any
                supplementary files it ships. You edit this when AUTHORING.
                See: facet instructions manifest
-  facets.json  A consuming project's dependency list: which facets it installs.
-               You touch this when USING facets (via `facet add`).
+  facets.json  A consuming project's dependency list: which facets it installs,
+               and how it wants their assets named. Each entry is either a
+               source string or an object carrying materialization choices, so
+               read both forms. You touch this when USING facets (via
+               `facet add`, or by hand to resolve a name collision).
+               See: facet instructions usage
   facets.lock  The install lockfile. Managed by the CLI; do not hand-edit.
 
 Command index
-  facet create        Scaffold a new facet (headless flags available).
+  facet create         Scaffold a new facet (headless flags available).
   facet modify         Make a scriptable edit to a facet.
   facet build          Build a facet; use --verify to validate without output.
   facet edit           Interactive editing wizard (TTY only — prefer `modify`).
   facet add            Add a facet to a project and install it.
+  facet install        Install every facet declared in facets.json.
+  facet remove         Remove a facet from the project (alias: facet rm).
+  facet list           List declared facets and their resolved versions.
+  facet search         Search the registry.
   facet adapter        Install / list / remove adapter tooling.
+  facet publish        Publish a built facet to the registry.
+  facet login          Authenticate with the registry (also: logout, whoami).
+  facet self-update    Update the CLI itself.
   facet instructions   Print these instructions (see the topic index above).
 
 Machine-readable output

--- a/packages/cli/src/prompts/usage.txt
+++ b/packages/cli/src/prompts/usage.txt
@@ -30,9 +30,55 @@ Add a facet to a project — `facet add`
     facet add ./path/to/facet            A local facet directory in the project.
 
 The project files
-  facets.json – Your dependency list: a map of facet name to source specifier.
-                `facet add` maintains it. You generally do not hand-edit it.
+  facets.json – Your dependency list. `facet add` and `facet remove` maintain
+                it; hand-edit it only to record materialization choices (below).
+                It carries a "manifestVersion" the CLI stamps for you.
+
+                Each entry is EITHER a source specifier string OR an object:
+                  "facets": {
+                    "cowsay": "1.*",
+                    "team-tools": {
+                      "source": "1.*",
+                      "materialization": { ... }
+                    }
+                  }
+                When reading or rewriting facets.json, handle BOTH forms. A
+                tool that assumes every value is a string will destroy any
+                recorded materialization choices.
+
   facets.lock – The install lockfile, managed by the CLI. Do not hand-edit.
+
+Name collisions — when two facets want the same name
+  Two facets cannot install an asset under the same name. Skills and commands
+  share one namespace; agents have their own. The install detects this before
+  writing anything and stops.
+
+  Without a TTY (CI, or any automated run) nothing is prompted: the command
+  exits non-zero and prints every claimant with the exact facets.json edit.
+  Resolve it by recording a choice per asset, keyed by the AUTHORED name:
+
+    "team-tools": {
+      "source": "1.*",
+      "materialization": {
+        "skills": {
+          "planning": { "kind": "aliased", "as": "team-planning" },
+          "scratch":  { "kind": "omitted" }
+        }
+      }
+    }
+
+  Group keys are "skills", "agents", and "commands". Only two kinds are legal
+  here: "aliased" (requires "as") and "omitted". Do NOT write
+  { "kind": "authored" } — installing under the published name is expressed by
+  recording NO override at all, and an explicit "authored" is rejected.
+
+  An alias must satisfy the asset-name grammar: 1-64 chars, lowercase letters,
+  digits and hyphens, no leading/trailing hyphen, no consecutive hyphens, no
+  slash. Invalid aliases are rejected, never auto-corrected.
+
+  Only one claimant has to change — the names just have to differ. Re-run
+  `facet install` after editing. There is no CLI flag for this; the resolver
+  UI (TTY only) and hand-editing facets.json are the two ways to record it.
 
 Adapter tooling — `facet adapter`
   Adapters teach facets how to target a specific AI coding tool. Installing an


### PR DESCRIPTION
### Why

Two facets can publish an asset with the same name, and previously the second one silently overwrote the first. This introduces cross-facet name collision detection, interactive and non-interactive resolution, and asset aliasing/omission — giving projects explicit control over how published assets are named on disk.

### Details

**Collision detection and resolution.** `facet add`, `facet install`, and `facet remove` now detect every cross-facet name collision across the complete desired asset set before writing anything. In an interactive terminal, the install pauses and opens a resolver where each contested asset can be kept under its published name, aliased to a name you type, or omitted entirely. Status is expressed with icon-plus-word pairs (`✕ unresolved`, `⚠ conflict`, `✓ resolved`) so it remains readable without color. Confirmation unlocks only when the planner reports the whole draft collision-free. `Esc` or `Ctrl-C` cancels with nothing written. In CI, piped output, or under `--frozen-lockfile`, nothing is prompted — the command exits non-zero and writes a full report to stderr with every claimant, the exact `facets.json` location to edit, and copy-pasteable alias/omit snippets. No winner is chosen and no alias is invented.

**Asset aliasing and omission.** Any asset can be aliased or omitted via a `materialization` block in `facets.json`, independent of collisions. Aliasing renames only the file on disk; archive paths, integrity hashes, and lockfile records keep the publisher's authored name. Omitted assets are still resolved, verified, and recorded in the lockfile — they are simply never written to disk.

**Breaking: `facets.json` gains `manifestVersion: 0.1` and expanded entries.** A facet entry is now either a source string or `{ source, materialization }`. Any tool reading `facets.json` must handle both forms. A manifest with no `manifestVersion` is read as legacy and migrated in place inside the same transaction that writes the lockfile and receipt. Comments survive writes.

**Breaking: `facets.lock` moves to `0.3` and the receipt to `0.3`.** Every lockfile asset entry carries a required `materialization` disposition. Omitted assets stay listed with their complete authored file records. Legacy `1` and `0.2` lockfiles remain readable and are migrated by any non-frozen install. A frozen install fails with `materialization-unrepresentable` when the manifest declares overrides against a pre-`0.3` lockfile.

**Install pipeline is now Resolve-all → Compose → Apply.** The previous interleaved per-facet loop could not detect a collision between the first and last facet because the first was already on disk. The first two phases are read-only, so a collision, invalid alias, or cancellation leaves the project byte-identical with no rollback needed. Deletion now runs in one global pass keyed by effective adapter identity before any write, making ownership transfer between facets correct and preventing double-deletion.

**Other changes.** A version-unchanged disposition change now classifies as `updated`. The install summary names every asset whose materialized name differs from its authored one. Stale overrides are pruned on a successful commit and reported without `--verbose`; frozen mode treats them as blocking drift. `facet list` reports an unsupported `manifestVersion` distinctly from a malformed manifest. Adapters receive the effective asset name in every install, read, and delete request — the adapter API version is unchanged and no adapter needs rebuilding. `facet instructions` now teaches agents both `facets.json` entry forms and the hand-edit path for resolving a collision without a TTY.

A new `docs/specification/materialization.mdx` page owns the authored/effective identity model, disposition definitions, namespace rules, collision detection semantics, and planner determinism guarantees, so the model is stated once rather than restated across every other page.

### Verification

New tests in `instructions.test.ts` assert that the `usage` and `authoring` prompts describe both `facets.json` entry forms, teach the non-TTY collision remedy, do not claim the file is a flat string map, and do not steer agents away from hand-editing. Documentation link and stale-text checks were run against lockfile/receipt `0.2` references, three-version-axis claims, string-only manifest assumptions, and the interleaved install loop description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking manifest/lockfile/receipt contracts and install semantics affect every consumer and CI frozen-lockfile path; this diff is mostly docs and prompts, so runtime risk depends on companion implementation commits in the same PR.
> 
> **Overview**
> This change set **documents and announces** cross-facet name collision handling and **materialization** (keep, alias, or omit assets), aligned with the **Resolve-all → Compose → Apply** install model where collisions are detected globally before any write.
> 
> **Breaking formats (described in changeset, spec, and changelog):** `facets.json` gains `manifestVersion: 0.1` and compact or expanded `{ source, materialization }` entries; `facets.lock` and the install receipt move to **0.3** with a required per-asset `materialization` disposition while lockfile `name`/`files` stay **authored** for integrity.
> 
> **Docs:** Adds `docs/specification/materialization.mdx` and wires it into the nav; updates commit/install/lockfile/project-manifest, CLI pages (`add`, `install`, `remove`, `list`), guides (install-facets, custom-adapters, troubleshooting), and a large changelog entry. CLI behavior is spelled out for interactive resolution, non-interactive/frozen failure reports, disposition-only `updated` outcomes, stale-override pruning, and effective adapter names.
> 
> **Agent guidance:** `facet instructions` prompts (`usage`, `overview`, `authoring`) now teach both `facets.json` entry shapes, the hand-edit collision path for non-TTY, and that authored names may not land verbatim on disk; `instructions.test.ts` locks that in.
> 
> **Misc:** Root `README.md` fixes dead links, registry bare-name wording, and package doc paths; OpenSpec doc tasks 11–12 are marked complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 864c8c0c282501ba33bd301381f064a548446d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->