### PR TITLE
Add `manifestVersion` 0.1 to facets.json and bump facet versions

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -7,5 +7,6 @@
     "@agentfacets/address-pr-feedback": "latest",
     "graphite": "0.1.0",
     "worktrunk": "0.1.0"
-  }
+  },
+  "manifestVersion": 0.1
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.0.0",
-      "integrity": "sha256:ed944fd6249d1eb4b1050d6ba1b8bc212136222c2ab2c498032eed2abf0e2360",
+      "version": "2.0.5",
+      "integrity": "sha256:4086e7797583194ddfd51e1724bb9ab2100c482122bcea891d232639bed70bd3",
       "assets": [
         {
           "scope": "project",
@@ -147,8 +147,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.0.0",
-      "integrity": "sha256:d9905f6076c5c454e9d563980eda52c5a9ceb9e761003f9c454e362cd56efd61",
+      "version": "2.3.0",
+      "integrity": "sha256:cca17795ad5e8091a2e16ef498087511494e125ab9212d880800ddc370fdb431",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Adds `manifestVersion` to `facets.json` to declare the manifest format version, and bumps two facet dependencies to their latest versions.

### Details

- `manifestVersion` is set to `0.1` in `facets.json`
- `@agentfacets/address-pr-feedback` updated from `1.0.0` to `2.0.5`
- `graphite` updated from `1.0.0` to `2.3.0`, with updated integrity hashes in the lockfile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and manifest-format metadata only; risk is limited to changed behavior in the bumped facet skills/commands, not core app logic.
> 
> **Overview**
> Declares **`manifestVersion`: `0.1`** on `facets.json` so tooling can treat the manifest as the new versioned format (legacy manifests without the field are still migrated on install per project docs).
> 
> **`facets.lock`** is refreshed for two registry facets pinned as `latest` in the manifest: **`@agentfacets/address-pr-feedback`** `1.0.0` → **`2.0.5`** and **`@agentfacets/review-openspec-design`** `1.0.0` → **`2.3.0`**, with updated package and file integrity hashes. No application runtime code changes—only manifest metadata and locked facet content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687322ea3907272929cc8da9b40026a69884db62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->