### PR TITLE
Add `worktrunk` facet at version 0.1.0

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -5,6 +5,7 @@
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.2",
     "@agentfacets/address-pr-feedback": "latest",
-    "graphite": "0.1.0"
+    "graphite": "0.1.0",
+    "worktrunk": "0.1.0"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -313,6 +313,74 @@
           ]
         }
       ]
+    },
+    "worktrunk": {
+      "source": {
+        "kind": "registry",
+        "registry": "https://api.agentfacets.io"
+      },
+      "version": "0.1.0",
+      "integrity": "sha256:9a83ea1e20a7277f5a71ed2e19f1f5a23de6168fdb061d5ccbaaca15e2c76600",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "using-worktrunk",
+          "files": [
+            {
+              "path": "skills/using-worktrunk/SKILL.md",
+              "integrity": "sha256:5176af6d234b0c79f607e034c2792cd0e8fc6c28dbfd01dcb62afe04d835c603"
+            },
+            {
+              "path": "skills/using-worktrunk/install.md",
+              "integrity": "sha256:c25bb51bb92b95d636066938e1fee4b879a3611780bf093b52aba50164cb518a"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/faq.md",
+              "integrity": "sha256:dd9a6506674e18855c5131af322f1b8a4e37a52d956fd607c21d2b2348586d6b"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/list.md",
+              "integrity": "sha256:79451f8d3ac4e0ecfd9a9cb87ec62293b35f4c8d61761e1d5ef3fbb0eaf598d4"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/merge.md",
+              "integrity": "sha256:3ed6cf71ca409302d8bfb53388d7d0d727ee24f48af6128fbde2398d88ac8fa9"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/remove.md",
+              "integrity": "sha256:c604069ea4525019f2b6cf082c2ff1cc6f1a3ced604b7bb44e1e1a647d769e65"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/shell-integration.md",
+              "integrity": "sha256:b617dca30ecdebc84d05701556098d9ded2dbf5f39849b625c3d799a49d576c8"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/step.md",
+              "integrity": "sha256:d55aaec34eac79081dfb05819a052b4ef5ed58d6953e792e21d64381d2bc16fc"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/switch.md",
+              "integrity": "sha256:5a479efe180c1fca1f50987a9c746bab0c847447110f90c1c5eb4625e2c4b30f"
+            },
+            {
+              "path": "skills/using-worktrunk/reference/worktrunk.md",
+              "integrity": "sha256:a6a279cfe47617e6cc7a677a61feede6f5b133bad06a73ed8279b9b3202de16d"
+            }
+          ]
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "wt-switch-create",
+          "files": [
+            {
+              "path": "commands/wt-switch-create.md",
+              "integrity": "sha256:83eceb6ba0e8b8efd4d192dcfb2443740cb90c65b92edd95b64e92f0d9760ed9"
+            }
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Why

Adds the `worktrunk` facet (v0.1.0) to the project to enable Worktrunk integration.

### Details

The `worktrunk` facet installs a `using-worktrunk` skill with reference documentation covering core Worktrunk commands (`list`, `merge`, `remove`, `step`, `switch`, `shell-integration`) as well as a `wt-switch-create` command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and manifest-only change with no application or security logic touched; risk is limited to pulling new agent skill/command assets on install.
> 
> **Overview**
> Adds the **`worktrunk`** facet at **0.1.0** to `facets.json` and pins it in `facets.lock` from the Agent Facets registry (same pattern as `graphite`).
> 
> The locked package brings in the **`using-worktrunk`** project skill (install notes plus reference docs for list, merge, remove, step, switch, shell integration, and FAQ) and the **`wt-switch-create`** command so agents can use Worktrunk workflows in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3dabcd99ea529e7401fa70661c3f1d9ec2733a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Graphite and Worktrunk version 0.1.0 to the available package list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->