### PR TITLE
Strip terminal control sequences from test helpers and normalize captured output before assertions

### DIFF
--- a/packages/cli/src/__tests__/candidate-archive.e2e.test.ts
+++ b/packages/cli/src/__tests__/candidate-archive.e2e.test.ts
@@ -36,7 +36,7 @@ afterAll(async () => {
 
 async function runCli(cwd: string, ...args: string[]) {
   const facetDir = await mkdtemp(join(testDir, 'facet-dir-'))
-  return await spawnCli(args, { cwd, env: { NO_COLOR: '1', FACET_DIR: facetDir } })
+  return await spawnCli(args, { cwd, env: { FACET_DIR: facetDir } })
 }
 
 const REPRESENTATIVE_BINARY = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0xff, 0xfe])

--- a/packages/cli/src/__tests__/create-build.e2e.test.ts
+++ b/packages/cli/src/__tests__/create-build.e2e.test.ts
@@ -30,7 +30,7 @@ async function runCli(...args: string[]) {
   // builds proceed with unknown-adapter warnings. Created under `testDir`
   // so the suite's afterAll cleanup sweeps it — no per-call leak.
   const facetDir = await mkdtemp(join(testDir, 'facet-dir-'))
-  const result = await spawnCli(args, { env: { NO_COLOR: '1', FACET_DIR: facetDir } })
+  const result = await spawnCli(args, { env: { FACET_DIR: facetDir } })
 
   // Don't let build errors flood test output — capture but don't dump
   if (result.exitCode !== 0 && result.stderr) {

--- a/packages/cli/src/__tests__/helpers/capture-std.ts
+++ b/packages/cli/src/__tests__/helpers/capture-std.ts
@@ -12,13 +12,32 @@
  * output. Use `withSilencedStderr` / `withSilencedStdout` when you only
  * care about the return value and want the stream muted.
  *
+ * Captured output has its terminal control sequences removed, because the
+ * handlers colour their output whenever the real stream is a TTY: the same
+ * assertion would then hold when the suite is piped and fail when a
+ * developer runs it in a terminal. Whitespace is left exactly as written —
+ * these streams carry the CLI's own formatting (the two-space `fix:` indent,
+ * one record per line), and an assertion about that layout is legitimate.
+ * Pass `{ raw: true }` when the escape sequences are the subject.
+ *
  * All four helpers restore the original stream in a `finally` block,
  * even if `fn` throws.
  */
 
+import { stripTerminalControls } from './terminal-output.ts'
+
 type StreamName = 'stdout' | 'stderr'
 
-async function captureStream<T>(stream: StreamName, fn: () => T | Promise<T>): Promise<{ result: T; output: string }> {
+export interface CaptureOptions {
+  /** Keep terminal control sequences instead of removing them. */
+  raw?: boolean
+}
+
+async function captureStream<T>(
+  stream: StreamName,
+  fn: () => T | Promise<T>,
+  opts: CaptureOptions = {},
+): Promise<{ result: T; output: string }> {
   const target = process[stream]
   const original = target.write.bind(target)
   const chunks: string[] = []
@@ -28,21 +47,28 @@ async function captureStream<T>(stream: StreamName, fn: () => T | Promise<T>): P
   }) as typeof target.write
   try {
     const result = await fn()
-    return { result, output: chunks.join('') }
+    const output = chunks.join('')
+    return { result, output: opts.raw === true ? output : stripTerminalControls(output) }
   } finally {
     target.write = original
   }
 }
 
 /** Run `fn` with process.stderr.write captured. Returns the captured string and fn's result. */
-export async function captureStderr<T>(fn: () => T | Promise<T>): Promise<{ result: T; stderr: string }> {
-  const { result, output } = await captureStream('stderr', fn)
+export async function captureStderr<T>(
+  fn: () => T | Promise<T>,
+  opts: CaptureOptions = {},
+): Promise<{ result: T; stderr: string }> {
+  const { result, output } = await captureStream('stderr', fn, opts)
   return { result, stderr: output }
 }
 
 /** Run `fn` with process.stdout.write captured. Returns the captured string and fn's result. */
-export async function captureStdout<T>(fn: () => T | Promise<T>): Promise<{ result: T; stdout: string }> {
-  const { result, output } = await captureStream('stdout', fn)
+export async function captureStdout<T>(
+  fn: () => T | Promise<T>,
+  opts: CaptureOptions = {},
+): Promise<{ result: T; stdout: string }> {
+  const { result, output } = await captureStream('stdout', fn, opts)
   return { result, stdout: output }
 }
 

--- a/packages/cli/src/__tests__/helpers/cli-process.ts
+++ b/packages/cli/src/__tests__/helpers/cli-process.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { stripTerminalControls } from './terminal-output.ts'
 
 /** The compiled binary the end-to-end suites drive. */
 export const CLI_PATH = resolve(import.meta.dir, '../../../dist/facet')
@@ -31,6 +32,15 @@ export interface SpawnCliOptions {
   stdin?: 'ignore' | 'inherit'
   /** Set false when a test asserts on exact stream bytes. */
   trim?: boolean
+  /**
+   * Keep terminal control sequences instead of removing them.
+   *
+   * Both streams are pipes, so the CLI normally emits none — but it inherits
+   * the caller's environment, and a `FORCE_COLOR` in a developer's shell or a
+   * future CI image turns them back on. Stripping by default keeps an
+   * assertion about the CLI's words from depending on that.
+   */
+  raw?: boolean
 }
 
 /** Run the compiled binary and collect both streams and the exit code. */
@@ -42,8 +52,13 @@ export async function spawnCli(args: readonly string[], opts: SpawnCliOptions = 
     cwd: opts.cwd,
     env: { ...process.env, ...opts.env },
   })
-  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  const [rawStdout, rawStderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
   const exitCode = await proc.exited
+  // Control sequences and surrounding whitespace are separate concerns: a
+  // test asserting on exact bytes keeps its newlines while still reading the
+  // CLI's words rather than its colours.
+  const stdout = opts.raw === true ? rawStdout : stripTerminalControls(rawStdout)
+  const stderr = opts.raw === true ? rawStderr : stripTerminalControls(rawStderr)
   if (opts.trim === false) return { stdout, stderr, exitCode }
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode }
 }

--- a/packages/cli/src/__tests__/helpers/terminal-output.ts
+++ b/packages/cli/src/__tests__/helpers/terminal-output.ts
@@ -1,0 +1,79 @@
+/**
+ * Test helpers for asserting on rendered terminal output.
+ *
+ * Rendered output is not the text a reader sees. Ink colours each `<Text>`
+ * span, and `wrap-ansi` re-opens the active style after every line wrap, so
+ * a single rendered sentence carries control sequences *between its words*:
+ *
+ *   "They are no \x1b[39m\n\x1b[38;2;253;224;71mlonger tracked"
+ *
+ * `toContain('no longer tracked')` is then false against output that renders
+ * that phrase perfectly. Worse, the same bytes make `not.toContain(...)` and
+ * `not.toMatch(/a\s+b/)` pass vacuously — a test that reports green while
+ * asserting nothing. Whether any of this happens depends on whether the
+ * runner is attached to a TTY, so a suite can be green in CI and red locally.
+ *
+ * These helpers put every assertion on the *visible* text instead:
+ *
+ *   `stripTerminalControls` — controls removed, line structure preserved.
+ *     Use when the assertion is about layout: a regex spanning a row, or a
+ *     negative assertion that must not match across two rows.
+ *   `visibleTerminalText`   — controls removed, then wrapping whitespace
+ *     collapsed. Use for prose, which wraps at whatever column the terminal
+ *     happens to be. Stripping must happen first: collapsing leaves the
+ *     control bytes sitting between the words it just joined.
+ *   `contentFrame` / `visibleContentFrame` — the same two levels, applied to
+ *     the last frame Ink rendered with anything in it.
+ *
+ * Raw bytes stay reachable: read `instance.lastFrame()` or `instance.frames`
+ * directly. Do that only when the escape sequences are the subject — the
+ * colour-contract tests in `tui/views/install/__tests__/collision-status.ts`
+ * and `util/__tests__/errors.test.ts` assert on presentation data and exact
+ * bytes on purpose, and normalizing them would delete what they check.
+ */
+
+import { stripVTControlCharacters } from 'node:util'
+
+/**
+ * Remove terminal control sequences (colour, cursor movement, hyperlinks),
+ * leaving line structure intact.
+ *
+ * Node's own implementation, so the CLI's tests and Node agree on what a
+ * control sequence is — a hand-rolled regex tends to miss OSC-8 hyperlinks
+ * and other non-SGR sequences.
+ */
+export function stripTerminalControls(text: string): string {
+  return stripVTControlCharacters(text)
+}
+
+/**
+ * The visible text of rendered output: control sequences removed, then every
+ * run of whitespace collapsed to a single space.
+ *
+ * Collapsing folds the terminal's line wrapping away, so an assertion can
+ * name a phrase without also encoding the column it happened to break at.
+ */
+export function visibleTerminalText(text: string): string {
+  return stripTerminalControls(text).replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * The last frame that rendered anything, with control sequences removed.
+ *
+ * Ink's final frame after an auto-unmount is blank, and a frame holding only
+ * colour codes is blank to a reader, so both are skipped. Throws when no
+ * frame had content: a missing frame must fail the test rather than quietly
+ * satisfy every assertion against `''`.
+ */
+export function contentFrame(frames: ReadonlyArray<string | undefined>): string {
+  for (let i = frames.length - 1; i >= 0; i--) {
+    const visible = stripTerminalControls(frames[i] ?? '')
+    if (visible.trim().length > 0) return visible
+  }
+  throw new Error(`no content frame found among ${frames.length} captured frames`)
+}
+
+/** {@link contentFrame}, with the terminal's wrapping collapsed away. */
+export function visibleContentFrame(frames: ReadonlyArray<string | undefined>): string {
+  return visibleTerminalText(contentFrame(frames))
+}

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -20,6 +20,7 @@ import {
   UNSUPPORTED_MANIFEST_VERSION_FIX,
   UNSUPPORTED_MANIFEST_VERSION_WHAT,
 } from '../util/unsupported-manifest-version.ts'
+import { visibleContentFrame, visibleTerminalText } from './helpers/terminal-output.ts'
 
 /**
  * Wait long enough for the view's `useEffect` chain to finish (run the
@@ -28,34 +29,6 @@ import {
  */
 function settle(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 50))
-}
-
-/**
- * `ink-testing-library`'s `lastFrame()` returns the literal final frame,
- * which post-unmount is just `"\n"`. We want the last frame with actual
- * content — the one rendered immediately before the view auto-unmounted.
- *
- * Searches backwards from the end and returns the most recent frame
- * with non-trivial text. Throws if no such frame exists, so a missing
- * frame fails loudly instead of silently passing assertions.
- */
-function findContentFrame(frames: ReadonlyArray<string | undefined>): string {
-  for (let i = frames.length - 1; i >= 0; i--) {
-    const frame = frames[i]
-    if (frame !== undefined && frame.trim().length > 0) return frame
-  }
-  throw new Error(`no content frame found among ${frames.length} captured frames`)
-}
-
-/**
- * Collapse a frame's whitespace so an assertion can name a phrase without
- * knowing where Ink wrapped it. A rendered sentence breaks at whatever column
- * the terminal width lands on, so `toContain('no longer tracked')` is really
- * an assertion about line width — it fails the moment the copy before it
- * changes length, which says nothing about the behavior under test.
- */
-function unwrapped(frame: string): string {
-  return frame.replace(/\s+/g, ' ')
 }
 
 /**
@@ -167,7 +140,7 @@ describe('InstallView — single-facet success', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('viper-plans installed.')
     expect(frame).toContain('1 installed')
     instance.unmount()
@@ -205,7 +178,7 @@ describe('InstallView — multi-facet success with update', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('Install complete.')
     expect(frame).toContain('2 installed')
     expect(frame).toContain('1 updated')
@@ -237,7 +210,7 @@ describe('InstallView — server warnings', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('with-servers')
     expect(frame).toContain('2 servers declared')
     expect(frame).toContain('inline-server')
@@ -278,7 +251,7 @@ describe('InstallView — drift removal', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('1 removed')
     instance.unmount()
   })
@@ -307,7 +280,7 @@ describe('InstallView — drift removal', () => {
     }
     const instance = render(createElement(InstallView, { mode: 'remove', run: makeFakeRun(events, result) }))
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     // Still named as removed — the declaration did go away.
     expect(frame).toContain('orphan')
     // Ink wraps at the test terminal width, so assert on wrap-safe fragments.
@@ -342,7 +315,7 @@ describe('InstallView — drift removal', () => {
     }
     const instance = render(createElement(InstallView, { mode: 'install', run: makeFakeRun(events, result) }))
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('unreadable')
     expect(frame).toContain('nothing already on disk is tracked')
     instance.unmount()
@@ -363,7 +336,7 @@ describe('InstallView — drift removal', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('different project')
     expect(frame).not.toContain('unreadable')
     instance.unmount()
@@ -385,7 +358,7 @@ describe('InstallView — drift removal', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('review')
     expect(frame).toContain('alpha')
     expect(frame).toContain('left in place')
@@ -407,7 +380,7 @@ describe('InstallView — drift removal', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('could not be written')
     expect(frame).toContain('untracked')
     instance.unmount()
@@ -436,7 +409,7 @@ describe('InstallView — drift removal', () => {
       }),
     )
     await settle()
-    const frame = unwrapped(findContentFrame(instance.frames))
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('review')
     expect(frame).toContain('refs/api.md')
     expect(frame).toContain('no longer tracked')
@@ -476,7 +449,7 @@ describe('InstallView — drift removal', () => {
       }),
     )
     await settle()
-    const frame = unwrapped(findContentFrame(instance.frames))
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('project scope')
     expect(frame).toContain('user scope')
     // Both rows rendered — a scope-free React key would have collapsed them.
@@ -545,7 +518,7 @@ describe('InstallView — marketing aesthetic on `add`', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('1 skill')
     expect(frame).toContain('1 command')
     // The "Now /x is available" line was removed in the marketing overhaul.
@@ -604,7 +577,7 @@ describe('InstallView — marketing aesthetic on `add`', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('1 skill')
     expect(frame).not.toContain('is available to your agents')
     instance.unmount()
@@ -698,7 +671,7 @@ describe('InstallView — marketing aesthetic on `add`', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     // Only cowsay's one command — no skills from `existing-skill`.
     expect(frame).toContain('1 command')
     expect(frame).not.toContain('skill')
@@ -758,7 +731,7 @@ describe('InstallView — marketing aesthetic on `add`', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('1 command')
     expect(frame).not.toContain('is available to your agents')
     instance.unmount()
@@ -778,7 +751,7 @@ describe('InstallView — empty / no-op', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('no changes')
     instance.unmount()
   })
@@ -814,7 +787,7 @@ describe('InstallView — integrity failure', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('integrity check failed')
     expect(frame).toContain('check: B')
     expect(frame).toContain(integrityFailure.expected)
@@ -846,7 +819,7 @@ describe('InstallView — integrity failure', () => {
     }
     const instance = render(createElement(InstallView, { mode: 'add', run: makeFakeRun(events, result) }))
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('file integrity mismatch')
     expect(frame).toContain('skills/planning/references/api.md')
     expect(frame).toContain(failure.code === 'RECONCILE_PER_FILE_INTEGRITY' ? failure.expected : '')
@@ -883,7 +856,7 @@ describe('InstallView — parse error failure', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('could not parse source for broken')
     expect(frame).toContain('git+ prefix is not supported')
     expect(frame).toContain('fix:')
@@ -916,7 +889,7 @@ describe('InstallView — aborted', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('install aborted')
     // Asserted against the shared helper rather than a literal: this is the
     // check that the view and the stderr `fix:` line cannot drift apart.
@@ -954,7 +927,7 @@ describe('InstallView — unsupported manifest version', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain(UNSUPPORTED_MANIFEST_VERSION_WHAT)
     expect(frame).toContain(UNSUPPORTED_MANIFEST_VERSION_FIX)
     expect(frame).toContain(describeUnsupportedManifestVersion({ ...detail, observed }))
@@ -978,7 +951,7 @@ describe('InstallView — unsupported manifest version', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain(UNSUPPORTED_MANIFEST_VERSION_WHAT)
     expect(frame).toContain(UNSUPPORTED_MANIFEST_VERSION_FIX)
     instance.unmount()
@@ -1008,7 +981,7 @@ describe('InstallView — partial rollback failure surfaces', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain(diskStateSentence(rollback))
     expect(frame).toContain('Some adapter writes could not be undone')
     expect(frame).toContain('disk full')
@@ -1038,7 +1011,7 @@ describe('InstallView — adapter registration', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     // Registration line: "Updated facets via 2 adapters"
     expect(frame).toContain('Updated facets via')
     expect(frame).toContain('2 adapter')
@@ -1077,7 +1050,7 @@ describe('InstallView — frozen-lockfile drift', () => {
       }),
     )
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('lockfile is out of date')
     expect(frame).toContain('locked 0.1.1 does not satisfy 0.1.2')
     expect(frame).toContain('not in lockfile (manifest wants 0.2.0)')
@@ -1157,7 +1130,7 @@ describe('InstallView — collision phase machine', () => {
       }),
     )
     await tick()
-    expect(instance.lastFrame() ?? '').toContain('Checking for name collisions')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Checking for name collisions')
     await settle()
     instance.unmount()
   })
@@ -1184,7 +1157,7 @@ describe('InstallView — collision phase machine', () => {
     )
     await tick()
 
-    const paused = instance.lastFrame() ?? ''
+    const paused = visibleTerminalText(instance.lastFrame() ?? '')
     expect(paused).toContain('Checking for name collisions across all facets')
     // One phase, not one per facet.
     expect(paused.match(/Checking for name collisions/g)).toHaveLength(1)
@@ -1209,11 +1182,11 @@ describe('InstallView — collision phase machine', () => {
       }),
     )
     await tick()
-    expect(instance.lastFrame() ?? '').toContain('Checking for name collisions')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Checking for name collisions')
 
     await tick()
     await tick()
-    expect(instance.lastFrame() ?? '').not.toContain('Checking for name collisions')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).not.toContain('Checking for name collisions')
 
     await settle()
     instance.unmount()
@@ -1230,7 +1203,7 @@ describe('InstallView — collision phase machine', () => {
     await tick()
 
     // Phase 2: the workspace has the screen.
-    expect(instance.lastFrame() ?? '').toContain('Installation is paused')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Installation is paused')
 
     // Resolve by omitting both claimants, then confirm.
     for (const key of [
@@ -1257,7 +1230,7 @@ describe('InstallView — collision phase machine', () => {
     // second Ink renderer, so the whole run is one continuous frame
     // stream.
     await settle()
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('Install complete.')
     expect(frame).toContain('1 installed')
     instance.unmount()
@@ -1276,7 +1249,7 @@ describe('InstallView — collision phase machine', () => {
     await settle()
 
     expect(resolutions).toEqual([{ kind: 'cancelled' }])
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('Cancelled')
     expect(frame).toContain(diskStateSentence({ kind: 'not-needed', reason: 'test fixture' }))
     expect(frame).not.toContain('Install complete.')
@@ -1297,7 +1270,7 @@ describe('InstallView — collision phase machine', () => {
       }),
     )
     await tick()
-    expect(instance.lastFrame() ?? '').toContain('Installation is paused')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Installation is paused')
 
     controller.abort()
     await settle()
@@ -1350,7 +1323,7 @@ describe('InstallView — materialization reporting', () => {
     )
     await settle()
 
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('review')
     expect(frame).toContain('vendor-review')
     expect(frame).toContain('deploy')
@@ -1370,7 +1343,7 @@ describe('InstallView — materialization reporting', () => {
     // The omitted command stays in the lockfile — it is part of the
     // resolved set — but claiming it in the bundle would advertise a
     // file that was never written.
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('1 skill')
     expect(frame).not.toContain('1 command')
     instance.unmount()
@@ -1393,7 +1366,7 @@ describe('InstallView — materialization reporting', () => {
 
     // No `onLog` was supplied — this has to be visible anyway, because
     // it silently changed what facets.json says.
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('gone')
     expect(frame).toContain('alpha')
     expect(frame).toContain('no longer contains')
@@ -1421,7 +1394,7 @@ describe('InstallView — disposition-only change', () => {
     )
     await settle()
 
-    const frame = findContentFrame(instance.frames)
+    const frame = visibleContentFrame(instance.frames)
     expect(frame).toContain('1 updated')
     expect(frame).not.toContain('repaired')
     expect(frame).not.toContain('1.0.0 → 1.0.0')

--- a/packages/cli/src/__tests__/instructions.e2e.test.ts
+++ b/packages/cli/src/__tests__/instructions.e2e.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { spawnCli } from './helpers/cli-process.ts'
 
-const runCli = (...args: string[]) => spawnCli(args, { env: { NO_COLOR: '1' } })
+const runCli = (...args: string[]) => spawnCli(args)
 
 describe('facet instructions', () => {
   test('default topic prints the overview and points at authoring', async () => {

--- a/packages/cli/src/__tests__/modify.e2e.test.ts
+++ b/packages/cli/src/__tests__/modify.e2e.test.ts
@@ -16,7 +16,7 @@ afterAll(async () => {
   await rm(testDir, { recursive: true, force: true })
 })
 
-const runCli = (...args: string[]) => spawnCli(args, { env: { NO_COLOR: '1' } })
+const runCli = (...args: string[]) => spawnCli(args)
 
 /**
  * Scaffold a fresh facet in its own dir and return the path. Includes a skill

--- a/packages/cli/src/__tests__/terminal-output.test.ts
+++ b/packages/cli/src/__tests__/terminal-output.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  contentFrame,
+  stripTerminalControls,
+  visibleContentFrame,
+  visibleTerminalText,
+} from './helpers/terminal-output.ts'
+
+/** Turn on a 24-bit foreground colour, the shape Ink's theme emits. */
+const YELLOW = '\u001B[38;2;253;224;71m'
+/** Return the foreground to its default. */
+const RESET = '\u001B[39m'
+
+describe('stripTerminalControls', () => {
+  test('removes colour sequences that sit between two words', () => {
+    expect(stripTerminalControls(`no ${RESET}${YELLOW}longer tracked`)).toBe('no longer tracked')
+  })
+
+  test('removes a hyperlink sequence, keeping its visible label', () => {
+    // Not an SGR sequence — the reason this delegates to Node rather than
+    // matching \u001B[...m by hand.
+    const linked = `\u001B]8;;https://agentfacets.io\u0007docs\u001B]8;;\u0007`
+    expect(stripTerminalControls(linked)).toBe('docs')
+  })
+
+  test('preserves line structure, so layout assertions stay possible', () => {
+    // A regex spanning one row, or a negative assertion that must not match
+    // across two rows, needs the rows to still be rows.
+    const frame = `${YELLOW}claude-code${RESET} (installed)\n${YELLOW}opencode${RESET}`
+    const stripped = stripTerminalControls(frame)
+
+    expect(stripped.split('\n')).toEqual(['claude-code (installed)', 'opencode'])
+    expect(stripped).toMatch(/claude-code.*\(installed\)/)
+    expect(stripped).not.toMatch(/opencode.*\(installed\)/)
+  })
+
+  test('leaves control-free text untouched', () => {
+    expect(stripTerminalControls('plain text\n  indented')).toBe('plain text\n  indented')
+  })
+})
+
+describe('visibleTerminalText', () => {
+  test('joins a phrase Ink wrapped and recoloured mid-sentence', () => {
+    // The rendered shape that made `toContain('no longer tracked')` fail
+    // against output that displayed exactly that: a wrap, and the active
+    // colour re-opened on the next row.
+    const wrapped = `They are no ${RESET}\n${YELLOW}longer tracked — remove whatever remains manually.`
+
+    expect(visibleTerminalText(wrapped)).toContain('no longer tracked')
+  })
+
+  test('strips before collapsing, so no control bytes survive between words', () => {
+    // Collapsing first would leave "no \u001B[39m \u001B[38;2;…mlonger" —
+    // whitespace-normalized, still unassertable.
+    const wrapped = `no ${RESET}\n${YELLOW}longer`
+    const collapsedFirst = wrapped.replace(/\s+/g, ' ')
+
+    expect(collapsedFirst).not.toContain('no longer')
+    expect(visibleTerminalText(wrapped)).toBe('no longer')
+  })
+
+  test('collapses every run of whitespace, including indentation and blank lines', () => {
+    expect(visibleTerminalText('  ⚠ skill “review”\n\n    was  missing  ')).toBe('⚠ skill “review” was missing')
+  })
+
+  test('a phrase already on one line is unaffected', () => {
+    expect(visibleTerminalText(`${YELLOW}1 installed · 1 asset written${RESET}`)).toBe('1 installed · 1 asset written')
+  })
+})
+
+describe('contentFrame', () => {
+  test('returns the last frame that rendered anything', () => {
+    expect(contentFrame(['first', 'second'])).toBe('second')
+  })
+
+  test('skips the blank frame Ink leaves behind after unmounting', () => {
+    expect(contentFrame(['Install complete.', '\n'])).toBe('Install complete.')
+  })
+
+  test('skips a frame carrying only colour codes, which shows a reader nothing', () => {
+    expect(contentFrame(['Install complete.', `${YELLOW}${RESET}`])).toBe('Install complete.')
+  })
+
+  test('skips undefined entries', () => {
+    expect(contentFrame(['Install complete.', undefined])).toBe('Install complete.')
+  })
+
+  test('strips control sequences from the frame it returns', () => {
+    expect(contentFrame([`${YELLOW}1 installed${RESET}`])).toBe('1 installed')
+  })
+
+  test('throws when no frame had content, rather than returning an empty string', () => {
+    // An empty string satisfies every `not.toContain` assertion in the file.
+    expect(() => contentFrame(['', '\n', undefined])).toThrow('no content frame found')
+  })
+
+  test('does not mutate the frames it was given', () => {
+    const raw = `${YELLOW}1 installed${RESET}`
+    const frames = [raw]
+
+    contentFrame(frames)
+
+    // Raw bytes stay reachable for the tests whose subject is the colour.
+    expect(frames).toEqual([raw])
+    expect(frames[0]).toContain(YELLOW)
+  })
+})
+
+describe('visibleContentFrame', () => {
+  test('applies both levels to the last frame with content', () => {
+    const frames = [
+      'Removing facets:',
+      `${YELLOW}⚠ its recorded files were left untouched. They are no ${RESET}\n${YELLOW}longer tracked.${RESET}`,
+      '\n',
+    ]
+
+    expect(visibleContentFrame(frames)).toBe('⚠ its recorded files were left untouched. They are no longer tracked.')
+  })
+
+  test('throws when no frame had content', () => {
+    expect(() => visibleContentFrame([])).toThrow('no content frame found')
+  })
+})

--- a/packages/cli/src/commands/adapter/__tests__/install-picker.test.tsx
+++ b/packages/cli/src/commands/adapter/__tests__/install-picker.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
+import { stripTerminalControls, visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
 import { InstallPicker } from '../install-picker.tsx'
 
 const KEY_DOWN = '\u001b[B'
@@ -27,7 +28,9 @@ describe('InstallPicker — initial render', () => {
         onAbort: () => {},
       }),
     )
-    expect(instance.lastFrame()).toContain('No AI tools are connected yet. Pick which adapter to install.')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain(
+      'No AI tools are connected yet. Pick which adapter to install.',
+    )
     instance.unmount()
   })
 
@@ -39,7 +42,7 @@ describe('InstallPicker — initial render', () => {
         onAbort: () => {},
       }),
     )
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('Pick which adapter to install or update.')
     expect(frame).not.toContain('No AI tools are connected yet')
     instance.unmount()
@@ -53,7 +56,11 @@ describe('InstallPicker — initial render', () => {
         onAbort: () => {},
       }),
     )
-    const frame = instance.lastFrame() ?? ''
+    // Row-scoped: the annotation must sit on the claude-code row and nowhere
+    // else, so this keeps the frame's rows rather than unwrapping them — `.*`
+    // across a single string would let one row's annotation satisfy another
+    // row's name.
+    const frame = stripTerminalControls(instance.lastFrame() ?? '')
     // claude-code marked as installed
     expect(frame).toMatch(/claude-code.*\(installed — select to update\)/)
     // opencode (not installed) stays un-annotated
@@ -68,7 +75,7 @@ describe('InstallPicker — initial render', () => {
         onAbort: () => {},
       }),
     )
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('claude-code')
     expect(frame).toContain('opencode')
     expect(frame).toContain('codex')
@@ -82,7 +89,9 @@ describe('InstallPicker — initial render', () => {
         onAbort: () => {},
       }),
     )
-    expect(instance.lastFrame()).toContain('↑↓ move · Space toggle · Enter confirm · Esc cancel')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain(
+      '↑↓ move · Space toggle · Enter confirm · Esc cancel',
+    )
     instance.unmount()
   })
 })
@@ -137,7 +146,7 @@ describe('InstallPicker — keyboard interaction', () => {
     await nextTick()
     expect(confirmed).toBe(false)
     expect(aborted).toBe(false)
-    expect(instance.lastFrame()).toContain('Select at least one with Space.')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Select at least one with Space.')
     instance.unmount()
   })
 
@@ -225,10 +234,10 @@ describe('InstallPicker — keyboard interaction', () => {
     )
     instance.stdin.write(KEY_ENTER)
     await nextTick()
-    expect(instance.lastFrame()).toContain('Select at least one with Space.')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Select at least one with Space.')
     instance.stdin.write(KEY_DOWN)
     await nextTick()
-    expect(instance.lastFrame()).not.toContain('Select at least one with Space.')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).not.toContain('Select at least one with Space.')
     instance.unmount()
   })
 })

--- a/packages/cli/src/commands/search/__tests__/search.test.ts
+++ b/packages/cli/src/commands/search/__tests__/search.test.ts
@@ -3,6 +3,7 @@ import { fixtures, type WirePackageListItem } from '@agent-facets/engine'
 import { render as inkRender } from 'ink-testing-library'
 import { createElement } from 'react'
 import { captureStderr } from '../../../__tests__/helpers/capture-std.ts'
+import { contentFrame, visibleContentFrame, visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
 import { type SearchResult, SearchView } from '../../../tui/views/search/search-view.tsx'
 import { searchCommand } from '../index.ts'
 
@@ -27,13 +28,9 @@ function mockFetch(items: WirePackageListItem[]): () => Promise<SearchResult> {
 /** Wait for async effects to settle. */
 const settle = () => new Promise((r) => setTimeout(r, 100))
 
-/** Find the last non-empty frame. */
+/** The visible text of the last frame that rendered anything. */
 function lastContentFrame(instance: ReturnType<typeof inkRender>): string {
-  const frames = [...instance.frames].reverse()
-  for (const f of frames) {
-    if (f.trim().length > 0) return f
-  }
-  return instance.lastFrame() ?? ''
+  return visibleContentFrame(instance.frames)
 }
 
 describe('SearchView — rendering', () => {
@@ -45,7 +42,7 @@ describe('SearchView — rendering', () => {
         onComplete: () => {},
       }),
     )
-    const f = instance.lastFrame() ?? ''
+    const f = visibleTerminalText(instance.lastFrame() ?? '')
     expect(f).toContain("Searching registry for 'cowsay'")
     instance.unmount()
   })
@@ -203,7 +200,10 @@ describe('SearchView — D10: assetCounts rendering', () => {
     const f = lastContentFrame(instance)
     expect(f).toContain('empty')
     expect(f).toContain('v1.0.0')
-    expect(f).not.toMatch(/\d+\s+(agent|command|server|skill)/)
+    // A count and its noun render on one row, so this reads the frame with
+    // its rows intact — unwrapped, `\s+` would span two rows and could match
+    // text that never appeared together.
+    expect(contentFrame(instance.frames)).not.toMatch(/\d+\s+(agent|command|server|skill)/)
   })
 })
 

--- a/packages/cli/src/tui/components/__tests__/boolean-toggle.test.tsx
+++ b/packages/cli/src/tui/components/__tests__/boolean-toggle.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { render } from 'ink-testing-library'
+import { visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
 import { FocusOrderProvider } from '../../context/focus-order-context.ts'
 import { BooleanToggle } from '../boolean-toggle.tsx'
 
@@ -37,23 +38,23 @@ function renderToggle(props: {
 describe('BooleanToggle — rendering', () => {
   test('shows Public when value is false', () => {
     const instance = renderToggle({ value: false })
-    expect(instance.lastFrame()).toContain('Public')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Public')
     instance.unmount()
   })
 
   test('shows Private when value is true', () => {
     const instance = renderToggle({ value: true })
-    expect(instance.lastFrame()).toContain('Private')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Private')
     instance.unmount()
   })
 
   test('shows key hints only when focused', () => {
     const focused = renderToggle({ value: false, focused: true })
-    expect(focused.lastFrame()).toContain('to toggle')
+    expect(visibleTerminalText(focused.lastFrame() ?? '')).toContain('to toggle')
     focused.unmount()
 
     const blurred = renderToggle({ value: false, focused: false })
-    expect(blurred.lastFrame()).not.toContain('to toggle')
+    expect(visibleTerminalText(blurred.lastFrame() ?? '')).not.toContain('to toggle')
     blurred.unmount()
   })
 })

--- a/packages/cli/src/tui/components/__tests__/confirm-prompt.test.tsx
+++ b/packages/cli/src/tui/components/__tests__/confirm-prompt.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
+import { visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
 import { ConfirmPrompt } from '../confirm-prompt.tsx'
 
 const KEY_ENTER = '\r'
@@ -25,7 +26,7 @@ describe('ConfirmPrompt — initial render', () => {
         onAnswer: () => {},
       }),
     )
-    const frame = instance.lastFrame()
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('Overwrite existing file?')
     expect(frame).toContain('(y/N)')
     instance.unmount()
@@ -39,7 +40,7 @@ describe('ConfirmPrompt — initial render', () => {
         onAnswer: () => {},
       }),
     )
-    expect(instance.lastFrame()).toContain('(Y/n)')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('(Y/n)')
     instance.unmount()
   })
 })

--- a/packages/cli/src/tui/components/__tests__/login-menu.test.tsx
+++ b/packages/cli/src/tui/components/__tests__/login-menu.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
+import { visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
 import { LoginMenu } from '../login-menu.tsx'
 
 const KEY_ENTER = '\r'
@@ -17,7 +18,7 @@ function afterEsc(): Promise<void> {
 describe('LoginMenu — menu phase', () => {
   test('shows both options with the browser option marked coming soon', () => {
     const instance = render(createElement(LoginMenu, { onSubmitToken: () => {}, onCancel: () => {} }))
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('Paste a personal access token')
     expect(frame).toContain('Sign in via browser')
     expect(frame).toContain('coming soon')
@@ -46,7 +47,7 @@ describe('LoginMenu — token phase', () => {
     const instance = render(createElement(LoginMenu, { onSubmitToken: () => {}, onCancel: () => {} }))
     instance.stdin.write(KEY_ENTER)
     await nextTick()
-    expect(instance.lastFrame()).toContain('Paste your personal access token')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Paste your personal access token')
     instance.unmount()
   })
 
@@ -64,7 +65,7 @@ describe('LoginMenu — token phase', () => {
     await nextTick()
     instance.stdin.write('fct_pub_abc')
     await nextTick()
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     // The raw token must not appear; masked asterisks render instead.
     expect(frame).not.toContain('fct_pub_abc')
     expect(frame).toContain('*')
@@ -82,7 +83,7 @@ describe('LoginMenu — token phase', () => {
         onCancel: () => {},
       }),
     )
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('invalid token — try again')
     expect(frame).toContain('Paste your personal access token')
     instance.unmount()

--- a/packages/cli/src/tui/views/__tests__/confirm-privacy.test.tsx
+++ b/packages/cli/src/tui/views/__tests__/confirm-privacy.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { EditOperation } from '@agent-facets/engine'
 import { render } from 'ink-testing-library'
+import { visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
 import { FocusOrderProvider } from '../../context/focus-order-context.ts'
 import { type FormState, FormStateProvider } from '../../context/form-state-context.ts'
 import { ConfirmView } from '../create/confirm-view.tsx'
@@ -59,7 +60,7 @@ function renderEdit(isPrivate: boolean) {
 describe('create confirmation summary privacy', () => {
   test('shows Public for a public facet', () => {
     const instance = renderCreate(false)
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('Privacy:')
     expect(frame).toContain('Public')
     instance.unmount()
@@ -67,7 +68,7 @@ describe('create confirmation summary privacy', () => {
 
   test('shows Private for a private facet', () => {
     const instance = renderCreate(true)
-    expect(instance.lastFrame()).toContain('Private')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Private')
     instance.unmount()
   })
 })
@@ -75,7 +76,7 @@ describe('create confirmation summary privacy', () => {
 describe('edit confirmation summary privacy', () => {
   test('shows Public for a public facet', () => {
     const instance = renderEdit(false)
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('Privacy:')
     expect(frame).toContain('Public')
     instance.unmount()
@@ -83,7 +84,7 @@ describe('edit confirmation summary privacy', () => {
 
   test('shows Private for a private facet', () => {
     const instance = renderEdit(true)
-    expect(instance.lastFrame()).toContain('Private')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Private')
     instance.unmount()
   })
 })
@@ -104,7 +105,7 @@ describe('edit confirmation lists queued README operations', () => {
       { op: 'write-manifest', manifest: { name: 'cowsay', version: '0.0.0', files: ['README.md'] } },
       { op: 'write-file', path: 'README.md', content: '# cowsay\n' },
     ])
-    const frame = instance.lastFrame() ?? ''
+    const frame = visibleTerminalText(instance.lastFrame() ?? '')
     expect(frame).toContain('File changes:')
     expect(frame).toContain('Write README.md')
     instance.unmount()
@@ -115,7 +116,7 @@ describe('edit confirmation lists queued README operations', () => {
       { op: 'write-manifest', manifest: { name: 'cowsay', version: '0.0.0' } },
       { op: 'delete-file', path: 'README' },
     ])
-    expect(instance.lastFrame() ?? '').toContain('Delete README')
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Delete README')
     instance.unmount()
   })
 })

--- a/packages/cli/src/tui/views/build/__tests__/build-view.test.tsx
+++ b/packages/cli/src/tui/views/build/__tests__/build-view.test.tsx
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
+import { contentFrame, visibleContentFrame } from '../../../../__tests__/helpers/terminal-output.ts'
 import { BuildView } from '../build-view.tsx'
 
 /**
@@ -15,14 +16,6 @@ import { BuildView } from '../build-view.tsx'
 
 function settle(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 50))
-}
-
-function findContentFrame(frames: ReadonlyArray<string | undefined>): string {
-  for (let i = frames.length - 1; i >= 0; i--) {
-    const frame = frames[i]
-    if (frame !== undefined && frame.trim().length > 0) return frame
-  }
-  throw new Error(`no content frame found among ${frames.length} captured frames`)
 }
 
 /** An adapter whose runtime API declaration is unsupported. */
@@ -54,13 +47,18 @@ describe('BuildView — adapter preflight rendering', () => {
         }),
       )
       await settle()
-      const frame = findContentFrame(frames)
+      const frame = visibleContentFrame(frames)
       // Distinct preflight block, not a stage failure.
       expect(frame).toContain('incompatible adapter')
       expect(frame).toContain('build did not start')
       expect(frame).toContain('future-adapter')
-      // "Parsing manifest" must not be marked failed (✕).
-      const parsingLine = frame.split('\n').find((l) => l.includes('Parsing manifest')) ?? ''
+      // "Parsing manifest" must not be marked failed (✕). This one is about
+      // layout — which row the mark sits on — so it reads the frame with its
+      // rows intact rather than the unwrapped prose.
+      const parsingLine =
+        contentFrame(frames)
+          .split('\n')
+          .find((l) => l.includes('Parsing manifest')) ?? ''
       expect(parsingLine).not.toContain('✕')
       expect(failureCount).toBe(1)
     } finally {

--- a/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
+++ b/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
@@ -4,6 +4,7 @@ import type { FacetContribution } from '@agent-facets/protocol'
 import { planMaterialization } from '@agent-facets/protocol'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
+import { stripTerminalControls, visibleTerminalText } from '../../../../../__tests__/helpers/terminal-output.ts'
 import { CollisionWorkspace } from '../workspace.tsx'
 
 const KEY = {
@@ -57,7 +58,7 @@ describe('CollisionWorkspace — overview', () => {
     const { app } = mount([skill('alpha', 'review', 'deploy'), skill('beta', 'review', 'deploy')])
     await nextTick()
 
-    const frame = app.lastFrame() ?? ''
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
     expect(frame).toContain('review')
     expect(frame).toContain('deploy')
     expect(frame).toContain('alpha')
@@ -70,7 +71,7 @@ describe('CollisionWorkspace — overview', () => {
     const { app, resolutions } = mount(TWO_WAY)
     await nextTick()
 
-    expect(app.lastFrame() ?? '').toContain('resolve every group first')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('resolve every group first')
 
     // Walk to the confirm row and press it anyway.
     await press(app, KEY.down, KEY.enter)
@@ -108,7 +109,7 @@ describe('CollisionWorkspace — overview', () => {
     await nextTick()
     await press(app, KEY.enter, KEY.right, KEY.enter)
     // The editor really is open.
-    expect(app.lastFrame() ?? '').toContain('type a name')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('type a name')
 
     await press(app, KEY.ctrlC)
 
@@ -125,7 +126,7 @@ describe('CollisionWorkspace — resolving a group', () => {
     // Open the group, then put both claimants on Omit. Arrows only
     // move the cursor; Enter applies.
     await press(app, KEY.enter, KEY.right, KEY.right, KEY.enter, KEY.down, KEY.right, KEY.right, KEY.enter)
-    expect(app.lastFrame() ?? '').toContain('not materialized')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('not materialized')
 
     // Back to the overview, onto the confirm row, submit.
     await press(app, KEY.escape, KEY.down, KEY.enter)
@@ -145,8 +146,7 @@ describe('CollisionWorkspace — resolving a group', () => {
 
     // An alias is not a decision until it has a name, so nothing is
     // recorded until the editor is submitted.
-    expect(app.lastFrame() ?? '').toContain('Enter')
-    expect(app.lastFrame() ?? '').toContain('apply')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('Enter apply')
     app.unmount()
   })
 
@@ -157,12 +157,12 @@ describe('CollisionWorkspace — resolving a group', () => {
 
     // Clear the seeded value and type something illegal.
     await press(app, ...'\u007f'.repeat(10).split(''), 'R')
-    const frame = app.lastFrame() ?? ''
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
     expect(frame.toLowerCase()).toContain('lowercase')
 
     // Enter is inert while invalid.
     await press(app, KEY.enter)
-    expect(app.lastFrame() ?? '').toContain('lowercase')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('lowercase')
     expect(resolutions).toHaveLength(0)
     app.unmount()
   })
@@ -176,7 +176,7 @@ describe('CollisionWorkspace — resolving a group', () => {
     await press(app, ...'vendor-review'.split(''))
     await press(app, KEY.enter)
 
-    expect(app.lastFrame() ?? '').toContain('vendor-review')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('vendor-review')
 
     await press(app, KEY.escape, KEY.down, KEY.enter)
 
@@ -196,7 +196,7 @@ describe('CollisionWorkspace — resolving a group', () => {
     await press(app, ...'zzz'.split(''))
     await press(app, KEY.escape)
 
-    const frame = app.lastFrame() ?? ''
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
     expect(frame).not.toContain('zzz')
     // Still the group view, still on Keep.
     expect(frame).toContain('(Keep)')
@@ -221,7 +221,7 @@ describe('CollisionWorkspace — focus across a group split', () => {
 
     // Move onto gamma, the claimant the alias dragged in.
     await press(app, KEY.down, KEY.down)
-    expect(app.lastFrame() ?? '').toContain('gamma')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('gamma')
 
     // Withdraw the alias from alpha's side by omitting gamma instead: put
     // gamma on Omit, which resolves the contest and splits the component.
@@ -253,11 +253,14 @@ describe('CollisionWorkspace — focus across a group split', () => {
     await press(app, KEY.enter)
     await press(app, KEY.escape)
 
-    const frame = app.lastFrame() ?? ''
-    expect(frame).toContain('audit')
-    expect(frame).toContain('(1 asset)')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('audit')
+    // The heading is one row, so this reads the frame with its rows intact:
+    // unwrapped, `\s+` would bridge the heading and the count on the row
+    // below and report a blank heading that never rendered.
+    const rows = stripTerminalControls(app.lastFrame() ?? '')
+    expect(rows).toContain('(1 asset)')
     // No heading line that is just the status tag followed by the count.
-    expect(frame).not.toMatch(/resolved\s+\(1 asset\)/)
+    expect(rows).not.toMatch(/resolved\s+\(1 asset\)/)
     app.unmount()
   })
 })
@@ -272,7 +275,7 @@ describe('CollisionWorkspace — conflicts the user creates', () => {
     await press(app, ...'audit'.split(''))
     await press(app, KEY.enter)
 
-    const frame = app.lastFrame() ?? ''
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
     // The dragged-in asset is now on screen, in the same group, so the
     // user can fix either side without hunting for the other.
     expect(frame).toContain('gamma')


### PR DESCRIPTION
### Why

Test assertions against Ink-rendered output were fragile: Ink colours each `<Text>` span and `wrap-ansi` re-opens the active style after every line wrap, so a phrase like "no longer tracked" could be split across two lines with colour reset/open sequences between the words. Whether this happened depended on whether the test runner was attached to a TTY, meaning the same suite could be green in CI and red locally. Tests also relied on `NO_COLOR=1` being passed to subprocesses to suppress colour, which is a leaky workaround rather than a fix at the assertion layer.

### Details

A new `terminal-output.ts` helper module centralises the normalisation logic:

- `stripTerminalControls` — delegates to Node's `stripVTControlCharacters`, which handles SGR colour codes, OSC-8 hyperlinks, and other non-SGR sequences that a hand-rolled regex would miss. Line structure is preserved so layout assertions (a regex spanning one row, or a negative assertion that must not match across two rows) remain valid.
- `visibleTerminalText` — strips controls then collapses all whitespace runs to a single space, folding away terminal line-wrapping so a phrase can be asserted without encoding the column it happened to break at.
- `contentFrame` / `visibleContentFrame` — find the last Ink frame that rendered anything visible (skipping the blank frame left after unmount and frames containing only colour codes), with controls stripped. These replace the local `findContentFrame` / `unwrapped` helpers that were duplicated across several test files.

`captureStderr` / `captureStdout` and `spawnCli` now strip terminal controls from captured output by default, with an opt-in `{ raw: true }` escape hatch for the tests whose subject is the colour bytes themselves. The `NO_COLOR=1` env var is removed from e2e test helpers since normalisation now happens at read time regardless of what the subprocess emits.

Tests that need row-scoped assertions (e.g. checking that an annotation sits on the `claude-code` row and not the `opencode` row) explicitly use `stripTerminalControls` rather than `visibleTerminalText`, with a comment explaining why the rows are kept.

### Verification

The new helpers are covered by `terminal-output.test.ts`, which exercises stripping, collapsing, frame selection, and the throw-on-no-content behaviour. CI runs the full suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to helpers and assertions; production CLI behaviour is unchanged aside from more stable CI/local test runs.
> 
> **Overview**
> Ink and coloured CLI output made assertions depend on TTY/`FORCE_COLOR` and could split phrases across lines with escape bytes between words. This PR fixes that at the **test helper layer**, not in product code.
> 
> A shared **`terminal-output.ts`** module adds `stripTerminalControls` (via Node’s `stripVTControlCharacters`), `visibleTerminalText` (strip + collapse whitespace for wrap-safe prose), and `contentFrame` / `visibleContentFrame` for the last Ink frame with real content. **`spawnCli`** and **`captureStderr`/`captureStdout`** strip controls on captured streams by default, with **`{ raw: true }`** when tests assert on exact colour bytes.
> 
> E2e helpers drop **`NO_COLOR=1`**; Ink/TUI tests replace local `findContentFrame` / `unwrapped` with the shared helpers. Row-scoped cases keep **`stripTerminalControls`** (not full unwrap) so regexes stay on one line. **`terminal-output.test.ts`** covers the new behaviour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c60b4141e187683c1068b84187a507cde618070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved command-line and interactive terminal testing by consistently handling colors, hyperlinks, and other terminal control sequences.
  - Added coverage for output normalization, visible frame selection, whitespace handling, empty output, and preserved raw output.
  - Updated CLI, installation, search, build, login, prompt, and privacy test coverage for more reliable assertions.
  - Preserved row structure where formatting and layout affect displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->