### PR TITLE
Implement native MCP server reconciliation for Claude Code, Codex, and OpenCode adapters

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "ignore": ["@agent-facets/engine", "@agent-facets/common"],
+  "ignore": ["@agent-facets/engine", "@agent-facets/common", "@agent-facets/adapter-test-kit"],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/bun.lock
+++ b/bun.lock
@@ -34,11 +34,18 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/adapter-test-kit": {
+      "name": "@agent-facets/adapter-test-kit",
+      "devDependencies": {
+        "@agent-facets/adapter": "workspace:*",
+      },
+    },
     "packages/adapters/claude-code": {
       "name": "@agent-facets/adapter-claude-code",
       "version": "0.9.0",
       "devDependencies": {
         "@agent-facets/adapter": "workspace:*",
+        "@agent-facets/adapter-test-kit": "workspace:*",
         "arktype": "2.2.0",
         "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
@@ -49,6 +56,8 @@
       "version": "0.7.0",
       "devDependencies": {
         "@agent-facets/adapter": "workspace:*",
+        "@agent-facets/adapter-test-kit": "workspace:*",
+        "@decimalturn/toml-patch": "^3.0.1",
         "arktype": "2.2.0",
         "smol-toml": "^1.7.0",
         "tsdown": "^0.22.3",
@@ -60,7 +69,9 @@
       "version": "0.10.0",
       "devDependencies": {
         "@agent-facets/adapter": "workspace:*",
+        "@agent-facets/adapter-test-kit": "workspace:*",
         "arktype": "2.2.0",
+        "jsonc-parser": "^3.3.1",
         "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
       },
@@ -164,6 +175,8 @@
 
     "@agent-facets/adapter-opencode": ["@agent-facets/adapter-opencode@workspace:packages/adapters/opencode"],
 
+    "@agent-facets/adapter-test-kit": ["@agent-facets/adapter-test-kit@workspace:packages/adapter-test-kit"],
+
     "@agent-facets/brand": ["@agent-facets/brand@workspace:packages/brand"],
 
     "@agent-facets/common": ["@agent-facets/common@workspace:packages/common"],
@@ -251,6 +264,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@decimalturn/toml-patch": ["@decimalturn/toml-patch@3.0.1", "", {}, "sha512-10uJJz+6Jm4DDrr7YcWG7Y47Njl9qc6Nbz2H92cLk/LnJ85XSKEdbMIop7ba6u6SyI6JqUGDw+KC8+EioYuGGQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -1412,7 +1427,7 @@
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
-    "jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -2375,6 +2390,8 @@
     "@sindresorhus/transliterate/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "@stoplight/better-ajv-errors/leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "@stoplight/json/jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
 
     "@stoplight/json/lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 

--- a/facets.json
+++ b/facets.json
@@ -9,5 +9,5 @@
     "worktrunk": "0.1.0",
     "openspec": "0.1.0"
   },
-  "manifestVersion": 0.2
+  "manifestVersion": 0.1
 }

--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -53,23 +53,23 @@
 
 ## 5. First-party native MCP adapters — Research
 
-- [ ] 5.1 Explore: Inspect Claude Code and OpenCode native JSON/JSONC schemas, project-file precedence, comment-preservation behavior, equality semantics, and package bundling constraints.
-- [ ] 5.2 Explore: Evaluate Codex TOML editing options against syntax-aware preservation, bundle size, trusted-project scope, and atomic-write requirements, and identify the comment-bearing round-trip proof the implementation must satisfy.
-- [ ] 5.3 Explore: Define a shared fixture matrix for absent, malformed, equivalent, divergent, tracked, untracked, unrelated-setting, native-extension, and no-op documents across all three adapters.
-- [ ] 5.4 Propose: Specify the common prepare/apply behavior and each adapter's native translation, project-only path, semantic-equality rules, safe extension preservation, and dependency/bundling approach.
+- [x] 5.1 Explore: Inspect Claude Code and OpenCode native JSON/JSONC schemas, project-file precedence, comment-preservation behavior, equality semantics, and package bundling constraints.
+- [x] 5.2 Explore: Evaluate Codex TOML editing options against syntax-aware preservation, bundle size, trusted-project scope, and atomic-write requirements, and identify the comment-bearing round-trip proof the implementation must satisfy.
+- [x] 5.3 Explore: Define a shared fixture matrix for absent, malformed, equivalent, divergent, tracked, untracked, unrelated-setting, native-extension, and no-op documents across all three adapters.
+- [x] 5.4 Propose: Specify the common prepare/apply behavior and each adapter's native translation, project-only path, semantic-equality rules, safe extension preservation, and dependency/bundling approach.
 
 ## 6. First-party native MCP adapters — Implementation
 
-- [ ] 6.1 Implement: Implement Claude Code batch prepare/apply for project `.mcp.json` and `mcpServers`, with read-only planning, native semantic equality, unrelated-state preservation, and atomic writes.
-- [ ] 6.2 Implement: Implement OpenCode batch prepare/apply using existing `opencode.jsonc` when present, otherwise existing `opencode.json`, otherwise creating `opencode.jsonc`; when both exist, treat JSONC as canonical and leave JSON unchanged; reconcile the selected document's `mcp` map with JSONC-aware preservation, native semantic equality, and atomic writes.
-- [ ] 6.3 Implement: Implement Codex batch prepare/apply for trusted-project `.codex/config.toml` and `mcp_servers` using the approved syntax-aware TOML strategy.
-- [ ] 6.4 Implement: Add per-adapter fixtures and tests for stdio/HTTP translation, project-only scope, complete occupancy outcomes, unowned-entry preservation, safe native extensions, parse failures, no-op adoption, atomic failure behavior, and absence of server execution/authentication.
-- [ ] 6.5 Verify: Build and run unit plus dist e2e checks for all first-party adapters, including API `0.2` metadata and bundled parser availability.
+- [x] 6.1 Implement: Implement Claude Code batch prepare/apply for project `.mcp.json` and `mcpServers`, with read-only planning, native semantic equality, unrelated-state preservation, and atomic writes.
+- [x] 6.2 Implement: Implement OpenCode batch prepare/apply using existing `opencode.jsonc` when present, otherwise existing `opencode.json`, otherwise creating `opencode.jsonc`; when both exist, treat JSONC as canonical and leave JSON unchanged; reconcile the selected document's `mcp` map with JSONC-aware preservation, native semantic equality, and atomic writes.
+- [x] 6.3 Implement: Implement Codex batch prepare/apply for trusted-project `.codex/config.toml` and `mcp_servers` using the approved syntax-aware TOML strategy.
+- [x] 6.4 Implement: Add per-adapter fixtures and tests for stdio/HTTP translation, project-only scope, complete occupancy outcomes, unowned-entry preservation, safe native extensions, parse failures, no-op adoption, atomic failure behavior, and absence of server execution/authentication.
+- [x] 6.5 Verify: Build and run unit plus dist e2e checks for all first-party adapters, including API `0.2` metadata and bundled parser availability.
 
 ## 7. Project intent, composition, and receipt ownership — Research
 
-- [ ] 7.1 Explore: Trace project-manifest mutation, stale-override pruning, collision composition, resolved-facet data, and frozen consistency paths that currently iterate only asset groups.
-- [ ] 7.2 Explore: Trace receipt exact dispatch, ownership indexes, tri-write receipt construction, corruption handling, and removal witnesses across receipt versions `1`, `0.2`, and `0.3`.
+- [x] 7.1 Explore: Trace project-manifest mutation, stale-override pruning, collision composition, resolved-facet data, and frozen consistency paths that currently iterate only asset groups.
+- [x] 7.2 Explore: Trace receipt exact dispatch, ownership indexes, tri-write receipt construction, corruption handling, and removal witnesses across receipt versions `1`, `0.2`, and `0.3`.
 - [ ] 7.3 Propose: Define tagged server-intent, composition, ownership, and witnessed/unwitnessed receipt models that preserve the unified desired-state/write and receipt-only/delete rule.
 
 ## 8. Project intent, composition, and receipt ownership — Implementation

--- a/packages/adapter-test-kit/bunfig.toml
+++ b/packages/adapter-test-kit/bunfig.toml
@@ -1,0 +1,2 @@
+[test.reporter]
+junit = "../../test-results/adapter-test-kit-junit.xml"

--- a/packages/adapter-test-kit/package.json
+++ b/packages/adapter-test-kit/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@agent-facets/adapter-test-kit",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "types": "tsgo --noEmit",
+    "test": "bun test --pass-with-no-tests"
+  },
+  "devDependencies": {
+    "@agent-facets/adapter": "workspace:*"
+  }
+}

--- a/packages/adapter-test-kit/src/dist-contract.ts
+++ b/packages/adapter-test-kit/src/dist-contract.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import type { McpServerCapability } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+
+/**
+ * The contract every first-party adapter's published bundle must satisfy.
+ *
+ * The CLI loads `dist/index.mjs` directly, with no `node_modules` tree beside
+ * it, so a dependency that was not inlined is a runtime failure at install time
+ * rather than a build warning. These assertions are the tripwire for that.
+ */
+export interface AssertDistBundleOptions {
+  /** Absolute path to the built `dist/index.mjs`. */
+  readonly bundlePath: string
+  /** The adapter as imported from source, for the facts that survive re-import. */
+  readonly sourceAdapter: { readonly name: string }
+}
+
+export function assertDistBundleContract(options: AssertDistBundleOptions): void {
+  test('built bundle declares the canonical adapter API version', async () => {
+    const loaded = await loadAdapter(options.bundlePath)
+    expect(loaded.name).toBe(options.sourceAdapter.name)
+    expect(loaded.apiVersion).toBe(ADAPTER_API_VERSION)
+  })
+
+  test('built bundle carries a complete MCP server capability', async () => {
+    // Two module instances never share object identity, so the assertion is on
+    // shape — which is also exactly what the SDK's completeness check looks at.
+    const capability = await loadDistMcpCapability(options.bundlePath)
+    expect(typeof capability.prepare).toBe('function')
+    expect(typeof capability.apply).toBe('function')
+  })
+
+  test('built bundle resolves nothing outside Node builtins', async () => {
+    const source = await readFile(options.bundlePath, 'utf8')
+    // A real scan, not a regex: a bundled dependency can contain a template
+    // literal that reads like an import, and — more importantly — a CommonJS
+    // dependency whose lazy `require('./impl/...')` calls survived bundling
+    // looks fine until the moment that code path runs.
+    const specifiers = new Bun.Transpiler({ loader: 'js' }).scanImports(source)
+    const unresolvable = specifiers.filter((specifier) => !specifier.path.startsWith('node:'))
+    expect(unresolvable).toEqual([])
+  })
+}
+
+/**
+ * The MCP capability as the *bundle* exposes it, so a caller can exercise it
+ * against a document only an inlined parser could read.
+ */
+export async function loadDistMcpCapability(bundlePath: string): Promise<McpServerCapability<unknown>> {
+  const adapter = await loadAdapter(bundlePath)
+  const capability = adapter.mcpServers
+  if (typeof capability !== 'object' || capability === null) expect.unreachable()
+  return capability as McpServerCapability<unknown>
+}
+
+async function loadAdapter(bundlePath: string): Promise<{ name?: string; apiVersion?: string; mcpServers?: unknown }> {
+  const module = (await import(bundlePath)) as {
+    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
+  }
+  const adapter = module.default
+  if (adapter === undefined) expect.unreachable()
+  return adapter
+}

--- a/packages/adapter-test-kit/src/index.ts
+++ b/packages/adapter-test-kit/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared conformance fixtures for adapter capabilities.
+ *
+ * Workspace-only and test-only: nothing here is published, and no adapter's
+ * `src/index.ts` imports it, so it never reaches a built bundle. It exists so
+ * the three first-party adapters prove the *same* behavior rather than three
+ * hand-written approximations of it.
+ */
+export type { AssertDistBundleOptions } from './dist-contract.ts'
+export { assertDistBundleContract, loadDistMcpCapability } from './dist-contract.ts'
+export type { McpMatrixCase, McpMatrixCaseId, McpMatrixExpectation } from './mcp-matrix.ts'
+export {
+  EXTENDED_SERVER,
+  HTTP_SERVER,
+  MCP_MATRIX_CASES,
+  OBSOLETE_NAME,
+  STDIO_SERVER,
+  STDIO_SERVER_MINIMAL,
+  UNOWNED_NAME,
+} from './mcp-matrix.ts'
+export type { McpMatrixProject, McpMatrixSeed, RunMcpServerMatrixOptions } from './run-mcp-matrix.ts'
+export { runMcpServerMatrix } from './run-mcp-matrix.ts'

--- a/packages/adapter-test-kit/src/mcp-matrix.ts
+++ b/packages/adapter-test-kit/src/mcp-matrix.ts
@@ -1,0 +1,281 @@
+import type {
+  McpServerCapabilityFailure,
+  McpServerContribution,
+  McpServerPreparationOutcome,
+} from '@agent-facets/adapter'
+
+/**
+ * The behavioral fixture matrix every MCP-capable adapter must satisfy.
+ *
+ * The cases here are stated in portable terms only — desired declarations,
+ * prior ownership, and the outcomes those imply. What a document *looks like*
+ * is the one thing that cannot be shared between a JSON, a JSONC, and a TOML
+ * adapter, so each adapter supplies its own native seed per case and the
+ * expectations stay here.
+ *
+ * `satisfies Record<McpMatrixCaseId, ...>` on an adapter's seed table is what
+ * makes this work: adding a case here fails to compile in all three adapters
+ * until each one says what its document looks like. Coverage cannot silently
+ * drift apart, and the expectations cannot be quietly reworded per adapter.
+ */
+
+/** The stdio server used wherever a case needs one. */
+export const STDIO_SERVER: McpServerContribution = {
+  name: 'fs',
+  declaration: { type: 'stdio', command: 'srv', args: ['--root', '/w'], env: { TOKEN_NAME: 'A' } },
+}
+
+/** The same server with both optional collections omitted. */
+export const STDIO_SERVER_MINIMAL: McpServerContribution = {
+  name: 'fs',
+  declaration: { type: 'stdio', command: 'srv' },
+}
+
+/** The Streamable HTTP server used wherever a case needs one. */
+export const HTTP_SERVER: McpServerContribution = {
+  name: 'api',
+  declaration: { type: 'http', url: 'https://mcp.example.com/mcp' },
+}
+
+/** A server carrying a native member outside the portable model. */
+export const EXTENDED_SERVER: McpServerContribution = {
+  name: 'ext',
+  declaration: { type: 'stdio', command: 'ext-server', args: ['--new'] },
+}
+
+/** The name a seed uses for an entry that is neither desired nor owned. */
+export const UNOWNED_NAME = 'manual'
+
+/** The name a seed uses for an entry the project owns but no longer wants. */
+export const OBSOLETE_NAME = 'legacy'
+
+export type McpMatrixExpectation =
+  | {
+      readonly kind: 'prepared'
+      readonly outcomes: readonly McpServerPreparationOutcome[]
+      readonly apply: 'unchanged' | 'changed'
+    }
+  | { readonly kind: 'prepare-failed'; readonly code: McpServerCapabilityFailure['code'] }
+
+export interface McpMatrixCase {
+  readonly id: string
+  /** What the case is proving, used as the test name. */
+  readonly describes: string
+  readonly desired: readonly McpServerContribution[]
+  readonly previouslyOwnedNames: readonly string[]
+  readonly expect: McpMatrixExpectation
+}
+
+/**
+ * Every case, in a fixed order.
+ *
+ * Read the `describes` text as the requirement; the outcome list is the proof.
+ */
+export const MCP_MATRIX_CASES = [
+  {
+    id: 'document-absent',
+    describes: 'plans an addition against a document that does not exist yet, without creating it',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepared', outcomes: [{ kind: 'absent', name: 'fs', ownership: 'untracked' }], apply: 'changed' },
+  },
+  {
+    id: 'absent-untracked',
+    describes: 'adds a desired server the document does not define',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepared', outcomes: [{ kind: 'absent', name: 'fs', ownership: 'untracked' }], apply: 'changed' },
+  },
+  {
+    id: 'absent-tracked',
+    describes: 'recreates an owned entry that was deleted out of band',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: { kind: 'prepared', outcomes: [{ kind: 'absent', name: 'fs', ownership: 'tracked' }], apply: 'changed' },
+  },
+  {
+    id: 'equivalent-tracked',
+    describes: 'adopts an owned entry that already says what is wanted, without writing',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'equivalent', name: 'fs', ownership: 'tracked' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'equivalent-untracked',
+    describes: 'reports an equal entry the project does not own as untracked, so consent can be asked for',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'equivalent', name: 'fs', ownership: 'untracked' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'equivalent-normalized',
+    describes: 'treats an omitted optional collection and an empty one as the same thing',
+    desired: [STDIO_SERVER_MINIMAL],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'equivalent', name: 'fs', ownership: 'tracked' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'equivalent-formatting-only',
+    describes: 'ignores member order and formatting when proving equality',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'equivalent', name: 'fs', ownership: 'tracked' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'divergent-tracked',
+    describes: 'repairs an owned entry whose behavior drifted',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'divergent', name: 'fs', ownership: 'tracked' }],
+      apply: 'changed',
+    },
+  },
+  {
+    id: 'divergent-untracked',
+    describes: 'reports a differing entry the project does not own as an untracked takeover',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'divergent', name: 'fs', ownership: 'untracked' }],
+      apply: 'changed',
+    },
+  },
+  {
+    id: 'divergent-unprovable',
+    describes: 'fails safe when an entry carries a member whose effect on launch or connection is unknown',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'divergent', name: 'fs', ownership: 'tracked' }],
+      apply: 'changed',
+    },
+  },
+  {
+    id: 'safe-extension-preserved',
+    describes: 'keeps a behavior-neutral native member when rewriting an owned entry',
+    desired: [EXTENDED_SERVER],
+    previouslyOwnedNames: ['ext'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'divergent', name: 'ext', ownership: 'tracked' }],
+      apply: 'changed',
+    },
+  },
+  {
+    id: 'http-absent',
+    describes: 'renders a Streamable HTTP declaration natively',
+    desired: [HTTP_SERVER],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepared', outcomes: [{ kind: 'absent', name: 'api', ownership: 'untracked' }], apply: 'changed' },
+  },
+  {
+    id: 'http-equivalent',
+    describes: 'proves an existing Streamable HTTP entry equal to the desired URL',
+    desired: [HTTP_SERVER],
+    previouslyOwnedNames: ['api'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'equivalent', name: 'api', ownership: 'tracked' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'obsolete-owned-present',
+    describes: 'removes an owned entry the desired set no longer names',
+    desired: [],
+    previouslyOwnedNames: [OBSOLETE_NAME],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'obsolete-owned', name: OBSOLETE_NAME, occupancy: 'present' }],
+      apply: 'changed',
+    },
+  },
+  {
+    id: 'obsolete-owned-absent',
+    describes: 'reports an owned entry that is already gone so the claim can be dropped, and writes nothing',
+    desired: [],
+    previouslyOwnedNames: [OBSOLETE_NAME],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'obsolete-owned', name: OBSOLETE_NAME, occupancy: 'absent' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'unowned-entry-untouched',
+    describes: 'says nothing about, and does not touch, an entry that is neither desired nor owned',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'equivalent', name: 'fs', ownership: 'tracked' }],
+      apply: 'unchanged',
+    },
+  },
+  {
+    id: 'complete-batch',
+    describes: 'reports every occupancy in one preparation and commits them in a single write',
+    desired: [STDIO_SERVER, HTTP_SERVER],
+    previouslyOwnedNames: ['fs', OBSOLETE_NAME],
+    expect: {
+      kind: 'prepared',
+      outcomes: [
+        { kind: 'equivalent', name: 'fs', ownership: 'tracked' },
+        { kind: 'divergent', name: 'api', ownership: 'untracked' },
+        { kind: 'obsolete-owned', name: OBSOLETE_NAME, occupancy: 'present' },
+      ],
+      apply: 'changed',
+    },
+  },
+  {
+    id: 'unrelated-settings-preserved',
+    describes: 'leaves settings that have nothing to do with MCP alone',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepared', outcomes: [{ kind: 'absent', name: 'fs', ownership: 'untracked' }], apply: 'changed' },
+  },
+  {
+    id: 'nothing-desired-nothing-owned',
+    describes: 'still discloses the document it inspected when there is nothing to do',
+    desired: [],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepared', outcomes: [], apply: 'unchanged' },
+  },
+  {
+    id: 'malformed-document',
+    describes: 'reports a document it cannot parse and leaves it byte-for-byte alone',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepare-failed', code: 'parse-failed' },
+  },
+  {
+    id: 'invalid-server-map',
+    describes: 'refuses a server map whose shape it cannot safely edit',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: [],
+    expect: { kind: 'prepare-failed', code: 'validation-failed' },
+  },
+] as const satisfies readonly McpMatrixCase[]
+
+/** The identifier of every case in {@link MCP_MATRIX_CASES}. */
+export type McpMatrixCaseId = (typeof MCP_MATRIX_CASES)[number]['id']

--- a/packages/adapter-test-kit/src/run-mcp-matrix.ts
+++ b/packages/adapter-test-kit/src/run-mcp-matrix.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, isAbsolute, join, relative } from 'node:path'
+import type { McpServerCapability } from '@agent-facets/adapter'
+import { MCP_MATRIX_CASES, type McpMatrixCaseId } from './mcp-matrix.ts'
+
+/** The native document(s) a case starts from, keyed by path relative to the project root. */
+export interface McpMatrixSeed {
+  readonly files: Readonly<Record<string, string>>
+  /**
+   * Extra assertions once the case has run — the place to prove a comment
+   * survived, an unrelated setting is intact, or a native extension was
+   * carried forward. Only called when the case reached `apply`.
+   */
+  readonly after?: (project: McpMatrixProject) => void
+}
+
+export interface McpMatrixProject {
+  readonly root: string
+  /** The document's text now, or `null` if it does not exist. */
+  readonly read: (relativePath: string) => string | null
+  /** The document's text as the seed wrote it. */
+  readonly seeded: (relativePath: string) => string | null
+}
+
+export interface RunMcpServerMatrixOptions {
+  readonly capability: McpServerCapability<unknown>
+  readonly seeds: Readonly<Record<McpMatrixCaseId, McpMatrixSeed>>
+}
+
+/**
+ * Run the shared MCP fixture matrix against one adapter's capability.
+ *
+ * Beyond each case's own expectations, four invariants are asserted for every
+ * case — they are properties of the capability contract rather than of any
+ * individual fixture, so stating them per case would be noise that eventually
+ * gets forgotten on the one case that needed it:
+ *
+ * 1. `prepare` changes nothing on disk.
+ * 2. `documentPaths` is non-empty and stays inside the project.
+ * 3. Every changed path was disclosed by `documentPaths` first.
+ * 4. Nothing is spawned and nothing is fetched — configuring a server is not
+ *    running it.
+ */
+export function runMcpServerMatrix(options: RunMcpServerMatrixOptions): void {
+  describe('MCP server matrix', () => {
+    let root: string
+
+    beforeEach(() => {
+      // `realpathSync` because macOS hands out `/var/...` temp paths that
+      // resolve to `/private/var/...`; without it, comparing a disclosed
+      // document path against the project root is a suffix match at best.
+      root = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-matrix-')))
+    })
+
+    afterEach(() => {
+      rmSync(root, { recursive: true, force: true })
+    })
+
+    for (const matrixCase of MCP_MATRIX_CASES) {
+      const seed = options.seeds[matrixCase.id]
+
+      test(`${matrixCase.id}: ${matrixCase.describes}`, async () => {
+        for (const [relativePath, contents] of Object.entries(seed.files)) {
+          const file = join(root, relativePath)
+          mkdirSync(dirname(file), { recursive: true })
+          writeFileSync(file, contents)
+          // Back-date so a same-millisecond rewrite cannot masquerade as "no
+          // write" on a filesystem with coarse timestamps.
+          const past = new Date(Date.now() - 60_000)
+          utimesSync(file, past, past)
+        }
+
+        const seeded = snapshot(root)
+        const project: McpMatrixProject = {
+          root,
+          read: (relativePath) => readIfPresent(join(root, relativePath)),
+          seeded: (relativePath) => seeded.get(relativePath)?.text ?? null,
+        }
+
+        const restoreGuards = forbidExecutionAndNetwork()
+        try {
+          const preparation = await options.capability.prepare({
+            projectRoot: root,
+            desired: matrixCase.desired,
+            previouslyOwnedNames: matrixCase.previouslyOwnedNames,
+          })
+
+          expect(snapshot(root)).toEqual(seeded)
+
+          if (matrixCase.expect.kind === 'prepare-failed') {
+            if (preparation.ok) expect.unreachable()
+            expect(preparation.failure.code).toBe(matrixCase.expect.code)
+            return
+          }
+
+          if (!preparation.ok) expect.unreachable()
+          const { plan, documentPaths, outcomes } = preparation.preparation
+
+          expect(outcomes).toEqual(matrixCase.expect.outcomes)
+          expect(documentPaths.length).toBeGreaterThan(0)
+          for (const path of documentPaths) {
+            expect(isAbsolute(path)).toBe(true)
+            expect(relative(root, path).startsWith('..')).toBe(false)
+          }
+
+          const before = documentPaths.map((path) => [path, identity(path)] as const)
+
+          const applied = await options.capability.apply({ plan })
+          if (!applied.ok) expect.unreachable()
+          expect(applied.status).toBe(matrixCase.expect.apply)
+
+          if (applied.status === 'changed') {
+            for (const path of applied.changedPaths) {
+              expect(documentPaths).toContain(path)
+            }
+          } else {
+            // "Unchanged" is a claim about the filesystem, not just a label:
+            // an adapter that rewrote identical bytes would still change the
+            // inode, and one that touched the file would change the mtime.
+            for (const [path, snapshotBefore] of before) {
+              expect(identity(path)).toEqual(snapshotBefore)
+            }
+          }
+
+          seed.after?.(project)
+        } finally {
+          restoreGuards()
+        }
+      })
+    }
+  })
+}
+
+/** A document's write identity: absent, or its bytes plus inode and mtime. */
+type DocumentIdentity =
+  | { readonly present: false }
+  | { readonly present: true; readonly text: string; readonly ino: number; readonly mtimeMs: number }
+
+function identity(path: string): DocumentIdentity {
+  if (!existsSync(path)) return { present: false }
+  const stats = statSync(path)
+  return { present: true, text: readFileSync(path, 'utf8'), ino: stats.ino, mtimeMs: stats.mtimeMs }
+}
+
+function readIfPresent(path: string): string | null {
+  return existsSync(path) ? readFileSync(path, 'utf8') : null
+}
+
+/** Every file under `root`, so "prepare wrote nothing" can be asserted whole. */
+function snapshot(root: string): Map<string, { text: string }> {
+  const files = new Map<string, { text: string }>()
+  const walk = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        walk(absolute)
+      } else {
+        files.set(relative(root, absolute), { text: readFileSync(absolute, 'utf8') })
+      }
+    }
+  }
+  walk(root)
+  return files
+}
+
+/**
+ * Make launching a process or opening a connection fail loudly for the
+ * duration of a case. Materializing configuration must never do either.
+ */
+function forbidExecutionAndNetwork(): () => void {
+  const originalFetch = globalThis.fetch
+  const originalSpawn = Bun.spawn
+  const originalSpawnSync = Bun.spawnSync
+
+  const forbid = (what: string) => () => {
+    throw new Error(`MCP reconciliation must not ${what}`)
+  }
+
+  globalThis.fetch = forbid('open a network connection') as unknown as typeof globalThis.fetch
+  Bun.spawn = forbid('spawn a process') as unknown as typeof Bun.spawn
+  Bun.spawnSync = forbid('spawn a process') as unknown as typeof Bun.spawnSync
+
+  return () => {
+    globalThis.fetch = originalFetch
+    Bun.spawn = originalSpawn
+    Bun.spawnSync = originalSpawnSync
+  }
+}

--- a/packages/adapter-test-kit/tsconfig.json
+++ b/packages/adapter-test-kit/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Re-exported from `@agent-facets/common` (which the bundler inlines) so an
+ * adapter can satisfy the MCP capability's "one atomic update per document"
+ * requirement without hand-rolling tmp-then-rename or taking a dependency an
+ * adapter author would have to install separately.
+ */
+export { atomicWriteFileSync } from '@agent-facets/common'
 export type { AdapterApiVersion, AdapterApiVersionAssetsOnly } from './api-version.ts'
 export {
   ADAPTER_API_VERSION,
@@ -20,6 +27,8 @@ export {
   validateContainedRelativePath,
 } from './asset-fs.ts'
 export { defineAdapter } from './define-adapter.ts'
+export type { McpNativeMatch, ReconcileMcpServersInput } from './mcp-reconcile.ts'
+export { mcpDeclarationLiterals, mcpOutcomesRequireWrite, reconcileMcpServers } from './mcp-reconcile.ts'
 export type {
   ApplyMcpServersResult,
   McpServerCapability,

--- a/packages/adapter/src/mcp-reconcile.ts
+++ b/packages/adapter/src/mcp-reconcile.ts
@@ -1,0 +1,118 @@
+import type { McpServerContribution, McpServerDeclaration, McpServerPreparationOutcome } from './mcp-servers.ts'
+
+/**
+ * The format-independent half of MCP preparation.
+ *
+ * Every adapter answers the same three questions — which desired entries are
+ * missing, which already say what we want, and which owned entries are now
+ * obsolete — and the answers depend only on set membership plus one semantic
+ * comparison per present entry. Only that comparison is format-specific.
+ *
+ * Keeping the bookkeeping here means the ownership rule ("desired state
+ * authorizes reconciliation; receipt ownership alone authorizes deletion") is
+ * implemented once. An adapter cannot accidentally delete an entry it was
+ * never told it owned, because it is not the code deciding.
+ */
+
+/** The result of an adapter's native comparison at a name the document defines. */
+export type McpNativeMatch = 'equivalent' | 'divergent'
+
+export interface ReconcileMcpServersInput {
+  /** The complete desired set, in the order outcomes should be reported. */
+  readonly desired: readonly McpServerContribution[]
+  /** Effective names a prior successful operation recorded for this adapter. */
+  readonly previouslyOwnedNames: readonly string[]
+  /** Every effective server name the native document currently defines. */
+  readonly presentNames: ReadonlySet<string>
+  /**
+   * Compare one desired declaration against the entry the document already has
+   * under that name. Called only for names `presentNames` contains, at most
+   * once each — presence is decided here, not by the comparison, so the two
+   * cannot disagree.
+   *
+   * An adapter that cannot *prove* equality returns `divergent`: unprovable
+   * equality fails safe.
+   */
+  readonly compare: (contribution: McpServerContribution) => McpNativeMatch
+}
+
+/**
+ * Classify the complete desired set plus every obsolete owned name.
+ *
+ * Outcomes are returned in a deterministic order — desired entries in the
+ * order supplied, then obsolete owned names in the order supplied — so a
+ * caller rendering them produces stable output without sorting.
+ *
+ * A name that is neither desired nor owned produces no outcome at all. That
+ * silence is the contract: it is someone else's entry, and the adapter has
+ * nothing to say about it.
+ */
+export function reconcileMcpServers(input: ReconcileMcpServersInput): readonly McpServerPreparationOutcome[] {
+  const owned = new Set(input.previouslyOwnedNames)
+  const desiredNames = new Set(input.desired.map((contribution) => contribution.name))
+  const outcomes: McpServerPreparationOutcome[] = []
+
+  for (const contribution of input.desired) {
+    const ownership = owned.has(contribution.name) ? 'tracked' : 'untracked'
+
+    if (!input.presentNames.has(contribution.name)) {
+      outcomes.push({ kind: 'absent', name: contribution.name, ownership })
+      continue
+    }
+
+    outcomes.push({ kind: input.compare(contribution), name: contribution.name, ownership })
+  }
+
+  for (const name of input.previouslyOwnedNames) {
+    if (desiredNames.has(name)) continue
+    outcomes.push({
+      kind: 'obsolete-owned',
+      name,
+      occupancy: input.presentNames.has(name) ? 'present' : 'absent',
+    })
+  }
+
+  return outcomes
+}
+
+/**
+ * Every string a native rendering of this declaration must reproduce verbatim.
+ *
+ * Portable declarations are literal: nothing in them is expanded, interpolated,
+ * or normalized. Several target tools *do* interpolate their own configuration
+ * values, so an adapter has to check whether writing these literals would hand
+ * its tool something to substitute. This is the list to check — collected here
+ * so "which values are literal" is answered once, and an adapter that later
+ * gains a field cannot forget to scan it.
+ *
+ * Server names are excluded: they are constrained to a portable grammar that
+ * contains no interpolation syntax in any supported format.
+ */
+export function mcpDeclarationLiterals(declaration: McpServerDeclaration): readonly string[] {
+  if (declaration.type === 'http') return [declaration.url]
+  return [declaration.command, ...(declaration.args ?? []), ...Object.values(declaration.env ?? {})]
+}
+
+/**
+ * Whether applying these outcomes would change the document.
+ *
+ * Derived from the outcomes rather than tracked alongside them, so "we
+ * reported everything equivalent" and "we are about to write" cannot drift
+ * apart. `equivalent` is adopted without a write and an `obsolete-owned` entry
+ * that is already gone needs no write to stay gone.
+ */
+export function mcpOutcomesRequireWrite(outcomes: readonly McpServerPreparationOutcome[]): boolean {
+  return outcomes.some(outcomeRequiresWrite)
+}
+
+function outcomeRequiresWrite(outcome: McpServerPreparationOutcome): boolean {
+  switch (outcome.kind) {
+    case 'absent':
+    case 'divergent':
+      return true
+    case 'equivalent':
+      return false
+    case 'obsolete-owned':
+      return outcome.occupancy === 'present'
+  }
+}

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",
+    "@agent-facets/adapter-test-kit": "workspace:*",
     "arktype": "2.2.0",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3"

--- a/packages/adapters/claude-code/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/dist.e2e.test.ts
@@ -1,27 +1,38 @@
 /**
  * Packed-runtime coverage: the built `dist/index.mjs` (the exact artifact
- * published to npm and loaded by the CLI at install time) must carry the
- * SDK-stamped canonical adapter API version. Requires `bun run build`
- * first — wired via the `test:e2e` script.
+ * published to npm and loaded by the CLI at install time) must satisfy the
+ * adapter contract on its own, with no `node_modules` tree beside it.
+ * Requires `bun run build` first — wired via the `test:e2e` script.
  */
+
 import { expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { assertDistBundleContract, loadDistMcpCapability, STDIO_SERVER } from '@agent-facets/adapter-test-kit'
 import sourceAdapter from '../index.ts'
 
-test('built dist bundle declares the canonical adapter API version', async () => {
-  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
-  }
-  expect(module.default?.name).toBe(sourceAdapter.name)
-  expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
-})
+const bundlePath = join(import.meta.dir, '../../dist/index.mjs')
 
-test('built dist bundle states its MCP server support', async () => {
-  // The field is required by the API this bundle declares, so its presence
-  // is part of what makes the artifact loadable — not an optional extra.
-  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { mcpServers?: unknown }
+assertDistBundleContract({ bundlePath, sourceAdapter })
+
+test('bundled capability reads a native document', async () => {
+  const capability = await loadDistMcpCapability(bundlePath)
+  const root = mkdtempSync(join(tmpdir(), 'claude-code-dist-'))
+  try {
+    await Bun.write(join(root, '.mcp.json'), '{ "mcpServers": {} }\n')
+    const prepared = await capability.prepare({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!prepared.ok) expect.unreachable()
+    expect(prepared.preparation.outcomes).toEqual([{ kind: 'absent', name: 'fs', ownership: 'untracked' }])
+
+    const applied = await capability.apply({ plan: prepared.preparation.plan })
+    if (!applied.ok) expect.unreachable()
+    expect(JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf8')).mcpServers.fs.command).toBe('srv')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
   }
-  expect(module.default?.mcpServers).toBe(sourceAdapter.mcpServers)
 })

--- a/packages/adapters/claude-code/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/mcp-servers.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test'
+import type { McpServerCapability } from '@agent-facets/adapter'
+import {
+  type McpMatrixCaseId,
+  type McpMatrixSeed,
+  OBSOLETE_NAME,
+  runMcpServerMatrix,
+  UNOWNED_NAME,
+} from '@agent-facets/adapter-test-kit'
+import adapter from '../index.ts'
+import { claudeCodeMcpServers } from '../mcp-servers.ts'
+
+const DOCUMENT = '.mcp.json'
+
+/** The canonical native rendering of the matrix's stdio server. */
+const NATIVE_STDIO = '{ "type": "stdio", "command": "srv", "args": ["--root", "/w"], "env": { "TOKEN_NAME": "A" } }'
+
+/** The same launch written the way a person would, leaning on Claude Code's defaults. */
+const NATIVE_STDIO_IMPLICIT = '{ "command": "srv", "args": ["--root", "/w"], "env": { "TOKEN_NAME": "A" } }'
+
+const _NATIVE_HTTP = '{ "type": "http", "url": "https://mcp.example.com/mcp" }'
+
+const UNOWNED_ENTRY = '{ "command": "do-not-touch", "headersHelper": "print-secret" }'
+
+function document(body: string): string {
+  return `${body}\n`
+}
+
+function servers(entries: Record<string, string>): string {
+  const members = Object.entries(entries)
+    .map(([name, entry]) => `    "${name}": ${entry}`)
+    .join(',\n')
+  return document(`{\n  "mcpServers": {\n${members}\n  }\n}`)
+}
+
+const seeds = {
+  'document-absent': { files: {} },
+
+  'absent-untracked': { files: { [DOCUMENT]: servers({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+
+  'absent-tracked': { files: { [DOCUMENT]: servers({}) } },
+
+  'equivalent-tracked': { files: { [DOCUMENT]: servers({ fs: NATIVE_STDIO }) } },
+
+  'equivalent-untracked': { files: { [DOCUMENT]: servers({ fs: NATIVE_STDIO }) } },
+
+  // `type` omitted defaults to stdio, and an omitted `args`/`env` is the same
+  // as an empty one — the desired declaration for this case supplies neither.
+  'equivalent-normalized': { files: { [DOCUMENT]: servers({ fs: '{ "command": "srv", "args": [], "env": {} }' }) } },
+
+  'equivalent-formatting-only': {
+    files: { [DOCUMENT]: servers({ fs: NATIVE_STDIO_IMPLICIT }) },
+    after: (project) => {
+      // Nothing was written, so the hand-written spelling is still there.
+      expect(project.read(DOCUMENT)).toBe(project.seeded(DOCUMENT))
+    },
+  },
+
+  'divergent-tracked': { files: { [DOCUMENT]: servers({ fs: '{ "command": "stale" }' }) } },
+
+  'divergent-untracked': { files: { [DOCUMENT]: servers({ fs: '{ "command": "stale" }' }) } },
+
+  // Portable fields all match; `headers` decides how the connection
+  // authenticates, which a credential-free declaration cannot vouch for.
+  'divergent-unprovable': {
+    files: {
+      [DOCUMENT]: servers({
+        fs: '{ "type": "stdio", "command": "srv", "args": ["--root", "/w"], "env": { "TOKEN_NAME": "A" }, "headers": { "X": "y" } }',
+      }),
+    },
+    after: (project) => {
+      const after = project.read(DOCUMENT) ?? ''
+      expect(after).not.toContain('headers')
+    },
+  },
+
+  'safe-extension-preserved': {
+    files: { [DOCUMENT]: servers({ ext: '{ "command": "ext-server", "args": ["--old"], "timeout": 45000 }' }) },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(DOCUMENT) ?? '{}')
+      expect(parsed.mcpServers.ext).toEqual({
+        type: 'stdio',
+        command: 'ext-server',
+        args: ['--new'],
+        timeout: 45000,
+      })
+    },
+  },
+
+  'http-absent': { files: { [DOCUMENT]: servers({}) } },
+
+  // `streamable-http` is Claude Code's own alias for the same transport.
+  'http-equivalent': {
+    files: { [DOCUMENT]: servers({ api: '{ "type": "streamable-http", "url": "https://mcp.example.com/mcp" }' }) },
+  },
+
+  'obsolete-owned-present': {
+    files: { [DOCUMENT]: servers({ [OBSOLETE_NAME]: '{ "command": "gone" }', [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(DOCUMENT) ?? '{}')
+      expect(parsed.mcpServers).not.toHaveProperty(OBSOLETE_NAME)
+      expect(parsed.mcpServers[UNOWNED_NAME]).toEqual(JSON.parse(UNOWNED_ENTRY))
+    },
+  },
+
+  'obsolete-owned-absent': { files: { [DOCUMENT]: servers({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+
+  'unowned-entry-untouched': {
+    files: { [DOCUMENT]: servers({ fs: NATIVE_STDIO, [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    after: (project) => {
+      expect(project.read(DOCUMENT)).toBe(project.seeded(DOCUMENT))
+    },
+  },
+
+  'complete-batch': {
+    files: {
+      [DOCUMENT]: servers({
+        fs: NATIVE_STDIO,
+        api: '{ "type": "http", "url": "https://elsewhere.example.com/mcp" }',
+        [OBSOLETE_NAME]: '{ "command": "gone" }',
+        [UNOWNED_NAME]: UNOWNED_ENTRY,
+      }),
+    },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(DOCUMENT) ?? '{}')
+      expect(Object.keys(parsed.mcpServers).sort()).toEqual(['api', 'fs', UNOWNED_NAME].sort())
+      expect(parsed.mcpServers.api).toEqual({ type: 'http', url: 'https://mcp.example.com/mcp' })
+    },
+  },
+
+  'unrelated-settings-preserved': {
+    files: { [DOCUMENT]: document('{\n  "$schema": "https://example.com/mcp.json",\n  "mcpServers": {}\n}') },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(DOCUMENT) ?? '{}')
+      expect(parsed.$schema).toBe('https://example.com/mcp.json')
+    },
+  },
+
+  'nothing-desired-nothing-owned': { files: { [DOCUMENT]: servers({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+
+  // A comment makes this a document Claude Code itself refuses to read, so
+  // reporting it beats silently "repairing" a file the tool was ignoring.
+  'malformed-document': { files: { [DOCUMENT]: document('{\n  // servers\n  "mcpServers": {}\n}') } },
+
+  // An array would accept string keys in memory and lose them on serialization.
+  'invalid-server-map': { files: { [DOCUMENT]: document('{ "mcpServers": [] }') } },
+} satisfies Record<McpMatrixCaseId, McpMatrixSeed>
+
+runMcpServerMatrix({ capability: claudeCodeMcpServers, seeds })
+
+describe('claude-code MCP capability', () => {
+  test('is declared on the adapter', () => {
+    expect(adapter.mcpServers).toBe(claudeCodeMcpServers)
+  })
+
+  test('rejects a plan it did not produce', async () => {
+    // The engine holds the plan as `unknown`, so this is the shape an untyped
+    // caller can actually reach `apply` with.
+    const asEngineSeesIt: McpServerCapability<unknown> = claudeCodeMcpServers
+    await expect(asEngineSeesIt.apply({ plan: { kind: 'nonsense' } })).rejects.toThrow('did not produce')
+  })
+})

--- a/packages/adapters/claude-code/src/index.ts
+++ b/packages/adapters/claude-code/src/index.ts
@@ -15,6 +15,7 @@ import {
   type SkillBundlePaths,
 } from '@agent-facets/adapter'
 import { type } from 'arktype'
+import { claudeCodeMcpServers } from './mcp-servers.ts'
 
 /** Claude Code per-asset metadata schema */
 const ClaudeCodeMetadataSchema = type({
@@ -30,9 +31,7 @@ export default defineAdapter({
   name: 'claude-code',
   supportsInstall: true,
 
-  // Native MCP reconciliation lands in a later task of this change; declaring
-  // it explicitly is the point of the required field.
-  mcpServers: false,
+  mcpServers: claudeCodeMcpServers,
 
   buildAssetMetadata(data) {
     const result = ClaudeCodeMetadataSchema(data)

--- a/packages/adapters/claude-code/src/mcp-servers.ts
+++ b/packages/adapters/claude-code/src/mcp-servers.ts
@@ -1,0 +1,405 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  type ApplyMcpServersResult,
+  atomicWriteFileSync,
+  errorMessage,
+  isMissingFileError,
+  type McpNativeMatch,
+  type McpServerCapability,
+  type McpServerContribution,
+  type McpServerDeclaration,
+  mcpOutcomesRequireWrite,
+  type PrepareMcpServersRequest,
+  type PrepareMcpServersResult,
+  reconcileMcpServers,
+} from '@agent-facets/adapter'
+
+/**
+ * Claude Code MCP server reconciliation.
+ *
+ * ## The document
+ *
+ * Claude Code reads project-scoped servers from `<projectRoot>/.mcp.json`
+ * under a top-level `mcpServers` map. That file — and only that file — is what
+ * this capability touches. Claude Code also merges a local scope out of
+ * `~/.claude.json` and a user scope beside it, but user-wide configuration is
+ * explicitly out of bounds, so an entry written here can still be shadowed by
+ * one a user set locally. That is the user's decision to make and not ours to
+ * silently override.
+ *
+ * ## Why strict JSON
+ *
+ * `.mcp.json` is parsed by Claude Code with `JSON.parse`. A comment or a
+ * trailing comma is not a stylistic choice this adapter should tolerate — it is
+ * a file Claude Code itself rejects, so reporting `parse-failed` tells the user
+ * something true and actionable rather than silently "fixing" a document the
+ * tool was already ignoring. That also means there is no comment-preservation
+ * problem here and no parser dependency: parse, mutate the keys we own,
+ * re-serialize in the document's own indentation and line endings.
+ */
+
+/** The only document this capability reads or writes. */
+const DOCUMENT_NAME = '.mcp.json'
+
+/** The top-level member Claude Code reads project servers from. */
+const SERVER_MAP_KEY = 'mcpServers'
+
+/**
+ * Members of a native entry that are outside the portable model but do not
+ * change how the server is launched or connected to, so they survive an update
+ * to an entry the project already owns.
+ *
+ * `timeout` and `alwaysLoad` tune startup and tool-search behavior; `role`,
+ * `tools`, and `toolPermissions` narrow which tools Claude Code surfaces. None
+ * of them decides what process runs or what endpoint is dialed.
+ *
+ * Conspicuously absent: `headers`, `headersHelper`, and `oauth`. Those decide
+ * how a connection authenticates — `headersHelper` literally runs a shell
+ * command — so an entry carrying one cannot be proven equal to a portable
+ * declaration that carries no credentials at all.
+ */
+const SAFE_EXTENSION_KEYS: ReadonlySet<string> = new Set(['timeout', 'alwaysLoad', 'role', 'tools', 'toolPermissions'])
+
+/** Members this adapter owns outright, per transport. */
+const PORTABLE_KEYS: Readonly<Record<'stdio' | 'http', ReadonlySet<string>>> = {
+  stdio: new Set(['type', 'command', 'args', 'env']),
+  http: new Set(['type', 'url']),
+}
+
+/**
+ * The prepared plan.
+ *
+ * `expected` is the document's exact prior text, or `null` when it did not
+ * exist. `apply` re-reads and compares before writing, so a document a user (or
+ * Claude Code) changed in the window between planning and committing is
+ * reported as a conflict rather than silently overwritten with a plan built
+ * from stale bytes.
+ */
+type ClaudeMcpPlan =
+  | { readonly kind: 'unchanged'; readonly path: string }
+  | { readonly kind: 'write'; readonly path: string; readonly expected: string | null; readonly contents: string }
+
+/** How the document is laid out, so a rewrite looks like the file we read. */
+interface DocumentFormat {
+  readonly indent: string
+  readonly newline: string
+  readonly trailingNewline: boolean
+  readonly bom: boolean
+}
+
+const DEFAULT_FORMAT: DocumentFormat = { indent: '  ', newline: '\n', trailingNewline: true, bom: false }
+
+export const claudeCodeMcpServers: McpServerCapability<ClaudeMcpPlan> = {
+  async prepare(request: PrepareMcpServersRequest): Promise<PrepareMcpServersResult<ClaudeMcpPlan>> {
+    const path = join(request.projectRoot, DOCUMENT_NAME)
+
+    let text: string | null
+    try {
+      text = await readFile(path, 'utf8')
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        return { ok: false, failure: { code: 'io-failed', operation: 'read', path, message: errorMessage(err) } }
+      }
+      text = null
+    }
+
+    let document: Record<string, unknown>
+    let format: DocumentFormat
+    if (text === null) {
+      document = {}
+      format = DEFAULT_FORMAT
+    } else {
+      const parsed = parseDocument(text)
+      if (!parsed.ok) {
+        return { ok: false, failure: { ...parsed.failure, path } }
+      }
+      document = parsed.document
+      format = parsed.format
+    }
+
+    const rawServers = document[SERVER_MAP_KEY]
+    if (rawServers !== undefined && !isPlainObject(rawServers)) {
+      return {
+        ok: false,
+        failure: {
+          code: 'validation-failed',
+          path,
+          message: `"${SERVER_MAP_KEY}" must be an object mapping server names to entries`,
+        },
+      }
+    }
+    const servers: Record<string, unknown> = rawServers ?? {}
+
+    const outcomes = reconcileMcpServers({
+      desired: request.desired,
+      previouslyOwnedNames: request.previouslyOwnedNames,
+      presentNames: new Set(Object.keys(servers)),
+      compare: (contribution) => compareEntry(servers[contribution.name], contribution.declaration),
+    })
+
+    if (!mcpOutcomesRequireWrite(outcomes)) {
+      return { ok: true, preparation: { plan: { kind: 'unchanged', path }, documentPaths: [path], outcomes } }
+    }
+
+    const tracked = new Set(request.previouslyOwnedNames)
+    const desiredByName = new Map(request.desired.map((contribution) => [contribution.name, contribution]))
+
+    for (const outcome of outcomes) {
+      switch (outcome.kind) {
+        case 'equivalent':
+          break
+        case 'absent':
+        case 'divergent': {
+          const contribution = desiredByName.get(outcome.name) as McpServerContribution
+          // Native extras are carried forward only for an entry the project
+          // already owns. At an untracked destination the user is consenting to
+          // a takeover, not to inheriting settings we cannot vouch for.
+          const preserved =
+            outcome.kind === 'divergent' && tracked.has(outcome.name)
+              ? preservableExtensions(servers[outcome.name], contribution.declaration)
+              : {}
+          servers[outcome.name] = renderEntry(contribution.declaration, preserved)
+          break
+        }
+        case 'obsolete-owned':
+          delete servers[outcome.name]
+          break
+      }
+    }
+
+    // Assigning the map back matters only when the document had no `mcpServers`
+    // member; when it did, `servers` is that same object and this is a no-op
+    // that keeps its position among the document's other members.
+    document[SERVER_MAP_KEY] = servers
+
+    return {
+      ok: true,
+      preparation: {
+        plan: { kind: 'write', path, expected: text, contents: serializeDocument(document, format) },
+        documentPaths: [path],
+        outcomes,
+      },
+    }
+  },
+
+  async apply(request: { readonly plan: unknown }): Promise<ApplyMcpServersResult> {
+    const plan = asPlan(request.plan)
+
+    if (plan.kind === 'unchanged') {
+      return { ok: true, status: 'unchanged' }
+    }
+
+    let current: string | null
+    try {
+      current = await readFile(plan.path, 'utf8')
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        return {
+          ok: false,
+          failure: { code: 'io-failed', operation: 'read', path: plan.path, message: errorMessage(err) },
+        }
+      }
+      current = null
+    }
+
+    if (current !== plan.expected) {
+      return {
+        ok: false,
+        failure: {
+          code: 'conflict',
+          path: plan.path,
+          message: `${DOCUMENT_NAME} changed after it was inspected; nothing was written`,
+        },
+      }
+    }
+
+    try {
+      atomicWriteFileSync(plan.path, plan.contents)
+    } catch (err) {
+      return {
+        ok: false,
+        failure: { code: 'io-failed', operation: 'write', path: plan.path, message: errorMessage(err) },
+      }
+    }
+
+    return { ok: true, status: 'changed', changedPaths: [plan.path] }
+  },
+}
+
+/**
+ * Narrow the opaque plan the engine handed back.
+ *
+ * The engine's contract is to return exactly what `prepare` produced, so a
+ * value that fails this check is a violated invariant rather than a condition a
+ * caller could handle — the one case where throwing is the honest answer.
+ */
+function asPlan(value: unknown): ClaudeMcpPlan {
+  if (isPlainObject(value)) {
+    if (value.kind === 'unchanged' && typeof value.path === 'string') {
+      return { kind: 'unchanged', path: value.path }
+    }
+    if (
+      value.kind === 'write' &&
+      typeof value.path === 'string' &&
+      typeof value.contents === 'string' &&
+      (value.expected === null || typeof value.expected === 'string')
+    ) {
+      return { kind: 'write', path: value.path, expected: value.expected, contents: value.contents }
+    }
+  }
+  throw new Error('claude-code: apply() received a plan this adapter did not produce')
+}
+
+type ParseDocumentResult =
+  | { readonly ok: true; readonly document: Record<string, unknown>; readonly format: DocumentFormat }
+  | { readonly ok: false; readonly failure: { readonly code: 'parse-failed' | 'validation-failed'; message: string } }
+
+function parseDocument(text: string): ParseDocumentResult {
+  const bom = text.charCodeAt(0) === 0xfeff
+  const body = bom ? text.slice(1) : text
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch (err) {
+    return { ok: false, failure: { code: 'parse-failed', message: errorMessage(err) } }
+  }
+
+  if (!isPlainObject(parsed)) {
+    return { ok: false, failure: { code: 'validation-failed', message: 'document root must be a JSON object' } }
+  }
+
+  return { ok: true, document: parsed, format: detectFormat(body, bom) }
+}
+
+function detectFormat(body: string, bom: boolean): DocumentFormat {
+  const newline = body.includes('\r\n') ? '\r\n' : '\n'
+  const indentMatch = body.match(/\n([ \t]+)\S/)
+  return {
+    indent: indentMatch?.[1] ?? DEFAULT_FORMAT.indent,
+    newline,
+    trailingNewline: /\r?\n\s*$/.test(body),
+    bom,
+  }
+}
+
+function serializeDocument(document: Record<string, unknown>, format: DocumentFormat): string {
+  let text = JSON.stringify(document, null, format.indent)
+  if (format.newline !== '\n') {
+    text = text.replaceAll('\n', format.newline)
+  }
+  if (format.trailingNewline) {
+    text += format.newline
+  }
+  return format.bom ? `\uFEFF${text}` : text
+}
+
+/**
+ * Compare an existing native entry with the rendering of a desired
+ * declaration.
+ *
+ * Everything that is not proof of equality is `divergent` — a shape this
+ * adapter does not recognize, a transport it cannot classify, or an extra
+ * member outside the safe set all fail closed rather than adopting an entry
+ * whose behavior we would be guessing at.
+ */
+function compareEntry(existing: unknown, declaration: McpServerDeclaration): McpNativeMatch {
+  if (!isPlainObject(existing)) return 'divergent'
+
+  const transport = effectiveTransport(existing)
+  if (transport !== declaration.type) return 'divergent'
+
+  if (declaration.type === 'stdio') {
+    if (existing.command !== declaration.command) return 'divergent'
+    if (!sameStringArray(existing.args, declaration.args ?? [])) return 'divergent'
+    if (!sameStringRecord(existing.env, declaration.env ?? {})) return 'divergent'
+  } else if (existing.url !== declaration.url) {
+    return 'divergent'
+  }
+
+  // A member we do not own and cannot vouch for could change behavior in a way
+  // this comparison did not model, so its mere presence defeats the proof.
+  const portable = PORTABLE_KEYS[declaration.type]
+  for (const key of Object.keys(existing)) {
+    if (portable.has(key)) continue
+    if (!SAFE_EXTENSION_KEYS.has(key)) return 'divergent'
+  }
+
+  return 'equivalent'
+}
+
+/**
+ * The transport an existing entry actually uses.
+ *
+ * Claude Code's stdio arm leaves `type` optional, and accepts both `http` and
+ * `streamable-http` for the same Streamable HTTP transport — a hand-written or
+ * copy-pasted entry that spells either of those is not a difference worth
+ * prompting about. Anything else (`sse`, `ws`, an unknown tag) is a transport
+ * this adapter does not model, and reports as such.
+ */
+function effectiveTransport(existing: Record<string, unknown>): 'stdio' | 'http' | 'unknown' {
+  const declared = existing.type
+  if (declared === undefined) return 'stdio'
+  if (declared === 'stdio') return 'stdio'
+  if (declared === 'http' || declared === 'streamable-http') return 'http'
+  return 'unknown'
+}
+
+/** The safe native members of an existing entry, when its transport is unchanged. */
+function preservableExtensions(existing: unknown, declaration: McpServerDeclaration): Record<string, unknown> {
+  if (!isPlainObject(existing)) return {}
+  // Across a transport change the whole entry is replaced: an http-only tool
+  // allowlist means nothing on a stdio entry.
+  if (effectiveTransport(existing) !== declaration.type) return {}
+
+  const preserved: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(existing)) {
+    if (SAFE_EXTENSION_KEYS.has(key)) preserved[key] = value
+  }
+  return preserved
+}
+
+/**
+ * Render a portable declaration in Claude Code's native shape.
+ *
+ * `args` and `env` are emitted only when non-empty: an omitted optional
+ * collection and an empty one mean the same thing, and the shorter form is what
+ * `claude mcp add` writes.
+ */
+function renderEntry(declaration: McpServerDeclaration, preserved: Record<string, unknown>): Record<string, unknown> {
+  const entry: Record<string, unknown> = { type: declaration.type }
+
+  if (declaration.type === 'stdio') {
+    entry.command = declaration.command
+    if (declaration.args !== undefined && declaration.args.length > 0) entry.args = [...declaration.args]
+    if (declaration.env !== undefined && Object.keys(declaration.env).length > 0) entry.env = { ...declaration.env }
+  } else {
+    entry.url = declaration.url
+  }
+
+  for (const [key, value] of Object.entries(preserved)) {
+    entry[key] = value
+  }
+
+  return entry
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sameStringArray(value: unknown, expected: readonly string[]): boolean {
+  if (value === undefined) return expected.length === 0
+  if (!Array.isArray(value) || value.length !== expected.length) return false
+  return value.every((item, index) => item === expected[index])
+}
+
+function sameStringRecord(value: unknown, expected: Readonly<Record<string, string>>): boolean {
+  const expectedKeys = Object.keys(expected)
+  if (value === undefined) return expectedKeys.length === 0
+  if (!isPlainObject(value)) return false
+  const keys = Object.keys(value)
+  if (keys.length !== expectedKeys.length) return false
+  return keys.every((key) => value[key] === expected[key])
+}

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -23,6 +23,8 @@
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",
+    "@agent-facets/adapter-test-kit": "workspace:*",
+    "@decimalturn/toml-patch": "^3.0.1",
     "arktype": "2.2.0",
     "smol-toml": "^1.7.0",
     "tsdown": "^0.22.3",

--- a/packages/adapters/codex/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/codex/src/__tests__/dist.e2e.test.ts
@@ -1,27 +1,42 @@
 /**
  * Packed-runtime coverage: the built `dist/index.mjs` (the exact artifact
- * published to npm and loaded by the CLI at install time) must carry the
- * SDK-stamped canonical adapter API version. Requires `bun run build`
- * first — wired via the `test:e2e` script.
+ * published to npm and loaded by the CLI at install time) must satisfy the
+ * adapter contract on its own, with no `node_modules` tree beside it.
+ * Requires `bun run build` first — wired via the `test:e2e` script.
  */
+
 import { expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { assertDistBundleContract, loadDistMcpCapability, STDIO_SERVER } from '@agent-facets/adapter-test-kit'
 import sourceAdapter from '../index.ts'
 
-test('built dist bundle declares the canonical adapter API version', async () => {
-  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
-  }
-  expect(module.default?.name).toBe(sourceAdapter.name)
-  expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
-})
+const bundlePath = join(import.meta.dir, '../../dist/index.mjs')
 
-test('built dist bundle states its MCP server support', async () => {
-  // The field is required by the API this bundle declares, so its presence
-  // is part of what makes the artifact loadable — not an optional extra.
-  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { mcpServers?: unknown }
+assertDistBundleContract({ bundlePath, sourceAdapter })
+
+test('bundled TOML editor preserves comments after bundling', async () => {
+  const capability = await loadDistMcpCapability(bundlePath)
+  const root = mkdtempSync(join(tmpdir(), 'codex-dist-'))
+  const configPath = join(root, '.codex', 'config.toml')
+  try {
+    await Bun.write(configPath, '# keep me\nmodel = "gpt-5.6"\n')
+    const prepared = await capability.prepare({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!prepared.ok) expect.unreachable()
+    const applied = await capability.apply({ plan: prepared.preparation.plan })
+    if (!applied.ok) expect.unreachable()
+
+    // A value-model TOML round trip would have dropped this comment; only the
+    // inlined syntax-aware editor keeps it.
+    const after = readFileSync(configPath, 'utf8')
+    expect(after).toContain('# keep me')
+    expect(after).toContain('[mcp_servers.fs]')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
   }
-  expect(module.default?.mcpServers).toBe(sourceAdapter.mcpServers)
 })

--- a/packages/adapters/codex/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/codex/src/__tests__/mcp-servers.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { McpServerCapability } from '@agent-facets/adapter'
+import {
+  type McpMatrixCaseId,
+  type McpMatrixSeed,
+  OBSOLETE_NAME,
+  runMcpServerMatrix,
+  STDIO_SERVER,
+  UNOWNED_NAME,
+} from '@agent-facets/adapter-test-kit'
+import { parse as parseToml } from 'smol-toml'
+import adapter from '../index.ts'
+import { codexMcpServers } from '../mcp-servers.ts'
+
+const DOCUMENT = '.codex/config.toml'
+
+/** Codex has no transport tag: a `command` is stdio, a `url` is Streamable HTTP. */
+const NATIVE_STDIO = `[mcp_servers.fs]
+command = "srv"
+args = ["--root", "/w"]
+env = { TOKEN_NAME = "A" }
+`
+
+const NATIVE_HTTP = `[mcp_servers.api]
+url = "https://mcp.example.com/mcp"
+`
+
+const UNOWNED_ENTRY = `[mcp_servers.${UNOWNED_NAME}]
+command = "do-not-touch"
+bearer_token_env_var = "SECRET"
+`
+
+const seeds = {
+  'document-absent': { files: {} },
+
+  'absent-untracked': { files: { [DOCUMENT]: UNOWNED_ENTRY } },
+
+  'absent-tracked': { files: { [DOCUMENT]: '[mcp_servers]\n' } },
+
+  'equivalent-tracked': { files: { [DOCUMENT]: NATIVE_STDIO } },
+
+  'equivalent-untracked': { files: { [DOCUMENT]: NATIVE_STDIO } },
+
+  'equivalent-normalized': { files: { [DOCUMENT]: '[mcp_servers.fs]\ncommand = "srv"\nargs = []\nenv = {}\n' } },
+
+  // Dotted keys, an inline table, and a quoted table name all denote the same
+  // TOML value as the canonical spelling.
+  'equivalent-formatting-only': {
+    files: {
+      [DOCUMENT]: `# hand-written
+[mcp_servers."fs"]
+env = { TOKEN_NAME = "A" }
+args = [
+  "--root",
+  "/w",
+]
+command = "srv"
+`,
+    },
+    after: (project) => {
+      expect(project.read(DOCUMENT)).toBe(project.seeded(DOCUMENT))
+    },
+  },
+
+  'divergent-tracked': { files: { [DOCUMENT]: '[mcp_servers.fs]\ncommand = "stale"\n' } },
+
+  'divergent-untracked': { files: { [DOCUMENT]: '[mcp_servers.fs]\ncommand = "stale"\n' } },
+
+  // Portable fields match, but the entry names an environment variable to
+  // authenticate with — a credential-free declaration cannot prove it equal.
+  'divergent-unprovable': {
+    files: {
+      [DOCUMENT]: `${NATIVE_STDIO}bearer_token_env_var = "SECRET"\n`,
+    },
+    after: (project) => {
+      expect(project.read(DOCUMENT) ?? '').not.toContain('bearer_token_env_var = "SECRET"\n[')
+    },
+  },
+
+  'safe-extension-preserved': {
+    files: {
+      [DOCUMENT]: `[mcp_servers.ext]
+command = "ext-server"
+args = ["--old"]
+startup_timeout_sec = 10.0
+`,
+    },
+    after: (project) => {
+      const after = project.read(DOCUMENT) ?? ''
+      // The float notation matters: Codex deserializes this field as an f64,
+      // and an integer `10` would be rejected.
+      expect(after).toContain('startup_timeout_sec = 10.0')
+      const parsed = parseToml(after) as { mcp_servers: Record<string, unknown> }
+      expect(parsed.mcp_servers.ext).toEqual({ command: 'ext-server', args: ['--new'], startup_timeout_sec: 10 })
+    },
+  },
+
+  'http-absent': { files: { [DOCUMENT]: '[mcp_servers]\n' } },
+
+  'http-equivalent': { files: { [DOCUMENT]: NATIVE_HTTP } },
+
+  'obsolete-owned-present': {
+    files: { [DOCUMENT]: `[mcp_servers.${OBSOLETE_NAME}]\ncommand = "gone"\n\n${UNOWNED_ENTRY}` },
+    after: (project) => {
+      const parsed = parseToml(project.read(DOCUMENT) ?? '') as { mcp_servers: Record<string, unknown> }
+      expect(parsed.mcp_servers).not.toHaveProperty(OBSOLETE_NAME)
+      expect(parsed.mcp_servers[UNOWNED_NAME]).toEqual({ command: 'do-not-touch', bearer_token_env_var: 'SECRET' })
+    },
+  },
+
+  'obsolete-owned-absent': { files: { [DOCUMENT]: UNOWNED_ENTRY } },
+
+  'unowned-entry-untouched': {
+    files: { [DOCUMENT]: `${NATIVE_STDIO}\n${UNOWNED_ENTRY}` },
+    after: (project) => {
+      expect(project.read(DOCUMENT)).toBe(project.seeded(DOCUMENT))
+    },
+  },
+
+  'complete-batch': {
+    files: {
+      [DOCUMENT]: `${NATIVE_STDIO}
+[mcp_servers.api]
+url = "https://elsewhere.example.com/mcp"
+
+[mcp_servers.${OBSOLETE_NAME}]
+command = "gone"
+
+${UNOWNED_ENTRY}`,
+    },
+    after: (project) => {
+      const parsed = parseToml(project.read(DOCUMENT) ?? '') as { mcp_servers: Record<string, unknown> }
+      expect(Object.keys(parsed.mcp_servers).sort()).toEqual(['api', 'fs', UNOWNED_NAME].sort())
+      expect(parsed.mcp_servers.api).toEqual({ url: 'https://mcp.example.com/mcp' })
+    },
+  },
+
+  'unrelated-settings-preserved': {
+    files: {
+      [DOCUMENT]: `# Codex configuration
+model = "gpt-5.6"            # keep this trailing comment
+project_doc_max_bytes = 32768
+`,
+    },
+    after: (project) => {
+      const after = project.read(DOCUMENT) ?? ''
+      expect(after).toContain('# Codex configuration')
+      expect(after).toContain('model = "gpt-5.6"            # keep this trailing comment')
+      // An integer stays an integer: re-emitting `32768.0` would be just as
+      // wrong as turning a float into an integer.
+      expect(after).toContain('project_doc_max_bytes = 32768\n')
+    },
+  },
+
+  'nothing-desired-nothing-owned': { files: { [DOCUMENT]: UNOWNED_ENTRY } },
+
+  'malformed-document': { files: { [DOCUMENT]: 'not = [valid\n' } },
+
+  'invalid-server-map': { files: { [DOCUMENT]: 'mcp_servers = "not a table"\n' } },
+} satisfies Record<McpMatrixCaseId, McpMatrixSeed>
+
+runMcpServerMatrix({ capability: codexMcpServers, seeds })
+
+describe('codex config.toml editing', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'codex-mcp-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  /**
+   * The comment-bearing round-trip proof. One tracked entry is updated; every
+   * other byte of a hand-written config has to come back untouched — which a
+   * parse-then-stringify TOML round trip cannot do.
+   */
+  test('updates one entry and leaves the rest of a hand-written config byte-for-byte', async () => {
+    const configPath = join(root, DOCUMENT)
+    const before = `# Codex config — hand-written
+model = "gpt-5.6"            # keep this trailing comment
+project_doc_max_bytes = 32768
+
+[mcp_servers]
+
+# Hand-configured; Facets must not touch this one.
+[mcp_servers.manual]
+command = "manual-server"
+startup_timeout_sec = 12.5
+
+[mcp_servers.docs]
+command = "old-server"
+startup_timeout_sec = 10.0   # native extension: must survive the update
+`
+    await Bun.write(configPath, before)
+
+    const prepared = await codexMcpServers.prepare({
+      projectRoot: root,
+      desired: [{ name: 'docs', declaration: { type: 'stdio', command: 'docs-server', args: ['--port', '4000'] } }],
+      previouslyOwnedNames: ['docs'],
+    })
+    if (!prepared.ok) expect.unreachable()
+    const applied = await codexMcpServers.apply({ plan: prepared.preparation.plan })
+    if (!applied.ok) expect.unreachable()
+    expect(applied.status).toBe('changed')
+
+    expect(readFileSync(configPath, 'utf8')).toBe(`# Codex config — hand-written
+model = "gpt-5.6"            # keep this trailing comment
+project_doc_max_bytes = 32768
+
+[mcp_servers]
+
+# Hand-configured; Facets must not touch this one.
+[mcp_servers.manual]
+command = "manual-server"
+startup_timeout_sec = 12.5
+
+[mcp_servers.docs]
+command = "docs-server"
+startup_timeout_sec = 10.0   # native extension: must survive the update
+args = [ "--port", "4000" ]
+`)
+  })
+
+  test('creates the .codex directory only when committing, never while planning', async () => {
+    const prepared = await codexMcpServers.prepare({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!prepared.ok) expect.unreachable()
+    expect(existsSync(join(root, '.codex'))).toBe(false)
+
+    const applied = await codexMcpServers.apply({ plan: prepared.preparation.plan })
+    if (!applied.ok) expect.unreachable()
+    expect(statSync(join(root, '.codex')).isDirectory()).toBe(true)
+  })
+
+  test('reports a document that changed after planning rather than overwriting it', async () => {
+    const configPath = join(root, DOCUMENT)
+    await Bun.write(configPath, '[mcp_servers]\n')
+
+    const prepared = await codexMcpServers.prepare({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!prepared.ok) expect.unreachable()
+
+    await Bun.write(configPath, '[mcp_servers]\n# somebody else got here first\n')
+    const applied = await codexMcpServers.apply({ plan: prepared.preparation.plan })
+
+    if (applied.ok) expect.unreachable()
+    expect(applied.failure.code).toBe('conflict')
+    expect(readFileSync(configPath, 'utf8')).toBe('[mcp_servers]\n# somebody else got here first\n')
+  })
+})
+
+describe('codex MCP capability', () => {
+  test('is declared on the adapter', () => {
+    expect(adapter.mcpServers).toBe(codexMcpServers)
+  })
+
+  test('rejects a plan it did not produce', async () => {
+    // The engine holds the plan as `unknown`, so this is the shape an untyped
+    // caller can actually reach `apply` with.
+    const asEngineSeesIt: McpServerCapability<unknown> = codexMcpServers
+    await expect(asEngineSeesIt.apply({ plan: { kind: 'nonsense' } })).rejects.toThrow('did not produce')
+  })
+})

--- a/packages/adapters/codex/src/index.ts
+++ b/packages/adapters/codex/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from '@agent-facets/adapter'
 import { type } from 'arktype'
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml'
+import { codexMcpServers } from './mcp-servers.ts'
 
 /**
  * Codex per-asset metadata schema.
@@ -68,9 +69,7 @@ export default defineAdapter({
   name: 'codex',
   supportsInstall: true,
 
-  // Native MCP reconciliation lands in a later task of this change; declaring
-  // it explicitly is the point of the required field.
-  mcpServers: false,
+  mcpServers: codexMcpServers,
 
   buildAssetMetadata(data) {
     const result = CodexMetadataSchema(data)

--- a/packages/adapters/codex/src/mcp-servers.ts
+++ b/packages/adapters/codex/src/mcp-servers.ts
@@ -1,0 +1,357 @@
+import { mkdir, readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import {
+  type ApplyMcpServersResult,
+  atomicWriteFileSync,
+  errorMessage,
+  isMissingFileError,
+  type McpNativeMatch,
+  type McpServerCapability,
+  type McpServerContribution,
+  type McpServerDeclaration,
+  mcpOutcomesRequireWrite,
+  type PrepareMcpServersRequest,
+  type PrepareMcpServersResult,
+  reconcileMcpServers,
+} from '@agent-facets/adapter'
+import { parseDocument, TomlFormat } from '@decimalturn/toml-patch'
+
+/**
+ * Codex MCP server reconciliation.
+ *
+ * ## The document
+ *
+ * Codex reads project-scoped settings from `<projectRoot>/.codex/config.toml`
+ * and merges them over the user-level `~/.codex/config.toml`. Both files use
+ * the same name and the same `mcp_servers` table, which makes writing to the
+ * wrong one an easy and expensive mistake; this capability only ever touches
+ * the project file.
+ *
+ * Codex loads project layers only for a *trusted* project, and trust is
+ * recorded in the user-level config this adapter is forbidden to write. A
+ * correct project file is therefore still the right output for an untrusted
+ * project — it simply stays inert until the user trusts the directory in Codex.
+ *
+ * ## Why a CST editor rather than the TOML serializer already in this package
+ *
+ * `smol-toml` (used elsewhere here for Facets-owned agent files, which are
+ * generated whole) is a value-model library: `stringify(parse(text))` discards
+ * every comment and re-renders every value. On a shared config that is
+ * destructive twice over — Codex's own sample config is mostly comments, and
+ * `stringify` re-emits the TOML float `10.0` as the integer `10`, which
+ * Codex's deserializer then rejects for an `f64` field.
+ *
+ * `@decimalturn/toml-patch` diffs against a concrete syntax tree and edits only
+ * the values that actually changed, so untouched entries — comments, spacing,
+ * table order, and float notation included — survive byte-for-byte.
+ */
+
+/** The project document, relative to the project root. */
+const DOCUMENT_PATH = ['.codex', 'config.toml'] as const
+
+/** The table Codex reads servers from. */
+const SERVER_MAP_KEY = 'mcp_servers'
+
+/**
+ * Members of a native entry outside the portable model that do not change how
+ * the server is launched or connected to, so they survive an update to an entry
+ * the project already owns: startup and tool timeouts, and the settings that
+ * decide which tools Codex surfaces and how it asks about them.
+ *
+ * Deliberately excluded: `cwd` and `env_vars` (what the process inherits and
+ * where it starts), `experimental_environment` (whether it runs locally at
+ * all), and everything authentication-shaped — `http_headers`,
+ * `env_http_headers`, `bearer_token_env_var`, `auth`, `oauth`, `oauth_resource`,
+ * `scopes`. A portable declaration carries no credentials, so an entry holding
+ * one cannot be proven equivalent to it.
+ */
+const SAFE_EXTENSION_KEYS: ReadonlySet<string> = new Set([
+  'startup_timeout_sec',
+  'startup_timeout_ms',
+  'tool_timeout_sec',
+  'supports_parallel_tool_calls',
+  'required',
+  'enabled_tools',
+  'disabled_tools',
+  'default_tools_approval_mode',
+  'tools',
+])
+
+/** Members this adapter renders from the declaration, per transport. */
+const PORTABLE_KEYS: Readonly<Record<'stdio' | 'http', ReadonlySet<string>>> = {
+  stdio: new Set(['command', 'args', 'env']),
+  http: new Set(['url']),
+}
+
+/**
+ * Where `mcp_servers.<name>.<member>` stops being rendered as its own `[table]`
+ * header and becomes an inline table.
+ *
+ * `2` puts `[mcp_servers.<name>]` on its own header — Codex's documented shape —
+ * while an entry's `env` renders as `env = { KEY = "value" }`, which is how
+ * Codex's own reference config writes it.
+ */
+const INLINE_TABLE_DEPTH = 2
+
+type CodexMcpPlan =
+  | { readonly kind: 'unchanged'; readonly path: string }
+  | { readonly kind: 'write'; readonly path: string; readonly expected: string | null; readonly contents: string }
+
+export const codexMcpServers: McpServerCapability<CodexMcpPlan> = {
+  async prepare(request: PrepareMcpServersRequest): Promise<PrepareMcpServersResult<CodexMcpPlan>> {
+    const path = join(request.projectRoot, ...DOCUMENT_PATH)
+
+    let text: string | null
+    try {
+      text = await readFile(path, 'utf8')
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        return { ok: false, failure: { code: 'io-failed', operation: 'read', path, message: errorMessage(err) } }
+      }
+      text = null
+    }
+
+    let document: ReturnType<typeof parseDocument> | null = null
+    let root: Record<string, unknown> = {}
+    if (text !== null) {
+      try {
+        document = parseDocument(text)
+        // `toJsObject` is typed `any` by the library; narrowing it here is the
+        // only place that looseness is allowed to exist.
+        const parsed: unknown = document.toJsObject
+        if (!isPlainObject(parsed)) {
+          return {
+            ok: false,
+            failure: { code: 'validation-failed', path, message: 'document root must be a TOML table' },
+          }
+        }
+        root = parsed
+      } catch (err) {
+        return { ok: false, failure: { code: 'parse-failed', path, message: errorMessage(err) } }
+      }
+    }
+
+    const rawServers = root[SERVER_MAP_KEY]
+    if (rawServers !== undefined && !isPlainObject(rawServers)) {
+      return {
+        ok: false,
+        failure: { code: 'validation-failed', path, message: `"${SERVER_MAP_KEY}" must be a table of server entries` },
+      }
+    }
+    const servers: Record<string, unknown> = rawServers ?? {}
+
+    const outcomes = reconcileMcpServers({
+      desired: request.desired,
+      previouslyOwnedNames: request.previouslyOwnedNames,
+      presentNames: new Set(Object.keys(servers)),
+      compare: (contribution) => compareEntry(servers[contribution.name], contribution.declaration),
+    })
+
+    if (!mcpOutcomesRequireWrite(outcomes)) {
+      return { ok: true, preparation: { plan: { kind: 'unchanged', path }, documentPaths: [path], outcomes } }
+    }
+
+    const tracked = new Set(request.previouslyOwnedNames)
+    const desiredByName = new Map(request.desired.map((contribution) => [contribution.name, contribution]))
+
+    for (const outcome of outcomes) {
+      switch (outcome.kind) {
+        case 'equivalent':
+          break
+        case 'absent':
+        case 'divergent': {
+          const contribution = desiredByName.get(outcome.name) as McpServerContribution
+          const preserved =
+            outcome.kind === 'divergent' && tracked.has(outcome.name)
+              ? preservableExtensions(servers[outcome.name], contribution.declaration)
+              : {}
+          servers[outcome.name] = renderEntry(contribution.declaration, preserved)
+          break
+        }
+        case 'obsolete-owned':
+          delete servers[outcome.name]
+          break
+      }
+    }
+    root[SERVER_MAP_KEY] = servers
+
+    let contents: string
+    try {
+      const format = text === null ? TomlFormat.default() : TomlFormat.autoDetectFormat(text)
+      format.inlineTableStart = INLINE_TABLE_DEPTH
+      const target = document ?? parseDocument('')
+      target.patch(root, format)
+      contents = target.toTomlString
+    } catch (err) {
+      return { ok: false, failure: { code: 'conflict', path, message: errorMessage(err) } }
+    }
+
+    return {
+      ok: true,
+      preparation: { plan: { kind: 'write', path, expected: text, contents }, documentPaths: [path], outcomes },
+    }
+  },
+
+  async apply(request: { readonly plan: unknown }): Promise<ApplyMcpServersResult> {
+    const plan = asPlan(request.plan)
+
+    if (plan.kind === 'unchanged') {
+      return { ok: true, status: 'unchanged' }
+    }
+
+    let current: string | null
+    try {
+      current = await readFile(plan.path, 'utf8')
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        return {
+          ok: false,
+          failure: { code: 'io-failed', operation: 'read', path: plan.path, message: errorMessage(err) },
+        }
+      }
+      current = null
+    }
+
+    if (current !== plan.expected) {
+      return {
+        ok: false,
+        failure: {
+          code: 'conflict',
+          path: plan.path,
+          message: 'the Codex configuration changed after it was inspected; nothing was written',
+        },
+      }
+    }
+
+    try {
+      // The atomic write puts its temporary file beside the target, so the
+      // `.codex` directory has to exist before the rename can be same-volume.
+      await mkdir(dirname(plan.path), { recursive: true })
+      atomicWriteFileSync(plan.path, plan.contents)
+    } catch (err) {
+      return {
+        ok: false,
+        failure: { code: 'io-failed', operation: 'write', path: plan.path, message: errorMessage(err) },
+      }
+    }
+
+    return { ok: true, status: 'changed', changedPaths: [plan.path] }
+  },
+}
+
+/**
+ * Narrow the opaque plan the engine handed back. A value that fails this check
+ * did not come from `prepare`, which is a violated contract rather than a
+ * condition a caller could act on.
+ */
+function asPlan(value: unknown): CodexMcpPlan {
+  if (isPlainObject(value)) {
+    if (value.kind === 'unchanged' && typeof value.path === 'string') {
+      return { kind: 'unchanged', path: value.path }
+    }
+    if (
+      value.kind === 'write' &&
+      typeof value.path === 'string' &&
+      typeof value.contents === 'string' &&
+      (value.expected === null || typeof value.expected === 'string')
+    ) {
+      return { kind: 'write', path: value.path, expected: value.expected, contents: value.contents }
+    }
+  }
+  throw new Error('codex: apply() received a plan this adapter did not produce')
+}
+
+/**
+ * Compare an existing native entry with the rendering of a desired
+ * declaration.
+ *
+ * Codex has no transport tag: an entry is stdio because it has a `command` and
+ * Streamable HTTP because it has a `url`. An entry with both, or neither, is a
+ * shape this adapter cannot classify, so it fails closed.
+ */
+function compareEntry(existing: unknown, declaration: McpServerDeclaration): McpNativeMatch {
+  if (!isPlainObject(existing)) return 'divergent'
+  if (nativeTransport(existing) !== declaration.type) return 'divergent'
+
+  if (declaration.type === 'stdio') {
+    if (existing.command !== declaration.command) return 'divergent'
+    if (!sameStringArray(existing.args, declaration.args ?? [])) return 'divergent'
+    if (!sameStringRecord(existing.env, declaration.env ?? {})) return 'divergent'
+  } else if (existing.url !== declaration.url) {
+    return 'divergent'
+  }
+
+  const portable = PORTABLE_KEYS[declaration.type]
+  for (const [key, value] of Object.entries(existing)) {
+    if (portable.has(key)) continue
+    if (!isSafeExtension(key, value)) return 'divergent'
+  }
+
+  return 'equivalent'
+}
+
+/**
+ * `enabled` is safe only when it is `true`; `enabled = false` means the server
+ * the project asked for would not start, which is a behavioral difference.
+ */
+function isSafeExtension(key: string, value: unknown): boolean {
+  if (key === 'enabled') return value === true
+  return SAFE_EXTENSION_KEYS.has(key)
+}
+
+function nativeTransport(existing: Record<string, unknown>): 'stdio' | 'http' | 'unknown' {
+  const hasCommand = typeof existing.command === 'string'
+  const hasUrl = typeof existing.url === 'string'
+  if (hasCommand && !hasUrl) return 'stdio'
+  if (hasUrl && !hasCommand) return 'http'
+  return 'unknown'
+}
+
+function preservableExtensions(existing: unknown, declaration: McpServerDeclaration): Record<string, unknown> {
+  if (!isPlainObject(existing)) return {}
+  if (nativeTransport(existing) !== declaration.type) return {}
+
+  const preserved: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(existing)) {
+    if (isSafeExtension(key, value)) preserved[key] = value
+  }
+  return preserved
+}
+
+/** Render a portable declaration as a Codex `mcp_servers` entry. */
+function renderEntry(declaration: McpServerDeclaration, preserved: Record<string, unknown>): Record<string, unknown> {
+  const entry: Record<string, unknown> = {}
+
+  if (declaration.type === 'stdio') {
+    entry.command = declaration.command
+    if (declaration.args !== undefined && declaration.args.length > 0) entry.args = [...declaration.args]
+    if (declaration.env !== undefined && Object.keys(declaration.env).length > 0) entry.env = { ...declaration.env }
+  } else {
+    entry.url = declaration.url
+  }
+
+  for (const [key, value] of Object.entries(preserved)) {
+    entry[key] = value
+  }
+
+  return entry
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sameStringArray(value: unknown, expected: readonly string[]): boolean {
+  if (value === undefined) return expected.length === 0
+  if (!Array.isArray(value) || value.length !== expected.length) return false
+  return value.every((item, index) => item === expected[index])
+}
+
+function sameStringRecord(value: unknown, expected: Readonly<Record<string, string>>): boolean {
+  const expectedKeys = Object.keys(expected)
+  if (value === undefined) return expectedKeys.length === 0
+  if (!isPlainObject(value)) return false
+  const keys = Object.keys(value)
+  if (keys.length !== expectedKeys.length) return false
+  return keys.every((key) => value[key] === expected[key])
+}

--- a/packages/adapters/codex/tsdown.config.ts
+++ b/packages/adapters/codex/tsdown.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
   // self-contained bundle. The CLI loads this file directly at install time
   // without needing a node_modules tree.
   deps: {
-    alwaysBundle: ['@agent-facets/adapter', 'arktype', 'smol-toml'],
+    alwaysBundle: ['@agent-facets/adapter', '@decimalturn/toml-patch', 'arktype', 'smol-toml'],
   },
 })

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -23,7 +23,9 @@
   },
   "devDependencies": {
     "@agent-facets/adapter": "workspace:*",
+    "@agent-facets/adapter-test-kit": "workspace:*",
     "arktype": "2.2.0",
+    "jsonc-parser": "^3.3.1",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3"
   },

--- a/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
@@ -1,27 +1,44 @@
 /**
  * Packed-runtime coverage: the built `dist/index.mjs` (the exact artifact
- * published to npm and loaded by the CLI at install time) must carry the
- * SDK-stamped canonical adapter API version. Requires `bun run build`
- * first — wired via the `test:e2e` script.
+ * published to npm and loaded by the CLI at install time) must satisfy the
+ * adapter contract on its own, with no `node_modules` tree beside it.
+ * Requires `bun run build` first — wired via the `test:e2e` script.
  */
+
 import { expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ADAPTER_API_VERSION } from '@agent-facets/adapter'
+import { assertDistBundleContract, loadDistMcpCapability, STDIO_SERVER } from '@agent-facets/adapter-test-kit'
 import sourceAdapter from '../index.ts'
 
-test('built dist bundle declares the canonical adapter API version', async () => {
-  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { name?: string; apiVersion?: string; mcpServers?: unknown }
-  }
-  expect(module.default?.name).toBe(sourceAdapter.name)
-  expect(module.default?.apiVersion).toBe(ADAPTER_API_VERSION)
-})
+const bundlePath = join(import.meta.dir, '../../dist/index.mjs')
 
-test('built dist bundle states its MCP server support', async () => {
-  // The field is required by the API this bundle declares, so its presence
-  // is part of what makes the artifact loadable — not an optional extra.
-  const module = (await import(join(import.meta.dir, '../../dist/index.mjs'))) as {
-    default?: { mcpServers?: unknown }
+assertDistBundleContract({ bundlePath, sourceAdapter })
+
+test('bundled JSONC parser survives bundling', async () => {
+  const capability = await loadDistMcpCapability(bundlePath)
+  const root = mkdtempSync(join(tmpdir(), 'opencode-dist-'))
+  try {
+    // Comments and a trailing comma are readable only if jsonc-parser was
+    // actually inlined; a bare specifier would have failed at import time and
+    // a JSON parser would fail here.
+    await Bun.write(join(root, 'opencode.jsonc'), '{\n  // servers\n  "mcp": {},\n}\n')
+    const prepared = await capability.prepare({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!prepared.ok) expect.unreachable()
+    expect(prepared.preparation.outcomes).toEqual([{ kind: 'absent', name: 'fs', ownership: 'untracked' }])
+
+    // The write path matters as much as the read path: jsonc-parser's UMD
+    // build parses fine but resolves its edit helpers lazily, so a mis-bundled
+    // dependency only fails here.
+    const applied = await capability.apply({ plan: prepared.preparation.plan })
+    if (!applied.ok) expect.unreachable()
+    expect(readFileSync(join(root, 'opencode.jsonc'), 'utf8')).toContain('// servers')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
   }
-  expect(module.default?.mcpServers).toBe(sourceAdapter.mcpServers)
 })

--- a/packages/adapters/opencode/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/opencode/src/__tests__/mcp-servers.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { McpServerCapability } from '@agent-facets/adapter'
+import {
+  type McpMatrixCaseId,
+  type McpMatrixSeed,
+  OBSOLETE_NAME,
+  runMcpServerMatrix,
+  STDIO_SERVER,
+  UNOWNED_NAME,
+} from '@agent-facets/adapter-test-kit'
+import adapter from '../index.ts'
+import { openCodeMcpServers } from '../mcp-servers.ts'
+
+const JSONC = 'opencode.jsonc'
+const JSON_DOCUMENT = 'opencode.json'
+
+/** OpenCode fuses the executable and its arguments into one `command` array. */
+const NATIVE_STDIO = '{ "type": "local", "command": ["srv", "--root", "/w"], "environment": { "TOKEN_NAME": "A" } }'
+
+const NATIVE_HTTP = '{ "type": "remote", "url": "https://mcp.example.com/mcp" }'
+
+const UNOWNED_ENTRY = '{ "type": "local", "command": ["do-not-touch"] }'
+
+function document(entries: Record<string, string>): string {
+  const members = Object.entries(entries)
+    .map(([name, entry]) => `    "${name}": ${entry}`)
+    .join(',\n')
+  return `{\n  "mcp": {\n${members}\n  }\n}\n`
+}
+
+const seeds = {
+  'document-absent': { files: {} },
+
+  'absent-untracked': { files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+
+  'absent-tracked': { files: { [JSONC]: document({}) } },
+
+  'equivalent-tracked': { files: { [JSONC]: document({ fs: NATIVE_STDIO }) } },
+
+  'equivalent-untracked': { files: { [JSONC]: document({ fs: NATIVE_STDIO }) } },
+
+  'equivalent-normalized': {
+    files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["srv"], "environment": {} }' }) },
+  },
+
+  'equivalent-formatting-only': {
+    files: {
+      [JSONC]: `{
+  // hand-written
+  "mcp": {
+    "fs": {
+      "environment": { "TOKEN_NAME": "A" },
+      "command": ["srv", "--root", "/w"],
+      "type": "local", // members in a different order
+    },
+  }
+}
+`,
+    },
+    after: (project) => {
+      expect(project.read(JSONC)).toBe(project.seeded(JSONC))
+    },
+  },
+
+  'divergent-tracked': { files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
+
+  'divergent-untracked': { files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
+
+  // Portable fields match, but the server is switched off — precisely the
+  // behavioral difference the project is asking to correct.
+  'divergent-unprovable': {
+    files: {
+      [JSONC]: document({
+        fs: '{ "type": "local", "command": ["srv", "--root", "/w"], "environment": { "TOKEN_NAME": "A" }, "enabled": false }',
+      }),
+    },
+    after: (project) => {
+      expect(project.read(JSONC) ?? '').not.toContain('"enabled": false')
+    },
+  },
+
+  'safe-extension-preserved': {
+    files: {
+      [JSONC]: document({ ext: '{ "type": "local", "command": ["ext-server", "--old"], "timeout": 45000 }' }),
+    },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(JSONC) ?? '{}')
+      expect(parsed.mcp.ext).toEqual({ type: 'local', command: ['ext-server', '--new'], timeout: 45000 })
+    },
+  },
+
+  'http-absent': { files: { [JSONC]: document({}) } },
+
+  'http-equivalent': { files: { [JSONC]: document({ api: NATIVE_HTTP }) } },
+
+  'obsolete-owned-present': {
+    files: {
+      [JSONC]: document({ [OBSOLETE_NAME]: '{ "type": "local", "command": ["gone"] }', [UNOWNED_NAME]: UNOWNED_ENTRY }),
+    },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(JSONC) ?? '{}')
+      expect(parsed.mcp).not.toHaveProperty(OBSOLETE_NAME)
+      expect(parsed.mcp[UNOWNED_NAME]).toEqual(JSON.parse(UNOWNED_ENTRY))
+    },
+  },
+
+  'obsolete-owned-absent': { files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+
+  'unowned-entry-untouched': {
+    files: { [JSONC]: document({ fs: NATIVE_STDIO, [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    after: (project) => {
+      expect(project.read(JSONC)).toBe(project.seeded(JSONC))
+    },
+  },
+
+  'complete-batch': {
+    files: {
+      [JSONC]: document({
+        fs: NATIVE_STDIO,
+        api: '{ "type": "remote", "url": "https://elsewhere.example.com/mcp" }',
+        [OBSOLETE_NAME]: '{ "type": "local", "command": ["gone"] }',
+        [UNOWNED_NAME]: UNOWNED_ENTRY,
+      }),
+    },
+    after: (project) => {
+      const parsed = JSON.parse(project.read(JSONC) ?? '{}')
+      expect(Object.keys(parsed.mcp).sort()).toEqual(['api', 'fs', UNOWNED_NAME].sort())
+      expect(parsed.mcp.api).toEqual({ type: 'remote', url: 'https://mcp.example.com/mcp' })
+    },
+  },
+
+  'unrelated-settings-preserved': {
+    files: {
+      [JSONC]: `{
+  // the model this project uses
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude",
+  "mcp": {}
+}
+`,
+    },
+    after: (project) => {
+      const after = project.read(JSONC) ?? ''
+      expect(after).toContain('// the model this project uses')
+      expect(after).toContain('"model": "anthropic/claude"')
+      expect(after).toContain('"$schema": "https://opencode.ai/config.json"')
+    },
+  },
+
+  'nothing-desired-nothing-owned': { files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+
+  'malformed-document': { files: { [JSONC]: '{ "mcp": { \n' } },
+
+  'invalid-server-map': { files: { [JSONC]: '{ "mcp": [] }\n' } },
+} satisfies Record<McpMatrixCaseId, McpMatrixSeed>
+
+runMcpServerMatrix({ capability: openCodeMcpServers, seeds })
+
+describe('opencode document selection', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'opencode-mcp-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  async function reconcile(): Promise<readonly string[]> {
+    const prepared = await openCodeMcpServers.prepare({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!prepared.ok) expect.unreachable()
+    const applied = await openCodeMcpServers.apply({ plan: prepared.preparation.plan })
+    if (!applied.ok) expect.unreachable()
+    return prepared.preparation.documentPaths
+  }
+
+  test('reconciles the JSONC document and leaves the JSON one alone when both exist', async () => {
+    writeFileSync(join(root, JSONC), '{ "mcp": {} }\n')
+    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": { "fs": { "type": "local", "command": ["other"] } } }\n')
+
+    const disclosed = await reconcile()
+
+    expect(disclosed).toEqual([join(root, JSONC)])
+    expect(readFileSync(join(root, JSONC), 'utf8')).toContain('"srv"')
+    expect(readFileSync(join(root, JSON_DOCUMENT), 'utf8')).toBe(
+      '{ "mcp": { "fs": { "type": "local", "command": ["other"] } } }\n',
+    )
+  })
+
+  test('reconciles an existing JSON document rather than creating a JSONC one beside it', async () => {
+    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": {} }\n')
+
+    const disclosed = await reconcile()
+
+    expect(disclosed).toEqual([join(root, JSON_DOCUMENT)])
+    expect(readFileSync(join(root, JSON_DOCUMENT), 'utf8')).toContain('"srv"')
+    expect(() => readFileSync(join(root, JSONC), 'utf8')).toThrow()
+  })
+
+  test('creates a JSONC document when neither exists', async () => {
+    const disclosed = await reconcile()
+
+    expect(disclosed).toEqual([join(root, JSONC)])
+    expect(readFileSync(join(root, JSONC), 'utf8')).toContain('"srv"')
+    expect(() => readFileSync(join(root, JSON_DOCUMENT), 'utf8')).toThrow()
+  })
+})
+
+describe('opencode MCP capability', () => {
+  test('is declared on the adapter', () => {
+    expect(adapter.mcpServers).toBe(openCodeMcpServers)
+  })
+
+  test('refuses a declaration OpenCode would interpolate instead of using literally', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'opencode-mcp-'))
+    try {
+      const prepared = await openCodeMcpServers.prepare({
+        projectRoot: root,
+        desired: [{ name: 'fs', declaration: { type: 'stdio', command: 'srv', env: { T: '{env:TOKEN}' } } }],
+        previouslyOwnedNames: [],
+      })
+      if (prepared.ok) expect.unreachable()
+      expect(prepared.failure.code).toBe('conflict')
+      expect(prepared.failure.message).toContain('{env:TOKEN}')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a plan it did not produce', async () => {
+    // The engine holds the plan as `unknown`, so this is the shape an untyped
+    // caller can actually reach `apply` with.
+    const asEngineSeesIt: McpServerCapability<unknown> = openCodeMcpServers
+    await expect(asEngineSeesIt.apply({ plan: { kind: 'nonsense' } })).rejects.toThrow('did not produce')
+  })
+})

--- a/packages/adapters/opencode/src/index.ts
+++ b/packages/adapters/opencode/src/index.ts
@@ -15,6 +15,7 @@ import {
   type SkillBundlePaths,
 } from '@agent-facets/adapter'
 import { type } from 'arktype'
+import { openCodeMcpServers } from './mcp-servers.ts'
 
 /**
  * OpenCode per-asset metadata schema.
@@ -50,9 +51,7 @@ export default defineAdapter({
   name: 'opencode',
   supportsInstall: true,
 
-  // Native MCP reconciliation lands in a later task of this change; declaring
-  // it explicitly is the point of the required field.
-  mcpServers: false,
+  mcpServers: openCodeMcpServers,
 
   buildAssetMetadata(data) {
     const result = OpenCodeMetadataSchema(data)

--- a/packages/adapters/opencode/src/mcp-servers.ts
+++ b/packages/adapters/opencode/src/mcp-servers.ts
@@ -1,0 +1,409 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  type ApplyMcpServersResult,
+  atomicWriteFileSync,
+  errorMessage,
+  isMissingFileError,
+  type McpNativeMatch,
+  type McpServerCapability,
+  type McpServerCapabilityFailure,
+  type McpServerContribution,
+  type McpServerDeclaration,
+  mcpDeclarationLiterals,
+  mcpOutcomesRequireWrite,
+  type PrepareMcpServersRequest,
+  type PrepareMcpServersResult,
+  reconcileMcpServers,
+} from '@agent-facets/adapter'
+import { applyEdits, type FormattingOptions, modify, type ParseError, parse as parseJsonc } from 'jsonc-parser'
+
+/**
+ * OpenCode MCP server reconciliation.
+ *
+ * ## Which document
+ *
+ * OpenCode loads `opencode.json` and then `opencode.jsonc` from the same
+ * directory and deep-merges them in that order, so when both exist the JSONC
+ * file wins. This adapter therefore reconciles `opencode.jsonc` when it exists,
+ * falls back to an existing `opencode.json`, and creates `opencode.jsonc` when
+ * neither does. Writing to the losing file would be a silent no-op from the
+ * user's point of view — the entry would be there, and OpenCode would still
+ * ignore it.
+ *
+ * ## Why JSONC, and why minimal edits
+ *
+ * OpenCode parses *both* filenames as JSONC, and its own `opencode mcp add`
+ * edits configuration with jsonc-parser's `modify`/`applyEdits`. This adapter
+ * does the same, for the same reason: those produce a minimal text edit rather
+ * than a re-serialization, so comments, member order, indentation, and trailing
+ * commas everywhere outside the one entry being changed survive byte-for-byte.
+ * A parse-then-stringify round trip would reflow a hand-formatted config on the
+ * first install.
+ */
+
+/** Candidate documents, in the order OpenCode's own merge makes authoritative. */
+const DOCUMENT_NAMES = ['opencode.jsonc', 'opencode.json'] as const
+
+/** Created when neither candidate exists. */
+const DEFAULT_DOCUMENT_NAME = DOCUMENT_NAMES[0]
+
+/** The top-level member OpenCode reads servers from. */
+const SERVER_MAP_KEY = 'mcp'
+
+/**
+ * OpenCode substitutes these forms inside configuration values before parsing.
+ *
+ * A portable declaration is literal, so a value containing one of these cannot
+ * be written faithfully — OpenCode would replace it with an environment
+ * variable or a file's contents. That is a conflict, not something to write and
+ * hope about.
+ */
+const INTERPOLATION_PATTERN = /\{(?:env|file):[^}]*\}/
+
+/** Members OpenCode owns that this adapter renders from the declaration. */
+const PORTABLE_KEYS: Readonly<Record<'local' | 'remote', ReadonlySet<string>>> = {
+  local: new Set(['type', 'command', 'environment']),
+  remote: new Set(['type', 'url']),
+}
+
+/**
+ * The prepared plan: the selected document, its exact prior text (or `null`
+ * when it does not exist), and the complete text to commit.
+ */
+type OpenCodeMcpPlan =
+  | { readonly kind: 'unchanged'; readonly path: string }
+  | { readonly kind: 'write'; readonly path: string; readonly expected: string | null; readonly contents: string }
+
+export const openCodeMcpServers: McpServerCapability<OpenCodeMcpPlan> = {
+  async prepare(request: PrepareMcpServersRequest): Promise<PrepareMcpServersResult<OpenCodeMcpPlan>> {
+    const selected = await selectDocument(request.projectRoot)
+    if (!selected.ok) return { ok: false, failure: selected.failure }
+    const { path, text } = selected
+
+    for (const contribution of request.desired) {
+      const literal = mcpDeclarationLiterals(contribution.declaration).find((value) =>
+        INTERPOLATION_PATTERN.test(value),
+      )
+      if (literal !== undefined) {
+        return {
+          ok: false,
+          failure: {
+            code: 'conflict',
+            path,
+            message: `server "${contribution.name}" declares a value OpenCode would interpolate rather than use literally: ${literal}`,
+          },
+        }
+      }
+    }
+
+    let document: Record<string, unknown> = {}
+    if (text !== null) {
+      const errors: ParseError[] = []
+      const parsed: unknown = parseJsonc(text, errors, { allowTrailingComma: true })
+      if (errors.length > 0) {
+        return { ok: false, failure: { code: 'parse-failed', path, message: describeParseErrors(text, errors) } }
+      }
+      if (!isPlainObject(parsed)) {
+        return {
+          ok: false,
+          failure: { code: 'validation-failed', path, message: 'document root must be a JSON object' },
+        }
+      }
+      document = parsed
+    }
+
+    const rawServers = document[SERVER_MAP_KEY]
+    if (rawServers !== undefined && !isPlainObject(rawServers)) {
+      return {
+        ok: false,
+        failure: {
+          code: 'validation-failed',
+          path,
+          message: `"${SERVER_MAP_KEY}" must be an object mapping server names to entries`,
+        },
+      }
+    }
+    const servers: Record<string, unknown> = rawServers ?? {}
+
+    const outcomes = reconcileMcpServers({
+      desired: request.desired,
+      previouslyOwnedNames: request.previouslyOwnedNames,
+      presentNames: new Set(Object.keys(servers)),
+      compare: (contribution) => compareEntry(servers[contribution.name], contribution.declaration),
+    })
+
+    if (!mcpOutcomesRequireWrite(outcomes)) {
+      return { ok: true, preparation: { plan: { kind: 'unchanged', path }, documentPaths: [path], outcomes } }
+    }
+
+    const tracked = new Set(request.previouslyOwnedNames)
+    const desiredByName = new Map(request.desired.map((contribution) => [contribution.name, contribution]))
+
+    // Each edit is computed against the text the previous one produced:
+    // jsonc-parser's edits carry absolute offsets, so they cannot be batched.
+    let contents = text ?? '{}\n'
+    const formatting = detectFormatting(text)
+
+    for (const outcome of outcomes) {
+      switch (outcome.kind) {
+        case 'equivalent':
+          break
+        case 'absent':
+        case 'divergent': {
+          const contribution = desiredByName.get(outcome.name) as McpServerContribution
+          const preserved =
+            outcome.kind === 'divergent' && tracked.has(outcome.name)
+              ? preservableExtensions(servers[outcome.name], contribution.declaration)
+              : {}
+          contents = editDocument(
+            contents,
+            [SERVER_MAP_KEY, outcome.name],
+            renderEntry(contribution.declaration, preserved),
+            formatting,
+          )
+          break
+        }
+        case 'obsolete-owned':
+          if (outcome.occupancy === 'present') {
+            contents = editDocument(contents, [SERVER_MAP_KEY, outcome.name], undefined, formatting)
+          }
+          break
+      }
+    }
+
+    return {
+      ok: true,
+      preparation: { plan: { kind: 'write', path, expected: text, contents }, documentPaths: [path], outcomes },
+    }
+  },
+
+  async apply(request: { readonly plan: unknown }): Promise<ApplyMcpServersResult> {
+    const plan = asPlan(request.plan)
+
+    if (plan.kind === 'unchanged') {
+      return { ok: true, status: 'unchanged' }
+    }
+
+    let current: string | null
+    try {
+      current = await readFile(plan.path, 'utf8')
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        return {
+          ok: false,
+          failure: { code: 'io-failed', operation: 'read', path: plan.path, message: errorMessage(err) },
+        }
+      }
+      current = null
+    }
+
+    if (current !== plan.expected) {
+      return {
+        ok: false,
+        failure: {
+          code: 'conflict',
+          path: plan.path,
+          message: 'the OpenCode configuration changed after it was inspected; nothing was written',
+        },
+      }
+    }
+
+    try {
+      atomicWriteFileSync(plan.path, plan.contents)
+    } catch (err) {
+      return {
+        ok: false,
+        failure: { code: 'io-failed', operation: 'write', path: plan.path, message: errorMessage(err) },
+      }
+    }
+
+    return { ok: true, status: 'changed', changedPaths: [plan.path] }
+  },
+}
+
+type SelectDocumentResult =
+  | { readonly ok: true; readonly path: string; readonly text: string | null }
+  | { readonly ok: false; readonly failure: McpServerCapabilityFailure }
+
+/**
+ * Pick the one document to reconcile.
+ *
+ * When both filenames exist only the JSONC one is read, disclosed, or written —
+ * the JSON file is left exactly as it was, because OpenCode already treats it
+ * as the losing half of the merge.
+ */
+async function selectDocument(projectRoot: string): Promise<SelectDocumentResult> {
+  for (const name of DOCUMENT_NAMES) {
+    const path = join(projectRoot, name)
+    try {
+      return { ok: true, path, text: await readFile(path, 'utf8') }
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        return { ok: false, failure: { code: 'io-failed', operation: 'read', path, message: errorMessage(err) } }
+      }
+    }
+  }
+  return { ok: true, path: join(projectRoot, DEFAULT_DOCUMENT_NAME), text: null }
+}
+
+function editDocument(
+  text: string,
+  path: readonly [string, string],
+  value: Record<string, unknown> | undefined,
+  formatting: FormattingOptions,
+): string {
+  return applyEdits(text, modify(text, [...path], value, { formattingOptions: formatting }))
+}
+
+/**
+ * Match the document's own indentation so an inserted entry does not look
+ * pasted in. A brand-new document gets two spaces, matching what OpenCode
+ * writes when it bootstraps a config.
+ */
+function detectFormatting(text: string | null): FormattingOptions {
+  const eol = text?.includes('\r\n') ? '\r\n' : '\n'
+  const indent = text?.match(/\n([ \t]+)\S/)?.[1]
+  if (indent === undefined) return { tabSize: 2, insertSpaces: true, eol }
+  if (indent.startsWith('\t')) return { tabSize: 2, insertSpaces: false, eol }
+  return { tabSize: indent.length, insertSpaces: true, eol }
+}
+
+function describeParseErrors(text: string, errors: readonly ParseError[]): string {
+  const first = errors[0]
+  if (first === undefined) return 'invalid JSONC'
+  const line = text.slice(0, first.offset).split('\n').length
+  return `invalid JSONC at line ${line} (offset ${first.offset})`
+}
+
+/**
+ * Narrow the opaque plan the engine handed back. A value that fails this check
+ * did not come from `prepare`, which is a violated contract rather than a
+ * condition a caller could act on.
+ */
+function asPlan(value: unknown): OpenCodeMcpPlan {
+  if (isPlainObject(value)) {
+    if (value.kind === 'unchanged' && typeof value.path === 'string') {
+      return { kind: 'unchanged', path: value.path }
+    }
+    if (
+      value.kind === 'write' &&
+      typeof value.path === 'string' &&
+      typeof value.contents === 'string' &&
+      (value.expected === null || typeof value.expected === 'string')
+    ) {
+      return { kind: 'write', path: value.path, expected: value.expected, contents: value.contents }
+    }
+  }
+  throw new Error('opencode: apply() received a plan this adapter did not produce')
+}
+
+/**
+ * Compare an existing native entry with the rendering of a desired
+ * declaration.
+ *
+ * OpenCode fuses the executable and its arguments into one `command` array, so
+ * equality is checked in that direction only: `['npx', '-y', 'srv']` is the
+ * rendering of `{ command: 'npx', args: ['-y', 'srv'] }`, while
+ * `['npx -y srv']` is a single argument that happens to contain spaces and is
+ * a different launch.
+ */
+function compareEntry(existing: unknown, declaration: McpServerDeclaration): McpNativeMatch {
+  if (!isPlainObject(existing)) return 'divergent'
+
+  const nativeType = nativeTypeFor(declaration.type)
+  if (existing.type !== nativeType) return 'divergent'
+
+  if (declaration.type === 'stdio') {
+    if (!sameStringArray(existing.command, commandArray(declaration))) return 'divergent'
+    if (!sameStringRecord(existing.environment, declaration.env ?? {})) return 'divergent'
+  } else if (existing.url !== declaration.url) {
+    return 'divergent'
+  }
+
+  const portable = PORTABLE_KEYS[nativeType]
+  for (const [key, value] of Object.entries(existing)) {
+    if (portable.has(key)) continue
+    if (!isSafeExtension(key, value)) return 'divergent'
+  }
+
+  return 'equivalent'
+}
+
+/**
+ * Whether a member outside the portable model can be left in place without
+ * changing how the server is launched or connected to.
+ *
+ * `timeout` only tunes how long OpenCode waits. `enabled` is safe only when it
+ * is `true`: `enabled: false` means the server the project asked for would not
+ * start, which is precisely a behavioral difference.
+ *
+ * `cwd`, `headers`, and `oauth` are absent by design — they change the working
+ * directory a process launches in, or how a connection authenticates.
+ */
+function isSafeExtension(key: string, value: unknown): boolean {
+  if (key === 'timeout') return true
+  if (key === 'enabled') return value === true
+  return false
+}
+
+function nativeTypeFor(transport: McpServerDeclaration['type']): 'local' | 'remote' {
+  return transport === 'stdio' ? 'local' : 'remote'
+}
+
+function commandArray(declaration: Extract<McpServerDeclaration, { type: 'stdio' }>): string[] {
+  return [declaration.command, ...(declaration.args ?? [])]
+}
+
+function preservableExtensions(existing: unknown, declaration: McpServerDeclaration): Record<string, unknown> {
+  if (!isPlainObject(existing)) return {}
+  if (existing.type !== nativeTypeFor(declaration.type)) return {}
+
+  const preserved: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(existing)) {
+    if (isSafeExtension(key, value)) preserved[key] = value
+  }
+  return preserved
+}
+
+/**
+ * Render a portable declaration in OpenCode's native shape. `environment` is
+ * emitted only when non-empty, matching what `opencode mcp add` writes.
+ */
+function renderEntry(declaration: McpServerDeclaration, preserved: Record<string, unknown>): Record<string, unknown> {
+  const entry: Record<string, unknown> = { type: nativeTypeFor(declaration.type) }
+
+  if (declaration.type === 'stdio') {
+    entry.command = commandArray(declaration)
+    if (declaration.env !== undefined && Object.keys(declaration.env).length > 0) {
+      entry.environment = { ...declaration.env }
+    }
+  } else {
+    entry.url = declaration.url
+  }
+
+  for (const [key, value] of Object.entries(preserved)) {
+    entry[key] = value
+  }
+
+  return entry
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sameStringArray(value: unknown, expected: readonly string[]): boolean {
+  if (value === undefined) return expected.length === 0
+  if (!Array.isArray(value) || value.length !== expected.length) return false
+  return value.every((item, index) => item === expected[index])
+}
+
+function sameStringRecord(value: unknown, expected: Readonly<Record<string, string>>): boolean {
+  const expectedKeys = Object.keys(expected)
+  if (value === undefined) return expectedKeys.length === 0
+  if (!isPlainObject(value)) return false
+  const keys = Object.keys(value)
+  if (keys.length !== expectedKeys.length) return false
+  return keys.every((key) => value[key] === expected[key])
+}

--- a/packages/adapters/opencode/tsdown.config.ts
+++ b/packages/adapters/opencode/tsdown.config.ts
@@ -11,6 +11,15 @@ export default defineConfig({
   // self-contained bundle. The CLI loads this file directly at install time
   // without needing a node_modules tree.
   deps: {
-    alwaysBundle: ['@agent-facets/adapter', 'arktype'],
+    alwaysBundle: ['@agent-facets/adapter', 'arktype', 'jsonc-parser'],
+  },
+  inputOptions: {
+    // `jsonc-parser` has no `exports` map, so the default field order resolves
+    // it to its UMD build — whose lazy `require('./impl/...')` calls cannot be
+    // resolved from `dist/` once bundled. Preferring `module` picks the ESM
+    // build, which bundles into a single self-contained file.
+    // `dist.e2e.test.ts` exercises the write path, which is where the UMD
+    // build fails.
+    resolve: { mainFields: ['module', 'main'] },
   },
 })


### PR DESCRIPTION
### Why

All three first-party adapters (Claude Code, Codex, OpenCode) now implement native MCP server reconciliation instead of declaring `mcpServers: false`. Each adapter reads its tool-specific configuration file, compares desired server declarations against what is already present, and writes only the minimum change needed — preserving comments, formatting, unrelated settings, and behavior-neutral native extensions.

### Details

**Shared reconciliation logic (`@agent-facets/adapter`)**

The format-independent bookkeeping — classifying desired entries as absent, equivalent, or divergent, and identifying obsolete owned entries — lives in a new `reconcileMcpServers` function exported from the adapter package. This ensures the ownership rule ("desired state authorizes reconciliation; receipt ownership alone authorizes deletion") is implemented once and cannot drift between adapters. `mcpOutcomesRequireWrite` derives the write decision from outcomes rather than tracking it separately, so "everything is equivalent" and "nothing will be written" cannot disagree. `mcpDeclarationLiterals` collects every string a declaration contributes so adapters can check for interpolation syntax without knowing which fields exist.

**Claude Code** reads and writes `.mcp.json` using `JSON.parse`/`JSON.stringify`, preserving the document's own indentation and line endings. Comments are not tolerated — a comment makes the file one Claude Code itself rejects, so `parse-failed` is the honest result. Safe native extensions (`timeout`, `alwaysLoad`, `role`, `tools`, `toolPermissions`) survive an update to an owned entry; members that affect authentication (`headers`, `headersHelper`, `oauth`) defeat the equivalence proof. Claude Code accepts both `http` and `streamable-http` as the same transport.

**Codex** reads and writes `.codex/config.toml` using `@decimalturn/toml-patch`, a CST editor that diffs against the concrete syntax tree and touches only the values that changed. This is necessary because `smol-toml`'s `stringify(parse(text))` discards comments and re-emits floats as integers (which Codex's own deserializer then rejects for `f64` fields). The `.codex` directory is created only at commit time, never during planning. Codex has no transport tag — `command` means stdio, `url` means Streamable HTTP.

**OpenCode** selects its document by precedence: `opencode.jsonc` wins over `opencode.json`; when neither exists, `opencode.jsonc` is created. When both exist, only the JSONC file is reconciled and the JSON file is left untouched. Edits are applied with `jsonc-parser`'s `modify`/`applyEdits`, matching what OpenCode's own `opencode mcp add` does, so comments and formatting outside the edited entry survive. OpenCode fuses the executable and arguments into a single `command` array. Values matching OpenCode's `{env:...}` / `{file:...}` interpolation syntax are rejected before any write, since a portable declaration is always literal. The `jsonc-parser` bundle is resolved via its ESM build (`module` field) rather than the UMD build, which contains lazy `require()` calls that cannot be resolved from `dist/` after bundling.

**`@agent-facets/adapter-test-kit`** is a new private workspace package that provides the shared fixture matrix (`MCP_MATRIX_CASES`) and the `runMcpServerMatrix` runner. Every case is stated in portable terms; each adapter supplies its own native seed per case. The `satisfies Record<McpMatrixCaseId, McpMatrixSeed>` constraint on each adapter's seed table means adding a case to the matrix is a compile error in all three adapters until each one provides a seed — coverage cannot silently drift. The package also provides `assertDistBundleContract` and `loadDistMcpCapability` for the dist e2e tests, replacing the hand-rolled checks that previously existed in each adapter.

The matrix runner asserts four invariants for every case regardless of the fixture: `prepare` changes nothing on disk, `documentPaths` is non-empty and stays inside the project root, every path written by `apply` was disclosed by `documentPaths` first, and nothing is spawned or fetched during reconciliation.

### Verification

CI runs unit tests and dist e2e tests for all three adapters. The dist e2e tests require `bun run build` first (wired via each adapter's `test:e2e` script) and verify that the built bundle carries no unresolved specifiers outside Node builtins, declares the canonical API version, exposes a complete MCP capability, and can actually parse and write a native document using only its inlined dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adapters read and write user project config files with semantic equality and conflict detection; mistakes could corrupt or overwrite tool configs, though scope is project-local and heavily matrix-tested.
> 
> **Overview**
> **Enables native MCP server reconciliation** on Claude Code, Codex, and OpenCode: each adapter switches from `mcpServers: false` to a full `prepare`/`apply` capability that plans against desired declarations and prior ownership, then commits with optimistic concurrency and atomic writes.
> 
> **Shared adapter SDK** gains `reconcileMcpServers`, `mcpOutcomesRequireWrite`, and `mcpDeclarationLiterals`, plus a re-export of `atomicWriteFileSync` for one-document atomic updates.
> 
> **Per-tool config editing:** Claude Code uses strict JSON on `.mcp.json`; OpenCode picks `opencode.jsonc` over `opencode.json`, edits with `jsonc-parser`, and rejects values OpenCode would interpolate; Codex patches `.codex/config.toml` with `@decimalturn/toml-patch` (bundled) so comments and float formatting survive.
> 
> **New private `@agent-facets/adapter-test-kit`** defines the shared `MCP_MATRIX_CASES` fixture matrix, `runMcpServerMatrix`, and `assertDistBundleContract` so all three adapters share the same behavioral coverage and dist bundles must inline parsers with no stray imports.
> 
> Dist e2e tests and unit matrix tests were expanded accordingly; changesets now ignore the test-kit package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe12e3723e555063fd6c80fad63267cabd96eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->