### PR TITLE
Remove `request.name` aliasing warning from custom adapters guide

### DIFF
--- a/docs/guides/custom-adapters.mdx
+++ b/docs/guides/custom-adapters.mdx
@@ -54,10 +54,6 @@ An adapter is a small TypeScript library. You write one file, build it, and inst
 
 When you run `facet install`, the CLI resolves each facet's assets and hands the ones the project wants materialized to every installed adapter. The adapter decides **where** on disk each asset goes and **how** it's formatted, so the target tool picks it up. That's the entire job: translate a facet asset into files your tool understands.
 
-<Warning>
-`request.name` is the asset's **effective** name — the name the consuming project chose, which is not necessarily the one the publisher declared. A project can [alias](/specification/materialization) any asset, so the same published skill may arrive as `planning` in one project and `team-planning` in another. Address the file by `request.name` and never re-derive it from a facet's manifest. Assets the project [omitted](/specification/materialization#dispositions) are never passed to you at all — their absence is a choice, not a bug.
-</Warning>
-
 An adapter implements a small contract from the SDK. Two methods matter most:
 
 - `buildAssetMetadata` validates the per-asset metadata an author put in `facet.json` (the `adapters.<name>` block) and enriches it with your defaults.


### PR DESCRIPTION
### Why

The warning block about `request.name` aliasing behavior was removed from the custom adapters guide.

### Verification

CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only deletion with no runtime or API impact; readers may miss aliasing/omission behavior unless it is covered elsewhere in the guide.
> 
> **Overview**
> Removes the **Warning** callout in the custom adapters guide that explained **`request.name` is the effective (possibly aliased) asset name**, that adapters must not re-derive paths from the facet manifest, and that omitted assets are never passed to adapters.
> 
> The **How an adapter fits in** section now goes straight from the install flow intro into the SDK contract (`buildAssetMetadata`, `installAsset`, etc.) without that upfront materialization/aliasing note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad2ca0a338e22b492bd73bbca5b50591e822e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->