### PR TITLE
Skip deletion of obsolete bundles whose primary is already absent; report retained companions as untracked

### DIFF
--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -541,18 +541,26 @@ For an explicit add:
 
 The system SHALL maintain a machine-local receipt describing the asset and file ownership successfully materialized for each project. The receipt SHALL be separate from version-controlled state, identified by canonical project location, and sufficient to delete the assets it records without cache or network access. Each canonical project location SHALL have its own receipt; two projects SHALL never share one, and concurrent operations in different projects SHALL NOT contend on the same receipt. The receipt SHALL survive lockfile changes made outside the system. Current receipts SHALL use schema version `0.3` and record only assets actually materialized, with authored identity, authored owned-file paths, and the authored-or-aliased materialization disposition needed to address the effective adapter identity, without storing adapter-encoded hashes. Omitted assets SHALL NOT appear. Receipt `1` and `0.2` assets SHALL refine losslessly to authored materialization. A legacy receipt that predates companion ownership MAY be refined to primary-only ownership because legacy installation could not materialize companions.
 
-The receipt SHALL be the sole authority for materialized ownership. A receipt that cannot be loaded — absent, corrupt, or path-mismatched — SHALL confer no ownership, and the system SHALL NOT derive ownership from the lockfile in its place, because the lockfile is shared, version-controlled state that describes intended rather than local materialization. A corrupt or path-mismatched receipt SHALL be reported, because it silently withdraws deletion authority the project previously had; an absent receipt SHALL NOT be, being the ordinary first-operation state. An asset the receipt records SHALL be a **tracked materialization**; an asset on disk that no receipt record covers SHALL be an **untracked materialization**. Desired project state SHALL authorize writes and tracked ownership SHALL authorize deletion: the system SHALL reconcile every desired effective adapter identity, overwriting an untracked file already occupying one and recording it as tracked thereafter, and SHALL leave untracked files at identities the desired state does not name untouched. Reconciling an identity SHALL mean either writing it or verifying that its rendered content, metadata, and owned companion set already match byte for byte; a verified match SHALL be recorded as tracked without a redundant write, because the operation established the same fact either way.
+The receipt SHALL be the sole authority for materialized ownership. A receipt that cannot be loaded — absent, corrupt, or path-mismatched — SHALL confer no ownership, and the system SHALL NOT derive ownership from the lockfile in its place, because the lockfile is shared, version-controlled state that describes intended rather than local materialization. A corrupt or path-mismatched receipt SHALL be reported, because it silently withdraws deletion authority the project previously had; an absent receipt SHALL NOT be, being the ordinary first-operation state. An asset the receipt records SHALL be a **tracked materialization**; an asset on disk that no receipt record covers SHALL be an **untracked materialization**. Desired project state SHALL authorize writes and tracked ownership SHALL authorize deletion: the system SHALL reconcile every desired effective adapter identity, including one an untracked file already occupies, recording it as tracked thereafter, and SHALL leave untracked files at identities the desired state does not name untouched. Reconciling an identity SHALL mean establishing that its rendered content, metadata, and owned companion set match the desired state before ownership is recorded. Whether that state is established by writing or by determining that it already holds SHALL be an implementation concern, because reconciliation is defined by the state it leaves behind rather than by the operations used to reach it.
 
 Receipt ownership SHALL be adapter-agnostic project ownership. A recorded identity SHALL be managed in every selected adapter, and selecting an adapter SHALL delegate management of the identities the project's receipt records within that adapter's storage. The system SHALL NOT record ownership per adapter, and SHALL NOT require separate evidence per adapter before reconciling or deleting a recorded identity.
 
-The receipt, lockfile, and materialized state SHALL commit together: within one operation, handled failures SHALL roll back all three, and an interruption that prevents rollback SHALL be recoverable by re-running installation, whose per-file integrity reconciliation converges disk, lockfile, and receipt without deleting unowned files. Receipt-driven deletion SHALL aggregate duplicate historical claims by effective adapter identity, delete each obsolete identity at most once, and pass each skill's validated authored companion ownership into the adapter deletion request so removal after a pulled lockfile drops an entry deletes exactly the recorded owned files without cache or network access. The receipt SHALL determine what is currently materialized when pulled version-control changes remove lockfile entries. In frozen-lockfile mode, receipt-driven cleanup SHALL begin only after the frozen consistency check passes. If that check rejects an orphaned lockfile entry, installation SHALL fail before cleanup changes any materialized state. Receipt data SHALL be treated as untrusted: project identity, record shape, and path containment within the selected adapter's storage SHALL be validated before deletion. Invalid or escaping records SHALL be reported and SHALL NOT cause deletion; files not recorded as owned SHALL never be deleted.
+The receipt, lockfile, and materialized state SHALL commit together: within one operation, handled failures SHALL roll back all three, and an interruption that prevents rollback SHALL be recoverable by re-running installation, whose per-file integrity reconciliation converges disk, lockfile, and receipt without deleting unowned files. Receipt-driven deletion SHALL aggregate duplicate historical claims by effective adapter identity, delete each obsolete identity at most once, and pass each skill's validated authored companion ownership into the adapter deletion request so removal after a pulled lockfile drops an entry deletes exactly the recorded owned files without cache or network access. Deletion SHALL be limited to state the operation can restore: because a skill bundle is addressed through its primary, an absent primary leaves the recorded companions unreadable as a rollback preimage, so the system SHALL leave those recorded paths untouched rather than perform a deletion a later failure could not undo. The claim SHALL still be dropped when the operation commits, and the paths left behind SHALL be reported as untracked, because a command that reports a removal SHALL NOT leave the user unaware that files remain. The receipt SHALL determine what is currently materialized when pulled version-control changes remove lockfile entries. In frozen-lockfile mode, receipt-driven cleanup SHALL begin only after the frozen consistency check passes. If that check rejects an orphaned lockfile entry, installation SHALL fail before cleanup changes any materialized state. Receipt data SHALL be treated as untrusted: project identity, record shape, and path containment within the selected adapter's storage SHALL be validated before deletion. Invalid or escaping records SHALL be reported and SHALL NOT cause deletion; files not recorded as owned SHALL never be deleted.
 
 #### Scenario: Pulled change cleans up a multi-file skill
 
 - **WHEN** pulled state removes a facet but the receipt records its effective skill and companions
+- **AND** that skill's primary is present on disk
 - **THEN** install SHALL supply the validated recorded companion paths in the adapter deletion request
 - **AND** it SHALL delete every recorded owned file from each selected adapter
 - **AND** no network or cache content SHALL be required
+
+#### Scenario: A recorded bundle whose primary is gone is retained rather than half-deleted
+
+- **WHEN** an obsolete recorded skill's primary is absent, so its recorded companions cannot be captured for rollback
+- **THEN** the system SHALL NOT issue a deletion for that identity
+- **AND** the committed receipt SHALL drop the claim regardless
+- **AND** the operation SHALL report the recorded paths it left behind as untracked and requiring manual cleanup
 
 #### Scenario: Interrupted install converges on re-run
 
@@ -579,16 +587,10 @@ The receipt, lockfile, and materialized state SHALL commit together: within one 
 - **WHEN** a lockfile asset is omitted
 - **THEN** the system SHALL NOT record it as materialized
 
-#### Scenario: Untracked file at a desired identity is overwritten and then tracked
+#### Scenario: Untracked file at a desired identity is reconciled and then tracked
 
 - **WHEN** an untracked file already occupies an effective adapter identity the desired state names
-- **THEN** installation SHALL write the desired content to that identity
-- **AND** the committed receipt SHALL record that identity as tracked
-
-#### Scenario: Untracked file already matching the desired state is adopted
-
-- **WHEN** an untracked file at a desired effective adapter identity already matches the desired rendered content, metadata, and owned companion set byte for byte
-- **THEN** installation SHALL NOT rewrite it
+- **THEN** installation SHALL reconcile that identity to the desired state
 - **AND** the committed receipt SHALL record that identity as tracked
 
 #### Scenario: Selecting an adapter delegates management of recorded identities
@@ -622,7 +624,7 @@ The receipt, lockfile, and materialized state SHALL commit together: within one 
 - **THEN** the system SHALL NOT delete anything based on that receipt
 - **AND** it SHALL NOT recreate ownership from the lockfile in its place
 - **AND** it SHALL report that the receipt could not be used
-- **AND** it SHALL record ownership only for the identities it writes
+- **AND** it SHALL record ownership only for the identities it reconciles
 
 #### Scenario: Unreadable receipt confers no ownership
 
@@ -1085,11 +1087,11 @@ Facet removal of tracked materialization SHALL remain independent of cached face
 
 ### Requirement: Removing a facet uninstalls it
 
-When a user removes a facet from a project, the system SHALL drop the facet from the project manifest, reconcile its effective materialized ownership across every selected adapter, and update the lockfile and receipt so neither records the facet—all in a single operation. A user SHALL NOT need to run a separate install step after removing. The ownership to reconcile SHALL be taken from the receipt alone, so deleting a tracked materialization SHALL require neither cache nor network access, and an untracked one SHALL delete nothing on disk. Whether the command as a whole completes without cache or network access SHALL additionally depend on the remaining desired state being fully tracked, per the refinement rules below. The system SHALL delete a recorded effective adapter identity only when no desired asset retains it, SHALL delete each obsolete identity once, and SHALL aggregate historical duplicate claims so a retained desired asset is never deleted. Skill deletion SHALL supply the validated authored companion ownership in the adapter deletion request and SHALL remove the primary and every obsolete owned companion atomically while leaving unowned files untouched.
+When a user removes a facet from a project, the system SHALL drop the facet from the project manifest, reconcile its effective materialized ownership across every selected adapter, and update the lockfile and receipt so neither records the facet—all in a single operation. A user SHALL NOT need to run a separate install step after removing. The ownership to reconcile SHALL be taken from the receipt alone, so deleting a tracked materialization SHALL require neither cache nor network access, and an untracked one SHALL delete nothing on disk. Whether the command as a whole completes without cache or network access SHALL additionally depend on the remaining desired state being fully tracked, per the refinement rules below. The system SHALL delete a recorded effective adapter identity only when no desired asset retains it, SHALL delete each obsolete identity once, and SHALL aggregate historical duplicate claims so a retained desired asset is never deleted. Skill deletion SHALL supply the validated authored companion ownership in the adapter deletion request and SHALL remove the primary and every obsolete owned companion atomically while leaving unowned files untouched. When the recorded primary is already absent, no read can capture the recorded companions for rollback, so the system SHALL leave them in place, drop the claim, and report them as untracked rather than delete what it could not restore.
 
 A non-frozen removal-only operation SHALL NOT fetch, rebuild, or reverify a remaining facet whose locked entry already answers the operation. It SHALL instead refine the remaining locked entries structurally from local state: it SHALL confirm locally that every remaining facet has a locked entry still matching its manifest source and specifier, SHALL plan over the remaining locked asset set so an already-recorded collision among the facets that stay is still reported, SHALL carry each remaining entry's source, version, integrity, file records, and unrecognized fields forward unchanged, and SHALL attach each remaining asset's recorded disposition — refining an entry that predates dispositions to authored materialization. Refinement is lossless, so it SHALL be permitted for every supported lockfile version, and the resulting lockfile SHALL be written at the current version. A frozen operation SHALL NOT refine, because it SHALL NOT rewrite the lockfile at all. Remaining materialized assets SHALL NOT be rewritten or deleted, and lockfile entries for facets the manifest no longer declares SHALL be dropped.
 
-Because the lockfile is shared state and the receipt is machine-local, refinement SHALL require every remaining materialization to be tracked before writing: each remaining facet SHALL have a receipt record, and that record's version, its materialized assets, each such asset's materialization disposition, and each such asset's owned file set SHALL agree with the locked entry. A remaining facet the receipt does not record, and any receipt that cannot be loaded — absent, corrupt, or path-mismatched — SHALL force ordinary resolution, because the operation would otherwise commit a claim on files this machine has no evidence it wrote, and the next operation would read that claim as authority to delete them. The committed receipt SHALL carry the witnessed records forward rather than re-derive them from the locked entries, so an operation that materializes nothing SHALL NOT record an effective identity it did not write. Assets the receipt records but the remaining locked entries no longer list SHALL be dropped from the committed receipt while remaining subject to ownership reconciliation.
+Because the lockfile is shared state and the receipt is machine-local, refinement SHALL require every remaining materialization to be tracked before writing: each remaining facet SHALL have a receipt record, and that record's version, its materialized assets, each such asset's materialization disposition, and each such asset's owned file set SHALL agree with the locked entry. A remaining facet the receipt does not record, and any receipt that cannot be loaded — absent, corrupt, or path-mismatched — SHALL force ordinary resolution, because the operation would otherwise commit a claim on files this machine has no evidence it wrote, and the next operation would read that claim as authority to delete them. The committed receipt SHALL carry the witnessed records forward rather than re-derive them from the locked entries, so an operation that materializes nothing SHALL NOT record an effective identity the receipt did not already witness. Assets the receipt records but the remaining locked entries no longer list SHALL be dropped from the committed receipt while remaining subject to ownership reconciliation.
 
 A refinement SHALL also confirm that every effective identity a remaining facet retains was previously claimed only by that facet. Identity comparison SHALL fold asset type into its materialization namespace and fold names portably, so a claim differing only by asset type within one namespace, by case, or by Unicode normalization is still recognized as the same identity. An identity that no remaining facet retains SHALL NOT block refinement, because ownership reconciliation removes it.
 
@@ -1110,6 +1112,7 @@ Before deleting any materialized asset, the system SHALL verify that every selec
 #### Scenario: Removing multi-file skill preserves unowned content
 
 - **WHEN** a removed facet owns `skills/review/SKILL.md` and `skills/review/references/api.md` but not `skills/review/notes.txt`
+- **AND** the primary is present on disk
 - **AND** every selected installed adapter loads as a valid adapter and declares an API supported by the CLI
 - **THEN** deletion SHALL remove the primary and obsolete owned companion
 - **AND** it SHALL preserve `notes.txt`
@@ -1190,13 +1193,13 @@ Before deleting any materialized asset, the system SHALL verify that every selec
 - **WHEN** a removal-only operation finds a remaining facet the receipt does not record at all
 - **THEN** the operation SHALL treat that facet's materialization as untracked
 - **AND** it SHALL fall back to ordinary resolution instead of refining
-- **AND** the committed receipt SHALL record only the identities the operation wrote
+- **AND** the committed receipt SHALL record only the identities the operation reconciled
 
 #### Scenario: A receipt that cannot be loaded is not refined
 
 - **WHEN** a removal-only operation finds an absent, corrupt, or path-mismatched receipt
 - **THEN** the operation SHALL fall back to ordinary resolution instead of refining
-- **AND** it SHALL rewrite remaining materialized assets before recording their identities
+- **AND** it SHALL reconcile remaining materialized assets before recording their identities
 - **AND** it SHALL NOT delete any untracked file
 
 #### Scenario: An identity a removed facet also claimed is rematerialized
@@ -1514,9 +1517,9 @@ When resolution is unavailable, cancelled, or forbidden by frozen mode, the syst
 
 ### Requirement: Materialized ownership is reconciled against the complete effective set
 
-The system SHALL plan deletion and replacement from the complete tracked previous ownership and complete desired effective set. Previous ownership SHALL be read from the receipt alone. A materialized identity SHALL be deleted only when the receipt records it and no desired asset still claims its adapter identity. Cross-facet ownership transfer SHALL replace content without leaving the retained identity deleted. Duplicate historical claims SHALL be aggregated, each obsolete identity SHALL be deleted at most once per adapter, and all recorded owned companions absent from the new owner SHALL be removed while unowned files remain untouched.
+The system SHALL plan deletion and replacement from the complete tracked previous ownership and complete desired effective set. Previous ownership SHALL be read from the receipt alone. A materialized identity SHALL be deleted only when the receipt records it and no desired asset still claims its adapter identity. Cross-facet ownership transfer SHALL replace content without leaving the retained identity deleted. Duplicate historical claims SHALL be aggregated, each obsolete identity SHALL be deleted at most once per adapter, and all recorded owned companions absent from the new owner SHALL be removed while unowned files remain untouched — except where the obsolete identity's primary is already absent, which leaves its recorded companions uncapturable for rollback and SHALL therefore leave them in place and untracked rather than delete them irreversibly.
 
-Changing an alias SHALL delete the old effective identity and write the new one transactionally. Changing to omitted SHALL delete prior ownership; removing omission SHALL materialize the asset. A disposition-only change SHALL be reported as updated, while disk-only drift SHALL remain repaired.
+Changing an alias SHALL delete the old effective identity and reconcile the new one transactionally. Changing to omitted SHALL delete prior ownership; removing omission SHALL materialize the asset. A disposition-only change SHALL be reported as updated, while disk-only drift SHALL remain repaired.
 
 #### Scenario: Ownership transfer retains the identity
 
@@ -1527,7 +1530,13 @@ Changing an alias SHALL delete the old effective identity and write the new one 
 #### Scenario: Alias change moves owned files
 
 - **WHEN** an alias changes from `vendor-review` to `partner-review`
-- **THEN** the old owned files SHALL be deleted and the new effective asset SHALL be written in one operation
+- **THEN** the old owned files SHALL be deleted and the new effective identity SHALL be reconciled in one operation
+
+#### Scenario: An alias change cannot half-delete a bundle whose primary is gone
+
+- **WHEN** an alias changes and the old effective identity's primary is already absent
+- **THEN** the old recorded companions SHALL be left in place and reported as untracked
+- **AND** the new effective identity SHALL still be reconciled and recorded
 
 #### Scenario: Historical duplicate claims do not delete a retained identity
 
@@ -1554,7 +1563,7 @@ Changing an alias SHALL delete the old effective identity and write the new one 
 
 - **WHEN** the lockfile records a materialized asset that no receipt record covers
 - **THEN** the system SHALL NOT delete anything on the strength of that entry
-- **AND** the identity SHALL be written, and only then recorded, if the desired state names it
+- **AND** the identity SHALL be reconciled, and only then recorded, if the desired state names it
 
 ### Requirement: Project-manifest format migration is transactional
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -48,6 +48,17 @@ function findContentFrame(frames: ReadonlyArray<string | undefined>): string {
 }
 
 /**
+ * Collapse a frame's whitespace so an assertion can name a phrase without
+ * knowing where Ink wrapped it. A rendered sentence breaks at whatever column
+ * the terminal width lands on, so `toContain('no longer tracked')` is really
+ * an assertion about line width — it fails the moment the copy before it
+ * changes length, which says nothing about the behavior under test.
+ */
+function unwrapped(frame: string): string {
+  return frame.replace(/\s+/g, ' ')
+}
+
+/**
  * Build a fake `run` driver that emits a canned event sequence and
  * resolves to a canned result. Lets each test exercise a specific
  * render path of `<InstallView />` without spinning up `runInstall`.
@@ -399,6 +410,78 @@ describe('InstallView — drift removal', () => {
     const frame = findContentFrame(instance.frames)
     expect(frame).toContain('could not be written')
     expect(frame).toContain('untracked')
+    instance.unmount()
+  })
+
+  test('warns when a bundle was left behind because its primary was missing', async () => {
+    // The summary says the facet was removed; these files are still there.
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'remove',
+        run: makeFakeRun(
+          [
+            { kind: 'install-start', totalFacets: 0 },
+            {
+              kind: 'obsolete-bundle-retained',
+              adapter: 'claude-code',
+              scope: 'project',
+              assetName: 'review',
+              facets: ['alpha'],
+              companionPaths: ['refs/api.md'],
+            },
+            { kind: 'install-complete', outcome: 'success' },
+          ],
+          emptySuccess(),
+        ),
+      }),
+    )
+    await settle()
+    const frame = unwrapped(findContentFrame(instance.frames))
+    expect(frame).toContain('review')
+    expect(frame).toContain('refs/api.md')
+    expect(frame).toContain('no longer tracked')
+    instance.unmount()
+  })
+
+  test('names the scope of each retained bundle so same-named ones stay distinguishable', async () => {
+    // One adapter resolves a different directory per scope, so these are two
+    // separate piles of files to clean up. Without the scope the two warnings
+    // are the same sentence twice, pointing at an unspecified skill root.
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'remove',
+        run: makeFakeRun(
+          [
+            { kind: 'install-start', totalFacets: 0 },
+            {
+              kind: 'obsolete-bundle-retained',
+              adapter: 'claude-code',
+              scope: 'project',
+              assetName: 'review',
+              facets: ['alpha'],
+              companionPaths: ['refs/project.md'],
+            },
+            {
+              kind: 'obsolete-bundle-retained',
+              adapter: 'claude-code',
+              scope: 'user',
+              assetName: 'review',
+              facets: ['alpha'],
+              companionPaths: ['refs/user.md'],
+            },
+            { kind: 'install-complete', outcome: 'success' },
+          ],
+          emptySuccess(),
+        ),
+      }),
+    )
+    await settle()
+    const frame = unwrapped(findContentFrame(instance.frames))
+    expect(frame).toContain('project scope')
+    expect(frame).toContain('user scope')
+    // Both rows rendered — a scope-free React key would have collapsed them.
+    expect(frame).toContain('refs/project.md')
+    expect(frame).toContain('refs/user.md')
     instance.unmount()
   })
 })

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -112,6 +112,16 @@ interface RejectedReceiptEntry {
 }
 
 /**
+ * A skill bundle left on disk because its primary file was already gone.
+ *
+ * The engine's event, not a hand-copied subset of it. A local interface has
+ * to be widened by hand every time the event gains a field, and the field it
+ * silently dropped last time — `scope` — was the one that told the user which
+ * directory the retained paths are relative to.
+ */
+type RetainedBundle = Extract<StageEvent, { kind: 'obsolete-bundle-retained' }>
+
+/**
  * What the single Ink mount is currently showing.
  *
  * Tagged rather than a set of booleans because the resolution phase
@@ -150,6 +160,7 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
   const [receiptUnpersisted, setReceiptUnpersisted] = useState<string | null>(null)
   const [removalResolutionReason, setRemovalResolutionReason] = useState<string | null>(null)
   const [rejectedReceiptEntries, setRejectedReceiptEntries] = useState<RejectedReceiptEntry[]>([])
+  const [retainedBundles, setRetainedBundles] = useState<RetainedBundle[]>([])
   const [elapsedMs, setElapsedMs] = useState(0)
   const startedRef = useRef(false)
   const startTimeRef = useRef(Date.now())
@@ -248,6 +259,11 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         // which is not something a user can deduce from a summary that says
         // the facet was removed.
         setRejectedReceiptEntries((prev) => [...prev, { facet: event.facet, asset: event.asset, reason: event.reason }])
+        return
+      case 'obsolete-bundle-retained':
+        // The removal succeeded, so the summary will say the facet is gone —
+        // but these files are still on disk with nothing left tracking them.
+        setRetainedBundles((prev) => [...prev, event])
         return
       case 'drift-removal':
       case 'asset-installed':
@@ -495,6 +511,25 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
             ⚠ this project’s install receipt could not be written ({receiptUnpersisted}) — the assets this run wrote are
             untracked, so a later removal will leave them in place.
           </Text>
+        </Box>
+      )}
+
+      {/* Cleanup we deliberately did not attempt. The primary was already
+          gone, so the bytes could not be captured for rollback, and deleting
+          what we cannot restore would make a later failure unrecoverable.
+          The claim is dropped either way, so whatever is left is untracked. */}
+      {retainedBundles.length > 0 && (
+        <Box flexDirection="column" marginLeft={2}>
+          {/* Keyed by scope as well: an adapter resolves one directory per
+              scope, so the same skill name can be retained twice in one run,
+              and those are two different directories to go clean up. */}
+          {retainedBundles.map((bundle) => (
+            <Text key={`${bundle.scope}:${bundle.adapter}:${bundle.assetName}`} color={THEME.caution}>
+              ⚠ skill “{bundle.assetName}” in {bundle.adapter}’s {bundle.scope} scope was missing its SKILL.md, so its
+              recorded files ({bundle.companionPaths.join(', ')}) were left untouched rather than deleted without a way
+              to restore them. They are no longer tracked — remove whatever remains manually.
+            </Text>
+          ))}
         </Box>
       )}
 

--- a/packages/engine/src/install/__tests__/apply-ownership.test.ts
+++ b/packages/engine/src/install/__tests__/apply-ownership.test.ts
@@ -670,6 +670,78 @@ describe('apply — global ownership reconciliation', () => {
     expect(result.summary.removedAssets).toBe(1)
   })
 
+  test('an obsolete bundle whose primary is gone keeps its companions and says so', async () => {
+    // The bundle reads as `not-found` because a bundle is addressed through
+    // its primary, so nothing captured the companion bytes the receipt still
+    // claims. Deleting them would be a mutation with no inverse: a later
+    // failure would report a clean rollback with the bytes gone for good.
+    const a = skillFixture('alpha', 'review', { companions: { 'refs/api.md': '# api\n' } })
+    writeManifest({ facets: { alpha: a } })
+    const { adapter, io } = recordingAdapter()
+    expect((await runInstall({ projectRoot, adapters: [adapter] })).ok).toBe(true)
+
+    rmSync(join(skillRoot('review'), 'SKILL.md'))
+
+    writeManifest({ facets: {} })
+    io.length = 0
+    const events: StageEvent[] = []
+    const result = await runInstall({ projectRoot, adapters: [adapter], onStage: (e) => events.push(e) })
+    if (!result.ok) expect.unreachable()
+
+    // No delete was attempted, and the companion is byte-for-byte intact.
+    expect(io.some((call) => call.startsWith('delete:'))).toBe(false)
+    expect(readFileSync(join(skillRoot('review'), 'refs/api.md'), 'utf8')).toBe('# api\n')
+    expect(existsSync(join(skillRoot('review'), 'SKILL.md'))).toBe(false)
+
+    // The declaration and the claim are gone regardless, which is exactly why
+    // the retained files have to be announced: nothing tracks them now.
+    const lock = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    expect(lock.facets.alpha).toBeUndefined()
+    expect(readReceipt().facets.alpha).toBeUndefined()
+    expect(events).toContainEqual({
+      kind: 'obsolete-bundle-retained',
+      adapter: 'rec',
+      // Carried through from the ownership record: the companion paths below
+      // are skill-root-relative, and the scope is what says which root.
+      scope: 'project',
+      assetName: 'review',
+      facets: ['alpha'],
+      companionPaths: ['refs/api.md'],
+    })
+    // Nothing left disk, so the asset count must not claim otherwise.
+    expect(result.summary.removedAssets).toBe(0)
+  })
+
+  test('a failure after a skipped bundle delete needs no inverse and loses nothing', async () => {
+    const a = skillFixture('alpha', 'review', { companions: { 'refs/api.md': '# api\n' } })
+    writeManifest({ facets: { alpha: a } })
+    const { adapter } = recordingAdapter()
+    expect((await runInstall({ projectRoot, adapters: [adapter] })).ok).toBe(true)
+    const before = {
+      lock: readFileSync(join(projectRoot, 'facets.lock'), 'utf8'),
+      receipt: readFileSync(receiptPath(projectRoot), 'utf8'),
+    }
+
+    rmSync(join(skillRoot('review'), 'SKILL.md'))
+    // Fail the first write of the trio, after the delete pass has run.
+    mkdirSync(join(projectRoot, 'facets.json.tmp'), { recursive: true })
+
+    writeManifest({ facets: {} })
+    const events: StageEvent[] = []
+    const result = await runInstall({ projectRoot, adapters: [adapter], onStage: (e) => events.push(e) })
+    if (result.ok) expect.unreachable()
+
+    // Nothing to undo, because nothing was destroyed — the rollback is clean
+    // by construction rather than by a preimage we could not have captured.
+    expect(result.rollback).toEqual({ kind: 'succeeded', entriesUndone: 0 })
+    expect(readFileSync(join(skillRoot('review'), 'refs/api.md'), 'utf8')).toBe('# api\n')
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(before.lock)
+    expect(readFileSync(receiptPath(projectRoot), 'utf8')).toBe(before.receipt)
+    // The removal never committed, so the files are still tracked: warning
+    // the user that they are orphaned here would be a lie.
+    expect(events.some((e) => e.kind === 'obsolete-bundle-retained')).toBe(false)
+  })
+
   test.each([
     ['corrupt', 'not json{'],
     ['path-mismatch', JSON.stringify({ version: CURRENT_RECEIPT_VERSION, path: '/nowhere/else', facets: {} })],

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -6,7 +6,7 @@ import type {
   InstallAssetRequest,
   ReadAssetRequest,
 } from '@agent-facets/adapter'
-import { splitFrontMatter } from '@agent-facets/common'
+import { type Scope, splitFrontMatter } from '@agent-facets/common'
 import { type MaterializedAsset, type ResolvedFacetManifest, skillRootPath } from '@agent-facets/protocol'
 import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
 import { ownedCompanionPathsFor, type PreviousOwnership } from './commit/ownership.ts'
@@ -319,8 +319,29 @@ export interface DeleteObsoleteOptions {
   onLog?: OnLog
 }
 
+/**
+ * An obsolete skill bundle whose cleanup was deliberately skipped because its
+ * primary file was already gone, leaving the recorded companion paths on disk
+ * and no longer tracked. Carries everything a view layer needs to tell the
+ * user what to clean up by hand.
+ *
+ * `type` is a literal rather than an `AssetType` because only a skill bundle
+ * has companions to retain — a single-file asset that reads as absent has
+ * nothing left to delete.
+ */
+export interface RetainedObsoleteBundle {
+  adapter: string
+  scope: Scope
+  type: 'skill'
+  effectiveName: string
+  /** Every facet that claimed this identity. */
+  facets: readonly string[]
+  /** Recorded companion paths, relative to the skill root. */
+  companionPaths: readonly string[]
+}
+
 export type DeleteObsoleteResult =
-  | { ok: true; deleted: number }
+  | { ok: true; deleted: number; retained: readonly RetainedObsoleteBundle[] }
   | { ok: false; failure: MaterializeFailure; facets: readonly string[] }
 
 /**
@@ -342,6 +363,7 @@ export type DeleteObsoleteResult =
  */
 export async function deleteObsoleteAssets(opts: DeleteObsoleteOptions): Promise<DeleteObsoleteResult> {
   let deleted = 0
+  const retained: RetainedObsoleteBundle[] = []
 
   for (const adapter of opts.adapters) {
     if (adapter.supportsInstall !== true) {
@@ -368,6 +390,27 @@ export async function deleteObsoleteAssets(opts: DeleteObsoleteOptions): Promise
         }
       }
       const previous = readOutcome.previous
+
+      // A skill whose primary is gone reads as wholly absent — the bundle read
+      // checks the primary first and never reaches the companions — so we hold
+      // no preimage for the companion bytes the receipt still claims. Deleting
+      // them anyway would be a mutation with no journal inverse: a later
+      // failure would roll everything else back and report a clean rollback
+      // while those bytes were gone for good. Keep them instead. They stop
+      // being tracked either way, so the honest outcome is to leave the files
+      // and say so, not to destroy what we cannot restore.
+      if (previous === null && ownership.type === 'skill' && ownedCompanionPaths.length > 0) {
+        retained.push({
+          adapter: adapter.name,
+          scope: ownership.scope,
+          type: 'skill',
+          effectiveName: ownership.effectiveName,
+          facets: ownership.facets,
+          companionPaths: [...ownedCompanionPaths].sort(),
+        })
+        opts.onLog?.(() => `[verbose]     ?${target.type}:${target.name} (primary missing — companions retained)`)
+        continue
+      }
 
       let deletedPath: string | undefined
       try {
@@ -420,7 +463,7 @@ export async function deleteObsoleteAssets(opts: DeleteObsoleteOptions): Promise
     }
   }
 
-  return { ok: true, deleted }
+  return { ok: true, deleted, retained }
 }
 
 /**

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -15,7 +15,7 @@ import { checkFrozenConsistency } from './frozen-gates.ts'
 import { InstallJournal } from './journal.ts'
 import { acquireInstallLock } from './lockfile-guard.ts'
 import { FACETS_LOCK_FILE, loadLockfile } from './lockfile-io.ts'
-import { deleteObsoleteAssets } from './materialize.ts'
+import { deleteObsoleteAssets, type RetainedObsoleteBundle } from './materialize.ts'
 import { materializeFailureToRunInstall } from './materialize-failure.ts'
 import { ownEntry } from './own-entry.ts'
 import { type Receipt, receiptBaseFor, resolveProjectReceipt } from './receipt.ts'
@@ -313,6 +313,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         return await rollbackAndFail(journal, committed.failure, onLog)
       }
       onStage({ kind: 'lockfile-write', path: join(projectRoot, FACETS_LOCK_FILE) })
+      reportRetainedBundles(deletion.retained)
       for (const entry of prunedIntent) {
         onStage({
           kind: 'stale-override-pruned',
@@ -494,6 +495,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     if (!frozenLockfile) {
       onStage({ kind: 'lockfile-write', path: join(projectRoot, FACETS_LOCK_FILE) })
     }
+    reportRetainedBundles(deletion.retained)
 
     // Reported only now: before the write, the prune had not happened, and a
     // failed transaction leaves every override on disk untouched.
@@ -526,6 +528,24 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
 
   function noopStage(_event: StageEvent): void {}
   function noopLog(_build: () => string): void {}
+
+  /**
+   * Announce obsolete bundles whose cleanup was skipped because their primary
+   * was already gone. Called only after the project files commit: before that
+   * the removal can still roll back, and the files are still tracked.
+   */
+  function reportRetainedBundles(retained: readonly RetainedObsoleteBundle[]): void {
+    for (const bundle of retained) {
+      onStage({
+        kind: 'obsolete-bundle-retained',
+        adapter: bundle.adapter,
+        scope: bundle.scope,
+        assetName: bundle.effectiveName,
+        facets: bundle.facets,
+        companionPaths: bundle.companionPaths,
+      })
+    }
+  }
 
   /**
    * Failure path that runs before the install lock has been released

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -180,6 +180,30 @@ export type StageEvent =
    */
   | { kind: 'removal-resolution-required'; reason: string }
   /**
+   * An obsolete skill bundle was left on disk because its primary file was
+   * already missing, so the recorded companion bytes could not be captured for
+   * rollback. The claim is dropped from the receipt regardless, which makes
+   * whatever remains untracked — the one thing the user cannot deduce from a
+   * command that otherwise reports a successful removal.
+   *
+   * Emitted only after the transaction commits: until then the removal is not
+   * real, and the files are still tracked.
+   *
+   * `scope` is load-bearing, not decoration: an adapter resolves a different
+   * directory per scope, so without it `companionPaths` — which are relative
+   * to a skill root — name a location the user cannot find. Two same-named
+   * bundles retained in different scopes are also two distinct warnings, and
+   * a scope-free event collapses them into one indistinguishable pair.
+   */
+  | {
+      kind: 'obsolete-bundle-retained'
+      adapter: string
+      scope: Scope
+      assetName: string
+      facets: ReadonlyArray<string>
+      companionPaths: ReadonlyArray<string>
+    }
+  /**
    * A materialization override was dropped because the resolved facet version
    * no longer contains the asset it named.
    *


### PR DESCRIPTION
### Why

When removing a facet whose skill bundle's primary file (`SKILL.md`) is already gone from disk, the system previously had no safe path forward: the bundle is addressed through its primary, so the companion bytes could not be read as a rollback preimage. Deleting the companions anyway would be an irreversible mutation — a later failure would report a clean rollback while those bytes were permanently gone.

### Details

The deletion pass now detects when an obsolete skill bundle reads as wholly absent (primary missing) but still has recorded companions. Rather than delete what it cannot restore, it skips the deletion, drops the receipt claim, and emits a new `obsolete-bundle-retained` event after the transaction commits. Emitting after commit is deliberate: before that point the removal can still roll back, and the files are still tracked — warning the user before commit would be a lie.

The `obsolete-bundle-retained` event carries the adapter name, asset name, originating facets, and the companion paths left behind. The CLI view surfaces this as a caution-coloured warning explaining that the files are no longer tracked and must be removed manually. The summary counts no removed assets for a skipped bundle, since nothing actually left disk.

The spec is updated throughout to replace "overwrite and record" language with "reconcile and record" language, making it clear that reconciliation is defined by the state it leaves behind rather than the specific operations used to reach it. The new scenario for a bundle whose primary is gone is added to the installation, removal, alias-change, and ownership-reconciliation sections.

### Verification

Two new engine tests cover the core behaviour: one confirms that companions are left intact, the lockfile and receipt drop the claim, and the event is emitted; the other confirms that a failure after the skipped delete requires no rollback inverse and leaves everything — including the tracking — exactly as it was before the failed operation. A new CLI view test confirms the warning renders with the asset name, companion paths, and "no longer tracked" copy. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion and rollback behavior on the install/receipt path; mistakes could leave orphan files or delete without restore, though commit-gated events and new tests target the edge case.
> 
> **Overview**
> When obsolete skill cleanup would delete companions but **SKILL.md** is already gone, the engine **skips deletion** (no rollback preimage), **drops the receipt claim** on commit, and emits **`obsolete-bundle-retained`** after commit with adapter, **scope**, asset name, and companion paths. **`removedAssets`** stays **0** for those bundles.
> 
> The CLI **InstallView** shows caution warnings keyed by scope so same-named skills in different scopes stay distinct; tests use **`unwrapped()`** for wrap-safe assertions.
> 
> The installation spec shifts **write/overwrite** language to **reconcile** (outcome-based) and documents **retain companions + report untracked** for removal, alias change, and ownership reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1b4a1d148440980745cff725088298a3c1c38c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->