### PR TITLE
Add `.config/wt.toml` with mise trust, `.env.local` copy, and pre-start pipeline

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,15 @@
+# Worktrunk project config. Hooks run on `wt switch --create`; the pipeline
+# form ([[pre-start]] blocks) runs each block in sequence.
+
+# mise keys trust by absolute path, so a freshly created worktree is always
+# untrusted and every `mise exec` below fails until this runs.
+[[pre-start]]
+trust = "mise trust"
+
+[[pre-start]]
+# .env.local is gitignored, so it never arrives with the checkout, but
+# .mise.development.toml loads it for AWS_PROFILE. Tolerate its absence:
+# teammates without one should still get a worktree.
+env = "if [ -f \"{{ primary_worktree_path }}/.env.local\" ]; then cp \"{{ primary_worktree_path }}/.env.local\" .env.local; fi"
+deps = "mise exec -- bun nuke"
+facets = "facet install"


### PR DESCRIPTION
### Why

<!-- Why does this change exist? Link an issue or describe the motivation. Remove this section for trivial changes where the title says it all. -->

### Details

<!-- What should the reviewer know that isn't obvious from the diff? Approach, trade-offs, edge cases. Remove this section if the change is self-explanatory. -->

### Verification

<!-- How do you know it works? Manual test steps, deployment notes, or just "CI". Remove this section if CI covers it. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only Worktrunk bootstrap config; no runtime, auth, or production paths.
> 
> **Overview**
> Adds **`.config/wt.toml`** so **`wt switch --create`** runs a two-step **pre-start** pipeline for new worktrees.
> 
> The first block runs **`mise trust`** so mise can execute in the new path. The second optionally copies **`.env.local`** from the primary worktree when it exists (skipped if missing), then runs **`mise exec -- bun nuke`** and **`facet install`** to reset deps and reinstall facets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e20fb2c0d9abf9db26c37897b533ba0184994a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project setup automation for new worktrees.
  * Automatically configures the environment, restores local settings when available, resets the project, and installs required components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->