### PR TITLE
Advance adapter SDK to API `0.2` with required `mcpServers` capability and widen engine support set to `{0.1, 0.2}`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@agent-facets/common": "workspace:*",
+        "@agent-facets/protocol": "workspace:*",
         "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
       },

--- a/facets.json
+++ b/facets.json
@@ -9,5 +9,5 @@
     "worktrunk": "0.1.0",
     "openspec": "0.1.0"
   },
-  "manifestVersion": 0.1
+  "manifestVersion": 0.2
 }

--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -38,18 +38,18 @@
 
 ## 3. Adapter SDK and compatibility window — Research
 
-- [ ] 3.1 Explore: Inspect Adapter SDK factory/types/build output and determine the zero-runtime type-import and declaration-bundling path from the protocol source of truth.
-- [ ] 3.2 Explore: Map engine adapter verification, loading, placement, npm selection, package/runtime agreement, diagnostics, and test helpers that currently assume one supported API token.
-- [ ] 3.3 Propose: Define the API `0.2` capability/result unions and the atomic rollout that keeps API `0.1` asset-only adapters usable while making `{0.1, 0.2}` the engine's sole concrete support-set declaration.
+- [x] 3.1 Explore: Inspect Adapter SDK factory/types/build output and determine the zero-runtime type-import and declaration-bundling path from the protocol source of truth.
+- [x] 3.2 Explore: Map engine adapter verification, loading, placement, npm selection, package/runtime agreement, diagnostics, and test helpers that currently assume one supported API token.
+- [x] 3.3 Propose: Define the API `0.2` capability/result unions and the atomic rollout that keeps API `0.1` asset-only adapters usable while making `{0.1, 0.2}` the engine's sole concrete support-set declaration.
 
 ## 4. Adapter SDK and compatibility window — Implementation
 
-- [ ] 4.1 Implement: Add the required `mcpServers: false | McpServerCapability` SDK field and complete batch prepare/apply request, outcome, opaque-plan, path-disclosure, and structured-failure types using the protocol declaration type directly.
-- [ ] 4.2 Implement: Update `defineAdapter` validation and exports so partial MCP capabilities are unrepresentable, author-supplied API identifiers remain ignored, and first-party definitions explicitly declare initial MCP support state.
-- [ ] 4.3 Implement: Atomically advance the SDK canonical API to `0.2` and widen the engine's authoritative exact support set to `{0.1, 0.2}` without range or ordering semantics.
-- [ ] 4.4 Implement: Make runtime shape verification API-aware: preserve the tagged asset contract for `0.1`, require the complete `mcpServers` field for `0.2`, and invoke no contract method before verification.
-- [ ] 4.5 Implement: Cover loading, listing, package/runtime mismatch, npm highest-compatible selection across both tokens, positional `0.0` rejection, and complete actionable diagnostics without duplicating the support-set literal.
-- [ ] 4.6 Verify: Run focused Adapter SDK, engine adapter-management, prepack, package-build, and dist e2e checks for both supported contracts.
+- [x] 4.1 Implement: Add the required `mcpServers: false | McpServerCapability` SDK field and complete batch prepare/apply request, outcome, opaque-plan, path-disclosure, and structured-failure types using the protocol declaration type directly.
+- [x] 4.2 Implement: Update `defineAdapter` validation and exports so partial MCP capabilities are unrepresentable, author-supplied API identifiers remain ignored, and first-party definitions explicitly declare initial MCP support state.
+- [x] 4.3 Implement: Atomically advance the SDK canonical API to `0.2` and widen the engine's authoritative exact support set to `{0.1, 0.2}` without range or ordering semantics.
+- [x] 4.4 Implement: Make runtime shape verification API-aware: preserve the tagged asset contract for `0.1`, require the complete `mcpServers` field for `0.2`, and invoke no contract method before verification.
+- [x] 4.5 Implement: Cover loading, listing, package/runtime mismatch, npm highest-compatible selection across both tokens, positional `0.0` rejection, and complete actionable diagnostics without duplicating the support-set literal.
+- [x] 4.6 Verify: Run focused Adapter SDK, engine adapter-management, prepack, package-build, and dist e2e checks for both supported contracts.
 
 ## 5. First-party native MCP adapters — Research
 

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -18,7 +18,8 @@
     "build": "tsdown",
     "prepack": "bun ../../scripts/prepack.ts",
     "postpack": "bun ../../scripts/postpack.ts",
-    "test": "bun test",
+    "test": "bun test --path-ignore-patterns '**/*.e2e.test.ts'",
+    "test:e2e": "bun run build && bun test src/__tests__/dist.e2e.test.ts",
     "types": "tsgo --noEmit"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@agent-facets/common": "workspace:*",
+    "@agent-facets/protocol": "workspace:*",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3"
   },

--- a/packages/adapter/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapter/src/__tests__/dist.e2e.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Packed-artifact coverage for the SDK's dependency invariant.
+ *
+ * `@agent-facets/adapter` is the one package third-party adapter authors
+ * install. Its published declarations inline every workspace type they
+ * reference — `@agent-facets/common` for the asset primitives, and
+ * `@agent-facets/protocol`'s portable MCP declaration — so an author needs
+ * neither package, and neither package's own dependencies.
+ *
+ * That invariant is invisible in source: it holds or breaks purely as a
+ * function of how the declaration bundler resolves a type. It broke once
+ * already, when the MCP declaration type was inferred from an arktype schema
+ * and the inferred form carried a deep `import("arktype/internal/...")` node
+ * into the emitted declarations. This test is the tripwire.
+ *
+ * Requires `bun run build` first — wired via the `test:e2e` script.
+ */
+import { expect, test } from 'bun:test'
+import { join } from 'node:path'
+
+const DIST_DIR = join(import.meta.dir, '../../dist')
+
+/** Module specifiers in `import`/`export ... from` statements, comments excluded. */
+function moduleSpecifiers(source: string): string[] {
+  const withoutComments = source.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/\/\/[^\n]*/g, '')
+  return [...withoutComments.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((match) => match[1] ?? '')
+}
+
+test('published declarations import nothing but the sibling api-version entry', async () => {
+  const declarations = await Bun.file(join(DIST_DIR, 'index.d.mts')).text()
+  expect(moduleSpecifiers(declarations)).toEqual(['./api-version.mjs'])
+})
+
+test('published JavaScript pulls in no workspace or validator runtime', async () => {
+  const bundle = await Bun.file(join(DIST_DIR, 'index.mjs')).text()
+  const external = moduleSpecifiers(bundle).filter((specifier) => !specifier.startsWith('.'))
+  // `yaml` is the SDK's one declared runtime dependency; node builtins are
+  // always fair game. Anything else means a workspace package or one of its
+  // dependencies escaped bundling.
+  const unexpected = external.filter((specifier) => specifier !== 'yaml' && !specifier.startsWith('node:'))
+  expect(unexpected).toEqual([])
+})
+
+test('the api-version entry stays dependency-free', async () => {
+  // Release tooling imports this entry by relative path with no node_modules
+  // resolution available, so it must not reach for anything.
+  const declarations = await Bun.file(join(DIST_DIR, 'api-version.d.mts')).text()
+  expect(moduleSpecifiers(declarations)).toEqual([])
+})

--- a/packages/adapter/src/__tests__/index.test.ts
+++ b/packages/adapter/src/__tests__/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from '../api-version.ts'
+import {
+  ADAPTER_API_VERSION,
+  ADAPTER_API_VERSION_ASSETS_ONLY,
+  ADAPTER_API_VERSION_PACKAGE_FIELD,
+} from '../api-version.ts'
 import { defineAdapter } from '../define-adapter.ts'
 import type { AdapterDefinition } from '../types.ts'
 
@@ -10,6 +14,7 @@ import type { AdapterDefinition } from '../types.ts'
 function validDefinition(): AdapterDefinition {
   return {
     name: 'test-adapter',
+    mcpServers: false,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset() {
       return { ok: true, primaryPath: '/tmp/test' }
@@ -51,13 +56,51 @@ describe('defineAdapter — required field validation', () => {
     const def = { ...validDefinition(), buildAssetMetadata: 'not-a-function' as any }
     expect(() => defineAdapter(def)).toThrow(/"buildAssetMetadata" is required/)
   })
+
+  test('throws when mcpServers is missing', () => {
+    const { mcpServers: _omitted, ...def } = validDefinition()
+    // biome-ignore lint/suspicious/noExplicitAny: intentional type hole for runtime validation test
+    expect(() => defineAdapter(def as any)).toThrow(/"mcpServers" is required/)
+  })
+
+  test('throws when mcpServers is true rather than a capability', () => {
+    // The exact shape this field exists to make unrepresentable: a bare
+    // "yes I support MCP" with nothing behind it.
+    // biome-ignore lint/suspicious/noExplicitAny: intentional type hole for runtime validation test
+    const def = { ...validDefinition(), mcpServers: true as any }
+    expect(() => defineAdapter(def)).toThrow(/"mcpServers" is required/)
+  })
+
+  test('throws when the MCP capability is partial', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional type hole for runtime validation test
+    const def = { ...validDefinition(), mcpServers: { async prepare() {} } as any }
+    expect(() => defineAdapter(def)).toThrow(/"mcpServers" is required/)
+  })
+
+  test('a complete MCP capability is accepted and preserved', () => {
+    const capability = { async prepare() {}, async apply() {} }
+    // biome-ignore lint/suspicious/noExplicitAny: the stub operations do not satisfy the full result types
+    const adapter = defineAdapter({ ...validDefinition(), mcpServers: capability as any })
+    expect(adapter.mcpServers as unknown).toBe(capability)
+  })
+
+  test('mcpServers false is preserved rather than stubbed', () => {
+    // Unlike the asset methods, an absent capability gets no fallback: the
+    // CLI must be able to tell "no MCP support" from "not implemented".
+    const adapter = defineAdapter(validDefinition())
+    expect(adapter.mcpServers).toBe(false)
+  })
 })
 
 describe('canonical adapter API constants', () => {
   // The one place tests anchor the spec literals — everywhere else compares
   // against the exported constants.
-  test('ADAPTER_API_VERSION is 0.1', () => {
-    expect(ADAPTER_API_VERSION).toBe('0.1')
+  test('ADAPTER_API_VERSION is 0.2', () => {
+    expect(ADAPTER_API_VERSION).toBe('0.2')
+  })
+
+  test('ADAPTER_API_VERSION_ASSETS_ONLY is 0.1', () => {
+    expect(ADAPTER_API_VERSION_ASSETS_ONLY).toBe('0.1')
   })
 
   test('ADAPTER_API_VERSION_PACKAGE_FIELD is facetAdapterApiVersion', () => {
@@ -132,6 +175,9 @@ describe('defineAdapter — stub fallbacks for missing asset methods', () => {
   function buildMinimal(overrides: Partial<AdapterDefinition> = {}): AdapterDefinition {
     const minimal = {
       name: 'stubbed-adapter',
+      // Present because it is required — these tests are about the *asset*
+      // methods, which do get stub fallbacks.
+      mcpServers: false,
       buildAssetMetadata: (data: unknown) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       ...overrides,
     }
@@ -173,6 +219,7 @@ describe('defineAdapter — stub fallbacks for missing asset methods', () => {
 
     const adapter = defineAdapter({
       name: 'impl-adapter',
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset() {
         installCalled = true

--- a/packages/adapter/src/api-version.ts
+++ b/packages/adapter/src/api-version.ts
@@ -12,16 +12,30 @@
 
 /**
  * The adapter API contract identifier this SDK stamps into every adapter
- * returned by `defineAdapter()`. Identifies the current tagged
- * request/result adapter method contract.
+ * returned by `defineAdapter()`. Identifies the tagged request/result asset
+ * method contract **plus** the required MCP server capability.
  *
- * This supersedes the earlier positional method contract, which was
- * identified by `0.0`. A CLI that supports only `0.1` classifies a `0.0`
- * adapter as well-formed but unsupported and fails closed — the exact-token
- * compatibility machinery cannot inspect method signatures, so the contract
- * change is signalled by this identifier, never inferred.
+ * The exact-token compatibility machinery cannot inspect method signatures or
+ * probe for fields, so every contract change is signalled by this identifier
+ * and never inferred. That is why adding `mcpServers` required a new token
+ * rather than a runtime feature check.
  */
-export const ADAPTER_API_VERSION = '0.1' as const
+export const ADAPTER_API_VERSION = '0.2' as const
+
+/**
+ * The superseded asset-only contract: the same tagged request/result asset
+ * methods, with no MCP server capability.
+ *
+ * This SDK no longer stamps it — `defineAdapter()` always produces
+ * {@link ADAPTER_API_VERSION}. It exists as a named constant because adapters
+ * published against it remain loadable during the compatibility window, and
+ * the literal `'0.1'` should appear in exactly one place across the monorepo.
+ *
+ * Older still is the positional method contract, identified by `0.0`. It has
+ * no constant here: nothing supports it, and naming it would invite someone to
+ * add it to a support set.
+ */
+export const ADAPTER_API_VERSION_ASSETS_ONLY = '0.1' as const
 
 /**
  * The top-level `package.json` field where a published npm adapter release
@@ -32,3 +46,6 @@ export const ADAPTER_API_VERSION_PACKAGE_FIELD = 'facetAdapterApiVersion' as con
 
 /** The adapter API identifier type produced by this SDK. */
 export type AdapterApiVersion = typeof ADAPTER_API_VERSION
+
+/** The superseded asset-only adapter API identifier type. */
+export type AdapterApiVersionAssetsOnly = typeof ADAPTER_API_VERSION_ASSETS_ONLY

--- a/packages/adapter/src/define-adapter.ts
+++ b/packages/adapter/src/define-adapter.ts
@@ -1,5 +1,23 @@
 import { ADAPTER_API_VERSION } from './api-version.ts'
-import type { Adapter, AdapterDefinition } from './types.ts'
+import type { McpServerCapability } from './mcp-servers.ts'
+import type { AdapterDefinition, McpCapableAdapter } from './types.ts'
+
+/**
+ * Whether a value is a complete MCP server capability.
+ *
+ * "Complete" is the only accepted form. A capability with `prepare` but no
+ * `apply` would be an adapter that can promise a change it cannot commit, so
+ * it is rejected at definition time rather than discovered mid-transaction.
+ * The check is structural because an author may reach this factory from
+ * untyped JavaScript, where the type system's guarantee does not apply.
+ */
+function isCompleteMcpServerCapability(value: unknown): value is McpServerCapability {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const capability = value as Record<string, unknown>
+  return typeof capability.prepare === 'function' && typeof capability.apply === 'function'
+}
 
 /**
  * Create an adapter from a definition object.
@@ -20,7 +38,7 @@ import type { Adapter, AdapterDefinition } from './types.ts'
  * })
  * ```
  */
-export function defineAdapter(definition: AdapterDefinition): Adapter {
+export function defineAdapter(definition: AdapterDefinition): McpCapableAdapter {
   // Validate required fields
   if (!definition.name || typeof definition.name !== 'string') {
     throw new Error('defineAdapter: "name" is required and must be a non-empty string')
@@ -30,7 +48,17 @@ export function defineAdapter(definition: AdapterDefinition): Adapter {
     throw new Error('defineAdapter: "buildAssetMetadata" is required and must be a function')
   }
 
-  const adapter: Adapter = {
+  // Unlike the asset methods below, an omitted or partial `mcpServers` gets no
+  // stub fallback. A not-implemented stub is the right answer for an operation
+  // the CLI can route around; MCP support is a capability the CLI has to know
+  // about *before* it plans a transaction, so an adapter must state it.
+  if (definition.mcpServers !== false && !isCompleteMcpServerCapability(definition.mcpServers)) {
+    throw new Error(
+      'defineAdapter: "mcpServers" is required and must be either false or an object with "prepare" and "apply" functions',
+    )
+  }
+
+  const adapter: McpCapableAdapter = {
     name: definition.name,
 
     // SDK-owned: always the canonical value, even if a non-TypeScript
@@ -38,6 +66,8 @@ export function defineAdapter(definition: AdapterDefinition): Adapter {
     apiVersion: ADAPTER_API_VERSION,
 
     supportsInstall: definition.supportsInstall,
+
+    mcpServers: definition.mcpServers,
 
     buildAssetMetadata: definition.buildAssetMetadata.bind(definition),
 

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,5 +1,9 @@
-export type { AdapterApiVersion } from './api-version.ts'
-export { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from './api-version.ts'
+export type { AdapterApiVersion, AdapterApiVersionAssetsOnly } from './api-version.ts'
+export {
+  ADAPTER_API_VERSION,
+  ADAPTER_API_VERSION_ASSETS_ONLY,
+  ADAPTER_API_VERSION_PACKAGE_FIELD,
+} from './api-version.ts'
 export type { AssetPath, ContainedRelativePathResult } from './asset-fs.ts'
 export {
   assembleAssetContent,
@@ -16,6 +20,18 @@ export {
   validateContainedRelativePath,
 } from './asset-fs.ts'
 export { defineAdapter } from './define-adapter.ts'
+export type {
+  ApplyMcpServersResult,
+  McpServerCapability,
+  McpServerCapabilityFailure,
+  McpServerContribution,
+  McpServerDeclaration,
+  McpServerOwnership,
+  McpServerPreparation,
+  McpServerPreparationOutcome,
+  PrepareMcpServersRequest,
+  PrepareMcpServersResult,
+} from './mcp-servers.ts'
 export type { SkillBundlePaths } from './skill-bundle.ts'
 export { deleteSkillBundle, installSkillBundle, readSkillBundle } from './skill-bundle.ts'
 export type {
@@ -23,12 +39,14 @@ export type {
   AdapterAssetFailure,
   AdapterDefinition,
   AdapterMetadata,
+  AssetOnlyAdapter,
   AssetType,
   CompanionMap,
   DeleteAssetRequest,
   DeleteAssetResult,
   InstallAssetRequest,
   InstallAssetResult,
+  McpCapableAdapter,
   ReadAsset,
   ReadAssetRequest,
   ReadAssetResult,

--- a/packages/adapter/src/mcp-servers.ts
+++ b/packages/adapter/src/mcp-servers.ts
@@ -1,0 +1,190 @@
+import type { McpServerDeclaration } from '@agent-facets/protocol/mcp-declaration'
+
+/**
+ * The MCP server capability: how an adapter reconciles a project's desired
+ * MCP servers into its tool's own native project configuration.
+ *
+ * The shape of this contract is driven by three requirements that the asset
+ * methods do not have to satisfy:
+ *
+ * 1. **Batch, not per-server.** Every desired server for one project lands in
+ *    the same native document. Applying them one at a time would mean one
+ *    parse/serialize cycle per server and a window in which the document holds
+ *    a partial set.
+ * 2. **Plan before mutate.** The engine has to ask "what would this change?"
+ *    and show the answer to the user *before* anything is written, so
+ *    preparation is strictly read-only and yields a plan the engine holds onto.
+ * 3. **No inverse operations.** Rollback is byte-exact restoration performed by
+ *    the engine, which journals the preimage of every document `prepare`
+ *    disclosed. An adapter is never asked to undo its own edit — undo fidelity
+ *    would otherwise depend on adapter code being correct twice, and on a
+ *    semantic inverse reproducing comments and formatting it never saw.
+ */
+
+/**
+ * One desired server: the effective name it must appear under, and the
+ * portable declaration to render natively.
+ *
+ * `name` is already the *effective* name — aliases and collisions are resolved
+ * upstream, so an adapter never sees an authored name and never resolves one.
+ * The declaration type is imported from the protocol contract rather than
+ * restated here, so an adapter's signature cannot drift from the published
+ * declaration shape.
+ */
+export interface McpServerContribution {
+  readonly name: string
+  readonly declaration: McpServerDeclaration
+}
+
+/**
+ * The complete desired MCP state for one project, handed to `prepare`.
+ *
+ * `desired` is exhaustive: a server absent from it is not desired, and
+ * `previouslyOwnedNames` is the caller-verified set of effective names a prior
+ * successful operation recorded for this adapter. Those two together are what
+ * let `prepare` classify occupancy — an entry the document has, the desired set
+ * lacks, and this list names is obsolete and owned; an entry no list names is
+ * someone else's and is never touched.
+ *
+ * The adapter must not infer ownership from the document, from a naming
+ * convention, or from a marker comment. Ownership arrives on every request and
+ * the supplied set is the complete extent of what may be removed.
+ */
+export interface PrepareMcpServersRequest {
+  readonly projectRoot: string
+  readonly desired: readonly McpServerContribution[]
+  readonly previouslyOwnedNames: readonly string[]
+}
+
+/**
+ * Whether the effective identity an outcome describes is already covered by
+ * machine-local ownership.
+ *
+ * `untracked` is the case that requires user consent before the entry is
+ * adopted or replaced, so it must be distinguishable from `tracked` even when
+ * the resulting write is identical.
+ */
+export type McpServerOwnership = 'tracked' | 'untracked'
+
+/**
+ * What preparation found for one server name, and what applying the plan would
+ * therefore do to it.
+ *
+ * The three desired-state arms are distinguished because they drive different
+ * user-visible outcomes, not because they need different writes: `equivalent`
+ * is adopted with no write at all, `divergent` overwrites content the user may
+ * care about, and `absent` is a pure addition.
+ */
+export type McpServerPreparationOutcome =
+  /** No entry exists under this name; applying the plan creates it. */
+  | { readonly kind: 'absent'; readonly name: string; readonly ownership: McpServerOwnership }
+  /**
+   * An entry exists and the adapter proved it is semantically equal to the
+   * native rendering of the desired declaration. Applying the plan writes
+   * nothing for this entry. An adapter that cannot *prove* equality reports
+   * `divergent` instead — unprovable equality fails safe.
+   */
+  | { readonly kind: 'equivalent'; readonly name: string; readonly ownership: McpServerOwnership }
+  /** An entry exists whose behavior differs; applying the plan replaces it. */
+  | { readonly kind: 'divergent'; readonly name: string; readonly ownership: McpServerOwnership }
+  /**
+   * An owned entry the desired set no longer names; applying the plan removes
+   * it. `occupancy` is `absent` when the entry is already gone — the claim is
+   * still reported so the engine can drop the ownership record.
+   */
+  | { readonly kind: 'obsolete-owned'; readonly name: string; readonly occupancy: 'present' | 'absent' }
+
+/**
+ * Structured failure data for MCP capability operations.
+ *
+ * Expected failures are values, not thrown errors — the caller branches on
+ * `code`. Adapters convert their internal exceptions into these; anything
+ * thrown past this boundary is a programmer bug.
+ *
+ * There is deliberately no rollback failure code: adapters do not roll back.
+ */
+export type McpServerCapabilityFailure =
+  /** A filesystem operation failed. */
+  | {
+      readonly code: 'io-failed'
+      readonly operation: 'read' | 'write'
+      readonly path: string
+      readonly message: string
+    }
+  /** The native document exists but could not be parsed. */
+  | { readonly code: 'parse-failed'; readonly path: string; readonly message: string }
+  /** The document parsed, but its MCP section is not a shape the adapter can safely edit. */
+  | { readonly code: 'validation-failed'; readonly path: string; readonly message: string }
+  /** The desired state cannot be represented in this document without destroying native state. */
+  | { readonly code: 'conflict'; readonly path: string; readonly message: string }
+
+/**
+ * A successful read-only preparation.
+ *
+ * `documentPaths` is the complete set of native documents applying `plan`
+ * could touch, disclosed *before* any mutation so the engine can journal their
+ * byte preimages. A path is listed even when the document does not exist yet —
+ * "absent" is a preimage the engine can restore to. The list is non-empty:
+ * an adapter that reconciles nothing still names the document it inspected.
+ *
+ * `plan` is opaque. The engine stores it and hands it back to `apply`; it never
+ * inspects, serializes, or reorders it, so an adapter may put whatever it likes
+ * in there — including the parsed document it already holds, which is what
+ * makes `apply` a single write rather than a second parse.
+ */
+export interface McpServerPreparation<Plan> {
+  readonly plan: Plan
+  readonly documentPaths: readonly [string, ...string[]]
+  readonly outcomes: readonly McpServerPreparationOutcome[]
+}
+
+/** Result of `prepare`. On failure, every inspected document is unchanged. */
+export type PrepareMcpServersResult<Plan> =
+  | { readonly ok: true; readonly preparation: McpServerPreparation<Plan> }
+  | { readonly ok: false; readonly failure: McpServerCapabilityFailure }
+
+/**
+ * Result of `apply`.
+ *
+ * `unchanged` and `changed` are separate arms rather than a boolean beside an
+ * always-present path list, so "nothing was written" cannot be reported
+ * alongside a non-empty set of changed paths. Every path in `changedPaths`
+ * must have appeared in the preparation's `documentPaths` — the engine cannot
+ * restore a document whose preimage it was never given.
+ *
+ * On failure the affected documents are unchanged; the operation is atomic per
+ * document, so a handled write failure never leaves a partial set behind.
+ */
+export type ApplyMcpServersResult =
+  | { readonly ok: true; readonly status: 'unchanged' }
+  | { readonly ok: true; readonly status: 'changed'; readonly changedPaths: readonly [string, ...string[]] }
+  | { readonly ok: false; readonly failure: McpServerCapabilityFailure }
+
+/**
+ * The complete MCP server capability.
+ *
+ * An adapter either implements both operations or declares `mcpServers: false`.
+ * There is no partial state: a capability object missing `apply` is not a
+ * capability, and the SDK factory refuses to build one.
+ *
+ * `Plan` is the adapter's own prepared-plan type. It defaults to `unknown` at
+ * the consumer boundary, which is precisely the point — the engine holds a
+ * value it structurally cannot read.
+ */
+export interface McpServerCapability<Plan = unknown> {
+  /**
+   * Inspect native project configuration and compute the complete desired
+   * change. Writes nothing, creates nothing, and runs nothing.
+   */
+  prepare(request: PrepareMcpServersRequest): Promise<PrepareMcpServersResult<Plan>>
+
+  /**
+   * Commit a prepared plan as one atomic update per affected document.
+   *
+   * Never launches, connects to, health-checks, or authenticates a declared
+   * server; materializing configuration is not running it.
+   */
+  apply(request: { readonly plan: Plan }): Promise<ApplyMcpServersResult>
+}
+
+export type { McpServerDeclaration }

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -1,5 +1,6 @@
 import type { AssetType, Scope, Validated, ValidationError } from '@agent-facets/common'
-import type { AdapterApiVersion } from './api-version.ts'
+import type { AdapterApiVersion, AdapterApiVersionAssetsOnly } from './api-version.ts'
+import type { McpServerCapability } from './mcp-servers.ts'
 
 /**
  * Opaque record type for adapter-specific asset metadata.
@@ -187,18 +188,9 @@ export type DeleteAssetResult =
  * prior bundle remains intact. Recovery from an interrupted process is
  * the caller's idempotent re-install, so operations must be convergent.
  */
-export interface Adapter {
+interface AdapterAssetContract {
   /** Unique adapter name (e.g., "opencode", "claude-code", "codex") */
   readonly name: string
-
-  /**
-   * The adapter API contract identifier this adapter implements.
-   *
-   * Stamped by `defineAdapter()` from the SDK's canonical
-   * `ADAPTER_API_VERSION` — adapter authors do not (and cannot) supply
-   * it; the factory's input type (`AdapterDefinition`) excludes it.
-   */
-  readonly apiVersion: AdapterApiVersion
 
   /**
    * When true, this adapter exposes real filesystem I/O (installAsset,
@@ -227,13 +219,68 @@ export interface Adapter {
 }
 
 /**
+ * An adapter published against the superseded asset-only contract.
+ *
+ * This SDK cannot produce one — `defineAdapter()` always stamps the current
+ * identifier. The type exists because such adapters are already published and
+ * remain loadable during the compatibility window, so consumers need a way to
+ * talk about them. It has no `mcpServers` member at all: a `0.1` adapter does
+ * not decline MCP support, it predates the question.
+ */
+export interface AssetOnlyAdapter extends AdapterAssetContract {
+  readonly apiVersion: AdapterApiVersionAssetsOnly
+}
+
+/**
+ * An adapter implementing the current contract: the tagged asset methods plus
+ * a stated MCP server capability.
+ */
+export interface McpCapableAdapter extends AdapterAssetContract {
+  /**
+   * The adapter API contract identifier this adapter implements.
+   *
+   * Stamped by `defineAdapter()` from the SDK's canonical
+   * `ADAPTER_API_VERSION` — adapter authors do not (and cannot) supply
+   * it; the factory's input type (`AdapterDefinition`) excludes it.
+   */
+  readonly apiVersion: AdapterApiVersion
+
+  /**
+   * Whether this adapter can reconcile MCP servers into its tool's native
+   * project configuration, and if so, how.
+   *
+   * Required, and deliberately one field rather than a boolean beside optional
+   * methods: a `supportsMcp: true` that could sit next to a missing `apply` is
+   * a representable lie. `false` is an explicit, unambiguous "this tool has no
+   * MCP configuration I can write" — it is not the same as "not implemented
+   * yet", and the CLI reports it as such when a project actually has servers.
+   *
+   * The capability is MCP-specific on purpose. A future project-configuration
+   * feature gets its own field with its own identity, composition, and consent
+   * rules rather than being bolted onto this one.
+   */
+  readonly mcpServers: false | McpServerCapability
+}
+
+/**
+ * Any adapter a current consumer may hold.
+ *
+ * Tagged by `apiVersion`, so "which contract is this?" is answered by an
+ * exhaustive switch rather than by probing for fields. Widening a support set
+ * to accept another contract means adding an arm here, which makes every
+ * consumer that must handle it fail to compile — the intended outcome.
+ */
+export type Adapter = AssetOnlyAdapter | McpCapableAdapter
+
+/**
  * The author-facing definition accepted by `defineAdapter()`.
  *
- * Identical to `Adapter` except the SDK-owned `apiVersion` field is
- * excluded — the factory stamps the canonical value, so an author cannot
- * declare a conflicting API identifier.
+ * Identical to the current adapter contract except the SDK-owned `apiVersion`
+ * field is excluded — the factory stamps the canonical value, so an author
+ * cannot declare a conflicting API identifier. There is no definition type for
+ * the superseded contract: this SDK only builds current adapters.
  */
-export type AdapterDefinition = Omit<Adapter, 'apiVersion'>
+export type AdapterDefinition = Omit<McpCapableAdapter, 'apiVersion'>
 
 // Re-export common types for convenience — SDK consumers don't need to install common
 export type { AssetType, Scope, Validated, ValidationError }

--- a/packages/adapter/tsdown.config.ts
+++ b/packages/adapter/tsdown.config.ts
@@ -11,6 +11,18 @@ export default defineConfig({
   },
   clean: true,
   deps: {
-    alwaysBundle: ['@agent-facets/common'],
+    // Both are development-only dependencies whose *types* appear in this
+    // package's public surface, so they must be inlined into the generated
+    // declarations — a published adapter author installs neither.
+    //
+    // `@agent-facets/protocol` contributes only `McpServerDeclaration`, which
+    // is a plain structural type, so nothing of protocol's runtime graph
+    // (arktype, nanotar, yaml) reaches the emitted JavaScript or the emitted
+    // declarations. `dist.e2e.test.ts` pins that invariant.
+    //
+    // Deliberately the single top-level list: setting `deps.dts.alwaysBundle`
+    // would *replace* this list for `.d.ts` importers rather than extend it,
+    // silently re-externalizing `@agent-facets/common`.
+    alwaysBundle: ['@agent-facets/common', '@agent-facets/protocol'],
   },
 })

--- a/packages/adapters/claude-code/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/dist.e2e.test.ts
@@ -11,8 +11,17 @@ import sourceAdapter from '../index.ts'
 
 test('built dist bundle declares the canonical adapter API version', async () => {
   const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { name?: string; apiVersion?: string }
+    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
   }
   expect(module.default?.name).toBe(sourceAdapter.name)
   expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
+})
+
+test('built dist bundle states its MCP server support', async () => {
+  // The field is required by the API this bundle declares, so its presence
+  // is part of what makes the artifact loadable — not an optional extra.
+  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
+    default?: { mcpServers?: unknown }
+  }
+  expect(module.default?.mcpServers).toBe(sourceAdapter.mcpServers)
 })

--- a/packages/adapters/claude-code/src/index.ts
+++ b/packages/adapters/claude-code/src/index.ts
@@ -30,6 +30,10 @@ export default defineAdapter({
   name: 'claude-code',
   supportsInstall: true,
 
+  // Native MCP reconciliation lands in a later task of this change; declaring
+  // it explicitly is the point of the required field.
+  mcpServers: false,
+
   buildAssetMetadata(data) {
     const result = ClaudeCodeMetadataSchema(data)
 

--- a/packages/adapters/codex/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/codex/src/__tests__/dist.e2e.test.ts
@@ -11,8 +11,17 @@ import sourceAdapter from '../index.ts'
 
 test('built dist bundle declares the canonical adapter API version', async () => {
   const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { name?: string; apiVersion?: string }
+    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
   }
   expect(module.default?.name).toBe(sourceAdapter.name)
   expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
+})
+
+test('built dist bundle states its MCP server support', async () => {
+  // The field is required by the API this bundle declares, so its presence
+  // is part of what makes the artifact loadable — not an optional extra.
+  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
+    default?: { mcpServers?: unknown }
+  }
+  expect(module.default?.mcpServers).toBe(sourceAdapter.mcpServers)
 })

--- a/packages/adapters/codex/src/index.ts
+++ b/packages/adapters/codex/src/index.ts
@@ -68,6 +68,10 @@ export default defineAdapter({
   name: 'codex',
   supportsInstall: true,
 
+  // Native MCP reconciliation lands in a later task of this change; declaring
+  // it explicitly is the point of the required field.
+  mcpServers: false,
+
   buildAssetMetadata(data) {
     const result = CodexMetadataSchema(data)
 

--- a/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
@@ -11,8 +11,17 @@ import sourceAdapter from '../index.ts'
 
 test('built dist bundle declares the canonical adapter API version', async () => {
   const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { name?: string; apiVersion?: string }
+    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
   }
   expect(module.default?.name).toBe(sourceAdapter.name)
   expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
+})
+
+test('built dist bundle states its MCP server support', async () => {
+  // The field is required by the API this bundle declares, so its presence
+  // is part of what makes the artifact loadable — not an optional extra.
+  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
+    default?: { mcpServers?: unknown }
+  }
+  expect(module.default?.mcpServers).toBe(sourceAdapter.mcpServers)
 })

--- a/packages/adapters/opencode/src/index.ts
+++ b/packages/adapters/opencode/src/index.ts
@@ -50,6 +50,10 @@ export default defineAdapter({
   name: 'opencode',
   supportsInstall: true,
 
+  // Native MCP reconciliation lands in a later task of this change; declaring
+  // it explicitly is the point of the required field.
+  mcpServers: false,
+
   buildAssetMetadata(data) {
     const result = OpenCodeMetadataSchema(data)
     if (result instanceof type.errors) {

--- a/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
@@ -112,6 +112,7 @@ import { defineAdapter } from '${ADAPTER_SDK_SOURCE}'
 
 export default defineAdapter({
   name: '${opts.name}',
+  mcpServers: false,
   buildAssetMetadata(data) {
     return { ok: true, data: (data ?? {}) }
   },

--- a/packages/cli/src/__tests__/adapter-integration.test.ts
+++ b/packages/cli/src/__tests__/adapter-integration.test.ts
@@ -38,6 +38,7 @@ import { defineAdapter } from '${adapterSdkPath}'
 
 export default defineAdapter({
   name: '${adapterName}',
+  mcpServers: false,
   buildAssetMetadata(data) {
     const input = (data ?? {})
     if (input.custom !== undefined && typeof input.custom !== 'string') {

--- a/packages/cli/src/__tests__/helpers/fake-adapter.ts
+++ b/packages/cli/src/__tests__/helpers/fake-adapter.ts
@@ -17,6 +17,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/cli/src/__tests__/instructions.e2e.test.ts
+++ b/packages/cli/src/__tests__/instructions.e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { renderAdapterApiSupportSet } from '../prompts/index.ts'
 import { spawnCli } from './helpers/cli-process.ts'
 
 const runCli = (...args: string[]) => spawnCli(args)
@@ -38,7 +39,7 @@ describe('facet instructions', () => {
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('agentfacets.io')
     expect(result.stdout).toContain('facet add viper-plans')
-    expect(result.stdout).toContain('adapter API 0.1')
+    expect(result.stdout).toContain(`adapter API ${renderAdapterApiSupportSet()}`)
     expect(result.stdout).toContain('facet adapter list')
   })
 

--- a/packages/cli/src/commands/adapter/index.ts
+++ b/packages/cli/src/commands/adapter/index.ts
@@ -116,7 +116,7 @@ async function handleInstallPicker(): Promise<number> {
 function apiColumn(inspection: InstalledAdapterInspection): string {
   switch (inspection.kind) {
     case 'compatible':
-      return `api ${inspection.verified.apiVersion}`
+      return `api ${inspection.verified.adapter.apiVersion}`
     case 'incompatible':
       switch (inspection.failure.kind) {
         case 'api-missing':

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -52,6 +52,7 @@ function path(type, name) {
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -53,6 +53,7 @@ function path(type, name) {
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {
@@ -345,6 +346,7 @@ function record(kind, req) {
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
+++ b/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test'
+import { SUPPORTED_ADAPTER_APIS } from '@agent-facets/engine'
 import { FacetManifestSchema } from '@agent-facets/protocol'
 import {
   DEFAULT_TOPIC,
   INSTRUCTION_TOPICS,
   isInstructionTopic,
   promptFor,
+  renderAdapterApiSupportSet,
   renderTopicIndex,
   TOPICS,
 } from '../../../prompts/index.ts'
@@ -51,10 +53,20 @@ describe('topic index', () => {
     expect(overview.indexOf('Instruction topics')).toBeLessThan(overview.indexOf('AUTHORING a facet'))
   })
 
-  test('non-overview prompts are returned verbatim (no marker substitution)', () => {
+  test('no rendered prompt still carries an unsubstituted marker', () => {
+    // Weaker than "returned verbatim", which stopped being true once a
+    // second topic gained a generated value — but it tests the thing that
+    // actually matters: a marker must never reach a reader.
     for (const topic of INSTRUCTION_TOPICS) {
-      if (topic === 'overview') continue
-      expect(promptFor(topic)).toBe(TOPICS[topic].prompt)
+      expect(promptFor(topic)).not.toContain('{{')
+    }
+  })
+
+  test('prompts without markers are returned verbatim', () => {
+    for (const topic of INSTRUCTION_TOPICS) {
+      const raw = TOPICS[topic].prompt
+      if (raw.includes('{{')) continue
+      expect(promptFor(topic)).toBe(raw)
     }
   })
 })
@@ -77,9 +89,16 @@ describe('0.29 guidance is present in the prompts', () => {
     expect(manifest).toContain('--- JSON Schema (generated) ---')
   })
 
-  test('usage covers adapter API 0.1 recovery guidance', () => {
-    const usage = TOPICS.usage.prompt
-    expect(usage).toContain('adapter API 0.1')
+  test('usage covers adapter API recovery guidance for the whole support set', () => {
+    // Rendered, not raw: the support set is generated from engine's single
+    // declaration, so asserting the raw prompt would only prove a marker
+    // exists — and asserting a literal would be the duplication the marker
+    // was introduced to remove.
+    const usage = promptFor('usage')
+    expect(usage).toContain(`adapter API ${renderAdapterApiSupportSet()}`)
+    for (const api of SUPPORTED_ADAPTER_APIS) {
+      expect(usage).toContain(api)
+    }
     expect(usage).toContain('facet adapter list')
   })
 })

--- a/packages/cli/src/prompts/index.ts
+++ b/packages/cli/src/prompts/index.ts
@@ -1,3 +1,4 @@
+import { SUPPORTED_ADAPTER_APIS } from '@agent-facets/engine'
 import authoring from './authoring.txt' with { type: 'text' }
 import manifest from './manifest.txt' with { type: 'text' }
 import overview from './overview.txt' with { type: 'text' }
@@ -59,6 +60,22 @@ export function isInstructionTopic(value: string): value is InstructionTopic {
 export const OVERVIEW_INDEX_MARKER = '{{TOPIC_INDEX}}'
 
 /**
+ * The marker in `usage.txt` where the CLI's adapter API support set is
+ * injected. Generated for the same reason as the topic index: the window is
+ * declared once, in engine's `SUPPORTED_ADAPTER_APIS`, and prose that restated
+ * it would silently go stale the next time the set changes.
+ */
+export const ADAPTER_API_SUPPORT_SET_MARKER = '{{ADAPTER_API_SUPPORT_SET}}'
+
+/** Render the support set as prose: `0.1`, or `0.1 and 0.2`, or `a, b, and c`. */
+export function renderAdapterApiSupportSet(): string {
+  const apis = [...SUPPORTED_ADAPTER_APIS]
+  if (apis.length <= 1) return apis.join('')
+  if (apis.length === 2) return apis.join(' and ')
+  return `${apis.slice(0, -1).join(', ')}, and ${apis.at(-1)}`
+}
+
+/**
  * Render the topic index block injected into the overview. Each line is the
  * exact invocation an agent would run, padded to a shared column, followed by
  * the topic's summary — so the overview always advertises every topic the CLI
@@ -82,5 +99,6 @@ export function renderTopicIndex(): string {
 export function promptFor(topic: InstructionTopic): string {
   const body = TOPICS[topic].prompt
   if (topic === 'overview') return body.replace(OVERVIEW_INDEX_MARKER, renderTopicIndex())
+  if (topic === 'usage') return body.replace(ADAPTER_API_SUPPORT_SET_MARKER, renderAdapterApiSupportSet())
   return body
 }

--- a/packages/cli/src/prompts/usage.txt
+++ b/packages/cli/src/prompts/usage.txt
@@ -87,7 +87,7 @@ Adapter tooling — `facet adapter`
     facet adapter list                    List installed adapters.
     facet adapter remove <name>           Remove an installed adapter.
 
-  This CLI supports adapter API 0.1. An adapter that declares an older or
+  This CLI supports adapter API {{ADAPTER_API_SUPPORT_SET}}. An adapter that declares an older or
   unsupported API fails closed before any project files change. If `facet
   build`, `facet add`, or `facet install` reports an incompatible adapter:
     1. Run `facet adapter list` to see each adapter's API and status. Failing

--- a/packages/cli/src/util/__tests__/adapter-install-errors.test.ts
+++ b/packages/cli/src/util/__tests__/adapter-install-errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test'
-import type { AdapterCompatibilityFailure, AdapterInstallFailure, NpmVersionRequest } from '@agent-facets/engine'
+import {
+  type AdapterCompatibilityFailure,
+  type AdapterInstallFailure,
+  type NpmVersionRequest,
+  SUPPORTED_ADAPTER_APIS,
+} from '@agent-facets/engine'
 import {
   compatibilityFailureMessage,
   describeAdapterInstallFailure,
@@ -21,8 +26,8 @@ describe('compatibilityFailureMessage — per-adapter JSON error identity', () =
     // Substring-adjacent names ("code" ⊂ "claude-code") would mispair
     // under any .includes()-based matching; the per-failure renderer must not.
     const failures: AdapterCompatibilityFailure[] = [
-      { kind: 'api-missing', adapter: 'code', supported: ['0.1'] },
-      { kind: 'api-unsupported', adapter: 'claude-code', found: '9.9', supported: ['0.1'] },
+      { kind: 'api-missing', adapter: 'code', supported: SUPPORTED_ADAPTER_APIS },
+      { kind: 'api-unsupported', adapter: 'claude-code', found: '9.9', supported: SUPPORTED_ADAPTER_APIS },
     ]
     const rows = failures.map((failure) => ({
       message: compatibilityFailureMessage(failure),
@@ -34,6 +39,46 @@ describe('compatibilityFailureMessage — per-adapter JSON error identity', () =
     expect(rows[1]?.path).toBe('adapters.claude-code')
     expect(rows[1]?.message).toContain('adapter "claude-code"')
     expect(rows[1]?.message).toContain('9.9')
+  })
+})
+
+describe('describeCompatibilityFailure — the whole support set reaches the user', () => {
+  test('every supported API appears in an unsupported-adapter diagnostic', () => {
+    // A user staring at "supported: 0.2" when their 0.1 adapter would in
+    // fact have worked is being told to do unnecessary work.
+    const rendered = describeCompatibilityFailure({
+      kind: 'api-unsupported',
+      adapter: 'claude-code',
+      found: '0.0',
+      supported: SUPPORTED_ADAPTER_APIS,
+    })
+    for (const api of SUPPORTED_ADAPTER_APIS) {
+      expect(rendered.detail).toContain(api)
+    }
+  })
+
+  test('a multi-token set renders as a comma-separated list', () => {
+    expect(SUPPORTED_ADAPTER_APIS.length).toBeGreaterThan(1)
+    const rendered = describeCompatibilityFailure({
+      kind: 'api-missing',
+      adapter: 'nameless',
+      supported: SUPPORTED_ADAPTER_APIS,
+    })
+    expect(rendered.detail).toContain(SUPPORTED_ADAPTER_APIS.join(', '))
+  })
+
+  test('a metadata mismatch between two supported tokens still lists both', () => {
+    const [first, second] = SUPPORTED_ADAPTER_APIS
+    if (first === undefined || second === undefined) expect.unreachable()
+    const rendered = describeCompatibilityFailure({
+      kind: 'api-metadata-mismatch',
+      adapter: 'split-brain',
+      packageDeclared: first,
+      runtimeDeclared: second,
+      supported: SUPPORTED_ADAPTER_APIS,
+    })
+    expect(rendered.detail).toContain(first)
+    expect(rendered.detail).toContain(second)
   })
 })
 
@@ -52,7 +97,7 @@ function noCompatibleReleaseFailure(
         reason: 'no-compatible-release',
         packageName: 'pkg',
         request,
-        supported: ['0.1'],
+        supported: SUPPORTED_ADAPTER_APIS,
         ...(newestConsidered ? { newestConsidered } : {}),
       },
     },
@@ -119,7 +164,7 @@ describe('describeCompatibilityFailure — install target', () => {
       kind: 'api-unsupported',
       adapter: 'future-adapter',
       found: '9.9',
-      supported: ['0.1'],
+      supported: SUPPORTED_ADAPTER_APIS,
     })
     expect(described.fix).toContain('facet adapter install future-adapter')
   })
@@ -129,7 +174,7 @@ describe('describeCompatibilityFailure — install target', () => {
       {
         kind: 'api-missing',
         adapter: '/tmp/facet-adapter-verify-abc123/adapter.mjs',
-        supported: ['0.1'],
+        supported: SUPPORTED_ADAPTER_APIS,
       },
       'my-adapter',
     )
@@ -149,7 +194,7 @@ describe('describeAdapterInstallFailure — nameless bundle verify failure', () 
         bundlePath,
         // Nameless bundle: verification falls back to the bundle path
         // as the adapter identity.
-        failure: { kind: 'api-missing', adapter: bundlePath, supported: ['0.1'] },
+        failure: { kind: 'api-missing', adapter: bundlePath, supported: SUPPORTED_ADAPTER_APIS },
       },
     }
     const described = describeAdapterInstallFailure(failure)

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -266,6 +266,12 @@ function describeVerifyFailure(
         detail: failure.detail,
         fix: 'rebuild the adapter with the @agent-facets/adapter SDK factory (defineAdapter)',
       }
+    case 'invalid-capability':
+      return {
+        what: `adapter "${failure.adapter}" declares adapter API ${failure.api} but does not implement it`,
+        detail: failure.detail,
+        fix: 'declare "mcpServers" as false or a complete { prepare, apply } capability, then rebuild the adapter',
+      }
   }
 }
 

--- a/packages/engine/src/__tests__/build-pipeline.test.ts
+++ b/packages/engine/src/__tests__/build-pipeline.test.ts
@@ -2,11 +2,12 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ADAPTER_API_VERSION, type Adapter, defineAdapter } from '@agent-facets/adapter'
+import { type Adapter, defineAdapter } from '@agent-facets/adapter'
 import type { FacetManifest } from '@agent-facets/protocol'
 import { computeContentHash, detectNamingCollisions, validateCompactFacets } from '@agent-facets/protocol'
 import dedent from 'dedent'
 import { parseTar, parseTarGzip } from 'nanotar'
+import { SUPPORTED_ADAPTER_APIS } from '../adapters/api-compatibility.ts'
 import { runBuildPipeline } from '../build/pipeline.ts'
 import { validateAdapterMetadata } from '../build/validate-adapters.ts'
 import { writeBuildOutput } from '../build/write-output.ts'
@@ -138,6 +139,7 @@ describe('detectNamingCollisions', () => {
 /** A mock adapter that accepts any data as valid metadata */
 const mockAdapter = defineAdapter({
   name: 'mock-adapter',
+  mcpServers: false,
   buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
   async installAsset() {
     return { ok: true as const, primaryPath: '/dev/null' }
@@ -153,6 +155,7 @@ const mockAdapter = defineAdapter({
 /** A mock adapter that rejects all metadata */
 const rejectingAdapter = defineAdapter({
   name: 'rejecting-adapter',
+  mcpServers: false,
   buildAssetMetadata: () => ({
     ok: false,
     errors: [{ path: 'tools', message: 'Invalid tools config', expected: 'Record<string, boolean>', actual: 'string' }],
@@ -489,6 +492,7 @@ describe('runBuildPipeline', () => {
 
     const mockAdapter = defineAdapter({
       name: 'mock-adapter',
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset() {
         return { ok: true as const, primaryPath: '/dev/null' }
@@ -527,6 +531,7 @@ describe('runBuildPipeline', () => {
 
     const rejectingAdapter = defineAdapter({
       name: 'rejecting-adapter',
+      mcpServers: false,
       buildAssetMetadata: () => ({
         ok: false,
         errors: [
@@ -607,6 +612,7 @@ describe('runBuildPipeline', () => {
 
     const defaultingAdapter = defineAdapter({
       name: 'defaulting-adapter',
+      mcpServers: false,
       buildAssetMetadata: (data) => {
         const input = (data ?? {}) as { model?: string }
         // Adapter enriches metadata by injecting a default "model" field
@@ -1067,7 +1073,7 @@ describe('runBuildPipeline — adapter API preflight', () => {
     if (result.ok) expect.unreachable()
     if (result.kind !== 'adapter-incompatible') expect.unreachable()
     expect(result.failures).toEqual([
-      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: [ADAPTER_API_VERSION] },
+      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: SUPPORTED_ADAPTER_APIS },
     ])
     // The preflight fires before stage 1 — no stage ever started.
     expect(stages).toEqual([])
@@ -1096,7 +1102,7 @@ describe('runBuildPipeline — adapter API preflight', () => {
     if (result.ok) expect.unreachable()
     if (result.kind !== 'adapter-incompatible') expect.unreachable()
     expect(result.failures).toEqual([
-      { kind: 'api-unsupported', adapter: 'legacy-positional', found: '0.0', supported: [ADAPTER_API_VERSION] },
+      { kind: 'api-unsupported', adapter: 'legacy-positional', found: '0.0', supported: SUPPORTED_ADAPTER_APIS },
     ])
     expect(stages).toEqual([])
   })

--- a/packages/engine/src/__tests__/materialize.test.ts
+++ b/packages/engine/src/__tests__/materialize.test.ts
@@ -6,6 +6,7 @@ import type { Adapter } from '@agent-facets/adapter'
 import { ADAPTER_API_VERSION, deleteAssetFile, installAssetFile, readAssetFile } from '@agent-facets/adapter'
 import type { ResolvedFacetManifest } from '@agent-facets/protocol'
 import { adapterKey, type MaterializedAsset } from '@agent-facets/protocol'
+import { SUPPORTED_ADAPTER_APIS } from '../adapters/api-compatibility.ts'
 import type { PreviousOwnership } from '../install/commit/ownership.ts'
 import { InstallJournal } from '../install/journal.ts'
 import { materialize } from '../install/materialize.ts'
@@ -82,6 +83,7 @@ function buildRecordingAdapter(name: string): {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
+    mcpServers: false,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(request) {
       calls.push({ name: request.name, metadata: request.metadata })
@@ -149,6 +151,7 @@ function buildSdkAdapter(name: string): {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
+    mcpServers: false,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(request) {
       installCalls++
@@ -540,7 +543,7 @@ describe('materialize — adapter API invariant check', () => {
       kind: 'api-unsupported',
       adapter: 'future-adapter',
       found: '9.9',
-      supported: [ADAPTER_API_VERSION],
+      supported: SUPPORTED_ADAPTER_APIS,
     })
   })
 
@@ -585,7 +588,7 @@ describe('materialize — adapter API invariant check', () => {
       kind: 'api-unsupported',
       adapter: 'legacy-positional',
       found: '0.0',
-      supported: [ADAPTER_API_VERSION],
+      supported: SUPPORTED_ADAPTER_APIS,
     })
   })
 })
@@ -612,6 +615,7 @@ describe('materialize — journal undo surfaces structured adapter failures', ()
       name: 'flaky',
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset(request) {
         installCount++
@@ -670,6 +674,7 @@ describe('materialize — journal undo surfaces structured adapter failures', ()
       name: 'flaky',
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset(request) {
         installCount++

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -61,6 +61,7 @@ function buildFakeAdapter(name: string): Adapter {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
+    mcpServers: false,
     buildAssetMetadata: (data) => ({
       ok: true,
       data: (data ?? {}) as Record<string, unknown>,
@@ -112,6 +113,7 @@ function buildNestedFakeAdapter(name: string): Adapter {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
+    mcpServers: false,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(request) {
       const p = path(request.assetType, request.name)
@@ -151,6 +153,7 @@ function buildBrokenAdapter(name: string, throwOnCall: number): Adapter {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
+    mcpServers: false,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset(request) {
       calls += 1
@@ -193,6 +196,7 @@ function buildBadReadAdapter(name: string): Adapter {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
+    mcpServers: false,
     buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
     async installAsset() {
       throw new Error('should not be reached: readAsset failed first')
@@ -1135,6 +1139,7 @@ describe('runInstall — multi-file skill materialization', () => {
       name,
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset(request) {
         if (request.assetType === 'skill') {

--- a/packages/engine/src/adapters/__tests__/api-compatibility.test.ts
+++ b/packages/engine/src/adapters/__tests__/api-compatibility.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_ASSETS_ONLY } from '@agent-facets/adapter'
 import { classifyApiDeclaration, isWellFormedAdapterApi, SUPPORTED_ADAPTER_APIS } from '../api-compatibility.ts'
 
 describe('SUPPORTED_ADAPTER_APIS', () => {
-  test('is exactly the SDK canonical version', () => {
-    expect(SUPPORTED_ADAPTER_APIS).toEqual([ADAPTER_API_VERSION])
+  test('is exactly the compatibility window: the asset-only and canonical contracts', () => {
+    expect([...SUPPORTED_ADAPTER_APIS].sort()).toEqual([ADAPTER_API_VERSION_ASSETS_ONLY, ADAPTER_API_VERSION].sort())
+  })
+
+  test('excludes the superseded positional contract', () => {
+    // Named as a literal on purpose: '0.0' has no constant anywhere in the
+    // monorepo, and this asserts it never acquires one by way of the set.
+    expect(SUPPORTED_ADAPTER_APIS).not.toContain('0.0')
   })
 })
 
@@ -38,17 +44,30 @@ describe('isWellFormedAdapterApi', () => {
 })
 
 describe('classifyApiDeclaration', () => {
-  test('classifies the supported canonical version as supported', () => {
-    expect(classifyApiDeclaration(ADAPTER_API_VERSION)).toEqual({ kind: 'supported', api: ADAPTER_API_VERSION })
+  test('classifies the canonical version as supported, carrying the MCP contract shape', () => {
+    expect(classifyApiDeclaration(ADAPTER_API_VERSION)).toEqual({
+      kind: 'supported',
+      api: ADAPTER_API_VERSION,
+      contract: 'assets-and-mcp',
+    })
+  })
+
+  test('classifies the superseded asset-only version as supported, carrying the asset-only shape', () => {
+    expect(classifyApiDeclaration(ADAPTER_API_VERSION_ASSETS_ONLY)).toEqual({
+      kind: 'supported',
+      api: ADAPTER_API_VERSION_ASSETS_ONLY,
+      contract: 'assets-only',
+    })
   })
 
   test.each(['9.9', '1.0', '0.0'])('classifies well-formed but unknown %s as unsupported', (value) => {
     expect(classifyApiDeclaration(value)).toEqual({ kind: 'unsupported', api: value })
   })
 
-  test('the superseded positional identifier 0.0 is unsupported by a 0.1-only CLI', () => {
-    // '0.0' is numerically adjacent to '0.1' but names the earlier
-    // positional contract — a different, unsupported wire contract.
+  test('the superseded positional identifier 0.0 stays outside the widened window', () => {
+    // '0.0' is numerically adjacent to both supported tokens but names the
+    // earlier positional contract. Widening the set to two members must not
+    // let proximity or ordering drag it in.
     const result = classifyApiDeclaration('0.0')
     expect(result.kind).toBe('unsupported')
   })

--- a/packages/engine/src/adapters/__tests__/inspect.test.ts
+++ b/packages/engine/src/adapters/__tests__/inspect.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_ASSETS_ONLY } from '@agent-facets/adapter/api-version'
+import { SUPPORTED_ADAPTER_APIS } from '../api-compatibility.ts'
 import { inspectInstalledAdapter, inspectInstalledAdapters } from '../inspect.ts'
 import { GENERATIONS_DIR_NAME, INSTALLATION_RECEIPT_NAME, type InstallationSource } from '../installation.ts'
 import { loadInstalledAdapters } from '../loader.ts'
@@ -45,6 +46,7 @@ async function makeBundle(
 export default {
   name: '${name}',
   ${api}
+  mcpServers: false,
   buildAssetMetadata: () => ({ ok: true, data: { marker: '${opts.marker ?? 'default'}' } }),
   installAsset: async () => undefined,
   readAsset: async () => ({ content: '' }),
@@ -63,7 +65,7 @@ const source: InstallationSource = {
   integrity: { kind: 'sri', value: 'sha512-test' },
 }
 
-async function installManaged(name: string, bundle: string, apiVersion = ADAPTER_API_VERSION): Promise<string> {
+async function installManaged(name: string, bundle: string, apiVersion: string = ADAPTER_API_VERSION): Promise<string> {
   const result = await placeAdapterManaged(name, bundle, { apiVersion, source }, baseDir)
   if (!result.ok) expect.unreachable(`test bug: managed install failed (${result.failure.kind})`)
   return result.receipt.activeGeneration
@@ -75,7 +77,7 @@ describe('inspectInstalledAdapter — managed', () => {
     const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
     if (inspection.kind !== 'compatible') expect.unreachable()
     expect(inspection.managed).toBe(true)
-    expect(inspection.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+    expect(inspection.verified.adapter.apiVersion).toBe(ADAPTER_API_VERSION)
     expect(inspection.repair).toEqual({ kind: 'managed', specifier: 'my-adapter@1.0.0' })
   })
 
@@ -97,39 +99,61 @@ describe('inspectInstalledAdapter — managed', () => {
       kind: 'api-unsupported',
       adapter: 'my-adapter',
       found: '9.9',
-      supported: [ADAPTER_API_VERSION],
+      supported: SUPPORTED_ADAPTER_APIS,
     })
     // The bundle was never imported.
     expect(await Bun.file(sideEffectFile).exists()).toBe(false)
   })
 
-  test('receipt/runtime disagreement is incompatible', async () => {
-    // Fabricate the managed layout directly (never imported before) so
-    // the runtime declaration genuinely differs from the receipt's.
-    // With a single supported API the disagreement classifies as
-    // api-unsupported (support check precedes metadata equality).
+  /**
+   * Fabricate a managed layout directly (never imported before) so the runtime
+   * declaration genuinely differs from the receipt's.
+   */
+  async function installDrifted(receiptApi: string, runtimeApi: string): Promise<void> {
     const genDir = join(baseDir, 'my-adapter', GENERATIONS_DIR_NAME, 'gen-fixture-drift')
     await mkdir(genDir, { recursive: true })
     await Bun.write(
       join(genDir, 'adapter.js'),
-      // '0.0' is the superseded positional contract: well-formed but
-      // unsupported by a 0.1-only CLI, so support check (which precedes
-      // metadata equality) classifies it api-unsupported.
-      await Bun.file(await makeBundle('my-adapter', { apiVersion: '0.0' })).text(),
+      await Bun.file(await makeBundle('my-adapter', { apiVersion: runtimeApi })).text(),
     )
     await Bun.write(
       join(baseDir, 'my-adapter', INSTALLATION_RECEIPT_NAME),
       JSON.stringify({
         schemaVersion: 1,
         activeGeneration: 'gen-fixture-drift',
-        apiVersion: ADAPTER_API_VERSION,
+        apiVersion: receiptApi,
         source,
       }),
     )
+  }
+
+  test('receipt/runtime disagreement on an unsupported runtime is api-unsupported', async () => {
+    // '0.0' is the superseded positional contract: well-formed but outside
+    // the window, so the support check — which precedes metadata equality —
+    // classifies it first.
+    await installDrifted(ADAPTER_API_VERSION, '0.0')
 
     const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
     if (inspection.kind !== 'incompatible') expect.unreachable()
     expect(inspection.failure.kind).toBe('api-unsupported')
+  })
+
+  test('receipt/runtime disagreement between two supported tokens is a metadata mismatch', async () => {
+    // Only reachable now that the window holds more than one token: both
+    // sides pass the support check, so the disagreement itself is the fault.
+    await installDrifted(ADAPTER_API_VERSION_ASSETS_ONLY, ADAPTER_API_VERSION)
+
+    const inspection = await inspectInstalledAdapter('my-adapter', baseDir)
+    if (inspection.kind !== 'incompatible') expect.unreachable()
+    expect(inspection.failure.kind).toBe('api-metadata-mismatch')
+  })
+
+  test('an asset-only installation stays loadable', async () => {
+    const bundle = await makeBundle('legacy-adapter', { apiVersion: ADAPTER_API_VERSION_ASSETS_ONLY })
+    await installManaged('legacy-adapter', bundle, ADAPTER_API_VERSION_ASSETS_ONLY)
+    const inspection = await inspectInstalledAdapter('legacy-adapter', baseDir)
+    if (inspection.kind !== 'compatible') expect.unreachable()
+    expect(inspection.verified.adapter.apiVersion).toBe(ADAPTER_API_VERSION_ASSETS_ONLY)
   })
 
   test('invalid receipt classifies as broken and keeps a repair source', async () => {
@@ -196,7 +220,7 @@ describe('inspectInstalledAdapter — unmanaged', () => {
     await placeAdapter('legacy', await makeBundle('legacy', { apiVersion: null }), baseDir)
     const inspection = await inspectInstalledAdapter('legacy', baseDir)
     if (inspection.kind !== 'incompatible') expect.unreachable()
-    expect(inspection.failure).toEqual({ kind: 'api-missing', adapter: 'legacy', supported: [ADAPTER_API_VERSION] })
+    expect(inspection.failure).toEqual({ kind: 'api-missing', adapter: 'legacy', supported: SUPPORTED_ADAPTER_APIS })
   })
 
   test('malformed unmanaged declaration is incompatible (api-malformed)', async () => {
@@ -225,6 +249,24 @@ describe('loadInstalledAdapters — fail-closed aggregation', () => {
     const result = await loadInstalledAdapters(baseDir)
     if (!result.ok) expect.unreachable()
     expect(result.adapters.map((adapter) => adapter.name)).toEqual(['alpha', 'beta'])
+  })
+
+  test('adapters on either supported contract load together', async () => {
+    // The compatibility window in one assertion: a project may hold one
+    // upgraded and one not-yet-upgraded adapter and still install.
+    await installManaged('current', await makeBundle('current'))
+    await installManaged(
+      'legacy',
+      await makeBundle('legacy', { apiVersion: ADAPTER_API_VERSION_ASSETS_ONLY }),
+      ADAPTER_API_VERSION_ASSETS_ONLY,
+    )
+
+    const result = await loadInstalledAdapters(baseDir)
+    if (!result.ok) expect.unreachable()
+    expect(result.adapters.map((adapter) => [adapter.name, adapter.apiVersion])).toEqual([
+      ['current', ADAPTER_API_VERSION],
+      ['legacy', ADAPTER_API_VERSION_ASSETS_ONLY],
+    ])
   })
 
   test('a single incompatible entry fails the whole load with all failures collected', async () => {

--- a/packages/engine/src/adapters/__tests__/locate-and-verify.test.ts
+++ b/packages/engine/src/adapters/__tests__/locate-and-verify.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { SUPPORTED_ADAPTER_APIS } from '../api-compatibility.ts'
 import { locateAndVerifyAdapter } from '../install-service.ts'
 
 /**
@@ -19,6 +20,7 @@ function validAdapterModule(name: string): string {
   return `export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   buildAssetMetadata: () => ({ ok: true, data: {} }),
   installAsset: async () => undefined,
   readAsset: async () => ({ content: '' }),
@@ -49,7 +51,7 @@ describe('locateAndVerifyAdapter — fallback eligibility', () => {
       const result = await locateAndVerifyAdapter(dir)
       if (!result.ok) expect.unreachable()
       expect(result.verified.adapter.name).toBe('fallback-adapter')
-      expect(result.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+      expect(result.verified.adapter.apiVersion).toBe(ADAPTER_API_VERSION)
       await result.cleanup()
     } finally {
       await rm(dir, { recursive: true, force: true }).catch(() => {})
@@ -79,7 +81,7 @@ describe('locateAndVerifyAdapter — fallback eligibility', () => {
         kind: 'api-unsupported',
         adapter: 'future-adapter',
         found: '9.9',
-        supported: [ADAPTER_API_VERSION],
+        supported: SUPPORTED_ADAPTER_APIS,
       })
     } finally {
       await rm(dir, { recursive: true, force: true }).catch(() => {})

--- a/packages/engine/src/adapters/__tests__/placement-managed.test.ts
+++ b/packages/engine/src/adapters/__tests__/placement-managed.test.ts
@@ -54,6 +54,7 @@ async function makeBundle(name: string, opts: { apiVersion?: string; marker?: st
 export default {
   name: '${name}',
   apiVersion: '${api}',
+  mcpServers: false,
   buildAssetMetadata: () => ({ ok: true, data: {} }),
   installAsset: async () => undefined,
   readAsset: async () => ({ content: '' }),

--- a/packages/engine/src/adapters/__tests__/verify.test.ts
+++ b/packages/engine/src/adapters/__tests__/verify.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_ASSETS_ONLY } from '@agent-facets/adapter'
+import { SUPPORTED_ADAPTER_APIS } from '../api-compatibility.ts'
 import { verifyAdapter } from '../verify.ts'
 
 /**
@@ -18,6 +19,10 @@ const THROWING_METHODS = `
   async installAsset() { throw new Error('contract method invoked during verification') },
   async readAsset() { throw new Error('contract method invoked during verification') },
   async deleteAsset() { throw new Error('contract method invoked during verification') },
+  mcpServers: {
+    async prepare() { throw new Error('contract method invoked during verification') },
+    async apply() { throw new Error('contract method invoked during verification') },
+  },
 `
 
 /** Write `source` as an .mjs bundle in a fresh temp dir; run `fn` on its path. */
@@ -34,6 +39,16 @@ async function withBundle(source: string, fn: (bundlePath: string) => Promise<vo
 
 function adapterSource(fields: string): string {
   return `export default {\n${fields}\n${THROWING_METHODS}\n}`
+}
+
+/**
+ * A bundle shaped like the superseded asset-only contract: the four asset
+ * methods and no `mcpServers` member at all. Not "declines MCP support" —
+ * predates the question.
+ */
+function assetOnlyAdapterSource(fields: string): string {
+  const assetMethods = THROWING_METHODS.slice(0, THROWING_METHODS.indexOf('  mcpServers:'))
+  return `export default {\n${fields}\n${assetMethods}\n}`
 }
 
 describe('verifyAdapter — ordered checks', () => {
@@ -69,7 +84,7 @@ describe('verifyAdapter — ordered checks', () => {
       expect(result.failure.failure).toEqual({
         kind: 'api-missing',
         adapter: 'undeclared',
-        supported: [ADAPTER_API_VERSION],
+        supported: SUPPORTED_ADAPTER_APIS,
       })
     })
   })
@@ -83,7 +98,7 @@ describe('verifyAdapter — ordered checks', () => {
         kind: 'api-malformed',
         adapter: 'malformed',
         found: '0.0.1',
-        supported: [ADAPTER_API_VERSION],
+        supported: SUPPORTED_ADAPTER_APIS,
       })
     })
   })
@@ -97,15 +112,16 @@ describe('verifyAdapter — ordered checks', () => {
         kind: 'api-unsupported',
         adapter: 'future',
         found: '9.9',
-        supported: [ADAPTER_API_VERSION],
+        supported: SUPPORTED_ADAPTER_APIS,
       })
     })
   })
 
   test('4: superseded positional 0.0 declaration fails as api-unsupported', async () => {
     // The exact cutover: a bundle built against the earlier positional
-    // contract declares 0.0, which is well-formed but unsupported by a
-    // 0.1-only CLI. It must fail closed before any contract method.
+    // contract declares 0.0, which is well-formed but outside the window
+    // even though it is numerically adjacent to a member of it. It must
+    // fail closed before any contract method.
     await withBundle(adapterSource(`  name: 'legacy-positional', apiVersion: '0.0',`), async (path) => {
       const result = await verifyAdapter(path)
       if (result.ok) expect.unreachable()
@@ -114,7 +130,7 @@ describe('verifyAdapter — ordered checks', () => {
         kind: 'api-unsupported',
         adapter: 'legacy-positional',
         found: '0.0',
-        supported: [ADAPTER_API_VERSION],
+        supported: SUPPORTED_ADAPTER_APIS,
       })
     })
   })
@@ -131,11 +147,9 @@ describe('verifyAdapter — ordered checks', () => {
   })
 
   test('5: package/runtime disagreement fails as api-metadata-mismatch', async () => {
-    // Runtime declares the supported API (so the support check passes),
-    // but the npm package metadata claims a different well-formed token —
-    // the mismatch check (5) fires. Use a high token that is neither the
-    // supported API nor the superseded 0.0, so this stays a mismatch
-    // rather than collapsing into the unsupported-runtime path.
+    // Runtime declares a supported API (so the support check passes), but
+    // the npm package metadata claims a different well-formed token — the
+    // mismatch check (5) fires.
     await withBundle(adapterSource(`  name: 'split-brain', apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
       const result = await verifyAdapter(path, { expectedApiVersion: '9.9' })
       if (result.ok) expect.unreachable()
@@ -145,9 +159,40 @@ describe('verifyAdapter — ordered checks', () => {
         adapter: 'split-brain',
         packageDeclared: '9.9',
         runtimeDeclared: ADAPTER_API_VERSION,
-        supported: [ADAPTER_API_VERSION],
+        supported: SUPPORTED_ADAPTER_APIS,
       })
     })
+  })
+
+  test('5: two supported tokens still have to agree', async () => {
+    // The case the window makes reachable for the first time: both tokens
+    // are members of the support set, so neither fails the support check —
+    // but one release cannot be two contracts, and picking either would
+    // mean verifying a shape the other half of the release never promised.
+    await withBundle(adapterSource(`  name: 'split-brain', apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
+      const result = await verifyAdapter(path, { expectedApiVersion: ADAPTER_API_VERSION_ASSETS_ONLY })
+      if (result.ok) expect.unreachable()
+      if (result.failure.kind !== 'incompatible') expect.unreachable()
+      expect(result.failure.failure).toEqual({
+        kind: 'api-metadata-mismatch',
+        adapter: 'split-brain',
+        packageDeclared: ADAPTER_API_VERSION_ASSETS_ONLY,
+        runtimeDeclared: ADAPTER_API_VERSION,
+        supported: SUPPORTED_ADAPTER_APIS,
+      })
+    })
+  })
+
+  test('5: the reverse disagreement fails the same way', async () => {
+    await withBundle(
+      assetOnlyAdapterSource(`  name: 'split-brain', apiVersion: '${ADAPTER_API_VERSION_ASSETS_ONLY}',`),
+      async (path) => {
+        const result = await verifyAdapter(path, { expectedApiVersion: ADAPTER_API_VERSION })
+        if (result.ok) expect.unreachable()
+        if (result.failure.kind !== 'incompatible') expect.unreachable()
+        expect(result.failure.failure.kind).toBe('api-metadata-mismatch')
+      },
+    )
   })
 
   test('6: missing name fails with invalid-name', async () => {
@@ -178,7 +223,7 @@ describe('verifyAdapter — ordered checks', () => {
       // success result proves none were called.
       if (!result.ok) expect.unreachable()
       expect(result.verified.adapter.name).toBe('good')
-      expect(result.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+      expect(result.verified.adapter.apiVersion).toBe(ADAPTER_API_VERSION)
     })
   })
 
@@ -186,8 +231,92 @@ describe('verifyAdapter — ordered checks', () => {
     await withBundle(adapterSource(`  name: 'good', apiVersion: '${ADAPTER_API_VERSION}',`), async (path) => {
       const result = await verifyAdapter(path, { expectedApiVersion: ADAPTER_API_VERSION })
       if (!result.ok) expect.unreachable()
-      expect(result.verified.apiVersion).toBe(ADAPTER_API_VERSION)
+      expect(result.verified.adapter.apiVersion).toBe(ADAPTER_API_VERSION)
     })
+  })
+
+  test('7: an asset-only bundle verifies without an mcpServers member', async () => {
+    // The whole point of the compatibility window: an adapter published
+    // before MCP existed still loads, and its missing capability field is
+    // not a defect.
+    await withBundle(
+      assetOnlyAdapterSource(`  name: 'legacy', apiVersion: '${ADAPTER_API_VERSION_ASSETS_ONLY}',`),
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (!result.ok) expect.unreachable()
+        expect(result.verified.adapter.apiVersion).toBe(ADAPTER_API_VERSION_ASSETS_ONLY)
+      },
+    )
+  })
+
+  test('7: a current bundle without mcpServers fails as invalid-capability', async () => {
+    await withBundle(
+      assetOnlyAdapterSource(`  name: 'incomplete', apiVersion: '${ADAPTER_API_VERSION}',`),
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (result.ok) expect.unreachable()
+        if (result.failure.kind !== 'invalid-capability') expect.unreachable()
+        expect(result.failure.adapter).toBe('incomplete')
+        expect(result.failure.api).toBe(ADAPTER_API_VERSION)
+        expect(result.failure.detail).toContain('mcpServers')
+      },
+    )
+  })
+
+  test('7: a partial MCP capability fails as invalid-capability', async () => {
+    // A bundle need not come from the SDK factory, so the factory's
+    // completeness guarantee is re-established here on untrusted input.
+    await withBundle(
+      `export default { name: 'partial', apiVersion: '${ADAPTER_API_VERSION}', mcpServers: { async prepare() {} },
+       buildAssetMetadata() {}, async installAsset() {}, async readAsset() {}, async deleteAsset() {} }`,
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (result.ok) expect.unreachable()
+        if (result.failure.kind !== 'invalid-capability') expect.unreachable()
+        expect(result.failure.detail).toContain('apply')
+      },
+    )
+  })
+
+  test('7: a current bundle declining MCP support verifies', async () => {
+    await withBundle(
+      `export default { name: 'declines', apiVersion: '${ADAPTER_API_VERSION}', mcpServers: false,
+       buildAssetMetadata() {}, async installAsset() {}, async readAsset() {}, async deleteAsset() {} }`,
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (!result.ok) expect.unreachable()
+        if (result.verified.adapter.apiVersion !== ADAPTER_API_VERSION) expect.unreachable()
+        expect(result.verified.adapter.mcpServers).toBe(false)
+      },
+    )
+  })
+
+  test('a throwing property getter becomes a structured failure, not an escaped throw', async () => {
+    // A bundle is arbitrary code. If a hostile or broken getter could throw
+    // out of the verifier, the one function whose job is to decide whether
+    // to trust this object would itself be bypassed.
+    await withBundle(
+      `export default { get name() { throw new Error('hostile') }, apiVersion: '${ADAPTER_API_VERSION}',
+       mcpServers: false, buildAssetMetadata() {}, async installAsset() {}, async readAsset() {}, async deleteAsset() {} }`,
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (result.ok) expect.unreachable()
+        expect(result.failure.kind).toBe('invalid-name')
+      },
+    )
+  })
+
+  test('a throwing mcpServers getter becomes a structured failure', async () => {
+    await withBundle(
+      `export default { name: 'hostile', apiVersion: '${ADAPTER_API_VERSION}',
+       get mcpServers() { throw new Error('hostile') },
+       buildAssetMetadata() {}, async installAsset() {}, async readAsset() {}, async deleteAsset() {} }`,
+      async (path) => {
+        const result = await verifyAdapter(path)
+        if (result.ok) expect.unreachable()
+        expect(result.failure.kind).toBe('invalid-capability')
+      },
+    )
   })
 
   test('incompatible bundle with throwing methods never invokes them', async () => {

--- a/packages/engine/src/adapters/api-compatibility.ts
+++ b/packages/engine/src/adapters/api-compatibility.ts
@@ -2,7 +2,7 @@
 // runtime graph stays free of the full SDK (yaml, asset-fs, common). This
 // also avoids a bun:test-runner cache collision between runtime-loaded SDK
 // sources and in-process `Bun.build` runs over the same files.
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
+import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_ASSETS_ONLY } from '@agent-facets/adapter/api-version'
 
 /**
  * Pure adapter-API compatibility primitives.
@@ -16,12 +16,42 @@ import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
  */
 
 /**
- * The exact adapter APIs this CLI supports. Derived from the SDK's
- * canonical constant — the current API literal lives only in the SDK. A
- * later change MAY add further exact identifiers without changing how the
- * SDK stamps newly built adapters.
+ * The runtime object shape a supported adapter API requires.
+ *
+ * Not a version comparison: the token is opaque, and this says what the CLI
+ * must find on the imported object once it knows which contract that token
+ * names.
  */
-export const SUPPORTED_ADAPTER_APIS: readonly string[] = [ADAPTER_API_VERSION]
+export type AdapterContractShape = 'assets-only' | 'assets-and-mcp'
+
+/**
+ * Every adapter API this CLI supports, mapped to the runtime shape it
+ * promises.
+ *
+ * Support and shape-verifiability are the same fact, so they are one table
+ * rather than a set plus a parallel lookup that could disagree. A token this
+ * CLI accepts but has no shape check for is not representable.
+ */
+const ADAPTER_API_CONTRACTS: Readonly<Record<string, AdapterContractShape>> = {
+  [ADAPTER_API_VERSION_ASSETS_ONLY]: 'assets-only',
+  [ADAPTER_API_VERSION]: 'assets-and-mcp',
+}
+
+/**
+ * The exact adapter APIs this CLI supports — the compatibility window.
+ *
+ * This is the CLI's sole concrete declaration of what it accepts. Every
+ * check (verification, loading, listing, npm selection, package-versus-runtime
+ * agreement) and every diagnostic derives from it; no other module, prose
+ * string, or test restates the literals.
+ *
+ * The values come from the SDK so each token's literal appears in exactly one
+ * place. Membership is unordered: the array order is presentation only, and
+ * nothing may read it as precedence. Widening the set adds an acceptable
+ * token; it never changes what an existing token means, and it never weakens
+ * an exact-token equality check.
+ */
+export const SUPPORTED_ADAPTER_APIS: readonly string[] = Object.keys(ADAPTER_API_CONTRACTS)
 
 /**
  * Canonical adapter API syntax: `MAJOR.MINOR` in decimal with no sign,
@@ -42,7 +72,7 @@ export function isWellFormedAdapterApi(value: string): boolean {
  * string classifies as malformed.
  */
 export type ApiDeclarationClassification =
-  | { kind: 'supported'; api: string }
+  | { kind: 'supported'; api: string; contract: AdapterContractShape }
   | { kind: 'unsupported'; api: string }
   | { kind: 'malformed'; found: string }
   | { kind: 'missing' }
@@ -71,10 +101,13 @@ export function classifyApiDeclaration(declared: unknown): ApiDeclarationClassif
   if (!isWellFormedAdapterApi(declared)) {
     return { kind: 'malformed', found: declared }
   }
-  if (!SUPPORTED_ADAPTER_APIS.includes(declared)) {
+  // Membership *is* having a known contract shape — one lookup, so a token
+  // cannot be accepted without the CLI knowing what to verify on it.
+  const contract = ADAPTER_API_CONTRACTS[declared]
+  if (contract === undefined) {
     return { kind: 'unsupported', api: declared }
   }
-  return { kind: 'supported', api: declared }
+  return { kind: 'supported', api: declared, contract }
 }
 
 /**

--- a/packages/engine/src/adapters/install-service.ts
+++ b/packages/engine/src/adapters/install-service.ts
@@ -188,7 +188,7 @@ export async function installAdapter(
 
     opts.onProgress?.('placing', adapter.name)
     const placed = await placeAdapterManaged(adapter.name, located.bundlePath, {
-      apiVersion: located.verified.apiVersion,
+      apiVersion: located.verified.adapter.apiVersion,
       source,
     })
     if (!placed.ok) {

--- a/packages/engine/src/adapters/placement.ts
+++ b/packages/engine/src/adapters/placement.ts
@@ -213,7 +213,7 @@ export async function placeAdapterManaged(
     const receipt: InstallationReceipt = {
       schemaVersion: INSTALLATION_SCHEMA_VERSION,
       activeGeneration: generationId,
-      apiVersion: verified.verified.apiVersion,
+      apiVersion: verified.verified.adapter.apiVersion,
       source: provenance.source,
     }
     try {

--- a/packages/engine/src/adapters/verify.ts
+++ b/packages/engine/src/adapters/verify.ts
@@ -1,4 +1,4 @@
-import type { Adapter } from '@agent-facets/adapter'
+import type { Adapter, AssetOnlyAdapter, McpCapableAdapter } from '@agent-facets/adapter'
 import {
   type AdapterCompatibilityFailure,
   classifyApiDeclaration,
@@ -7,13 +7,15 @@ import {
 } from './api-compatibility.ts'
 
 /**
- * A bundle that passed every verification check. `apiVersion` is the
- * exact supported API the runtime bundle declared — carried separately
- * so consumers (receipts, listings) don't re-derive it from the adapter.
+ * A bundle that passed every verification check.
+ *
+ * The declared API is not carried beside the adapter: `Adapter` is tagged by
+ * `apiVersion`, so consumers (receipts, listings) read `adapter.apiVersion`
+ * and there is no second copy that could disagree with the object it
+ * describes.
  */
 export interface VerifiedAdapter {
   adapter: Adapter
-  apiVersion: string
 }
 
 /**
@@ -25,7 +27,9 @@ export interface VerifiedAdapter {
  *      malformed, unsupported, or disagrees with the npm package
  *      declaration used for selection.
  *   6. `invalid-name` / `invalid-shape` — the verified adapter object is
- *      missing its name or a required method.
+ *      missing its name or a required asset method.
+ *   7. `invalid-capability` — the object satisfies the asset contract but not
+ *      the additional shape its declared API promises.
  *
  * A compatibility contradiction is classified before any adapter
  * contract method could be invoked; verification never calls one.
@@ -36,12 +40,29 @@ export type VerifyAdapterFailure =
   | { kind: 'incompatible'; bundlePath: string; failure: AdapterCompatibilityFailure }
   | { kind: 'invalid-name'; bundlePath: string }
   | { kind: 'invalid-shape'; adapter: string; bundlePath: string; detail: string }
+  | { kind: 'invalid-capability'; adapter: string; bundlePath: string; api: string; detail: string }
 
 /** Result of `verifyAdapter`. Discriminated by `ok`; never throws for expected failures. */
 export type VerifyAdapterResult = { ok: true; verified: VerifiedAdapter } | { ok: false; failure: VerifyAdapterFailure }
 
-/** The contract methods every supported adapter object must expose. */
+/** The asset contract methods every supported adapter object must expose. */
 const REQUIRED_METHODS = ['buildAssetMetadata', 'installAsset', 'readAsset', 'deleteAsset'] as const
+
+/**
+ * Read a property off an untrusted imported object.
+ *
+ * A bundle is arbitrary code, and a property access can run a getter that
+ * throws. Without this, such a throw would escape `verifyAdapter` entirely and
+ * bypass its result contract — the one function whose whole job is to decide
+ * whether this object can be trusted.
+ */
+function safeRead(target: Record<string, unknown>, key: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: target[key] }
+  } catch {
+    return { ok: false }
+  }
+}
 
 /**
  * Verifies that a built adapter.js file exports a valid, compatible
@@ -79,10 +100,15 @@ export async function verifyAdapter(
     return { ok: false, failure: { kind: 'no-default-export', bundlePath } }
   }
   const adapter = candidate as Record<string, unknown>
-  const identity = typeof adapter.name === 'string' && adapter.name ? adapter.name : bundlePath
+  const readName = safeRead(adapter, 'name')
+  const declaredName = readName.ok ? readName.value : undefined
+  const identity = typeof declaredName === 'string' && declaredName ? declaredName : bundlePath
 
   // 3./4. Runtime API declaration: present, well-formed, supported
-  const classified = classifyApiDeclaration(adapter.apiVersion)
+  const readApi = safeRead(adapter, 'apiVersion')
+  // A throwing `apiVersion` getter declares nothing readable, which is exactly
+  // what `missing` means to the classifier.
+  const classified = classifyApiDeclaration(readApi.ok ? readApi.value : undefined)
   if (classified.kind !== 'supported') {
     return {
       ok: false,
@@ -108,17 +134,18 @@ export async function verifyAdapter(
     }
   }
 
-  // 6. API `0.0` name and method shape
-  if (typeof adapter.name !== 'string' || !adapter.name) {
+  // 6. Name and asset method shape — common to every supported contract
+  if (typeof declaredName !== 'string' || !declaredName) {
     return { ok: false, failure: { kind: 'invalid-name', bundlePath } }
   }
   for (const method of REQUIRED_METHODS) {
-    if (typeof adapter[method] !== 'function') {
+    const read = safeRead(adapter, method)
+    if (!read.ok || typeof read.value !== 'function') {
       return {
         ok: false,
         failure: {
           kind: 'invalid-shape',
-          adapter: adapter.name,
+          adapter: declaredName,
           bundlePath,
           detail: `"${method}" is not a function`,
         },
@@ -126,5 +153,68 @@ export async function verifyAdapter(
     }
   }
 
-  return { ok: true, verified: { adapter: candidate as Adapter, apiVersion: classified.api } }
+  // 7. Contract-specific shape. Dispatched on the shape the classified API
+  // promises, so this switch cannot fall out of step with the support set.
+  switch (classified.contract) {
+    case 'assets-only':
+      // The asset-only contract has no further members. An adapter that
+      // happens to carry extra fields is still a valid asset-only adapter;
+      // its API declaration is what says they mean nothing here.
+      return { ok: true, verified: { adapter: candidate as AssetOnlyAdapter } }
+
+    case 'assets-and-mcp': {
+      const read = safeRead(adapter, 'mcpServers')
+      if (!read.ok) {
+        return {
+          ok: false,
+          failure: {
+            kind: 'invalid-capability',
+            adapter: declaredName,
+            bundlePath,
+            api: classified.api,
+            detail: '"mcpServers" could not be read',
+          },
+        }
+      }
+      const capabilityFailure = checkMcpServersShape(read.value)
+      if (capabilityFailure !== null) {
+        return {
+          ok: false,
+          failure: {
+            kind: 'invalid-capability',
+            adapter: declaredName,
+            bundlePath,
+            api: classified.api,
+            detail: capabilityFailure,
+          },
+        }
+      }
+      return { ok: true, verified: { adapter: candidate as McpCapableAdapter } }
+    }
+  }
+}
+
+/**
+ * Validate the `mcpServers` member of an adapter declaring the current
+ * contract. Returns null when valid, otherwise a diagnostic detail.
+ *
+ * Partial capabilities are rejected here as well as in the SDK factory,
+ * because a bundle can be built by anything — the factory's guarantee covers
+ * adapters built with the factory, and this covers the rest.
+ */
+function checkMcpServersShape(value: unknown): string | null {
+  if (value === false) {
+    return null
+  }
+  if (typeof value !== 'object' || value === null) {
+    return '"mcpServers" must be false or a capability object'
+  }
+  const capability = value as Record<string, unknown>
+  for (const operation of ['prepare', 'apply'] as const) {
+    const read = safeRead(capability, operation)
+    if (!read.ok || typeof read.value !== 'function') {
+      return `"mcpServers.${operation}" is not a function`
+    }
+  }
+  return null
 }

--- a/packages/engine/src/install/__tests__/apply-ownership.test.ts
+++ b/packages/engine/src/install/__tests__/apply-ownership.test.ts
@@ -60,6 +60,7 @@ function recordingAdapter(opts: { failInstallOf?: ReadonlySet<string> } = {}): {
       name: 'rec',
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset(request) {
         io.push(`install:${request.assetType}:${request.name}`)

--- a/packages/engine/src/install/__tests__/compose.test.ts
+++ b/packages/engine/src/install/__tests__/compose.test.ts
@@ -35,6 +35,7 @@ function recordingAdapter(name: string): { adapter: Adapter; io: string[] } {
       name,
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset(request) {
         io.push(`install:${request.assetType}:${request.name}`)
@@ -459,6 +460,7 @@ describe('compose — persisting and pruning intent', () => {
       name: 'failing',
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
+      mcpServers: false,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset() {
         return { ok: false, failure: { code: 'io-failed', operation: 'write', message: 'disk on fire' } }

--- a/packages/engine/src/install/__tests__/manifest-transaction.test.ts
+++ b/packages/engine/src/install/__tests__/manifest-transaction.test.ts
@@ -69,6 +69,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/engine/src/install/__tests__/run-add.test.ts
+++ b/packages/engine/src/install/__tests__/run-add.test.ts
@@ -97,6 +97,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/engine/src/install/__tests__/run-install.chain.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.chain.test.ts
@@ -159,6 +159,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/engine/src/install/__tests__/run-install.concurrency.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.concurrency.test.ts
@@ -68,6 +68,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/engine/src/install/__tests__/run-install.receipt.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.receipt.test.ts
@@ -104,6 +104,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import type { CurrentBuildManifest, ProjectFacetEntry } from '@agent-facets/protocol'
+import { SUPPORTED_ADAPTER_APIS } from '../../adapters/api-compatibility.ts'
 
 /**
  * Tests for `runInstall`'s manifest-vs-lockfile reconciliation.
@@ -155,6 +156,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {
@@ -615,7 +617,7 @@ describe('runInstall — ADAPTER_INCOMPATIBLE preflight', () => {
     if (result.ok) expect.unreachable()
     if (result.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
     expect(result.failure.failures).toEqual([
-      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: [ADAPTER_API_VERSION] },
+      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: SUPPORTED_ADAPTER_APIS },
     ])
     expect(result.rollback.kind).toBe('not-needed')
 
@@ -651,7 +653,7 @@ describe('runInstall — ADAPTER_INCOMPATIBLE preflight', () => {
     if (result.ok) expect.unreachable()
     if (result.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
     expect(result.failure.failures).toEqual([
-      { kind: 'api-unsupported', adapter: 'legacy-positional', found: '0.0', supported: [ADAPTER_API_VERSION] },
+      { kind: 'api-unsupported', adapter: 'legacy-positional', found: '0.0', supported: SUPPORTED_ADAPTER_APIS },
     ])
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBytes)
     expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import { CURRENT_LOCKFILE_VERSION, LOCKFILE_VERSION_0_2, type ProjectFacetEntry } from '@agent-facets/protocol'
+import { SUPPORTED_ADAPTER_APIS } from '../../adapters/api-compatibility.ts'
 import type { StageEvent } from '../types.ts'
 
 /**
@@ -98,6 +99,7 @@ function path(type, name) { return join(process.cwd(), '.${name}', type + 's', n
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
+  mcpServers: false,
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {
@@ -614,7 +616,7 @@ describe('runRemove — adapter compatibility is not bypassed', () => {
     if (result.phase !== 'install') expect.unreachable()
     if (result.install.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
     expect(result.install.failure.failures).toEqual([
-      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: [ADAPTER_API_VERSION] },
+      { kind: 'api-unsupported', adapter: 'future-adapter', found: '9.9', supported: SUPPORTED_ADAPTER_APIS },
     ])
     expect(result.install.rollback.kind).toBe('not-needed')
 
@@ -648,7 +650,7 @@ describe('runRemove — adapter compatibility is not bypassed', () => {
     if (result.phase !== 'install') expect.unreachable()
     if (result.install.failure.code !== 'ADAPTER_INCOMPATIBLE') expect.unreachable()
     expect(result.install.failure.failures).toEqual([
-      { kind: 'api-unsupported', adapter: 'legacy-positional', found: '0.0', supported: [ADAPTER_API_VERSION] },
+      { kind: 'api-unsupported', adapter: 'legacy-positional', found: '0.0', supported: SUPPORTED_ADAPTER_APIS },
     ])
 
     // Nothing deleted; every project file byte-for-byte unchanged.

--- a/packages/engine/src/sources/adapter/__tests__/npm-resolve.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/npm-resolve.test.ts
@@ -1,6 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
-import { ADAPTER_API_VERSION, ADAPTER_API_VERSION_PACKAGE_FIELD } from '@agent-facets/adapter/api-version'
+import {
+  ADAPTER_API_VERSION,
+  ADAPTER_API_VERSION_ASSETS_ONLY,
+  ADAPTER_API_VERSION_PACKAGE_FIELD,
+} from '@agent-facets/adapter/api-version'
+import { SUPPORTED_ADAPTER_APIS } from '../../../adapters/api-compatibility.ts'
 import { downloadNpmRelease, resolveNpmAdapter } from '../npm.ts'
 import type { NpmVersionRequest } from '../specifier.ts'
 
@@ -123,6 +128,57 @@ describe('resolveNpmAdapter — compatible selection', () => {
     expect(result.release.dist.integrity).toBe(goodSri)
   })
 
+  test('highest package version wins across supported tokens', async () => {
+    // Both tokens are in the window, so neither is "more compatible" than
+    // the other. Package version is the only ranking key.
+    packuments.set('mixed-window', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '2.0.0': { api: ADAPTER_API_VERSION_ASSETS_ONLY },
+      },
+    })
+    const result = await resolveNpmAdapter('mixed-window', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('2.0.0')
+    expect(result.release.apiVersion).toBe(ADAPTER_API_VERSION_ASSETS_ONLY)
+  })
+
+  test('the newer supported token does not outrank a higher package version either', async () => {
+    // The mirror image of the previous case, so a passing result cannot be
+    // explained by an accidental preference for the asset-only token.
+    packuments.set('mixed-window-reversed', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION_ASSETS_ONLY },
+        '2.0.0': { api: ADAPTER_API_VERSION },
+      },
+    })
+    const result = await resolveNpmAdapter('mixed-window-reversed', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('2.0.0')
+    expect(result.release.apiVersion).toBe(ADAPTER_API_VERSION)
+  })
+
+  test('an asset-only release stays installable during the window', async () => {
+    packuments.set('asset-only-only', {
+      versions: { '1.0.0': { api: ADAPTER_API_VERSION_ASSETS_ONLY } },
+    })
+    const result = await resolveNpmAdapter('asset-only-only', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('1.0.0')
+  })
+
+  test('a newer positional 0.0 release is skipped for an older supported one', async () => {
+    packuments.set('positional-newer', {
+      versions: {
+        '1.0.0': { api: ADAPTER_API_VERSION },
+        '2.0.0': { api: '0.0' },
+      },
+    })
+    const result = await resolveNpmAdapter('positional-newer', implicit, opts())
+    if (!result.ok) expect.unreachable()
+    expect(result.release.version).toBe('1.0.0')
+  })
+
   test('wildcard selector constrains compatible selection', async () => {
     packuments.set('wildcarded', {
       versions: {
@@ -200,7 +256,7 @@ describe('resolveNpmAdapter — incompatibility failures', () => {
     if (result.ok) expect.unreachable()
     if (result.reason !== 'no-compatible-release') expect.unreachable()
     expect(result.request).toEqual(request)
-    expect(result.supported).toEqual([ADAPTER_API_VERSION])
+    expect(result.supported).toEqual(SUPPORTED_ADAPTER_APIS)
     expect(result.newestConsidered).toEqual({ version: '2.0.0', declared: { kind: 'unsupported', api: '9.9' } })
   })
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -11,7 +11,8 @@
     "dist"
   ],
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./mcp-declaration": "./src/schemas/mcp-server-declaration.ts"
   },
   "engines": {
     "node": ">=22"
@@ -44,6 +45,10 @@
       ".": {
         "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts"
+      },
+      "./mcp-declaration": {
+        "import": "./dist/mcp-declaration.mjs",
+        "types": "./dist/mcp-declaration.d.mts"
       }
     }
   }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -278,17 +278,19 @@ export {
   ProjectAssetOverrideSchema,
   sameDisposition,
 } from './schemas/materialization.ts'
-// portable MCP server declarations — the closed tagged union a facet author
-// writes in `facet.json`. This schema and its inferred type are the single
-// source of truth for the shape; the Adapter SDK consumes the type directly
-// so a capability signature cannot drift from the published contract.
-export type { McpServerDeclaration, McpServerTransport } from './schemas/mcp-server.ts'
 export {
-  MCP_SERVER_TRANSPORTS,
   McpServerDeclarationSchema,
   validateMcpEnvironmentName,
   validateMcpServerName,
 } from './schemas/mcp-server.ts'
+// portable MCP server declarations — the closed tagged union a facet author
+// writes in `facet.json`. The declaration type lives in its own
+// dependency-free module (also published as the `./mcp-declaration` subpath)
+// so the Adapter SDK can consume the authoritative contract without inheriting
+// arktype; `mcp-server.ts` holds the validating schema and a compile-time
+// assertion that the two agree.
+export type { McpServerDeclaration, McpServerTransport } from './schemas/mcp-server-declaration.ts'
+export { MCP_SERVER_TRANSPORTS } from './schemas/mcp-server-declaration.ts'
 // project manifest (`facets.json`) — versioned schemas plus the accessors
 // read-only consumers use so a compact and an expanded entry are never
 // handled differently by accident.

--- a/packages/protocol/src/materialization/servers.ts
+++ b/packages/protocol/src/materialization/servers.ts
@@ -4,7 +4,7 @@ import type {
   MaterializedDisposition,
   ProjectAssetOverride,
 } from '../schemas/materialization.ts'
-import type { McpServerDeclaration } from '../schemas/mcp-server.ts'
+import type { McpServerDeclaration } from '../schemas/mcp-server-declaration.ts'
 import type { FacetMaterializationOverrides } from '../schemas/project-manifest.ts'
 import { SERVER_OVERRIDE_GROUP } from '../schemas/project-manifest.ts'
 import { type MaterializedName, planEffectiveNames } from './effective-name.ts'

--- a/packages/protocol/src/mcp/fingerprint.ts
+++ b/packages/protocol/src/mcp/fingerprint.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { compareCodeUnits } from '../ordering.ts'
-import type { McpServerDeclaration } from '../schemas/mcp-server.ts'
+import type { McpServerDeclaration } from '../schemas/mcp-server-declaration.ts'
 
 /**
  * Canonical semantic fingerprint for a portable MCP server declaration.

--- a/packages/protocol/src/schemas/mcp-server-declaration.ts
+++ b/packages/protocol/src/schemas/mcp-server-declaration.ts
@@ -1,0 +1,47 @@
+/**
+ * The portable MCP server declaration type, and nothing else.
+ *
+ * This module is deliberately **dependency-free** — no arktype, no imports at
+ * all — and is published as its own `@agent-facets/protocol/mcp-declaration`
+ * entry point, mirroring the Adapter SDK's `api-version` subpath.
+ *
+ * The reason is the Adapter SDK. Its capability signatures are typed over this
+ * declaration, and its published declarations inline everything they reference
+ * so third-party adapter authors install one package. Reaching this type
+ * through `@agent-facets/protocol`'s main entry would pull arktype's type graph
+ * into every adapter author's project. Splitting the type out means the SDK
+ * consumes the authoritative contract without acquiring a validator it never
+ * calls.
+ *
+ * The validating schema lives beside this in `mcp-server.ts`, which imports
+ * this type and asserts at compile time that the two agree. That file is the
+ * place to read for what these fields *mean* and why the union is closed.
+ */
+
+/** The transports a portable declaration may use, in canonical order. */
+export const MCP_SERVER_TRANSPORTS = ['stdio', 'http'] as const
+
+/** A declared transport. */
+export type McpServerTransport = (typeof MCP_SERVER_TRANSPORTS)[number]
+
+/**
+ * A validated portable MCP server declaration.
+ *
+ * A closed tagged union: `stdio` launches a local process and speaks MCP over
+ * its standard I/O; `http` connects to a Streamable HTTP endpoint. Values are
+ * literal — nothing here is expanded, interpolated, or normalized.
+ *
+ * An omitted `args` or `env` is semantically identical to an empty one
+ * everywhere declarations are compared.
+ */
+export type McpServerDeclaration =
+  | {
+      type: 'stdio'
+      command: string
+      args?: string[]
+      env?: Record<string, string>
+    }
+  | {
+      type: 'http'
+      url: string
+    }

--- a/packages/protocol/src/schemas/mcp-server.ts
+++ b/packages/protocol/src/schemas/mcp-server.ts
@@ -1,5 +1,6 @@
 import { type } from 'arktype'
 import { validateAssetNameSegment } from './asset-name.ts'
+import type { McpServerDeclaration } from './mcp-server-declaration.ts'
 
 /**
  * Portable MCP server declarations — the connection and launch information a
@@ -40,12 +41,6 @@ import { validateAssetNameSegment } from './asset-name.ts'
  * rather than any one platform's maximum.
  */
 const ENVIRONMENT_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
-
-/** The transports a portable declaration may use, in canonical order. */
-export const MCP_SERVER_TRANSPORTS = ['stdio', 'http'] as const
-
-/** A declared transport. */
-export type McpServerTransport = (typeof MCP_SERVER_TRANSPORTS)[number]
 
 /**
  * Validate one environment-variable name. Errors are data, not exceptions,
@@ -162,5 +157,20 @@ const HttpMcpServerDeclaration = type({
  */
 export const McpServerDeclarationSchema = StdioMcpServerDeclaration.or(HttpMcpServerDeclaration)
 
-/** Inferred type for a validated portable MCP server declaration. */
-export type McpServerDeclaration = typeof McpServerDeclarationSchema.infer
+/** True only when `A` and `B` are mutually assignable. */
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+
+/** Fails to compile unless its argument is exactly `true`. */
+type Assert<T extends true> = T
+
+/**
+ * Compile-time proof that the dependency-free `McpServerDeclaration` and the
+ * type `McpServerDeclarationSchema` actually infers describe the same shape.
+ * Adding an arm, field, or optionality to the schema without updating the type
+ * (or the reverse) makes this alias fail to compile — which is what makes the
+ * split into two files a mechanically checked restatement rather than a second
+ * definition free to drift.
+ */
+export type McpServerDeclarationSchemaAgreement = Assert<
+  Exact<McpServerDeclaration, typeof McpServerDeclarationSchema.infer>
+>

--- a/packages/protocol/tsdown.config.ts
+++ b/packages/protocol/tsdown.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // `mcp-server-declaration.ts` is a separate, dependency-free entry so the
+  // Adapter SDK can inline the portable declaration type into its published
+  // declarations without dragging arktype's type graph along with it.
+  entry: { index: 'src/index.ts', 'mcp-declaration': 'src/schemas/mcp-server-declaration.ts' },
   format: ['esm'],
   dts: {
     eager: true,


### PR DESCRIPTION
### Why

Adapter API `0.2` introduces a required `mcpServers` field on every adapter, making MCP server support an explicit, verifiable capability declaration rather than an absent or inferred one. This advances the SDK's canonical API token from `0.1` to `0.2` and widens the engine's compatibility window to `{0.1, 0.2}`, keeping adapters published against the asset-only contract loadable during the transition.

### Details

**Protocol split.** `McpServerDeclaration` is extracted from `mcp-server.ts` into a new dependency-free module (`mcp-server-declaration.ts`), published as the `@agent-facets/protocol/mcp-declaration` subpath. The Adapter SDK imports the type from there so its published declarations inline the portable declaration type without pulling arktype's type graph into every adapter author's project. A compile-time mutual-assignability assertion in `mcp-server.ts` ensures the two files cannot drift.

**SDK changes.** `AdapterDefinition` now requires `mcpServers: false | McpServerCapability`. The `McpServerCapability` interface enforces both `prepare` and `apply` — a partial capability is unrepresentable. `defineAdapter` validates this at runtime for callers arriving from untyped JavaScript. The superseded `0.1` token is preserved as `ADAPTER_API_VERSION_ASSETS_ONLY` with its own exported constant and type; `defineAdapter` always stamps `0.2`.

**Engine verification.** `verifyAdapter` gains a step 7 dispatched on the contract shape the classified API promises. `assets-only` (`0.1`) passes with no `mcpServers` member — it predates the question. `assets-and-mcp` (`0.2`) requires `mcpServers` to be `false` or a complete `{ prepare, apply }` object, and a new `invalid-capability` failure kind is returned when it is not. All property reads on untrusted imported objects go through a `safeRead` helper so a throwing getter produces a structured failure rather than escaping the verifier. The `VerifiedAdapter` type drops its redundant `apiVersion` field; consumers read `adapter.apiVersion` directly.

**Compatibility window.** `SUPPORTED_ADAPTER_APIS` is now backed by a `Record<string, AdapterContractShape>` table so support and shape-verifiability are one declaration. Every check — verification, loading, listing, npm version selection, package/runtime agreement, and diagnostics — derives from this table. No module restates the literal tokens.

**First-party adapters.** `claude-code`, `codex`, and `opencode` each declare `mcpServers: false` explicitly; native MCP reconciliation is a later task.

**CLI prompt.** The `usage.txt` adapter API support set is now injected via a `{{ADAPTER_API_SUPPORT_SET}}` marker rendered from `SUPPORTED_ADAPTER_APIS`, so the prose cannot go stale when the window changes.

**Dist e2e test.** A new `dist.e2e.test.ts` in the adapter SDK asserts that published declarations import nothing beyond the sibling `api-version` entry, that the JavaScript bundle pulls in no workspace or validator runtime, and that the `api-version` entry itself is dependency-free. This is the tripwire for the declaration-bundling invariant that broke once already when an inferred arktype type carried internal import nodes into emitted declarations.

### Verification

CI covers unit, integration, and e2e tests across the adapter SDK, engine adapter management, placement, verification, npm resolution, build pipeline, and install/remove flows for both supported contracts. The `test:e2e` script in the adapter SDK requires a prior `bun run build` and is wired separately from the standard `test` script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches adapter loading, verification, and install/build preflights across the monorepo; behavior changes are gated on API tokens but misclassified bundles could block installs until adapters are rebuilt.
> 
> **Overview**
> **Adapter API 0.2** bumps the SDK canonical token to `0.2` and makes every `defineAdapter` definition declare **`mcpServers: false | McpServerCapability`** (batch `prepare`/`apply`, protocol-backed declaration types). Partial or missing MCP fields fail at factory time; `0.1` remains as **`ADAPTER_API_VERSION_ASSETS_ONLY`** for published asset-only adapters.
> 
> **Engine** widens **`SUPPORTED_ADAPTER_APIS`** to `{0.1, 0.2}` via a single API→contract-shape table. **`verifyAdapter`** adds contract-aware step 7 (`invalid-capability` for incomplete `0.2` bundles), **`safeRead`** on untrusted imports, and drops duplicate **`VerifiedAdapter.apiVersion`** in favor of **`adapter.apiVersion`**. Diagnostics and npm selection use the full support set.
> 
> **Protocol** splits **`McpServerDeclaration`** into a dependency-free **`@agent-facets/protocol/mcp-declaration`** entry; the adapter package bundles that type into published `.d.mts` (new **`dist.e2e`** tripwire). First-party adapters set **`mcpServers: false`** until native MCP lands.
> 
> **CLI** injects the support set into usage instructions from engine; **`facets.json`** sample bumps **`manifestVersion`** to `0.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b04e8c5b86ca9cc5102824ce829a2d573d6aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->