### PR TITLE
Scope JUnit reports to package-local files and introduce a `transit` node to parallelize the Turbo task graph

### DIFF
--- a/.circleci/development.yml
+++ b/.circleci/development.yml
@@ -14,8 +14,16 @@ commands:
       - run:
           command: bun turbo check
           environment:
-            TURBO_CONCURRENCY: "1"
+            TURBO_CONCURRENCY: "2"
           name: Check
+      - run:
+          command: |
+            mkdir -p test-results
+            find packages -name 'junit*.xml' -not -path '*/node_modules/*' | while read -r report; do
+              cp "$report" "test-results/$(dirname "$report" | tr '/' '-')-$(basename "$report")"
+            done
+          name: Collect package test reports
+          when: always
       - save_cache:
           key: v1-mint-{{ checksum "bun.lock" }}
           paths:
@@ -108,7 +116,6 @@ jobs:
     environment:
       LEFTHOOK: "0"
       MISE_ENV: release
-      TURBO_CONCURRENCY: "1"
     resource_class: medium
     steps:
       - setup-mise

--- a/.circleci/development/commands/run-check.yml
+++ b/.circleci/development/commands/run-check.yml
@@ -5,17 +5,34 @@ steps:
         - v1-mint-
   - run:
       name: Check
-      # Runs on a `medium` resource class (4 GB, 2 vCPU). Even on `medium`,
-      # parallel DTS builds (arktype inlined via tsdown's `deps.alwaysBundle`,
-      # heavy `rolldown-plugin-dts:generate` pass) peak over 4 GB when
-      # protocol + engine + three adapter builds fan out simultaneously and
-      # intermittently get SIGKILL'd by the OOM killer (exit 137). Forcing
-      # `TURBO_CONCURRENCY=1` serializes all tasks at the cost of ~30–45s of
-      # wall-time, which is well under the cost of a flaky CI. The release
-      # job applies the same mitigations — see development/jobs/release.yml.
+      # Runs on a `medium` resource class (4 GB, 2 vCPU). tsdown's DTS pass
+      # (`rolldown-plugin-dts:generate`, with arktype inlined via
+      # `deps.alwaysBundle`) is memory-hungry, and letting every package build
+      # fan out at once peaked over 4 GB and got tasks SIGKILL'd by the OOM
+      # killer (exit 137). `check` still schedules those builds, so the cap
+      # stays — but at "2" rather than "1": at most two DTS passes can overlap,
+      # while the rest of the graph (tests and type checks, which no longer
+      # queue behind each other's packages) can use both vCPUs instead of
+      # serializing all ~57 nodes. If exit 137 comes back, drop this to "1"
+      # before reaching for a bigger resource class.
       environment:
-        TURBO_CONCURRENCY: "1"
+        TURBO_CONCURRENCY: "2"
       command: bun turbo check
+  - run:
+      name: Collect package test reports
+      # Every package's `test` / `test:e2e` task writes its report to the same
+      # relative path inside its own directory (`junit.xml` / `junit-e2e.xml`),
+      # which is what makes each task's declared `outputs` unique and stops
+      # cache restores from clobbering each other. Turbo restores those files on
+      # a cache hit, so flattening them here is enough for `store_test_results`
+      # to see every suite whether it ran or was replayed. `//#test:scripts`
+      # already writes straight into test-results/.
+      when: always
+      command: |
+        mkdir -p test-results
+        find packages -name 'junit*.xml' -not -path '*/node_modules/*' | while read -r report; do
+          cp "$report" "test-results/$(dirname "$report" | tr '/' '-')-$(basename "$report")"
+        done
   - save_cache:
       # Caches the ~306 MB Mintlify framework workspace that `mint validate`
       # lazily downloads to ~/.mintlify/mint/ on first run. Keyed on bun.lock

--- a/.circleci/development/jobs/release.yml
+++ b/.circleci/development/jobs/release.yml
@@ -1,18 +1,15 @@
 docker:
   - image: cimg/base:current
 # `medium` (4 GB, 2 vCPU). `small` (2 GB) gets OOM-killed by the
-# rolldown-plugin-dts:generate pass during `turbo build` even with the build
-# scoped to one package — see scripts/release/publish.ts and the equivalent
-# rationale in development/commands/run-check.yml.
+# rolldown-plugin-dts:generate pass during `turbo build` even though the build
+# is scoped to a single package — see scripts/release/publish.ts and the
+# equivalent rationale in development/commands/run-check.yml.
 resource_class: medium
 environment:
   LEFTHOOK: "0"
   MISE_ENV: release
-  # Belt-and-suspenders against the same OOM. With the build scoped to one
-  # package + its deps, this is rarely needed, but on a cache miss the dts
-  # build still spends most of its time in a memory-hungry plugin pass — and
-  # serializing tasks costs us seconds, not minutes.
-  TURBO_CONCURRENCY: "1"
+  # No TURBO_CONCURRENCY cap: publish.ts scopes the build to exactly one
+  # package, so there is never more than one DTS pass to overlap.
 steps:
   - setup-mise
   - run:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -102,7 +102,6 @@ jobs:
     environment:
       LEFTHOOK: "0"
       MISE_ENV: release
-      TURBO_CONCURRENCY: "1"
     resource_class: medium
     steps:
       - setup-mise

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ dist/
 docs/.mintlify/
 node_modules/
 
+# Per-package JUnit reports. Each package's `test` / `test:e2e` turbo task
+# writes one of these into its own directory, which is what makes each task's
+# declared `outputs` unique. CI flattens them into test-results/ for upload.
+junit.xml
+junit-e2e.xml
+
 # postinstall cached binary (hard-link created by packages/cli/scripts/postinstall.mjs)
 packages/cli/bin/.facet
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,27 +390,60 @@ itself is the assertion.
 
 The `check` pipeline (`bun check`) orchestrates `test`, `types`, `lint`, and other tasks via Turborepo. Caching rules:
 
-- **`build`** is cached by default. The CLI package (`packages/cli`) overrides `outputs` to `[]` in its package-level `turbo.json` — Turbo caches the hash (knows the build succeeded) but never uploads the ~63 MB compiled binary to the remote cache.
-- **`test`** and **`types`** are cached and never depend on `build`. End-to-end tests that need a compiled binary live in a separate **`test:e2e`** task — see "Test conventions" below.
-- Package-level overrides live in `packages/<name>/turbo.json`.
+- **`transit`** is a scriptless [Transit Node](https://turborepo.com/docs/core-concepts/package-and-task-graph#transit-nodes). It is the task that propagates dependency-source hashes through the package graph (`dependsOn: ["^transit"]`), and the only one that does so *recursively* — `transit` depends on `^transit`, so the traversal reaches the entire transitive dependency closure. It is not the only task with a topological edge: `check` also has one (`^build`, below), but that edge is a single hop whose purpose is scheduling real work, not hash propagation. `build`, `test`, `types`, and `test:e2e` each depend on their own package's `transit`, so a change to a dependency's source still busts every downstream hash, but nothing waits for a dependency's tests, type check, or build to finish. This is what lets the whole graph start in parallel.
+- Removing those `transit` edges would silently break caching. Turbo only hashes a package's *own* files; because every workspace `exports` points at `src/`, `transit` is what folds dependency source into a downstream hash. Verify with: change a file in `packages/protocol/src/`, then confirm `agent-facets#test`'s hash moves (`turbo test --filter=agent-facets --dry=json`).
+- `transit` excludes `**/*.test.ts` / `**/*.test.tsx` from its inputs, so editing one package's tests never invalidates another package's tasks.
+- **`test`** and **`types`** never depend on `build`. Unit tests import from source, and no package's build consumes another package's `dist/` (tsdown inlines private workspace deps via `deps.alwaysBundle`).
+- **`test:e2e`** does **not** depend on `^build` either. An e2e task either builds what it needs inline or declares an edge to the one task that owns that artifact — see "Build artifacts and the cache" below.
+- **`check`** depends on `^build`, not `build`. That builds every package something else depends on (`protocol`, `engine`, `adapter`, `brand`, `adapter-opencode`) so a broken `tsdown`/DTS pass fails CI instead of surfacing at release time. It deliberately skips leaf packages — the CLI (63 MB binary) and the codex/claude-code adapters, all of which already build inline in their own `test:e2e`.
+- Package-level overrides live in `packages/<name>/turbo.json`. Keep them to a minimum: an override that resolves identically to the root definition is dead config.
+
+### Build artifacts and the cache
+
+Whether a compiled artifact belongs in the cache is a question of size, and the answer differs per package:
+
+- The CLI binary is ~63 MB — far too large for the Lambda-backed remote cache. `packages/cli/turbo.json` sets `outputs: []` on `build`, so Turbo records the hash and logs without uploading the binary, and `agent-facets#test:e2e` builds it inline (`bun run build && bun test ...`).
+- Every other `dist/` is small (the largest is engine's at ~700 KB) and keeps the root `outputs: ["dist/**"]`, so Turbo uploads and restores it normally.
+
+A `dist/` directory has exactly one writer: that package's `build` task, or Turbo restoring that task's cached output. A task that needs another package's `dist/` declares an edge to its `build` rather than running the build itself — two processes running `tsdown` (which is configured with `clean: true`) against one directory would delete it out from under each other.
+
+### The opencode adapter's `dist/`
+
+`packages/adapters/opencode/dist/` is the one directory in the repo read by more than one task, so it is the one place that edge is spelled out:
+
+- `packages/adapters/opencode/turbo.json` — `test:e2e` depends on same-package `build`. `src/__tests__/dist.e2e.test.ts` imports `../../dist/index.mjs`.
+- `packages/cli/turbo.json` — `test:e2e` depends on `@agent-facets/adapter-opencode#build`. `packOpencode()` in `src/__tests__/adapter-install-cli.e2e.test.ts` runs `npm pack` there (`files: ["dist"]`) to produce a tarball identical to what `npm publish` would upload.
+
+Neither consumer builds the adapter. Both edges use `$TURBO_EXTENDS$` to keep the inherited `dependsOn: ["transit"]` — a bare `dependsOn` array in a Package Configuration *replaces* the root value rather than appending to it, which would drop hash propagation.
+
+### Test reports
+
+Every package's `test` / `test:e2e` writes JUnit XML to the **same relative path inside its own package** — `junit.xml` and `junit-e2e.xml` — via `--reporter=junit --reporter-outfile=` in its `package.json` script. That means the root `turbo.json` declares `outputs: ["junit.xml"]` once and Turbo resolves it per package, giving every task exclusive ownership of exactly one file.
+
+Do **not** declare a shared directory (e.g. `$TURBO_ROOT$/test-results/**`) as a task's `outputs`. Doing so makes every task's cache artifact snapshot every other task's reports, and a restore then clobbers them — which is how stale suites from other branches used to end up in CI results.
+
+CircleCI's `store_test_results` still reads one directory. The `Collect package test reports` step in `.circleci/development/commands/run-check.yml` flattens `packages/**/junit*.xml` into `test-results/` with a package-path prefix. It runs `when: always`, and because Turbo restores the report files on a cache hit, cached packages still report their suites. `//#test:scripts` is the exception that writes straight to `test-results/scripts-junit.xml` — it is a root task, so there is no package directory to write into.
+
+### CI concurrency
+
+`.circleci/development/commands/run-check.yml` pins `TURBO_CONCURRENCY=2` on a `medium` (4 GB, 2 vCPU) executor. tsdown's `rolldown-plugin-dts:generate` pass is memory-hungry; letting all builds fan out peaked over 4 GB and got tasks OOM-killed (exit 137). Two is the bound that keeps both vCPUs busy without overlapping more than two DTS passes. If exit 137 returns, drop to `1` before reaching for a larger resource class.
+
+Releases (`scripts/release/publish.ts`) scope the build to exactly one package — `turboBuild(pkg.name)`, no `...` dependency filter — because dependency `dist/` is never consumed. `transit` still folds dependency source into that build's hash, so the narrower filter costs no cache correctness.
 
 ### Test conventions
 
 - `*.test.ts` files are unit tests. They import from source (`../index.ts`, not `dist/`) and never depend on `build`.
-- `*.e2e.test.ts` files are end-to-end tests. They may spawn compiled binaries or read from `dist/`. They run via `test:e2e`, which `dependsOn: ["^build"]` (upstream package builds). The CLI's `test:e2e` script inlines its own build (`bun run build && bun test ...`) so the compiled binary is produced fresh without making Turbo's cache depend on the large artifact.
-- `bun check` is the canonical entry point — it runs lint, types, unit tests, e2e tests, and the root-level `scripts/` tests via Turbo.
-- `bun test` at the repo root tests files in `scripts/` only (configured via root `bunfig.toml` `[test] root`). For per-package work use `bun test --cwd packages/<pkg>` (unit only) or `bun run --cwd packages/<pkg> test:e2e`.
+- `*.e2e.test.ts` files are end-to-end tests. They may spawn compiled binaries or read from `dist/`. The root `test` task excludes them from its `inputs`, so touching an e2e file doesn't bust the unit-test cache.
+- **Run tests through Turbo, always.** `bun check` is the canonical entry point. To narrow the run, filter — `bun turbo test --filter=@agent-facets/engine`, `bun turbo test:e2e --filter=@agent-facets/adapter-opencode` — rather than invoking a package's script directly.
+- Reaching into a package with `bun test --cwd packages/<pkg>` or `bun run --cwd packages/<pkg> test:e2e` is an anti-pattern: it bypasses the task graph, so dependency builds a suite relies on are never scheduled and the run either fails or reads a stale `dist/`.
+- `bun test` at the repo root tests files in `scripts/` only (configured via root `bunfig.toml` `[test] root`).
 - The `test` script in each package excludes e2e files via `bun test --path-ignore-patterns '**/*.e2e.test.ts'` (set per-package in `package.json`).
-
-### CLI build caching
-
-The CLI compiled binary (~63 MB) is too large for the Lambda-based Turbo remote cache. To handle this, `packages/cli/turbo.json` sets `outputs: []` on the `build` task — Turbo caches the hash (knows the build succeeded for these inputs) but never tries to upload or download the binary. The `test:e2e` script inlines `bun run build &&` so the binary is produced fresh when e2e tests run, without poisoning the Turbo cache chain.
 
 ### When adding a new package
 
-1. Add `"test": "bun test"` and `"types": "tsc --noEmit"` scripts to its `package.json` so turbo picks them up for the `check` pipeline.
-2. If the package has end-to-end tests that depend on build output, name them `*.e2e.test.ts`, add a `test:e2e` script that inlines the build (`bun run build && bun test ...`), and ensure the root `turbo.json`'s `test:e2e` task has `dependsOn: ["^build"]` (upstream builds only). See `packages/cli/` for an example.
-3. If the package's build output is too large for remote cache, set `"outputs": []` in the package-level `turbo.json` so Turbo caches the hash without uploading artifacts.
+1. Add `"test"` and `"types"` scripts to its `package.json` so turbo picks them up for the `check` pipeline. Point the test reporter at the package-local file: `bun test --reporter=junit --reporter-outfile=junit.xml`.
+2. If the package has end-to-end tests, name them `*.e2e.test.ts` and add a `test:e2e` script that writes its own report: `bun test --reporter=junit --reporter-outfile=junit-e2e.xml ...`. If those tests read a `dist/`, add a package-level `turbo.json` declaring the edge to whichever `build` owns it — same-package `build`, or `<pkg>#build` for another package's. See `packages/adapters/opencode/` for an example.
+3. Apart from that edge, no package-level `turbo.json` is needed — the root task definitions resolve per package.
 
 ## Frontend
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "docs:validate": "bun --cwd docs mint validate",
     "docs:broken-links": "bun --cwd docs mint broken-links",
     "postinstall": "bun scripts/postinstall.ts",
-    "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify",
+    "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet packages/*/junit*.xml packages/adapters/*/junit*.xml test-results/*.xml tmp docs/.mintlify",
     "nuke": "bun run clean && bun install && bun check"
   },
   "devDependencies": {

--- a/packages/adapter/bunfig.toml
+++ b/packages/adapter/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../test-results/adapter-junit.xml"

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -18,7 +18,7 @@
     "build": "tsdown",
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
-    "test": "bun test",
+    "test": "bun test --reporter=junit --reporter-outfile=junit.xml",
     "types": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/adapters/claude-code/bunfig.toml
+++ b/packages/adapters/claude-code/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../../test-results/adapter-claude-code-junit.xml"

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -18,8 +18,8 @@
     "prepack": "bun ../../../scripts/prepack.ts",
     "postpack": "bun ../../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
-    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts' --reporter=junit --reporter-outfile=junit.xml",
+    "test:e2e": "bun run build && bun test --reporter=junit --reporter-outfile=junit-e2e.xml src/__tests__/dist.e2e.test.ts"
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/adapters/claude-code/turbo.json
+++ b/packages/adapters/claude-code/turbo.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://turborepo.com/schema.json",
-  "extends": ["//"],
-  "tasks": {
-    "build": {}
-  }
-}

--- a/packages/adapters/codex/bunfig.toml
+++ b/packages/adapters/codex/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../../test-results/adapter-codex-junit.xml"

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -18,8 +18,8 @@
     "prepack": "bun ../../../scripts/prepack.ts",
     "postpack": "bun ../../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
-    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts' --reporter=junit --reporter-outfile=junit.xml",
+    "test:e2e": "bun run build && bun test --reporter=junit --reporter-outfile=junit-e2e.xml src/__tests__/dist.e2e.test.ts"
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/adapters/codex/turbo.json
+++ b/packages/adapters/codex/turbo.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://turborepo.com/schema.json",
-  "extends": ["//"],
-  "tasks": {
-    "build": {}
-  }
-}

--- a/packages/adapters/opencode/bunfig.toml
+++ b/packages/adapters/opencode/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../../test-results/adapter-opencode-junit.xml"

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -18,8 +18,8 @@
     "prepack": "bun ../../../scripts/prepack.ts",
     "postpack": "bun ../../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
-    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts' --reporter=junit --reporter-outfile=junit.xml",
+    "test:e2e": "bun test --reporter=junit --reporter-outfile=junit-e2e.xml src/__tests__/dist.e2e.test.ts"
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/adapters/opencode/turbo.json
+++ b/packages/adapters/opencode/turbo.json
@@ -2,6 +2,8 @@
   "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
-    "build": {}
+    "test:e2e": {
+      "dependsOn": ["$TURBO_EXTENDS$", "build"]
+    }
   }
 }

--- a/packages/brand/bunfig.toml
+++ b/packages/brand/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../test-results/brand-junit.xml"

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -18,7 +18,7 @@
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test"
+    "test": "bun test --reporter=junit --reporter-outfile=junit.xml"
   },
   "devDependencies": {
     "tsdown": "^0.22.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,8 +17,8 @@
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts' --reporter=junit --reporter-outfile=../../test-results/cli-junit.xml",
-    "test:e2e": "bun run build && bun test --timeout 15000 --reporter=junit --reporter-outfile=../../test-results/cli-e2e-junit.xml src/__tests__/*.e2e.test.ts"
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts' --reporter=junit --reporter-outfile=junit.xml",
+    "test:e2e": "bun run build && bun test --timeout 15000 --reporter=junit --reporter-outfile=junit-e2e.xml src/__tests__/*.e2e.test.ts"
   },
   "dependencies": {
     "@bomb.sh/args": "0.3.1",

--- a/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
@@ -38,6 +38,13 @@ async function packOpencode(): Promise<string> {
   const adapterDir = resolve(REPO_ROOT, 'packages/adapters/opencode')
   const workDir = await mkdtemp(join(tmpdir(), 'facet-pack-opencode-'))
 
+  // `@agent-facets/adapter-opencode` ships `files: ["dist"]`, so the tarball
+  // below is only meaningful once `dist/` is present. This suite does not build
+  // it: `packages/cli/turbo.json` declares a `@agent-facets/adapter-opencode#build`
+  // dependency, so turbo has either run that build or restored its cached
+  // `dist/**` before this task starts. That build task is the single writer of
+  // that directory — building here too would race it.
+  //
   // Run `npm pack --pack-destination <workDir>` inside the adapter directory.
   // This triggers prepack (rewrites workspace:* deps + hoists publishConfig)
   // and produces a .tgz identical to what `npm publish` would upload.
@@ -232,8 +239,9 @@ async function activeManagedBundle(facetDir: string, name: string): Promise<stri
 
 beforeAll(async () => {
   // Verify the compiled binary exists — if it doesn't, the test suite can't
-  // run. The turbo config declares test depends on build, but surface a
-  // clearer error if somebody runs `bun test` directly without building.
+  // run. The package's `test:e2e` script builds the CLI inline before invoking
+  // bun test, but surface a clearer error if somebody runs `bun test` directly
+  // without building.
   try {
     await stat(CLI_PATH)
   } catch {

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -5,6 +5,8 @@
     "build": {
       "outputs": []
     },
-    "test": {}
+    "test:e2e": {
+      "dependsOn": ["$TURBO_EXTENDS$", "@agent-facets/adapter-opencode#build"]
+    }
   }
 }

--- a/packages/common/bunfig.toml
+++ b/packages/common/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../test-results/common-junit.xml"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "types": "tsgo --noEmit",
-    "test": "bun test"
+    "test": "bun test --reporter=junit --reporter-outfile=junit.xml"
   },
   "dependencies": {
     "yaml": "2.9.0"

--- a/packages/engine/bunfig.toml
+++ b/packages/engine/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../test-results/engine-junit.xml"

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -14,7 +14,7 @@
     "build": "tsdown",
     "codegen:registry": "bun ./scripts/sync-registry-openapi.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test"
+    "test": "bun test --reporter=junit --reporter-outfile=junit.xml"
   },
   "dependencies": {
     "@agent-facets/adapter": "workspace:*",

--- a/packages/protocol/bunfig.toml
+++ b/packages/protocol/bunfig.toml
@@ -1,2 +1,0 @@
-[test.reporter]
-junit = "../../test-results/protocol-junit.xml"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -21,7 +21,7 @@
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
     "types": "tsgo --noEmit",
-    "test": "bun test --pass-with-no-tests"
+    "test": "bun test --pass-with-no-tests --reporter=junit --reporter-outfile=junit.xml"
   },
   "dependencies": {
     "arktype": "2.2.0",

--- a/scripts/release/publish.test.ts
+++ b/scripts/release/publish.test.ts
@@ -117,8 +117,9 @@ describe('publish.ts', () => {
     })
 
     test('builds with scoped filter for the released package', async () => {
-      // Releases scope the turbo build to the released package + its workspace
-      // deps so we don't fan out to all 11 packages and OOM the executor.
+      // Releases scope the turbo build to exactly the released package. Deps
+      // resolve to source and are inlined by tsdown, so building them would
+      // produce artifacts nothing reads — and would risk OOMing the executor.
       process.env.CIRCLE_TAG = '@agent-facets/protocol@1.1.0'
       setupPublishPath()
 
@@ -128,7 +129,7 @@ describe('publish.ts', () => {
       await release()
 
       expect(buildSpy).toHaveBeenCalledTimes(1)
-      expect(buildSpy).toHaveBeenCalledWith('@agent-facets/protocol...')
+      expect(buildSpy).toHaveBeenCalledWith('@agent-facets/protocol')
     })
 
     test('skips private packages without publishing', async () => {

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -77,12 +77,15 @@ export async function release(): Promise<number> {
   // Library packages — build and publish directly
   if (!alreadyPublished) {
     await mintNpmToken()
-    // Scope build to the released package + its workspace deps. The trailing
-    // `...` is Turbo's "include dependencies" filter, so e.g. `engine` still
-    // builds `protocol` first when an engine tag fires. Avoids the OOM that
-    // killed releases when all 11 packages built in parallel — see
+    // Scope the build to exactly the released package — no `...` dependency
+    // filter. Every workspace dep resolves to source (`exports` points at
+    // `src/`) and tsdown inlines the private ones via `deps.alwaysBundle`, so
+    // a package's tarball never consumes another package's `dist/`. Turbo's
+    // `transit` nodes still fold dependency source into this build's hash, so
+    // dropping the dependency builds costs no cache correctness — it just
+    // avoids running four DTS passes we'd throw away. See
     // .circleci/development/commands/run-check.yml for the memory analysis.
-    await io.shell.turboBuild(`${pkg.name}...`)
+    await io.shell.turboBuild(pkg.name)
     await packAndPublish(pkg.dir)
     io.console.log(`Published ${parsed.name}@${parsed.version} to npm`)
   }

--- a/turbo.json
+++ b/turbo.json
@@ -2,27 +2,33 @@
   "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["bun.lock", "mise.toml"],
   "tasks": {
+    "transit": {
+      "dependsOn": ["^transit"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.test.ts", "!**/*.test.tsx"]
+    },
     "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
+      "dependsOn": ["transit"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.json"],
       "outputs": ["dist/**"]
     },
     "test": {
-      "dependsOn": ["^test"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
-      "outputs": ["$TURBO_ROOT$/test-results/**"]
+      "dependsOn": ["transit"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.e2e.test.ts", "$TURBO_ROOT$/tsconfig.json"],
+      "outputs": ["junit.xml"]
     },
     "test:e2e": {
-      "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/bunfig.toml"],
-      "outputs": ["$TURBO_ROOT$/test-results/**"]
+      "dependsOn": ["transit"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.json"],
+      "outputs": ["junit-e2e.xml"]
     },
     "types": {
-      "dependsOn": ["^types"]
+      "dependsOn": ["transit"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.json"]
     },
     "check": {
       "dependsOn": [
         "//#lint",
+        "^build",
         "types",
         "test",
         "test:e2e",
@@ -45,6 +51,7 @@
       "inputs": [
         "scripts/**",
         ".changeset/**",
+        "bunfig.toml",
         "package.json",
         "packages/*/package.json",
         "packages/adapters/*/package.json",


### PR DESCRIPTION
### Why

JUnit reports from different packages were writing to a shared `test-results/` directory, causing Turbo cache restores to clobber reports from other packages and surfacing stale test suites in CI results. Additionally, `test` and `test:e2e` tasks were serialized behind each other's package builds via `^build` and `^test` dependency edges, preventing the graph from running in parallel.

### Details

**Test report isolation**

Each package's `test` and `test:e2e` script now writes its JUnit XML to a package-local path (`junit.xml` / `junit-e2e.xml`) rather than a shared `test-results/` directory. The root `turbo.json` declares `outputs: ["junit.xml"]` and `outputs: ["junit-e2e.xml"]` once, and Turbo resolves them per package — giving every task exclusive ownership of exactly one file. A new `Collect package test reports` CI step (running `when: always`) flattens `packages/**/junit*.xml` into `test-results/` with a package-path prefix so `store_test_results` still sees every suite, including those replayed from cache. Per-package `bunfig.toml` files that previously configured the shared paths are removed.

**Transit node**

A new `transit` task replaces the `^build`, `^test`, and `^types` dependency edges. `transit` is a scriptless task that walks the package graph (`dependsOn: ["^transit"]`) and excludes test files from its inputs. `build`, `test`, `types`, and `test:e2e` each depend only on their own package's `transit`, so a dependency source change still busts downstream hashes, but nothing waits for a dependency's tests, type check, or build to finish before starting. This lets all ~57 graph nodes fan out in parallel instead of serializing.

**Release build scope**

`publish.ts` previously used a `pkg.name...` Turbo filter to include workspace dependencies in the release build. Since every workspace dep resolves to source and tsdown inlines private deps via `deps.alwaysBundle`, no package's tarball consumes another's `dist/`. The filter is narrowed to exactly `pkg.name` — `transit` still folds dependency source into the hash, so cache correctness is preserved while avoiding unnecessary DTS passes. The `TURBO_CONCURRENCY=1` cap is removed from the release job for the same reason: with the build scoped to one package, there is never more than one DTS pass to overlap.

**CI concurrency**

`TURBO_CONCURRENCY` on the `check` job is raised from `1` to `2`. The original cap was a blunt fix for OOM kills caused by multiple DTS passes overlapping on the 4 GB `medium` executor. With the transit node allowing tests and type checks to run without waiting behind builds, `2` keeps both vCPUs busy while bounding DTS overlap to at most two concurrent passes. If exit 137 returns, the comment instructs dropping back to `1` before reaching for a larger resource class.

**`check` task**

`check` now explicitly depends on `^build` (builds every package something else depends on) so a broken `tsdown`/DTS pass fails CI rather than surfacing at release time. Leaf packages — the CLI binary and the codex/claude-code adapters — are intentionally excluded since they build inline in their own `test:e2e` tasks.

### Verification

CI — the `Collect package test reports` step runs `when: always` and Turbo restores report files on cache hits, so both fresh runs and cache replays populate `test-results/` for upload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CI caching, task ordering, and release build scope; misconfigured Turbo edges could cause flaky e2e or incorrect cache hits, though behavior is documented and covered by updated publish tests.
> 
> **Overview**
> Fixes **stale or missing CI test suites** by writing each package’s JUnit XML to **`junit.xml` / `junit-e2e.xml` inside that package** (Turbo `outputs` per task) instead of a shared `test-results/**` tree that cache restores could overwrite. Per-package `bunfig.toml` reporter config is removed; CI **Collect package test reports** flattens `packages/**/junit*.xml` into `test-results/` for `store_test_results` (`when: always`, including cache hits).
> 
> Reworks the **Turbo task graph** with a scriptless **`transit`** task (`^transit`, non-test inputs) so `build` / `test` / `types` / `test:e2e` propagate dependency hashes without waiting on upstream tests, types, or builds. **`check`** gains **`^build`** so depended-on packages still get a DTS/build pass in CI; **`test:e2e`** gets explicit **`build`** edges only where needed (opencode adapter, CLI → `@agent-facets/adapter-opencode#build`). Opencode e2e drops inline `bun run build` from the script where Turbo owns the build.
> 
> **CI/release tuning:** `TURBO_CONCURRENCY` on check goes **1 → 2**; release drops the concurrency cap and **`publish.ts`** narrows `turboBuild` from **`pkg...`** to **`pkg.name`** only. **`AGENTS.md`** documents transit, reports, artifacts, and “always run tests via Turbo.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5285d560281bf1a4153093295c0caea10cf0e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - CI checks can run with increased parallelism, helping reduce validation time.
  - Test results are now consistently collected, including reports from cached runs.
  - Unit and end-to-end tests produce standardized JUnit reports for clearer CI visibility.
  - End-to-end CLI testing now builds required components automatically and provides more actionable failure details.
  - Release builds are scoped to the selected package, reducing unnecessary build work.

- **Documentation**
  - Added guidance for testing, caching, concurrency, reporting, and creating new packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->