### PR TITLE
Add MCP server composition, receipt `0.4` configuration claims, and cross-domain collision reporting

### DIFF
--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -70,17 +70,17 @@
 
 - [x] 7.1 Explore: Trace project-manifest mutation, stale-override pruning, collision composition, resolved-facet data, and frozen consistency paths that currently iterate only asset groups.
 - [x] 7.2 Explore: Trace receipt exact dispatch, ownership indexes, tri-write receipt construction, corruption handling, and removal witnesses across receipt versions `1`, `0.2`, and `0.3`.
-- [ ] 7.3 Propose: Define tagged server-intent, composition, ownership, and witnessed/unwitnessed receipt models that preserve the unified desired-state/write and receipt-only/delete rule.
+- [x] 7.3 Propose: Define tagged server-intent, composition, ownership, and witnessed/unwitnessed receipt models that preserve the unified desired-state/write and receipt-only/delete rule.
 
 ## 8. Project intent, composition, and receipt ownership — Implementation
 
-- [ ] 8.1 Implement: Implement receipt `0.4` exact dispatch with facet integrity and configuration claims, preserving earlier asset authority while explicitly withholding configuration authority and approval from pre-`0.4` receipts; ensure the next successful receipt write emits `0.4` and never an intermediate writer format.
-- [ ] 8.2 Implement: Extend receipt loading/validation for absent, corrupt, path-mismatched, escaping, and duplicate historical claims without storing commands, arguments, URLs, or environment data.
-- [ ] 8.3 Implement: Extend project-manifest mutations and transaction commits for `0.2` server overrides, source-change preservation, compact/expanded canonicalization, successful stale-server pruning, failed-operation retention, and frozen no-migration.
-- [ ] 8.4 Implement: Carry verified concrete declarations through resolution and compose aliases, omissions, identical fingerprints, complete collision groups, claimant sets, and stale overrides separately from asset plans and lockfile entries.
-- [ ] 8.5 Implement: Add configuration ownership indexes and receipt construction so successful reconciliation records project-wide adapter-agnostic claims, omitted declarations remain absent, and deletion never derives from lockfile intent.
-- [ ] 8.6 Implement: Add focused tests for receipt refinement, teammate-local approval separation, server dispositions, migration rollback, server/asset namespace separation, collision exhaustiveness, and unchanged lockfile shape.
-- [ ] 8.7 Verify: Run focused manifest, composition, receipt, ownership, and tri-write tests and type checks.
+- [x] 8.1 Implement: Implement receipt `0.4` exact dispatch with facet integrity and configuration claims, preserving earlier asset authority while explicitly withholding configuration authority and approval from pre-`0.4` receipts; ensure the next successful receipt write emits `0.4` and never an intermediate writer format.
+- [x] 8.2 Implement: Extend receipt loading/validation for absent, corrupt, path-mismatched, escaping, and duplicate historical claims without storing commands, arguments, URLs, or environment data.
+- [x] 8.3 Implement: Extend project-manifest mutations and transaction commits for `0.2` server overrides, source-change preservation, compact/expanded canonicalization, successful stale-server pruning, failed-operation retention, and frozen no-migration.
+- [x] 8.4 Implement: Carry verified concrete declarations through resolution and compose aliases, omissions, identical fingerprints, complete collision groups, claimant sets, and stale overrides separately from asset plans and lockfile entries.
+- [x] 8.5 Implement: Add configuration ownership indexes and receipt construction so successful reconciliation records project-wide adapter-agnostic claims, omitted declarations remain absent, and deletion never derives from lockfile intent.
+- [x] 8.6 Implement: Add focused tests for receipt refinement, teammate-local approval separation, server dispositions, migration rollback, server/asset namespace separation, collision exhaustiveness, and unchanged lockfile shape.
+- [x] 8.7 Verify: Run focused manifest, composition, receipt, ownership, and tri-write tests and type checks.
 
 ## 9. Transaction, consent, frozen, removal, and takeover — Research
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -1356,7 +1356,12 @@ describe('InstallView — materialization reporting', () => {
         run: makeFakeRun(
           [
             { kind: 'install-start', totalFacets: 1 },
-            { kind: 'stale-override-pruned', facet: 'alpha', assetType: 'skill', authoredName: 'gone' },
+            {
+              kind: 'stale-override-pruned',
+              facet: 'alpha',
+              contribution: { kind: 'asset', assetType: 'skill' },
+              authoredName: 'gone',
+            },
           ],
           successResultSingle,
         ),

--- a/packages/cli/src/tui/views/install/collision/__tests__/draft.test.ts
+++ b/packages/cli/src/tui/views/install/collision/__tests__/draft.test.ts
@@ -21,7 +21,16 @@ function requestFor(contributions: FacetContribution[]): CollisionResolutionRequ
   const planned = planMaterialization(contributions)
   if (planned.ok) expect.unreachable()
   if (planned.reason !== 'collision') expect.unreachable()
-  return { groups: planned.groups, contributions, staleOverrides: planned.staleOverrides }
+  return {
+    groups: planned.groups,
+    contributions,
+    staleOverrides: planned.staleOverrides.map((stale) => ({
+      facet: stale.facet,
+      contribution: { kind: 'asset' as const, assetType: stale.type },
+      authoredName: stale.authoredName,
+      disposition: stale.disposition,
+    })),
+  }
 }
 
 function skill(facet: string, ...names: string[]): FacetContribution {

--- a/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
+++ b/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
@@ -29,7 +29,16 @@ function requestFor(contributions: FacetContribution[]): CollisionResolutionRequ
   const planned = planMaterialization(contributions)
   if (planned.ok) expect.unreachable()
   if (planned.reason !== 'collision') expect.unreachable()
-  return { groups: planned.groups, contributions, staleOverrides: planned.staleOverrides }
+  return {
+    groups: planned.groups,
+    contributions,
+    staleOverrides: planned.staleOverrides.map((stale) => ({
+      facet: stale.facet,
+      contribution: { kind: 'asset' as const, assetType: stale.type },
+      authoredName: stale.authoredName,
+      disposition: stale.disposition,
+    })),
+  }
 }
 
 function mount(contributions: FacetContribution[]) {

--- a/packages/cli/src/tui/views/install/collision/draft.ts
+++ b/packages/cli/src/tui/views/install/collision/draft.ts
@@ -1,12 +1,7 @@
 import type { AssetType, Scope } from '@agent-facets/common'
-import type { CollisionResolutionRequest } from '@agent-facets/engine'
+import type { CollisionResolutionRequest, StaleMaterializationOverride } from '@agent-facets/engine'
 import { ownEntry, ownRecord } from '@agent-facets/engine'
-import type {
-  CollisionGroup,
-  FacetMaterializationOverrides,
-  MaterializationDisposition,
-  StaleOverride,
-} from '@agent-facets/protocol'
+import type { CollisionGroup, FacetMaterializationOverrides, MaterializationDisposition } from '@agent-facets/protocol'
 import {
   compareCodeUnits,
   isMaterialized,
@@ -118,7 +113,7 @@ export interface WorkspaceModel {
    * final check then answer the same question the same way.
    */
   confirmable: boolean
-  staleOverrides: readonly StaleOverride[]
+  staleOverrides: readonly StaleMaterializationOverride[]
 }
 
 /** Seed a draft from the overrides the project already has. */
@@ -232,7 +227,14 @@ export function evaluateDraft(request: CollisionResolutionRequest, draft: Collis
   return {
     groups,
     confirmable: planned.ok,
-    staleOverrides: planned.ok ? planned.staleOverrides : request.staleOverrides,
+    staleOverrides: planned.ok
+      ? planned.staleOverrides.map((stale) => ({
+          facet: stale.facet,
+          contribution: { kind: 'asset' as const, assetType: stale.type },
+          authoredName: stale.authoredName,
+          disposition: stale.disposition,
+        }))
+      : request.staleOverrides,
   }
 }
 

--- a/packages/cli/src/tui/views/install/collision/workspace.tsx
+++ b/packages/cli/src/tui/views/install/collision/workspace.tsx
@@ -2,6 +2,7 @@ import type { CollisionResolution, CollisionResolutionRequest } from '@agent-fac
 import type { MaterializationDisposition } from '@agent-facets/protocol'
 import { Box, Text, useInput } from 'ink'
 import { useCallback, useMemo, useState } from 'react'
+import { contributionKey, describeContribution } from '../../../../util/contribution.ts'
 import { THEME } from '../../../theme.ts'
 import { CHOICES, type ChoiceKind, ClaimantRow, choiceOf, StatusTag } from './claimant-row.tsx'
 import {
@@ -241,9 +242,12 @@ function Overview({ model, index }: { model: ReturnType<typeof evaluateDraft>; i
       {staleOverrides.length > 0 && (
         <Box flexDirection="column" marginTop={1}>
           {staleOverrides.map((stale) => (
-            <Text key={`${stale.facet}:${stale.type}:${stale.authoredName}`} color={THEME.caution}>
-              ⚠ {stale.facet} has a leftover choice for {stale.type} {stale.authoredName}, which this version no longer
-              contains.
+            <Text
+              key={`${stale.facet}:${contributionKey(stale.contribution)}:${stale.authoredName}`}
+              color={THEME.caution}
+            >
+              ⚠ {stale.facet} has a leftover choice for {describeContribution(stale.contribution)} {stale.authoredName},
+              which this version no longer contains.
             </Text>
           ))}
         </Box>

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -2,7 +2,8 @@ import type { LockfileDriftEntry, RollbackOutcome, RunInstallFailure, RunInstall
 import { Box, Text } from 'ink'
 import type React from 'react'
 import { describeCompatibilityFailure } from '../../../util/adapter-install-errors.ts'
-import { describeNamespace, manifestLocation } from '../../../util/collision-report.ts'
+import { collisionClaimants, collisionGroupKey, describeCollisionGroup } from '../../../util/collision-report.ts'
+import { contributionKey, describeContribution } from '../../../util/contribution.ts'
 import { diskStateSentence } from '../../../util/install-outcome.ts'
 import { THEME } from '../../theme.ts'
 import { UnsupportedManifestVersionBlock } from './unsupported-version-block.tsx'
@@ -22,8 +23,9 @@ function describeDisposition(disposition: { kind: string; as?: string }): string
 function driftKey(entry: LockfileDriftEntry): string {
   switch (entry.reason) {
     case 'materialization-drift':
-    case 'stale-override':
       return `${entry.name}:${entry.reason}:${entry.assetType}:${entry.authoredName}`
+    case 'stale-override':
+      return `${entry.name}:${entry.reason}:${contributionKey(entry.contribution)}:${entry.authoredName}`
     default:
       return `${entry.name}:${entry.reason}`
   }
@@ -52,7 +54,7 @@ function describeDrift(entry: LockfileDriftEntry): string {
     case 'materialization-drift':
       return `${entry.assetType} "${entry.authoredName}": facets.json says ${describeDisposition(entry.manifest)}, lockfile says ${describeDisposition(entry.locked)}`
     case 'stale-override':
-      return `${entry.assetType} "${entry.authoredName}" has a materialization override but is not in the locked content`
+      return `${describeContribution(entry.contribution)} "${entry.authoredName}" has a materialization override but is not in the locked content`
     case 'materialization-unrepresentable':
       return `lockfile v${entry.lockfileVersion} cannot record materialization overrides (needs v${entry.requiredVersion})`
   }
@@ -513,29 +515,29 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
           <Text color={THEME.warning} bold>
             ✕ two or more facets want the same name
           </Text>
-          {failure.groups.map((group) => (
-            <Box key={`${group.scope}:${group.namespace}:${group.effectiveName}`} flexDirection="column">
+          {failure.groups.map((entry) => (
+            <Box key={collisionGroupKey(entry)} flexDirection="column">
               <Text>
                 {' '}
-                {describeNamespace(group.namespace, group.scope)} — “{group.effectiveName}” is claimed by:
+                {describeCollisionGroup(entry)} — “{entry.group.effectiveName}” is claimed by:
               </Text>
-              {group.members.map((member) => (
-                <Box key={`${member.facet}:${member.type}:${member.authoredName}`} flexDirection="column">
+              {collisionClaimants(entry).map((claimant) => (
+                <Box key={claimant.key} flexDirection="column">
                   <Text color={THEME.hint}>
                     {'   '}
-                    {member.facet} ({member.type} {member.authoredName})
+                    {claimant.facet} ({claimant.label})
                   </Text>
                   {/* The exact edit site, derived from the published
                       group mapping so it cannot drift from the schema. */}
                   <Text color={THEME.hint}>
                     {'     '}
-                    {manifestLocation(member.facet, member.type, member.authoredName)}
+                    {claimant.location}
                   </Text>
                 </Box>
               ))}
             </Box>
           ))}
-          <Text color={THEME.hint}> Record an alias or omission per asset in facets.json, then re-run.</Text>
+          <Text color={THEME.hint}> Record an alias or omission per claimant in facets.json, then re-run.</Text>
         </Box>
       )
     case 'MATERIALIZATION_ALIAS_INVALID':
@@ -564,14 +566,16 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
               {problem.facet}: “{problem.alias}” {problem.reason}
             </Text>
           ))}
-          {failure.groups.map((group) => (
-            <Text key={`${group.scope}:${group.namespace}:${group.effectiveName}`} color={THEME.hint}>
+          {failure.groups.map((entry) => (
+            <Text key={collisionGroupKey(entry)} color={THEME.hint}>
               {' '}
               {/* Humanized, like the collision arm above: the raw
                   discriminant (`skill-command`) is an internal name, and it
                   drops the scope entirely. */}
-              {describeNamespace(group.namespace, group.scope)} “{group.effectiveName}” is still claimed by{' '}
-              {group.members.map((m) => m.facet).join(', ')}
+              {describeCollisionGroup(entry)} “{entry.group.effectiveName}” is still claimed by{' '}
+              {collisionClaimants(entry)
+                .map((claimant) => claimant.facet)
+                .join(', ')}
             </Text>
           ))}
         </Box>

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -4,6 +4,7 @@ import type {
   CollisionResolution,
   CollisionResolutionRequest,
   CollisionResolver,
+  MaterializationOverrideRef,
   RemovePrepareFailure,
   RunInstallResult,
   StageEvent,
@@ -11,6 +12,7 @@ import type {
 import { LOCKFILE_VERSION_0_3 } from '@agent-facets/protocol'
 import { Box, Text, useApp, useStderr } from 'ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { contributionKey, describeContribution } from '../../../util/contribution.ts'
 import { ProgressBar } from '../../components/progress-bar.tsx'
 import { ASSET_TYPE_COLORS, THEME } from '../../theme.ts'
 import { AddPrepareFailureBlock } from './add-prepare-failure-block.tsx'
@@ -97,18 +99,17 @@ interface ServerWarning {
   servers: ReadonlyArray<string>
 }
 
-/** A materialization choice dropped because its asset no longer exists. */
-interface PrunedOverride {
-  facet: string
-  assetType: AssetType
-  authoredName: string
-}
+/** A materialization choice dropped because its contribution no longer exists. */
+type PrunedOverride = MaterializationOverrideRef
 
 /** A receipt claim that failed validation and can no longer be acted on. */
 interface RejectedReceiptEntry {
   facet: string
-  asset: string
+  /** The asset name or server name the claim covered. */
+  claimed: string
   reason: string
+  /** What is left behind, phrased for the kind of claim that was lost. */
+  consequence: string
 }
 
 /**
@@ -183,7 +184,7 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         // visible without `--verbose`, so it is state, not a log line.
         setPrunedOverrides((prev) => [
           ...prev,
-          { facet: event.facet, assetType: event.assetType, authoredName: event.authoredName },
+          { facet: event.facet, contribution: event.contribution, authoredName: event.authoredName },
         ])
         return
       case 'facet-start':
@@ -258,7 +259,30 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         // stay on disk and no longer have anything that could clean them up,
         // which is not something a user can deduce from a summary that says
         // the facet was removed.
-        setRejectedReceiptEntries((prev) => [...prev, { facet: event.facet, asset: event.asset, reason: event.reason }])
+        setRejectedReceiptEntries((prev) => [
+          ...prev,
+          {
+            facet: event.facet,
+            claimed: event.asset,
+            reason: event.reason,
+            consequence: 'that asset’s files are left in place and will not be cleaned up',
+          },
+        ])
+        return
+      case 'receipt-invalid-configuration':
+        // Losing a server claim costs both of the things it carried: the
+        // entry is no longer ours to remove, and the declaration behind it is
+        // no longer recorded as approved on this machine.
+        setRejectedReceiptEntries((prev) => [
+          ...prev,
+          {
+            facet: event.facet,
+            claimed: event.server,
+            reason: event.reason,
+            consequence:
+              'that server’s configuration is no longer tracked, and its declaration will need approval again',
+          },
+        ])
         return
       case 'obsolete-bundle-retained':
         // The removal succeeded, so the summary will say the facet is gone —
@@ -469,9 +493,12 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
       {prunedOverrides.length > 0 && (
         <Box flexDirection="column" marginLeft={2}>
           {prunedOverrides.map((pruned) => (
-            <Text key={`${pruned.facet}:${pruned.assetType}:${pruned.authoredName}`} color={THEME.caution}>
-              ⚠ dropped the materialization choice for {pruned.assetType} “{pruned.authoredName}” in {pruned.facet} —
-              this version no longer contains that asset.
+            <Text
+              key={`${pruned.facet}:${contributionKey(pruned.contribution)}:${pruned.authoredName}`}
+              color={THEME.caution}
+            >
+              ⚠ dropped the materialization choice for {describeContribution(pruned.contribution)} “
+              {pruned.authoredName}” in {pruned.facet} — this version no longer contains it.
             </Text>
           ))}
         </Box>
@@ -495,9 +522,9 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
       {rejectedReceiptEntries.length > 0 && (
         <Box flexDirection="column" marginLeft={2}>
           {rejectedReceiptEntries.map((entry) => (
-            <Text key={`${entry.facet}:${entry.asset}`} color={THEME.caution}>
-              ⚠ this project’s install receipt records “{entry.asset}” in {entry.facet} unusably ({entry.reason}) — that
-              asset’s files are left in place and will not be cleaned up.
+            <Text key={`${entry.facet}:${entry.claimed}`} color={THEME.caution}>
+              ⚠ this project’s install receipt records “{entry.claimed}” in {entry.facet} unusably ({entry.reason}) —{' '}
+              {entry.consequence}.
             </Text>
           ))}
         </Box>

--- a/packages/cli/src/util/__tests__/collision-report.test.ts
+++ b/packages/cli/src/util/__tests__/collision-report.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
-import type { CollisionGroup, StaleOverride } from '@agent-facets/protocol'
+import type { MaterializationCollisionGroup, StaleMaterializationOverride } from '@agent-facets/engine'
+import type { CollisionGroup } from '@agent-facets/protocol'
 import { formatCollisionReport, manifestLocation, PLACEHOLDER_ALIAS } from '../collision-report.ts'
+
+/** Tag asset-domain fixtures for the cross-domain report. */
+function assetGroups(...groups: CollisionGroup[]): MaterializationCollisionGroup[] {
+  return groups.map((group) => ({ kind: 'asset', group }))
+}
 
 const TWO_WAY: CollisionGroup[] = [
   {
@@ -68,7 +74,7 @@ describe('manifestLocation', () => {
 
 describe('formatCollisionReport', () => {
   test('names every group and every claimant', () => {
-    const report = formatCollisionReport([...TWO_WAY, SECOND_GROUP], [])
+    const report = formatCollisionReport(assetGroups(...TWO_WAY, SECOND_GROUP), [])
 
     expect(report).toContain('"review"')
     expect(report).toContain('"auditor"')
@@ -79,14 +85,14 @@ describe('formatCollisionReport', () => {
   })
 
   test('gives every claimant its own manifest location', () => {
-    const report = formatCollisionReport(TWO_WAY, [])
+    const report = formatCollisionReport(assetGroups(...TWO_WAY), [])
 
     expect(report).toContain('facets["alpha"].materialization.skills["review"]')
     expect(report).toContain('facets["beta"].materialization.commands["review"]')
   })
 
   test('offers an alias and an omission snippet for each claimant', () => {
-    const report = formatCollisionReport(TWO_WAY, [])
+    const report = formatCollisionReport(assetGroups(...TWO_WAY), [])
     const aliasLines = report.split('\n').filter((line) => line.includes('"kind": "aliased"'))
     const omitLines = report.split('\n').filter((line) => line.includes('"kind": "omitted"'))
 
@@ -95,7 +101,7 @@ describe('formatCollisionReport', () => {
   })
 
   test('the snippets it prints are parseable JSON', () => {
-    const report = formatCollisionReport(TWO_WAY, [])
+    const report = formatCollisionReport(assetGroups(...TWO_WAY), [])
     const snippets = report
       .split('\n')
       .map((line) => line.trim())
@@ -114,11 +120,11 @@ describe('formatCollisionReport', () => {
     // The spec requires syntactically valid examples, so the placeholder
     // cannot be something like `<your-name>`.
     expect(PLACEHOLDER_ALIAS).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-    expect(formatCollisionReport(TWO_WAY, [])).toContain(PLACEHOLDER_ALIAS)
+    expect(formatCollisionReport(assetGroups(...TWO_WAY), [])).toContain(PLACEHOLDER_ALIAS)
   })
 
   test('does not prefer a claimant or invent a resolution', () => {
-    const report = formatCollisionReport(TWO_WAY, []).toLowerCase()
+    const report = formatCollisionReport(assetGroups(...TWO_WAY), []).toLowerCase()
 
     for (const word of ['winner', 'preferred', 'takes precedence', 'wins', 'recommend']) {
       expect(report).not.toContain(word)
@@ -160,7 +166,7 @@ describe('formatCollisionReport', () => {
   }
 
   test('states that nothing was changed', () => {
-    const report = formatCollisionReport(TWO_WAY, [])
+    const report = formatCollisionReport(assetGroups(...TWO_WAY), [])
 
     expect(report).toContain('facets.json')
     expect(report).toContain('facets.lock')
@@ -170,21 +176,26 @@ describe('formatCollisionReport', () => {
 
   test('explains that skills and commands share one namespace', () => {
     // Without this, a skill colliding with a command reads as a bug.
-    expect(formatCollisionReport(TWO_WAY, [])).toContain('skills and commands')
-    expect(formatCollisionReport([SECOND_GROUP], [])).toContain('project agents')
+    expect(formatCollisionReport(assetGroups(...TWO_WAY), [])).toContain('skills and commands')
+    expect(formatCollisionReport(assetGroups(SECOND_GROUP), [])).toContain('project agents')
   })
 
   test('lists stale overrides when there are any', () => {
-    const stale: StaleOverride[] = [
-      { facet: 'alpha', type: 'skill', authoredName: 'gone', disposition: { kind: 'omitted' } },
+    const stale: StaleMaterializationOverride[] = [
+      {
+        facet: 'alpha',
+        contribution: { kind: 'asset', assetType: 'skill' },
+        authoredName: 'gone',
+        disposition: { kind: 'omitted' },
+      },
     ]
-    const report = formatCollisionReport(TWO_WAY, stale)
+    const report = formatCollisionReport(assetGroups(...TWO_WAY), stale)
 
     expect(report).toContain('no longer contain')
     expect(report).toContain('"gone"')
   })
 
   test('omits the stale-override section entirely when there are none', () => {
-    expect(formatCollisionReport(TWO_WAY, [])).not.toContain('no longer contain')
+    expect(formatCollisionReport(assetGroups(...TWO_WAY), [])).not.toContain('no longer contain')
   })
 })

--- a/packages/cli/src/util/collision-report.ts
+++ b/packages/cli/src/util/collision-report.ts
@@ -1,7 +1,12 @@
 import type { AssetType, Scope } from '@agent-facets/common'
-import type { RunInstallFailure } from '@agent-facets/engine'
-import type { CollisionGroup, MaterializationNamespace, StaleOverride } from '@agent-facets/protocol'
-import { overrideGroupKey } from '@agent-facets/protocol'
+import type {
+  MaterializationCollisionGroup,
+  RunInstallFailure,
+  StaleMaterializationOverride,
+} from '@agent-facets/engine'
+import type { MaterializationNamespace, McpServerDeclaration } from '@agent-facets/protocol'
+import { overrideGroupKey, SERVER_OVERRIDE_GROUP } from '@agent-facets/protocol'
+import { describeContribution } from './contribution.ts'
 
 /**
  * The complete, copy-pasteable account of a materialization collision.
@@ -59,25 +64,94 @@ export function describeNamespace(namespace: MaterializationNamespace, scope: Sc
   }
 }
 
+/** Where in `facets.json` a choice for this server is written. */
+export function serverManifestLocation(facet: string, authoredName: string): string {
+  return `facets[${JSON.stringify(facet)}].materialization.${SERVER_OVERRIDE_GROUP}[${JSON.stringify(authoredName)}]`
+}
+
+/** A stable React/list key for one collision group. */
+export function collisionGroupKey(entry: MaterializationCollisionGroup): string {
+  return entry.kind === 'asset'
+    ? `asset:${entry.group.scope}:${entry.group.namespace}:${entry.group.effectiveName}`
+    : `mcp-server:${entry.group.effectiveName}`
+}
+
+/** The heading naming what is being contested, and by which name. */
+export function describeCollisionGroup(entry: MaterializationCollisionGroup): string {
+  return entry.kind === 'asset' ? describeNamespace(entry.group.namespace, entry.group.scope) : 'MCP servers'
+}
+
+/** One claimant, flattened for rendering. */
+export interface CollisionClaimant {
+  key: string
+  facet: string
+  /** What the claimant is, in the user's words. */
+  label: string
+  authoredName: string
+  /** The exact `facets.json` path a choice is written to. */
+  location: string
+}
+
+/**
+ * Every claimant of a group, in one shape.
+ *
+ * Shared so the Ink block and the stderr report cannot disagree about which
+ * claimants exist or where a user edits them — the two surfaces render the
+ * same failure, and only one of them is visible in CI.
+ */
+export function collisionClaimants(entry: MaterializationCollisionGroup): CollisionClaimant[] {
+  if (entry.kind === 'asset') {
+    return entry.group.members.map((member) => ({
+      key: `${member.facet}:${member.type}:${member.authoredName}`,
+      facet: member.facet,
+      label: `${member.type} ${member.authoredName}`,
+      authoredName: member.authoredName,
+      location: manifestLocation(member.facet, member.type, member.authoredName),
+    }))
+  }
+  return entry.group.members.map((member) => ({
+    key: `${member.facet}:mcp-server:${member.authoredName}`,
+    facet: member.facet,
+    label: `server ${member.authoredName}`,
+    authoredName: member.authoredName,
+    location: serverManifestLocation(member.facet, member.authoredName),
+  }))
+}
+
 /** The full stderr report for an unresolved collision. */
 export function formatCollisionReport(
-  groups: readonly CollisionGroup[],
-  staleOverrides: readonly StaleOverride[],
+  groups: readonly MaterializationCollisionGroup[],
+  staleOverrides: readonly StaleMaterializationOverride[],
 ): string {
   const lines: string[] = []
 
   lines.push(
     `Two or more facets want the same name, so installation stopped before writing anything.`,
-    `Every asset below needs one choice: keep its name, give it a different one, or leave it out.`,
+    `Every claimant below needs one choice: keep its name, give it a different one, or leave it out.`,
     ``,
   )
 
-  for (const group of groups) {
-    lines.push(`  ${describeNamespace(group.namespace, group.scope)} — "${group.effectiveName}" is claimed by:`)
+  for (const entry of groups) {
+    if (entry.kind === 'asset') {
+      const group = entry.group
+      lines.push(`  ${describeNamespace(group.namespace, group.scope)} — "${group.effectiveName}" is claimed by:`)
+      for (const member of group.members) {
+        const via = member.disposition.kind === 'aliased' ? ` (already aliased from "${member.authoredName}")` : ''
+        lines.push(`    • ${member.facet}: ${member.type} "${member.authoredName}" → "${member.effectiveName}"${via}`)
+        lines.push(`        edit ${manifestLocation(member.facet, member.type, member.authoredName)}`)
+        lines.push(`          alias:  ${aliasSnippet(member.authoredName)}`)
+        lines.push(`          omit:   ${omitSnippet(member.authoredName)}`)
+      }
+      lines.push(``)
+      continue
+    }
+    const group = entry.group
+    lines.push(`  MCP servers — "${group.effectiveName}" is claimed by:`)
     for (const member of group.members) {
       const via = member.disposition.kind === 'aliased' ? ` (already aliased from "${member.authoredName}")` : ''
-      lines.push(`    • ${member.facet}: ${member.type} "${member.authoredName}" → "${member.effectiveName}"${via}`)
-      lines.push(`        edit ${manifestLocation(member.facet, member.type, member.authoredName)}`)
+      lines.push(`    • ${member.facet}: server "${member.authoredName}" → "${member.effectiveName}"${via}`)
+      lines.push(`        ${describeDeclaration(member.declaration)}`)
+      lines.push(`        edit ${serverManifestLocation(member.facet, member.authoredName)}`)
       lines.push(`          alias:  ${aliasSnippet(member.authoredName)}`)
       lines.push(`          omit:   ${omitSnippet(member.authoredName)}`)
     }
@@ -96,9 +170,9 @@ export function formatCollisionReport(
   )
 
   if (staleOverrides.length > 0) {
-    lines.push(`  Also note — these recorded choices name assets the resolved versions no longer contain:`)
+    lines.push(`  Also note — these recorded choices name contributions the resolved versions no longer contain:`)
     for (const stale of staleOverrides) {
-      lines.push(`    • ${stale.facet}: ${stale.type} "${stale.authoredName}"`)
+      lines.push(`    • ${stale.facet}: ${describeContribution(stale.contribution)} "${stale.authoredName}"`)
     }
     lines.push(``)
   }
@@ -106,6 +180,26 @@ export function formatCollisionReport(
   lines.push(`  facets.json, facets.lock, the install receipt, and your materialized assets were NOT changed.`)
 
   return lines.join('\n')
+}
+
+/**
+ * A one-line summary of a declaration, enough to tell two colliding servers
+ * apart without reproducing the declaration itself.
+ *
+ * Deliberately not the full command, arguments, environment, or URL. This
+ * report goes to stderr, which is a log file in exactly the situations that
+ * produce it, and the complete declaration belongs only on the interactive
+ * approval screen. The fingerprint prefix is the tiebreaker when two
+ * summaries coincide: it is derived from the whole declaration but reveals
+ * none of it.
+ */
+function describeDeclaration(declaration: McpServerDeclaration): string {
+  switch (declaration.type) {
+    case 'stdio':
+      return `stdio, command "${declaration.command}"`
+    case 'http':
+      return `http, ${new URL(declaration.url).origin}`
+  }
 }
 
 function aliasSnippet(authoredName: string): string {
@@ -123,12 +217,19 @@ function omitSnippet(authoredName: string): string {
  * concrete. It is not a suggestion about which facet should yield —
  * every claimant already got the identical pair of snippets above.
  */
-function exampleFacet(groups: readonly CollisionGroup[]): string {
-  return groups[0]?.members[0]?.facet ?? 'your-facet'
+function exampleFacet(groups: readonly MaterializationCollisionGroup[]): string {
+  return groups[0]?.group.members[0]?.facet ?? 'your-facet'
 }
 
-function exampleOverrideBody(groups: readonly CollisionGroup[]): string {
-  const member = groups[0]?.members[0]
+function exampleOverrideBody(groups: readonly MaterializationCollisionGroup[]): string {
+  const first = groups[0]
+  if (first === undefined) return `"skills": { ${aliasSnippet('asset-name')} }`
+  if (first.kind === 'mcp-server') {
+    const member = first.group.members[0]
+    if (member === undefined) return `"${SERVER_OVERRIDE_GROUP}": { ${aliasSnippet('server-name')} }`
+    return `"${SERVER_OVERRIDE_GROUP}": { ${aliasSnippet(member.authoredName)} }`
+  }
+  const member = first.group.members[0]
   if (member === undefined) return `"skills": { ${aliasSnippet('asset-name')} }`
   return `"${overrideGroupKey(member.type)}": { ${aliasSnippet(member.authoredName)} }`
 }

--- a/packages/cli/src/util/contribution.ts
+++ b/packages/cli/src/util/contribution.ts
@@ -1,0 +1,22 @@
+import type { ContributionKind } from '@agent-facets/engine'
+
+/**
+ * How a contribution kind is named in user-facing output, and how it is keyed
+ * in a React list.
+ *
+ * One place, because a materialization override shows up in five different
+ * surfaces — the pruned-intent notice, the frozen drift list, the collision
+ * workspace, the non-interactive collision report, and verbose logging — and
+ * a server that reads as "servers" in one and "mcp-server" in another looks
+ * like two different things to the person trying to fix it.
+ */
+
+/** The noun a user sees. Asset types are already the words users know. */
+export function describeContribution(contribution: ContributionKind): string {
+  return contribution.kind === 'asset' ? contribution.assetType : 'MCP server'
+}
+
+/** A stable key fragment, distinct across kinds. */
+export function contributionKey(contribution: ContributionKind): string {
+  return contribution.kind === 'asset' ? `asset:${contribution.assetType}` : 'mcp-server'
+}

--- a/packages/engine/src/__tests__/manifest-mutations.test.ts
+++ b/packages/engine/src/__tests__/manifest-mutations.test.ts
@@ -259,6 +259,19 @@ describe('countOverrides', () => {
       }),
     ).toBe(3)
   })
+
+  // This count decides whether an entry stays expanded. A servers-only entry
+  // counting as zero is not a cosmetic undercount — it collapses the entry to
+  // a compact source string and erases the intent from `facets.json`.
+  test('counts server overrides too', () => {
+    expect(countOverrides({ servers: { filesystem: { kind: 'omitted' } } })).toBe(1)
+    expect(
+      countOverrides({
+        skills: { review: { kind: 'omitted' } },
+        servers: { filesystem: { kind: 'aliased', as: 'project-filesystem' } },
+      }),
+    ).toBe(2)
+  })
 })
 
 describe('emptyProjectManifest', () => {
@@ -306,6 +319,54 @@ describe('applyDesiredFacets — canonical form', () => {
     const out = roundTrip('{"facets":{"a":"1.*","b":"2.*"}}', { a: entry('1.*') })
     expect(JSON.parse(out).facets).toEqual({ a: '1.*' })
   })
+
+  test('a server-only entry stays expanded rather than collapsing', () => {
+    const out = roundTrip('{"facets":{}}', {
+      a: entry('1.*', { servers: { filesystem: { kind: 'aliased', as: 'project-filesystem' } } }),
+    })
+    expect(JSON.parse(out).facets.a).toEqual({
+      source: '1.*',
+      materialization: { servers: { filesystem: { kind: 'aliased', as: 'project-filesystem' } } },
+    })
+  })
+
+  test('a server override is reconciled in place, not left behind', () => {
+    const raw = JSON.stringify({
+      manifestVersion: 0.2,
+      facets: {
+        a: {
+          source: '1.*',
+          materialization: { servers: { filesystem: { kind: 'aliased', as: 'old' }, docs: { kind: 'omitted' } } },
+        },
+      },
+    })
+    // `docs` is dropped and `filesystem` retargeted. Both edits have to land:
+    // a group this writer does not visit keeps whatever the document said.
+    const out = roundTrip(raw, {
+      a: entry('1.*', { servers: { filesystem: { kind: 'aliased', as: 'new' } } }),
+    })
+    expect(JSON.parse(out).facets.a).toEqual({
+      source: '1.*',
+      materialization: { servers: { filesystem: { kind: 'aliased', as: 'new' } } },
+    })
+  })
+
+  test('an emptied servers group is removed rather than left as an empty object', () => {
+    const raw = JSON.stringify({
+      manifestVersion: 0.2,
+      facets: {
+        a: {
+          source: '1.*',
+          materialization: { skills: { review: { kind: 'omitted' } }, servers: { docs: { kind: 'omitted' } } },
+        },
+      },
+    })
+    const out = roundTrip(raw, { a: entry('1.*', { skills: { review: { kind: 'omitted' } } }) })
+    expect(JSON.parse(out).facets.a).toEqual({
+      source: '1.*',
+      materialization: { skills: { review: { kind: 'omitted' } } },
+    })
+  })
 })
 
 describe('applyDesiredFacets — version stamping', () => {
@@ -332,6 +393,18 @@ describe('applyDesiredFacets — source updates preserve overrides', () => {
     expect(JSON.parse(out).facets.a).toEqual({
       source: '2.*',
       materialization: { commands: { deploy: { kind: 'omitted' } } },
+    })
+  })
+
+  test('changing a source preserves a server override', () => {
+    const raw = JSON.stringify({
+      manifestVersion: 0.2,
+      facets: { a: { source: '1.*', materialization: { servers: { filesystem: { kind: 'omitted' } } } } },
+    })
+    const out = roundTrip(raw, { a: entry('2.*', { servers: { filesystem: { kind: 'omitted' } } }) })
+    expect(JSON.parse(out).facets.a).toEqual({
+      source: '2.*',
+      materialization: { servers: { filesystem: { kind: 'omitted' } } },
     })
   })
 })

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -185,12 +185,15 @@ export { prepareRemove, runRemove } from './install/run-remove.ts'
 export type {
   Addition,
   AssetIdentity,
+  ContributionKind,
   EffectiveAssetName,
   FacetOutcome,
   FacetStage,
   InstallDelta,
   InstallSummary,
   LockfileDriftEntry,
+  MaterializationCollisionGroup,
+  MaterializationOverrideRef,
   OnLog,
   Removal,
   RollbackOutcome,
@@ -198,6 +201,7 @@ export type {
   RunInstallOptions,
   RunInstallResult,
   StageEvent,
+  StaleMaterializationOverride,
 } from './install/types.ts'
 // `AssetIdentity` names an asset by its EFFECTIVE name, and the brand on
 // that field makes the type unconstructible from a bare string. Adapter

--- a/packages/engine/src/install/__tests__/apply-ownership.test.ts
+++ b/packages/engine/src/install/__tests__/apply-ownership.test.ts
@@ -277,6 +277,7 @@ describe('apply — global ownership reconciliation', () => {
     const receipt = readReceipt()
     const claim = (_facet: string, companion: string): Receipt['facets'][string] => ({
       version: '1.0.0',
+      integrity: 'sha256:ghost',
       assets: [
         {
           scope: 'project',
@@ -286,6 +287,7 @@ describe('apply — global ownership reconciliation', () => {
           files: ['skills/shared/SKILL.md', `skills/shared/${companion}`],
         },
       ],
+      configurations: [],
     })
     writeReceipt(projectRoot, {
       version: CURRENT_RECEIPT_VERSION,
@@ -985,7 +987,7 @@ describe('apply — frozen reproduction of recorded intent', () => {
     // claimant named, exactly as a non-interactive install would get it.
     if (result.failure.code !== 'MATERIALIZATION_COLLISION') expect.unreachable()
     expect(result.failure.groups).toHaveLength(1)
-    expect(result.failure.groups[0]?.members.map((m) => m.facet).sort()).toEqual(['alpha', 'beta'])
+    expect(result.failure.groups[0]?.group.members.map((m) => m.facet).sort()).toEqual(['alpha', 'beta'])
     expect(prompted).toBe(false)
     expectUntouched(lock, manifestText)
   })

--- a/packages/engine/src/install/__tests__/compose.test.ts
+++ b/packages/engine/src/install/__tests__/compose.test.ts
@@ -77,6 +77,16 @@ function fixture(facet: string, skill: string, version = '1.0.0'): string {
   return `./vendor/${facet}`
 }
 
+/** A local facet whose only deliverable is one MCP server declaration. */
+function serverFixture(facet: string, server: string, declaration: unknown, version = '1.0.0'): string {
+  const dir = join(projectRoot, 'vendor', facet)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'facet.json'), JSON.stringify({ name: facet, version, servers: { [server]: declaration } }))
+  return `./vendor/${facet}`
+}
+
+const STDIO = { type: 'stdio', command: 'npx', args: ['-y', 'server-filesystem'] }
+
 function writeManifest(value: unknown): string {
   const text = `${JSON.stringify(value, null, 2)}\n`
   writeFileSync(join(projectRoot, 'facets.json'), text)
@@ -117,9 +127,10 @@ describe('compose — collision detection', () => {
 
     // Both claimants are named, in one report.
     expect(result.failure.groups).toHaveLength(1)
-    const group = result.failure.groups[0]
-    expect(group?.effectiveName).toBe('review')
-    expect(group?.members.map((m) => m.facet).sort()).toEqual(['alpha', 'beta'])
+    const entry = result.failure.groups[0]
+    if (entry?.kind !== 'asset') expect.unreachable()
+    expect(entry.group.effectiveName).toBe('review')
+    expect(entry.group.members.map((m) => m.facet).sort()).toEqual(['alpha', 'beta'])
 
     // Nothing was written, and no adapter I/O method ran at all.
     expect(io).toEqual([])
@@ -142,7 +153,7 @@ describe('compose — collision detection', () => {
     if (result.failure.code !== 'MATERIALIZATION_COLLISION') expect.unreachable()
     // Two independent conflicts: a user should learn both at once rather
     // than discovering the second only after fixing the first.
-    expect(result.failure.groups.map((g) => g.effectiveName).sort()).toEqual(['deploy', 'review'])
+    expect(result.failure.groups.map((g) => g.group.effectiveName).sort()).toEqual(['deploy', 'review'])
   })
 
   test('agents do not collide with skills of the same name', async () => {
@@ -165,6 +176,156 @@ describe('compose — collision detection', () => {
 
     const result = await runInstall({ projectRoot, adapters: [adapter] })
     expect(result.ok).toBe(true)
+  })
+})
+
+describe('compose — MCP server composition', () => {
+  test('two facets declaring the identical server compose instead of colliding', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = serverFixture('beta', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a, beta: b } })
+    const { adapter } = recordingAdapter('rec')
+
+    // Same declaration, same effective name: one configuration, two
+    // claimants. Contesting here would block an install over an agreement.
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    expect(result.ok).toBe(true)
+  })
+
+  test('two facets declaring different servers at one name collide before any write', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = serverFixture('beta', 'filesystem', { type: 'http', url: 'https://example.test/mcp' })
+    writeManifest({ facets: { alpha: a, beta: b } })
+    const { adapter, io } = recordingAdapter('rec')
+
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MATERIALIZATION_COLLISION') expect.unreachable()
+    const entry = result.failure.groups[0]
+    if (entry?.kind !== 'mcp-server') expect.unreachable()
+    expect(entry.group.effectiveName).toBe('filesystem')
+    expect(entry.group.members.map((m) => m.facet).sort()).toEqual(['alpha', 'beta'])
+    expect(io).toEqual([])
+    expect(existsSyncSafe(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  test('a server and a skill of the same name do not collide', async () => {
+    const a = serverFixture('alpha', 'review', STDIO)
+    const b = fixture('beta', 'review')
+    writeManifest({ facets: { alpha: a, beta: b } })
+    const { adapter } = recordingAdapter('rec')
+
+    // Separate identity spaces, so there is no shared key to contend in.
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    expect(result.ok).toBe(true)
+  })
+
+  test('an alias resolves a server collision, and both survive', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = serverFixture('beta', 'filesystem', { type: 'http', url: 'https://example.test/mcp' })
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: {
+        alpha: { source: a, materialization: { servers: { filesystem: { kind: 'aliased', as: 'alpha-fs' } } } },
+        beta: b,
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    expect(result.ok).toBe(true)
+  })
+
+  test('an omission resolves a server collision', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = serverFixture('beta', 'filesystem', { type: 'http', url: 'https://example.test/mcp' })
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: {
+        alpha: { source: a, materialization: { servers: { filesystem: { kind: 'omitted' } } } },
+        beta: b,
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    expect(result.ok).toBe(true)
+  })
+
+  test('a server-only facet installs with zero assets', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const { adapter, io } = recordingAdapter('rec')
+
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+
+    if (!result.ok) expect.unreachable()
+    // The lockfile records the facet with an empty asset list; no adapter
+    // asset method runs, because there is no asset.
+    expect(io).toEqual([])
+    expect(existsSyncSafe(join(projectRoot, 'facets.lock'))).toBe(true)
+  })
+
+  test('asset and server collisions are reported together in one pass', async () => {
+    const a = fixture('alpha', 'review')
+    const b = fixture('beta', 'review')
+    const c = serverFixture('gamma', 'filesystem', STDIO)
+    const d = serverFixture('delta', 'filesystem', { type: 'http', url: 'https://example.test/mcp' })
+    writeManifest({ facets: { alpha: a, beta: b, gamma: c, delta: d } })
+    const { adapter } = recordingAdapter('rec')
+
+    const result = await runInstall({ projectRoot, adapters: [adapter] })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MATERIALIZATION_COLLISION') expect.unreachable()
+    // Both domains in one report: a user shown the asset conflict now and the
+    // server conflict on the next attempt learns the shape of the problem one
+    // round trip at a time.
+    expect(result.failure.groups.map((g) => g.kind).sort()).toEqual(['asset', 'mcp-server'])
+  })
+
+  test('a server-only facet locks with an empty asset list and no server data', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const { adapter } = recordingAdapter('rec')
+
+    expect((await runInstall({ projectRoot, adapters: [adapter] })).ok).toBe(true)
+
+    // The lockfile is unchanged by MCP support: a declaration travels inside
+    // the integrity-pinned `facet.json`, so duplicating it here would give a
+    // shared file a second, unverifiable copy.
+    const lockfile = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    expect(lockfile.lockfileVersion).toBe(0.3)
+    expect(lockfile.facets.alpha.assets).toEqual([])
+    expect(JSON.stringify(lockfile)).not.toContain('npx')
+    expect(JSON.stringify(lockfile)).not.toContain('servers')
+  })
+
+  test('a server override naming an undeclared server is reported as stale, not fatal', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: {
+        alpha: { source: a, materialization: { servers: { gone: { kind: 'omitted' } } } },
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+    const events: StageEvent[] = []
+
+    const result = await runInstall({ projectRoot, adapters: [adapter], onStage: (e) => events.push(e) })
+
+    expect(result.ok).toBe(true)
+    expect(events.filter((e) => e.kind === 'stale-override-pruned')).toEqual([
+      {
+        kind: 'stale-override-pruned',
+        facet: 'alpha',
+        contribution: { kind: 'mcp-server' },
+        authoredName: 'gone',
+      },
+    ])
+    // Its last override is gone, so the entry collapses to its compact form.
+    expect(JSON.parse(readManifest()).facets.alpha).toBe('./vendor/alpha')
   })
 })
 
@@ -429,7 +590,12 @@ describe('compose — persisting and pruning intent', () => {
     // the user committed has changed.
     const prunes = events.filter((e) => e.kind === 'stale-override-pruned')
     expect(prunes).toEqual([
-      { kind: 'stale-override-pruned', facet: 'alpha', assetType: 'skill', authoredName: 'gone' },
+      {
+        kind: 'stale-override-pruned',
+        facet: 'alpha',
+        contribution: { kind: 'asset', assetType: 'skill' },
+        authoredName: 'gone',
+      },
     ])
   })
 

--- a/packages/engine/src/install/__tests__/finalize-intent.test.ts
+++ b/packages/engine/src/install/__tests__/finalize-intent.test.ts
@@ -75,10 +75,64 @@ describe('finalizeMaterializationIntent — keys that collide with Object.protot
     }
 
     const pruned = finalizeMaterializationIntent(desiredFacets, accepted, [
-      { facet: 'vendor', type: 'skill', authoredName: '__proto__', disposition: aliased('safe') },
+      {
+        facet: 'vendor',
+        contribution: { kind: 'asset', assetType: 'skill' },
+        authoredName: '__proto__',
+        disposition: aliased('safe'),
+      },
     ])
 
-    expect(pruned).toEqual([{ facet: 'vendor', type: 'skill', authoredName: '__proto__' }])
+    expect(pruned).toEqual([
+      { facet: 'vendor', contribution: { kind: 'asset', assetType: 'skill' }, authoredName: '__proto__' },
+    ])
+    expect(desiredFacets.vendor?.overrides).toBeUndefined()
+  })
+
+  // The whole reason the group list is derived rather than written out: a
+  // servers-only entry counted as zero overrides, so the canonical writer
+  // collapsed it back to a compact source string and the intent vanished.
+  test('a server override survives a prune that does not name it', () => {
+    const desiredFacets: Record<string, NormalizedFacetEntry> = { vendor: { source: './v', overrides: undefined } }
+    const accepted: Record<string, FacetMaterializationOverrides> = {
+      vendor: {
+        skills: record<ProjectAssetOverride>([['gone', aliased('safe')]]),
+        servers: record<ProjectAssetOverride>([['filesystem', aliased('project-filesystem')]]),
+      },
+    }
+
+    const pruned = finalizeMaterializationIntent(desiredFacets, accepted, [
+      {
+        facet: 'vendor',
+        contribution: { kind: 'asset', assetType: 'skill' },
+        authoredName: 'gone',
+        disposition: aliased('safe'),
+      },
+    ])
+
+    expect(pruned).toHaveLength(1)
+    expect(desiredFacets.vendor?.overrides).toEqual({
+      servers: { filesystem: aliased('project-filesystem') },
+    })
+  })
+
+  test('a stale server override is pruned and reported as an MCP server', () => {
+    const desiredFacets: Record<string, NormalizedFacetEntry> = { vendor: { source: './v', overrides: undefined } }
+    const accepted: Record<string, FacetMaterializationOverrides> = {
+      vendor: { servers: record<ProjectAssetOverride>([['filesystem', aliased('project-filesystem')]]) },
+    }
+
+    const pruned = finalizeMaterializationIntent(desiredFacets, accepted, [
+      {
+        facet: 'vendor',
+        contribution: { kind: 'mcp-server' },
+        authoredName: 'filesystem',
+        disposition: aliased('project-filesystem'),
+      },
+    ])
+
+    expect(pruned).toEqual([{ facet: 'vendor', contribution: { kind: 'mcp-server' }, authoredName: 'filesystem' }])
+    // Its last override is gone, so the entry collapses to its compact form.
     expect(desiredFacets.vendor?.overrides).toBeUndefined()
   })
 })

--- a/packages/engine/src/install/__tests__/manifest-transaction.test.ts
+++ b/packages/engine/src/install/__tests__/manifest-transaction.test.ts
@@ -12,7 +12,7 @@ import { loadInstalledAdapters } from '../../adapters/loader.ts'
 import { parseFacetSource } from '../../sources/facet/parse-source.ts'
 import { runAdd } from '../add/index.ts'
 import { acquireInstallLock } from '../lockfile-guard.ts'
-import { CURRENT_RECEIPT_VERSION, receiptPath } from '../receipt.ts'
+import { CURRENT_RECEIPT_VERSION, RECEIPT_VERSION_0_3, receiptPath } from '../receipt.ts'
 import { runRemove } from '../remove/index.ts'
 import { runInstall } from '../run-install.ts'
 
@@ -455,10 +455,39 @@ describe('every command writes the current formats, and only frozen mode does no
     expect(readReceipt().version).toBe(CURRENT_RECEIPT_VERSION)
   }
 
-  test('facet add writes manifest 0.1, lockfile 0.3, and receipt 0.3', async () => {
+  test('facet add writes the current manifest, lockfile, and receipt formats', async () => {
     const a = buildFixture('alpha', '1.0.0')
     expect((await add(a)).ok).toBe(true)
     expectCurrentFormats()
+  })
+
+  // The next successful write emits the current receipt format, never an
+  // intermediate one — the property that bounds how long a project stays on
+  // a receipt that cannot witness configuration.
+  test('an earlier receipt is rewritten at the current version by the next success', async () => {
+    const a = buildFixture('alpha', '1.0.0')
+    expect((await add(a)).ok).toBe(true)
+
+    const current = readReceipt()
+    const downgraded = {
+      version: RECEIPT_VERSION_0_3,
+      path: current.path,
+      facets: Object.fromEntries(
+        Object.entries(current.facets as Record<string, { version: string; assets: unknown }>).map(([name, entry]) => [
+          name,
+          { version: entry.version, assets: entry.assets },
+        ]),
+      ),
+    }
+    writeFileSync(receiptPath(projectRoot), `${JSON.stringify(downgraded, null, 2)}\n`)
+
+    expect((await install()).ok).toBe(true)
+
+    expect(readReceipt().version).toBe(CURRENT_RECEIPT_VERSION)
+    // Asset ownership survived the round trip; only configuration authority
+    // was absent, and this run reconciled none to record.
+    expect(readReceipt().facets.alpha.assets).toHaveLength(1)
+    expect(readReceipt().facets.alpha.configurations).toEqual([])
   })
 
   test('facet install writes the current formats', async () => {

--- a/packages/engine/src/install/__tests__/receipt.test.ts
+++ b/packages/engine/src/install/__tests__/receipt.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Lockfile02, SupportedLockfile } from '@agent-facets/protocol'
@@ -10,14 +10,39 @@ import {
   LEGACY_RECEIPT_VERSION,
   loadReceipt,
   RECEIPT_VERSION_0_2,
+  RECEIPT_VERSION_0_3,
   type Receipt,
   type ReceiptAsset,
-  receiptBaseFor,
+  type ReceiptConfigurationClaim,
+  type ReceiptFacetEntry,
   receiptEntryForLockedFacet,
   receiptPath,
+  receiptProjectPath,
   resolveProjectReceipt,
   writeReceipt,
 } from '../receipt.ts'
+
+/** Placeholder facet integrity. Only its identity across a round trip matters. */
+const INTEGRITY = 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+/** A configuration claim. The fingerprint stands in for a declaration. */
+function claim(name: string, materialization: ReceiptConfigurationClaim['materialization'] = { kind: 'authored' }) {
+  return {
+    kind: 'mcp-server',
+    name,
+    materialization,
+    fingerprint: `sha256:${'a'.repeat(64)}`,
+  } satisfies ReceiptConfigurationClaim
+}
+
+/** A current facet record. Most tests care only about its assets. */
+function facetEntry(
+  version: string,
+  assets: ReceiptAsset[],
+  configurations: ReceiptConfigurationClaim[] = [],
+): ReceiptFacetEntry {
+  return { version, integrity: INTEGRITY, assets, configurations }
+}
 
 /** An authored-materialization skill asset owning exactly its SKILL.md. */
 function skillAsset(name: string): ReceiptAsset {
@@ -55,6 +80,12 @@ function commandAsset(name: string): ReceiptAsset {
 let facetDir: string
 let projectDir: string
 let originalFacetDir: string | undefined
+
+/** Write receipt bytes verbatim, bypassing the writer's own shaping. */
+function writeRawReceipt(body: string): void {
+  mkdirSync(join(facetDir, 'receipts'), { recursive: true })
+  writeFileSync(receiptPath(projectDir), body)
+}
 
 beforeEach(() => {
   originalFacetDir = process.env.FACET_DIR
@@ -154,14 +185,8 @@ describe('loadReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [{ ...skillAsset('escape'), name: '../escape' }, skillAsset('cowsay')],
-        },
-        hello: {
-          version: '1.0.0',
-          assets: [agentAsset('greeter')],
-        },
+        cowsay: facetEntry('0.0.1', [{ ...skillAsset('escape'), name: '../escape' }, skillAsset('cowsay')]),
+        hello: facetEntry('1.0.0', [agentAsset('greeter')]),
       },
     }
     const path = receiptPath(projectDir)
@@ -171,12 +196,14 @@ describe('loadReceipt', () => {
     if (!result.ok) expect.unreachable()
     // The invalid entry is reported with its facet, name, and reason.
     expect(result.invalidEntries).toHaveLength(1)
-    expect(result.invalidEntries[0]?.facet).toBe('cowsay')
-    expect(result.invalidEntries[0]?.asset).toBe('../escape')
-    expect(result.invalidEntries[0]?.reason.length).toBeGreaterThan(0)
+    const invalid = result.invalidEntries[0]
+    if (invalid?.kind !== 'asset') expect.unreachable()
+    expect(invalid.facet).toBe('cowsay')
+    expect(invalid.asset).toBe('../escape')
+    expect(invalid.reason.length).toBeGreaterThan(0)
     // The valid sibling asset and the untouched facet still load.
-    expect(result.receipt.facets.cowsay?.assets).toEqual([skillAsset('cowsay')])
-    expect(result.receipt.facets.hello?.assets).toHaveLength(1)
+    expect(result.record.facets.cowsay?.assets).toEqual([skillAsset('cowsay')])
+    expect(result.record.facets.hello?.assets).toHaveLength(1)
   })
 
   test('drops an asset whose owned file path escapes, reporting it', () => {
@@ -187,19 +214,16 @@ describe('loadReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [
-            {
-              scope: 'project',
-              type: 'skill',
-              name: 'cowsay',
-              materialization: { kind: 'authored' },
-              files: ['skills/cowsay/../../escape.md'],
-            },
-            skillAsset('safe'),
-          ],
-        },
+        cowsay: facetEntry('0.0.1', [
+          {
+            scope: 'project',
+            type: 'skill',
+            name: 'cowsay',
+            materialization: { kind: 'authored' },
+            files: ['skills/cowsay/../../escape.md'],
+          },
+          skillAsset('safe'),
+        ]),
       },
     }
     const path = receiptPath(projectDir)
@@ -208,9 +232,11 @@ describe('loadReceipt', () => {
     const result = loadReceipt(projectDir)
     if (!result.ok) expect.unreachable()
     expect(result.invalidEntries).toHaveLength(1)
-    expect(result.invalidEntries[0]?.asset).toBe('cowsay')
-    expect(result.invalidEntries[0]?.reason).toContain('owned path')
-    expect(result.receipt.facets.cowsay?.assets).toEqual([skillAsset('safe')])
+    const invalid = result.invalidEntries[0]
+    if (invalid?.kind !== 'asset') expect.unreachable()
+    expect(invalid.asset).toBe('cowsay')
+    expect(invalid.reason).toContain('owned path')
+    expect(result.record.facets.cowsay?.assets).toEqual([skillAsset('safe')])
   })
 
   test('refines a legacy (1) receipt to primary-only ownership', () => {
@@ -235,8 +261,8 @@ describe('loadReceipt', () => {
     writeFileSync(path, JSON.stringify(legacy))
     const result = loadReceipt(projectDir)
     if (!result.ok) expect.unreachable()
-    expect(result.receipt.version).toBe(CURRENT_RECEIPT_VERSION)
-    expect(result.receipt.facets.cowsay?.assets).toEqual([skillAsset('cowsay'), commandAsset('moo')])
+    expect(result.record.authority).toBe('assets-only')
+    expect(result.record.facets.cowsay?.assets).toEqual([skillAsset('cowsay'), commandAsset('moo')])
   })
 
   test('refines a 0.2 receipt to authored, retaining its complete ownership', () => {
@@ -265,9 +291,9 @@ describe('loadReceipt', () => {
     writeFileSync(path, JSON.stringify(receipt02))
     const result = loadReceipt(projectDir)
     if (!result.ok) expect.unreachable()
-    expect(result.receipt.version).toBe(CURRENT_RECEIPT_VERSION)
-    expect(result.receipt.facets.cowsay?.assets[0]?.materialization).toEqual({ kind: 'authored' })
-    expect(result.receipt.facets.cowsay?.assets[0]?.files).toEqual([
+    expect(result.record.authority).toBe('assets-only')
+    expect(result.record.facets.cowsay?.assets[0]?.materialization).toEqual({ kind: 'authored' })
+    expect(result.record.facets.cowsay?.assets[0]?.files).toEqual([
       'skills/cowsay/SKILL.md',
       'skills/cowsay/references/art.md',
     ])
@@ -278,18 +304,15 @@ describe('loadReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [
-            {
-              scope: 'project',
-              type: 'skill',
-              name: 'cowsay',
-              materialization: { kind: 'aliased', as: 'vendor-cowsay' },
-              files: ['skills/cowsay/SKILL.md'],
-            },
-          ],
-        },
+        cowsay: facetEntry('0.0.1', [
+          {
+            scope: 'project',
+            type: 'skill',
+            name: 'cowsay',
+            materialization: { kind: 'aliased', as: 'vendor-cowsay' },
+            files: ['skills/cowsay/SKILL.md'],
+          },
+        ]),
       },
     }
     const path = receiptPath(projectDir)
@@ -299,12 +322,12 @@ describe('loadReceipt', () => {
     if (!result.ok) expect.unreachable()
     // Both names survive: authored anchors ownership and canonical paths,
     // the alias is what the adapter must be asked to delete.
-    expect(result.receipt.facets.cowsay?.assets[0]?.name).toBe('cowsay')
-    expect(result.receipt.facets.cowsay?.assets[0]?.materialization).toEqual({
+    expect(result.record.facets.cowsay?.assets[0]?.name).toBe('cowsay')
+    expect(result.record.facets.cowsay?.assets[0]?.materialization).toEqual({
       kind: 'aliased',
       as: 'vendor-cowsay',
     })
-    expect(result.receipt.facets.cowsay?.assets[0]?.files).toEqual(['skills/cowsay/SKILL.md'])
+    expect(result.record.facets.cowsay?.assets[0]?.files).toEqual(['skills/cowsay/SKILL.md'])
   })
 
   test('a receipt recording an omitted asset is corrupt, not silently accepted', () => {
@@ -343,10 +366,7 @@ describe('loadReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [skillAsset('cowsay')],
-        },
+        cowsay: facetEntry('0.0.1', [skillAsset('cowsay')]),
       },
     }
     writeReceipt(projectDir, receipt)
@@ -360,18 +380,139 @@ describe('loadReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [skillAsset('cowsay')],
-        },
+        cowsay: facetEntry('0.0.1', [skillAsset('cowsay')]),
       },
     }
     writeReceipt(projectDir, receipt)
     const result = loadReceipt(projectDir)
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(result.receipt.facets.cowsay?.version).toBe('0.0.1')
-    expect(result.receipt.facets.cowsay?.assets).toHaveLength(1)
+    expect(result.record.facets.cowsay?.version).toBe('0.0.1')
+    expect(result.record.facets.cowsay?.assets).toHaveLength(1)
+  })
+
+  test('round-trips a configuration claim without recording the declaration', () => {
+    const receipt: Receipt = {
+      version: CURRENT_RECEIPT_VERSION,
+      path: realpathSync(projectDir),
+      facets: {
+        cowsay: facetEntry('0.0.1', [], [claim('filesystem', { kind: 'aliased', as: 'project-filesystem' })]),
+      },
+    }
+    writeReceipt(projectDir, receipt)
+
+    const result = loadReceipt(projectDir)
+
+    if (!result.ok) expect.unreachable()
+    if (result.record.authority !== 'assets-and-configuration') expect.unreachable()
+    expect(result.record.facets.cowsay?.configurations).toEqual([
+      claim('filesystem', { kind: 'aliased', as: 'project-filesystem' }),
+    ])
+    // The whole point of storing a fingerprint: the file names no command,
+    // no URL, and no environment data.
+    const raw = readFileSync(receiptPath(projectDir), 'utf8')
+    for (const secret of ['command', 'args', 'url', 'env', 'npx', 'https://']) {
+      expect(raw).not.toContain(secret)
+    }
+  })
+
+  // Per-entry containment, exactly as for assets: one unusable claim must not
+  // withdraw authority over the rest of the file.
+  test.each([
+    ['a malformed server name', { ...claim('ok'), name: 'Not Valid' }],
+    ['a fingerprint that is not a digest', { ...claim('ok'), fingerprint: 'sha256:nope' }],
+  ])('drops %s, reporting it, while valid claims still load', (_label, bad) => {
+    writeRawReceipt(
+      JSON.stringify({
+        version: CURRENT_RECEIPT_VERSION,
+        path: realpathSync(projectDir),
+        facets: {
+          cowsay: { version: '0.0.1', integrity: INTEGRITY, assets: [], configurations: [bad, claim('good')] },
+        },
+      }),
+    )
+
+    const result = loadReceipt(projectDir)
+
+    if (!result.ok) expect.unreachable()
+    expect(result.invalidEntries).toHaveLength(1)
+    const invalid = result.invalidEntries[0]
+    if (invalid?.kind !== 'configuration') expect.unreachable()
+    expect(invalid.facet).toBe('cowsay')
+    if (result.record.authority !== 'assets-and-configuration') expect.unreachable()
+    expect(result.record.facets.cowsay?.configurations).toEqual([claim('good')])
+  })
+
+  test('collapses a claim the receipt repeats verbatim', () => {
+    writeRawReceipt(
+      JSON.stringify({
+        version: CURRENT_RECEIPT_VERSION,
+        path: realpathSync(projectDir),
+        facets: {
+          cowsay: { version: '0.0.1', integrity: INTEGRITY, assets: [], configurations: [claim('fs'), claim('fs')] },
+        },
+      }),
+    )
+
+    const result = loadReceipt(projectDir)
+
+    if (!result.ok) expect.unreachable()
+    expect(result.invalidEntries).toEqual([])
+    if (result.record.authority !== 'assets-and-configuration') expect.unreachable()
+    expect(result.record.facets.cowsay?.configurations).toEqual([claim('fs')])
+  })
+
+  test('drops both claims when a facet contradicts itself about one server', () => {
+    // File order must not get to decide which effective entry this machine
+    // believes it owns, or which declaration it believes was approved.
+    writeRawReceipt(
+      JSON.stringify({
+        version: CURRENT_RECEIPT_VERSION,
+        path: realpathSync(projectDir),
+        facets: {
+          cowsay: {
+            version: '0.0.1',
+            integrity: INTEGRITY,
+            assets: [],
+            configurations: [claim('fs'), { ...claim('fs'), fingerprint: `sha256:${'b'.repeat(64)}` }],
+          },
+        },
+      }),
+    )
+
+    const result = loadReceipt(projectDir)
+
+    if (!result.ok) expect.unreachable()
+    expect(result.invalidEntries).toHaveLength(1)
+    const invalid = result.invalidEntries[0]
+    if (invalid?.kind !== 'configuration') expect.unreachable()
+    expect(invalid.server).toBe('fs')
+    if (result.record.authority !== 'assets-and-configuration') expect.unreachable()
+    expect(result.record.facets.cowsay?.configurations).toEqual([])
+  })
+
+  test('a claim carrying an unrecognized member is corrupt, not silently accepted', () => {
+    // The closure is the whole reason a receipt can be trusted to hold no
+    // secrets: an unrecognized member is exactly where one would live.
+    writeRawReceipt(
+      JSON.stringify({
+        version: CURRENT_RECEIPT_VERSION,
+        path: realpathSync(projectDir),
+        facets: {
+          cowsay: {
+            version: '0.0.1',
+            integrity: INTEGRITY,
+            assets: [],
+            configurations: [{ ...claim('fs'), command: 'npx' }],
+          },
+        },
+      }),
+    )
+
+    const result = loadReceipt(projectDir)
+
+    if (result.ok) expect.unreachable()
+    expect(result.reason).toBe('corrupt')
   })
 
   test('returns corrupt (not throw) on an unresolvable project path (#19)', () => {
@@ -405,23 +546,17 @@ describe('writeReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [skillAsset('cowsay'), commandAsset('moo')],
-        },
-        hello: {
-          version: '1.0.0',
-          assets: [agentAsset('greeter')],
-        },
+        cowsay: facetEntry('0.0.1', [skillAsset('cowsay'), commandAsset('moo')]),
+        hello: facetEntry('1.0.0', [agentAsset('greeter')]),
       },
     }
     writeReceipt(projectDir, receipt)
     const result = loadReceipt(projectDir)
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(Object.keys(result.receipt.facets)).toHaveLength(2)
-    expect(result.receipt.facets.cowsay?.assets).toHaveLength(2)
-    expect(result.receipt.facets.hello?.assets).toHaveLength(1)
+    expect(Object.keys(result.record.facets)).toHaveLength(2)
+    expect(result.record.facets.cowsay?.assets).toHaveLength(2)
+    expect(result.record.facets.hello?.assets).toHaveLength(1)
   })
 
   test('normalizes receipt.path so a stale path does not cause path-mismatch (#20)', () => {
@@ -430,17 +565,14 @@ describe('writeReceipt', () => {
       version: CURRENT_RECEIPT_VERSION,
       path: '/some/other/path', // intentionally wrong
       facets: {
-        cowsay: {
-          version: '0.0.1',
-          assets: [skillAsset('cowsay')],
-        },
+        cowsay: facetEntry('0.0.1', [skillAsset('cowsay')]),
       },
     }
     writeReceipt(projectDir, receipt)
     const result = loadReceipt(projectDir)
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(result.receipt.path).toBe(canonical)
+    expect(result.record.path).toBe(canonical)
   })
 })
 
@@ -478,7 +610,7 @@ describe('receiptEntryForLockedFacet', () => {
       ],
     }
 
-    const projected = receiptEntryForLockedFacet(entry)
+    const projected = receiptEntryForLockedFacet(entry, [])
 
     expect(projected.version).toBe('0.0.1')
     // Paths are mirrored; the hashes are not part of what a receipt records.
@@ -486,9 +618,13 @@ describe('receiptEntryForLockedFacet', () => {
     // A pre-disposition entry can only have meant authored materialization.
     expect(projected.assets[0]?.materialization).toEqual({ kind: 'authored' })
     expect(projected.assets[1]).toEqual(commandAsset('moo'))
-    // Provenance belongs to the lockfile, never the receipt.
+    // Provenance belongs to the lockfile, never the receipt. Integrity does
+    // travel — it is what anchors the entry's claims to an exact resolved
+    // facet — but the source that produced it does not.
     expect('source' in projected).toBe(false)
-    expect('integrity' in projected).toBe(false)
+    expect(projected.integrity).toBe('sha256:abc')
+    // A run that reconciled no configuration claims records none.
+    expect(projected.configurations).toEqual([])
   })
 
   test('carries dispositions through and excludes omitted assets', () => {
@@ -521,7 +657,7 @@ describe('receiptEntryForLockedFacet', () => {
       ],
     }
 
-    const projected = receiptEntryForLockedFacet(entry)
+    const projected = receiptEntryForLockedFacet(entry, [])
 
     // The omitted agent is absent: the lockfile records the resolved SET, the
     // receipt records what is on disk, and an omitted asset was never written.
@@ -537,22 +673,17 @@ describe('receiptEntryForLockedFacet', () => {
 // ---------------------------------------------------------------------------
 
 describe('resolveProjectReceipt', () => {
-  function writeRawReceipt(body: string): void {
-    mkdirSync(join(facetDir, 'receipts'), { recursive: true })
-    writeFileSync(receiptPath(projectDir), body)
-  }
-
   test('tags a readable receipt as loaded', () => {
     writeReceipt(projectDir, {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
-      facets: { cowsay: { version: '0.0.1', assets: [skillAsset('cowsay')] } },
+      facets: { cowsay: facetEntry('0.0.1', [skillAsset('cowsay')]) },
     })
 
     const state = resolveProjectReceipt(projectDir)
 
     if (state.kind !== 'loaded') expect.unreachable()
-    expect(state.receipt.facets.cowsay?.assets).toHaveLength(1)
+    expect(state.record.facets.cowsay?.assets).toHaveLength(1)
     expect(state.invalidEntries).toEqual([])
   })
 
@@ -572,25 +703,57 @@ describe('resolveProjectReceipt', () => {
     if (state.kind !== 'unavailable') expect.unreachable()
     expect(state.reason).toBe(reason)
     expect(state.projectPath).toBe(realpathSync(projectDir))
-    // The commit's base is derived, and claims nothing.
-    expect(receiptBaseFor(state).facets).toEqual({})
-    expect(receiptBaseFor(state).path).toBe(realpathSync(projectDir))
+    // The commit is told only where to write, so there is no field an
+    // ownership claim could ride in on.
+    expect(receiptProjectPath(state)).toBe(realpathSync(projectDir))
     // And it authorizes no deletion.
     expect(buildPreviousOwnership(state).size).toBe(0)
   })
 
-  test('a loaded receipt is its own base, and its claims authorize deletion', () => {
+  test('a loaded receipt names its own location, and its claims authorize deletion', () => {
     writeReceipt(projectDir, {
       version: CURRENT_RECEIPT_VERSION,
       path: realpathSync(projectDir),
-      facets: { cowsay: { version: '0.0.1', assets: [skillAsset('cowsay')] } },
+      facets: { cowsay: facetEntry('0.0.1', [skillAsset('cowsay')]) },
     })
 
     const state = resolveProjectReceipt(projectDir)
 
     if (state.kind !== 'loaded') expect.unreachable()
-    expect(receiptBaseFor(state)).toBe(state.receipt)
+    expect(receiptProjectPath(state)).toBe(realpathSync(projectDir))
     expect([...buildPreviousOwnership(state).values()].map((o) => o.effectiveName)).toEqual(['cowsay'])
+  })
+
+  // Earlier versions keep every file they ever owned, and gain nothing they
+  // could not have witnessed. The two halves are reported separately because
+  // they are separate authorities.
+  test.each([
+    [
+      'legacy 1',
+      LEGACY_RECEIPT_VERSION,
+      { version: '0.0.1', assets: [{ scope: 'project', type: 'skill', name: 'cowsay' }] },
+    ],
+    [
+      '0.2',
+      RECEIPT_VERSION_0_2,
+      {
+        version: '0.0.1',
+        assets: [{ scope: 'project', type: 'skill', name: 'cowsay', files: ['skills/cowsay/SKILL.md'] }],
+      },
+    ],
+    ['0.3', RECEIPT_VERSION_0_3, { version: '0.0.1', assets: [skillAsset('cowsay')] }],
+  ] as const)('a %s receipt keeps asset authority and confers no configuration authority', (_label, version, entry) => {
+    writeRawReceipt(JSON.stringify({ version, path: realpathSync(projectDir), facets: { cowsay: entry } }))
+
+    const state = resolveProjectReceipt(projectDir)
+
+    if (state.kind !== 'loaded') expect.unreachable()
+    if (state.record.authority !== 'assets-only') expect.unreachable()
+    expect(state.record.refinedFrom).toBe(version)
+    // Full deletion authority over the files it recorded.
+    expect([...buildPreviousOwnership(state).values()].map((o) => o.effectiveName)).toEqual(['cowsay'])
+    // And no claim field at all — not an empty one.
+    expect('configurations' in (state.record.facets.cowsay ?? {})).toBe(false)
   })
 })
 
@@ -618,10 +781,11 @@ describe('buildUpdatedReceipt', () => {
       }).replace('"PLACEHOLDER"', '"__proto__"'),
     )
 
-    const updated = buildUpdatedReceipt(
-      { version: CURRENT_RECEIPT_VERSION, path: realpathSync(projectDir), facets: {} },
-      { kind: 'written', facetEntries: newFacetEntries },
-    )
+    const updated = buildUpdatedReceipt(realpathSync(projectDir), {
+      kind: 'written',
+      facetEntries: newFacetEntries,
+      configurations: {},
+    })
 
     expect(Object.hasOwn(updated.facets, '__proto__')).toBe(true)
     expect(Object.keys(updated.facets)).toEqual(['__proto__'])
@@ -631,35 +795,33 @@ describe('buildUpdatedReceipt', () => {
   // written, so claiming ownership of it would make the next removal try to
   // delete a file that does not exist.
   test('an omitted asset is not recorded as materialized', () => {
-    const updated = buildUpdatedReceipt(
-      { version: CURRENT_RECEIPT_VERSION, path: realpathSync(projectDir), facets: {} },
-      {
-        kind: 'written',
-        facetEntries: {
-          cowsay: {
-            source: { kind: 'local', path: './vendor/cowsay' },
-            version: '1.0.0',
-            integrity: 'sha256:abc',
-            assets: [
-              {
-                scope: 'project',
-                type: 'skill',
-                name: 'kept',
-                materialization: { kind: 'authored' },
-                files: [{ path: 'skills/kept/SKILL.md', integrity: `sha256:${'0'.repeat(64)}` }],
-              },
-              {
-                scope: 'project',
-                type: 'skill',
-                name: 'dropped',
-                materialization: { kind: 'omitted' },
-                files: [{ path: 'skills/dropped/SKILL.md', integrity: `sha256:${'1'.repeat(64)}` }],
-              },
-            ],
-          },
+    const updated = buildUpdatedReceipt(realpathSync(projectDir), {
+      kind: 'written',
+      configurations: {},
+      facetEntries: {
+        cowsay: {
+          source: { kind: 'local', path: './vendor/cowsay' },
+          version: '1.0.0',
+          integrity: 'sha256:abc',
+          assets: [
+            {
+              scope: 'project',
+              type: 'skill',
+              name: 'kept',
+              materialization: { kind: 'authored' },
+              files: [{ path: 'skills/kept/SKILL.md', integrity: `sha256:${'0'.repeat(64)}` }],
+            },
+            {
+              scope: 'project',
+              type: 'skill',
+              name: 'dropped',
+              materialization: { kind: 'omitted' },
+              files: [{ path: 'skills/dropped/SKILL.md', integrity: `sha256:${'1'.repeat(64)}` }],
+            },
+          ],
         },
       },
-    )
+    })
 
     expect(updated.facets.cowsay?.assets.map((a) => a.name)).toEqual(['kept'])
   })
@@ -670,24 +832,18 @@ describe('buildUpdatedReceipt', () => {
   // effective identity no file on this machine has.
   test('carried-forward records are committed verbatim', () => {
     const carried = {
-      cowsay: {
-        version: '1.0.0',
-        assets: [
-          {
-            scope: 'project' as const,
-            type: 'skill' as const,
-            name: 'review',
-            materialization: { kind: 'aliased' as const, as: 'vendor-review' },
-            files: ['skills/review/SKILL.md'],
-          },
-        ],
-      },
+      cowsay: facetEntry('1.0.0', [
+        {
+          scope: 'project' as const,
+          type: 'skill' as const,
+          name: 'review',
+          materialization: { kind: 'aliased' as const, as: 'vendor-review' },
+          files: ['skills/review/SKILL.md'],
+        },
+      ]),
     }
 
-    const updated = buildUpdatedReceipt(
-      { version: CURRENT_RECEIPT_VERSION, path: realpathSync(projectDir), facets: {} },
-      { kind: 'carried-forward', facets: carried },
-    )
+    const updated = buildUpdatedReceipt(realpathSync(projectDir), { kind: 'carried-forward', facets: carried })
 
     expect(updated.facets.cowsay).toEqual(carried.cowsay)
   })
@@ -699,10 +855,7 @@ describe('buildUpdatedReceipt', () => {
       }).replace('"PLACEHOLDER"', '"__proto__"'),
     )
 
-    const updated = buildUpdatedReceipt(
-      { version: CURRENT_RECEIPT_VERSION, path: realpathSync(projectDir), facets: {} },
-      { kind: 'carried-forward', facets: carried },
-    )
+    const updated = buildUpdatedReceipt(realpathSync(projectDir), { kind: 'carried-forward', facets: carried })
 
     expect(Object.hasOwn(updated.facets, '__proto__')).toBe(true)
     expect(Object.keys(updated.facets)).toEqual(['__proto__'])
@@ -731,16 +884,25 @@ describe('loadReceipt — facet keys that collide with Object.prototype', () => 
 
   // Every version arm rebuilds the facet map, and each did it by assignment.
   test.each([
-    ['current', CURRENT_RECEIPT_VERSION, { version: '0.0.1', assets: [asset] }],
-    ['0.2', 0.2, { version: '0.0.1', assets: [asset] }],
-    ['legacy 1', 1, { version: '0.0.1', assets: [{ type: 'skill', name: 'cowsay', scope: 'project' }] }],
+    [
+      'current',
+      CURRENT_RECEIPT_VERSION,
+      { version: '0.0.1', integrity: INTEGRITY, assets: [asset], configurations: [] },
+    ],
+    ['0.3', RECEIPT_VERSION_0_3, { version: '0.0.1', assets: [asset] }],
+    ['0.2', RECEIPT_VERSION_0_2, { version: '0.0.1', assets: [asset] }],
+    [
+      'legacy 1',
+      LEGACY_RECEIPT_VERSION,
+      { version: '0.0.1', assets: [{ type: 'skill', name: 'cowsay', scope: 'project' }] },
+    ],
   ])('a %s receipt keeps a __proto__ facet as an own key', (_label, version, entry) => {
     writeRaw(version, entry)
 
     const result = loadReceipt(projectDir)
 
     if (!result.ok) expect.unreachable()
-    expect(Object.hasOwn(result.receipt.facets, '__proto__')).toBe(true)
-    expect(Object.keys(result.receipt.facets)).toEqual(['__proto__'])
+    expect(Object.hasOwn(result.record.facets, '__proto__')).toBe(true)
+    expect(Object.keys(result.record.facets)).toEqual(['__proto__'])
   })
 })

--- a/packages/engine/src/install/__tests__/refine-removal.test.ts
+++ b/packages/engine/src/install/__tests__/refine-removal.test.ts
@@ -106,13 +106,17 @@ function receiptFor(lockfile: SupportedLockfile, opts: { without?: string } = {}
   const facets: Array<[string, ReceiptFacetEntry]> = []
   for (const [name, entry] of Object.entries(lockfile.facets)) {
     if (name === opts.without) continue
-    facets.push([name, receiptEntryForLockedFacet(entry)])
+    facets.push([name, receiptEntryForLockedFacet(entry, [])])
   }
   return { version: CURRENT_RECEIPT_VERSION, path: '/tmp/project', facets: record(facets) }
 }
 
 function loaded(receipt: Receipt): ProjectReceiptState {
-  return { kind: 'loaded', receipt, invalidEntries: [] }
+  return {
+    kind: 'loaded',
+    record: { authority: 'assets-and-configuration', path: receipt.path, facets: receipt.facets },
+    invalidEntries: [],
+  }
 }
 
 /** No usable local evidence, whatever the reason. Ownership is zero. */

--- a/packages/engine/src/install/__tests__/run-install.receipt.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.receipt.test.ts
@@ -213,6 +213,7 @@ describe('runInstall — frozen orphan-on-pull cleanup', () => {
     const receipt = JSON.parse(readFileSync(receiptFile, 'utf8')) as Receipt
     receipt.facets.ghost = {
       version: '1.0.0',
+      integrity: 'sha256:ghost',
       assets: [
         {
           scope: 'project',
@@ -222,6 +223,7 @@ describe('runInstall — frozen orphan-on-pull cleanup', () => {
           files: ['skills/ghostly/SKILL.md'],
         },
       ],
+      configurations: [],
     }
     writeReceipt(projectRoot, receipt)
     mkdirSync(join(projectRoot, '.test-adapter/skills'), { recursive: true })
@@ -289,6 +291,7 @@ describe('runInstall — receipt escape entries (W2)', () => {
       facets: {
         ghost: {
           version: '1.0.0',
+          integrity: 'sha256:ghost',
           assets: [
             {
               scope: 'project',
@@ -305,6 +308,7 @@ describe('runInstall — receipt escape entries (W2)', () => {
               files: ['skills/ghostly/SKILL.md'],
             },
           ],
+          configurations: [],
         },
       },
     }

--- a/packages/engine/src/install/__tests__/server-ownership.test.ts
+++ b/packages/engine/src/install/__tests__/server-ownership.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from 'bun:test'
+import type { McpServerFingerprint, PlannedServerConfiguration } from '@agent-facets/protocol'
+import { mcpServerKey } from '@agent-facets/protocol'
+import {
+  buildPreviousMcpOwnership,
+  claimsByFacet,
+  isDeclarationApproved,
+  obsoleteMcpOwnership,
+  previouslyOwnedServerNames,
+} from '../commit/server-ownership.ts'
+import { buildUpdatedReceipt } from '../commit/tri-write.ts'
+import {
+  CURRENT_RECEIPT_VERSION,
+  type LoadedReceipt,
+  type ProjectReceiptState,
+  RECEIPT_VERSION_0_3,
+  type ReceiptConfigurationClaim,
+  type ReceiptFacetEntry,
+} from '../receipt.ts'
+
+const FP_A = `sha256:${'a'.repeat(64)}` as McpServerFingerprint
+const FP_B = `sha256:${'b'.repeat(64)}` as McpServerFingerprint
+
+const STDIO = { type: 'stdio', command: 'npx' } as const
+
+function claim(
+  name: string,
+  fingerprint: McpServerFingerprint = FP_A,
+  materialization: ReceiptConfigurationClaim['materialization'] = { kind: 'authored' },
+): ReceiptConfigurationClaim {
+  return { kind: 'mcp-server', name, materialization, fingerprint }
+}
+
+function facetEntry(configurations: ReceiptConfigurationClaim[]): ReceiptFacetEntry {
+  return { version: '1.0.0', integrity: 'sha256:abc', assets: [], configurations }
+}
+
+function loaded(facets: Record<string, ReceiptFacetEntry>): ProjectReceiptState {
+  return {
+    kind: 'loaded',
+    record: { authority: 'assets-and-configuration', path: '/tmp/project', facets },
+    invalidEntries: [],
+  }
+}
+
+function assetsOnly(): ProjectReceiptState {
+  const record: LoadedReceipt = {
+    authority: 'assets-only',
+    refinedFrom: RECEIPT_VERSION_0_3,
+    path: '/tmp/project',
+    facets: { alpha: { version: '1.0.0', assets: [] } },
+  }
+  return { kind: 'loaded', record, invalidEntries: [] }
+}
+
+function configuration(
+  effectiveName: string,
+  claimants: PlannedServerConfiguration['claimants'],
+  fingerprint: McpServerFingerprint = FP_A,
+): PlannedServerConfiguration {
+  return {
+    identity: { kind: 'mcp-server', effectiveName },
+    key: mcpServerKey(effectiveName),
+    declaration: STDIO,
+    fingerprint,
+    claimants,
+  }
+}
+
+describe('buildPreviousMcpOwnership', () => {
+  test('keys by effective identity, not authored name', () => {
+    const state = loaded({
+      alpha: facetEntry([claim('filesystem', FP_A, { kind: 'aliased', as: 'project-fs' })]),
+    })
+
+    const index = buildPreviousMcpOwnership(state)
+
+    expect([...index.keys()]).toEqual([mcpServerKey('project-fs')])
+    expect(index.get(mcpServerKey('project-fs'))?.effectiveName).toBe('project-fs')
+  })
+
+  test('folds duplicate historical claims into one owned identity', () => {
+    // Two facets recorded the same effective server. Deleting per claim would
+    // issue two removals for one native entry.
+    const state = loaded({ beta: facetEntry([claim('fs')]), alpha: facetEntry([claim('fs')]) })
+
+    const index = buildPreviousMcpOwnership(state)
+
+    expect(index.size).toBe(1)
+    expect(index.get(mcpServerKey('fs'))?.facets).toEqual(['alpha', 'beta'])
+    expect(index.get(mcpServerKey('fs'))?.fingerprints).toEqual([FP_A])
+  })
+
+  test('keeps every fingerprint recorded at one identity', () => {
+    // Disagreeing historical claims are both evidence of approval. Dropping
+    // either would re-prompt for something already accepted here.
+    const state = loaded({ alpha: facetEntry([claim('fs', FP_A)]), beta: facetEntry([claim('fs', FP_B)]) })
+
+    const index = buildPreviousMcpOwnership(state)
+
+    expect(index.get(mcpServerKey('fs'))?.fingerprints).toEqual([FP_A, FP_B])
+  })
+
+  // The two halves of "a pre-current receipt confers no configuration
+  // authority": it cannot delete, and it cannot vouch for consent.
+  test('a receipt predating configuration claims owns nothing', () => {
+    expect(buildPreviousMcpOwnership(assetsOnly()).size).toBe(0)
+  })
+
+  test.each(['missing', 'corrupt', 'path-mismatch'] as const)('an %s receipt owns nothing', (reason) => {
+    const state: ProjectReceiptState = { kind: 'unavailable', reason, projectPath: '/tmp/project' }
+    expect(buildPreviousMcpOwnership(state).size).toBe(0)
+  })
+})
+
+describe('obsoleteMcpOwnership', () => {
+  test('retains an identity any desired configuration still claims', () => {
+    const previous = buildPreviousMcpOwnership(loaded({ alpha: facetEntry([claim('fs'), claim('docs')]) }))
+
+    const obsolete = obsoleteMcpOwnership(previous, [
+      configuration('fs', [{ facet: 'beta', authoredName: 'fs', disposition: { kind: 'authored' } }]),
+    ])
+
+    // `fs` transferred to another facet rather than becoming stale; only
+    // `docs` is unwanted.
+    expect(obsolete.map((o) => o.effectiveName)).toEqual(['docs'])
+  })
+
+  test('is ordered deterministically', () => {
+    const previous = buildPreviousMcpOwnership(
+      loaded({ alpha: facetEntry([claim('zulu'), claim('alfa'), claim('mike')]) }),
+    )
+
+    expect(obsoleteMcpOwnership(previous, []).map((o) => o.effectiveName)).toEqual(['alfa', 'mike', 'zulu'])
+  })
+})
+
+describe('previouslyOwnedServerNames', () => {
+  test('is exactly what the receipt recorded, sorted', () => {
+    const previous = buildPreviousMcpOwnership(loaded({ alpha: facetEntry([claim('zulu'), claim('alfa')]) }))
+    expect(previouslyOwnedServerNames(previous)).toEqual(['alfa', 'zulu'])
+  })
+
+  test('is empty for a receipt that cannot witness configuration', () => {
+    expect(previouslyOwnedServerNames(buildPreviousMcpOwnership(assetsOnly()))).toEqual([])
+  })
+})
+
+describe('isDeclarationApproved', () => {
+  const previous = buildPreviousMcpOwnership(loaded({ alpha: facetEntry([claim('fs', FP_A)]) }))
+
+  test('an identical declaration at the same identity is approved', () => {
+    expect(
+      isDeclarationApproved(
+        previous,
+        configuration('fs', [{ facet: 'alpha', authoredName: 'fs', disposition: { kind: 'authored' } }], FP_A),
+      ),
+    ).toBe(true)
+  })
+
+  test('a changed declaration at the same identity is not', () => {
+    expect(
+      isDeclarationApproved(
+        previous,
+        configuration('fs', [{ facet: 'alpha', authoredName: 'fs', disposition: { kind: 'authored' } }], FP_B),
+      ),
+    ).toBe(false)
+  })
+
+  test('the same declaration at a new identity is not', () => {
+    expect(
+      isDeclarationApproved(
+        previous,
+        configuration('other', [{ facet: 'alpha', authoredName: 'fs', disposition: { kind: 'authored' } }], FP_A),
+      ),
+    ).toBe(false)
+  })
+
+  test('a receipt predating configuration claims approves nothing', () => {
+    expect(
+      isDeclarationApproved(
+        buildPreviousMcpOwnership(assetsOnly()),
+        configuration('fs', [{ facet: 'alpha', authoredName: 'fs', disposition: { kind: 'authored' } }], FP_A),
+      ),
+    ).toBe(false)
+  })
+
+  // Approval is machine-local. A teammate committing `facets.json` and
+  // `facets.lock` publishes what the project WANTS; it cannot publish that
+  // their machine agreed to run it. Every state that is not this machine's
+  // own readable receipt therefore approves nothing.
+  test.each([
+    ['a teammate has a receipt this machine does not', { kind: 'unavailable', reason: 'missing' } as const],
+    ['the receipt belongs to another project', { kind: 'unavailable', reason: 'path-mismatch' } as const],
+  ])('%s, so nothing is approved here', (_label, unavailable) => {
+    const state: ProjectReceiptState = { ...unavailable, projectPath: '/tmp/project' }
+    const desired = configuration('fs', [{ facet: 'alpha', authoredName: 'fs', disposition: { kind: 'authored' } }])
+
+    expect(isDeclarationApproved(buildPreviousMcpOwnership(state), desired)).toBe(false)
+  })
+})
+
+describe('claimsByFacet', () => {
+  test('records one claim per claimant, under its own authored name', () => {
+    // One effective configuration, two facets. Both must be recorded, or
+    // removing one would take the other's configuration with it.
+    const claims = claimsByFacet([
+      configuration('fs', [
+        { facet: 'alpha', authoredName: 'filesystem', disposition: { kind: 'aliased', as: 'fs' } },
+        { facet: 'beta', authoredName: 'fs', disposition: { kind: 'authored' } },
+      ]),
+    ])
+
+    expect(claims.alpha).toEqual([claim('filesystem', FP_A, { kind: 'aliased', as: 'fs' })])
+    expect(claims.beta).toEqual([claim('fs', FP_A)])
+  })
+
+  test('a facet named __proto__ becomes an own key', () => {
+    const claims = claimsByFacet([
+      configuration('fs', [{ facet: '__proto__', authoredName: 'fs', disposition: { kind: 'authored' } }]),
+    ])
+
+    expect(Object.hasOwn(claims, '__proto__')).toBe(true)
+    expect(Object.keys(claims)).toEqual(['__proto__'])
+  })
+
+  test('round-trips through the receipt and back into ownership', () => {
+    const configurations = [
+      configuration('fs', [
+        { facet: 'alpha', authoredName: 'filesystem', disposition: { kind: 'aliased', as: 'fs' } },
+        { facet: 'beta', authoredName: 'fs', disposition: { kind: 'authored' } },
+      ]),
+    ]
+
+    const receipt = buildUpdatedReceipt('/tmp/project', {
+      kind: 'written',
+      facetEntries: {
+        alpha: { source: { kind: 'local', path: './a' }, version: '1.0.0', integrity: 'sha256:a', assets: [] },
+        beta: { source: { kind: 'local', path: './b' }, version: '1.0.0', integrity: 'sha256:b', assets: [] },
+      },
+      configurations: claimsByFacet(configurations),
+    })
+
+    expect(receipt.version).toBe(CURRENT_RECEIPT_VERSION)
+    // Two per-facet claims fold back into ONE owned identity with both
+    // claimants — the property that makes removing one facet safe.
+    const index = buildPreviousMcpOwnership(loaded(receipt.facets))
+    expect(index.size).toBe(1)
+    expect(index.get(mcpServerKey('fs'))?.facets).toEqual(['alpha', 'beta'])
+    // And it authorizes deleting nothing while the configuration is desired.
+    expect(obsoleteMcpOwnership(index, configurations)).toEqual([])
+  })
+
+  test('records nothing when nothing was reconciled', () => {
+    expect(claimsByFacet([])).toEqual({})
+  })
+})

--- a/packages/engine/src/install/commit/compose.ts
+++ b/packages/engine/src/install/commit/compose.ts
@@ -6,13 +6,42 @@ import type {
   FacetMaterializationOverrides,
   MaterializationDisposition,
   MaterializedAsset,
+  PlannedServer,
+  PlannedServerConfiguration,
+  ServerContribution,
   StaleOverride,
+  StaleServerOverride,
 } from '@agent-facets/protocol'
-import { planMaterialization } from '@agent-facets/protocol'
+import { planMaterialization, planServerMaterialization } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { ownEntry, ownRecord } from '../own-entry.ts'
-import type { RunInstallFailure, StageEvent } from '../types.ts'
+import type {
+  MaterializationCollisionGroup,
+  RunInstallFailure,
+  StageEvent,
+  StaleMaterializationOverride,
+} from '../types.ts'
 import type { ResolvedFacetRecord } from './resolve-all.ts'
+
+/** Tag an asset-planner stale override for the cross-domain report. */
+function taggedAssetStale(stale: StaleOverride): StaleMaterializationOverride {
+  return {
+    facet: stale.facet,
+    contribution: { kind: 'asset', assetType: stale.type },
+    authoredName: stale.authoredName,
+    disposition: stale.disposition,
+  }
+}
+
+/** Tag a server-planner stale override for the cross-domain report. */
+function taggedServerStale(stale: StaleServerOverride): StaleMaterializationOverride {
+  return {
+    facet: stale.facet,
+    contribution: { kind: 'mcp-server' },
+    authoredName: stale.authoredName,
+    disposition: stale.disposition,
+  }
+}
 
 /**
  * Compose: turn the complete set of verified authored contributions plus the
@@ -43,7 +72,7 @@ export interface CollisionResolutionRequest {
    */
   contributions: readonly FacetContribution[]
   /** Overrides naming assets the resolved versions no longer contain. */
-  staleOverrides: readonly StaleOverride[]
+  staleOverrides: readonly StaleMaterializationOverride[]
 }
 
 /**
@@ -59,6 +88,30 @@ export type CollisionResolution =
 
 export type CollisionResolver = (request: CollisionResolutionRequest) => Promise<CollisionResolution>
 
+/**
+ * The MCP half of a collision-free plan.
+ *
+ * Kept beside the asset half rather than folded into it. The two domains
+ * share one planning rule and one override document, but nothing else: a
+ * server contributes no lockfile entry, occupies its own identity space, and
+ * composes rather than contests when two facets declare it identically.
+ * Merging them would mean widening `MaterializedAsset` — and therefore
+ * `AssetType` — to describe something that is not an asset.
+ */
+export interface ComposedMcpServers {
+  /**
+   * Every authored declaration with its resolved disposition, INCLUDING
+   * omitted ones. Reporting needs to say "omitted" about a server, which is
+   * unanswerable from the active set alone.
+   */
+  planned: readonly PlannedServer[]
+  /**
+   * The active effective configurations to reconcile, one per identity, each
+   * carrying every facet that claims it.
+   */
+  configurations: readonly PlannedServerConfiguration[]
+}
+
 /** A collision-free global plan. */
 export interface ComposedPlan {
   /** Current lockfile entries with dispositions applied, keyed by facet. */
@@ -69,14 +122,17 @@ export interface ComposedPlan {
    * integrity) alongside its effective name and adapter key (for placement).
    */
   materialized: readonly MaterializedAsset[]
+  /** The MCP configurations to reconcile, planned in their own identity space. */
+  mcpServers: ComposedMcpServers
   /** The overrides to persist: those loaded, or those a resolver chose. */
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>
   /**
-   * Overrides naming assets absent from the resolved facet versions.
-   * Reported, never fatal: an override is durable project intent, so it
-   * survives a failed operation and is pruned only by a successful commit.
+   * Overrides naming assets or servers absent from the resolved facet
+   * versions. Reported, never fatal: an override is durable project intent,
+   * so it survives a failed operation and is pruned only by a successful
+   * commit.
    */
-  staleOverrides: readonly StaleOverride[]
+  staleOverrides: readonly StaleMaterializationOverride[]
 }
 
 export type ComposeResult = { ok: true; plan: ComposedPlan } | { ok: false; failure: RunInstallFailure }
@@ -108,6 +164,22 @@ function contributionsOf(args: ComposeArgs): FacetContribution[] {
       type: asset.type,
       name: asset.name,
     })),
+    overrides: ownEntry(args.desiredFacets, record.facet)?.overrides,
+  }))
+}
+
+/**
+ * The server contributions, in the same order.
+ *
+ * Every facet appears, including one that declares nothing: the planner's
+ * stale sweep is driven by the override map, so a facet whose only server
+ * override names a declaration it no longer publishes has to be visible here
+ * for that override to be reported at all.
+ */
+function serverContributionsOf(args: ComposeArgs): ServerContribution[] {
+  return args.resolved.map((record) => ({
+    facet: record.facet,
+    servers: record.servers,
     overrides: ownEntry(args.desiredFacets, record.facet)?.overrides,
   }))
 }
@@ -160,25 +232,71 @@ function dispositionKey(facet: string, scope: string, type: string, authoredName
 function planWith(
   resolved: readonly ResolvedFacetRecord[],
   contributions: readonly FacetContribution[],
+  serverContributions: readonly ServerContribution[],
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
 ):
   | { ok: true; plan: ComposedPlan }
-  | { ok: false; reason: 'collision'; groups: readonly CollisionGroup[]; staleOverrides: readonly StaleOverride[] }
+  | {
+      ok: false
+      reason: 'collision'
+      groups: readonly MaterializationCollisionGroup[]
+      staleOverrides: readonly StaleMaterializationOverride[]
+    }
   | { ok: false; reason: 'invalid-alias'; problems: readonly { facet: string; alias: string; reason: string }[] } {
   const withOverrides = contributions.map((contribution) => ({
     ...contribution,
     overrides: ownEntry(overrides, contribution.facet),
   }))
-  const result = planMaterialization(withOverrides)
-  if (!result.ok) {
-    if (result.reason === 'invalid-alias') {
-      return { ok: false, reason: 'invalid-alias', problems: result.problems }
-    }
-    return { ok: false, reason: 'collision', groups: result.groups, staleOverrides: result.staleOverrides }
+  const serversWithOverrides = serverContributions.map((contribution) => ({
+    ...contribution,
+    overrides: ownEntry(overrides, contribution.facet),
+  }))
+
+  // Both domains are planned from the SAME override map, in separate identity
+  // spaces. Planning them independently is what makes a skill and a server
+  // sharing a name structurally incapable of contending — there is no shared
+  // key they could collide in.
+  const assets = planMaterialization(withOverrides)
+  const servers = planServerMaterialization(serversWithOverrides)
+
+  // Invalid aliases first, and from both domains: an alias that does not
+  // satisfy the grammar is a problem with what the user wrote, and reporting
+  // a collision instead would send them looking for a conflict that is really
+  // a typo.
+  const aliasProblems = [
+    ...(!assets.ok && assets.reason === 'invalid-alias' ? assets.problems : []),
+    ...(!servers.ok && servers.reason === 'invalid-alias'
+      ? servers.problems.map((p) => ({ facet: p.facet, alias: p.alias, reason: p.reason }))
+      : []),
+  ]
+  if (aliasProblems.length > 0) {
+    return { ok: false, reason: 'invalid-alias', problems: aliasProblems }
+  }
+
+  // A stale override is reported from whichever domain still planned, so a
+  // collision in one does not suppress the other's diagnostics.
+  const staleOverrides: StaleMaterializationOverride[] = [
+    ...(assets.ok || assets.reason === 'collision' ? assets.staleOverrides.map(taggedAssetStale) : []),
+    ...(!servers.ok && servers.reason === 'invalid-alias' ? [] : servers.staleOverrides.map(taggedServerStale)),
+  ]
+
+  if (!assets.ok || !servers.ok) {
+    // Every group from both domains, in one report. A user shown asset
+    // collisions now and server collisions on the next attempt learns the
+    // shape of the problem one round trip at a time.
+    const groups: MaterializationCollisionGroup[] = [
+      ...(!assets.ok && assets.reason === 'collision'
+        ? assets.groups.map((group) => ({ kind: 'asset' as const, group }))
+        : []),
+      ...(!servers.ok && servers.reason === 'collision'
+        ? servers.groups.map((group) => ({ kind: 'mcp-server' as const, group }))
+        : []),
+    ]
+    return { ok: false, reason: 'collision', groups, staleOverrides }
   }
 
   const dispositions = new Map<string, MaterializationDisposition>()
-  for (const planned of result.plan.assets) {
+  for (const planned of assets.plan.assets) {
     dispositions.set(
       dispositionKey(planned.facet, planned.scope, planned.type, planned.authoredName),
       planned.disposition,
@@ -189,9 +307,10 @@ function planWith(
     ok: true,
     plan: {
       facetEntries: lockfileEntriesFor(resolved, dispositions),
-      materialized: result.plan.materialized,
+      materialized: assets.plan.materialized,
+      mcpServers: { planned: servers.planned, configurations: servers.configurations },
       overrides,
-      staleOverrides: result.staleOverrides,
+      staleOverrides,
     },
   }
 }
@@ -202,6 +321,7 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
   onStage({ kind: 'collision-check' })
 
   const contributions = contributionsOf(args)
+  const serverContributions = serverContributionsOf(args)
   // Null-prototype: the keys are facet names from `facets.json`, and this is
   // where the map the resolver later edits and returns is born. A facet named
   // `__proto__` assigned into a plain `{}` would vanish here rather than in
@@ -211,7 +331,7 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
     if (entry.overrides !== undefined) loadedOverrides[facet] = entry.overrides
   }
 
-  const first = planWith(resolved, contributions, loadedOverrides)
+  const first = planWith(resolved, contributions, serverContributions, loadedOverrides)
   if (first.ok) {
     return { ok: true, plan: first.plan }
   }
@@ -219,22 +339,28 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
     return { ok: false, failure: { code: 'MATERIALIZATION_ALIAS_INVALID', problems: first.problems } }
   }
 
-  // Collisions. Frozen mode reproduces recorded intent and never collects
-  // new decisions, so it reports rather than resolves — the same report a
+  const assetGroups = first.groups.flatMap((entry) => (entry.kind === 'asset' ? [entry.group] : []))
+  const collisionFailure: RunInstallFailure = {
+    code: 'MATERIALIZATION_COLLISION',
+    groups: first.groups,
+    staleOverrides: first.staleOverrides,
+  }
+
+  // Collisions. Frozen mode reproduces recorded intent and never collects new
+  // decisions, so it reports rather than resolves — the same report a
   // non-interactive command gets.
-  if (frozenLockfile || resolveCollisions === undefined) {
-    return {
-      ok: false,
-      failure: {
-        code: 'MATERIALIZATION_COLLISION',
-        groups: first.groups,
-        staleOverrides: first.staleOverrides,
-      },
-    }
+  //
+  // A server collision also reports rather than resolves, for now: the
+  // resolution workspace speaks only about assets, so handing it a set whose
+  // server half it cannot express would let a user confirm a draft that
+  // resolves nothing and fail on the re-plan. Reporting is the honest answer
+  // until the workspace can offer a choice for every claimant.
+  if (frozenLockfile || resolveCollisions === undefined || assetGroups.length !== first.groups.length) {
+    return { ok: false, failure: collisionFailure }
   }
 
   const resolution = await resolveCollisions({
-    groups: first.groups,
+    groups: assetGroups,
     contributions,
     staleOverrides: first.staleOverrides,
   })
@@ -246,7 +372,7 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
   // the same pure rule. The resolver is NOT reopened on failure — an
   // automatic retry loop would let a broken resolver spin indefinitely, and
   // the user has already been shown the groups once.
-  const second = planWith(resolved, contributions, resolution.overrides)
+  const second = planWith(resolved, contributions, serverContributions, resolution.overrides)
   if (second.ok) {
     return { ok: true, plan: second.plan }
   }

--- a/packages/engine/src/install/commit/drift-removal.ts
+++ b/packages/engine/src/install/commit/drift-removal.ts
@@ -1,7 +1,7 @@
 import type { SupportedLockfile } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { ownEntry } from '../own-entry.ts'
-import type { ProjectReceiptState } from '../receipt.ts'
+import { assetOwnershipOf, type ProjectReceiptState } from '../receipt.ts'
 import type { FacetOutcome } from '../types.ts'
 
 export interface DriftRemovalArgs {
@@ -34,7 +34,7 @@ export interface DriftRemovalArgs {
  */
 export function removedFacetOutcomes(args: DriftRemovalArgs): FacetOutcome[] {
   const { desiredFacets, receiptState, previousLockfile } = args
-  const tracked = receiptState.kind === 'loaded' ? receiptState.receipt.facets : undefined
+  const tracked = receiptState.kind === 'loaded' ? assetOwnershipOf(receiptState.record) : undefined
 
   const unwantedFromReceipt =
     tracked === undefined ? [] : Object.keys(tracked).filter((name) => ownEntry(desiredFacets, name) === undefined)

--- a/packages/engine/src/install/commit/finalize-facet.ts
+++ b/packages/engine/src/install/commit/finalize-facet.ts
@@ -1,7 +1,9 @@
-import type { FacetManifest, LockfileSource, ResolvedFacetManifest } from '@agent-facets/protocol'
+import type { AuthoredServer, FacetManifest, LockfileSource, ResolvedFacetManifest } from '@agent-facets/protocol'
+import { compareCodeUnits } from '@agent-facets/protocol'
 import { loadManifest, resolvePrompts } from '../../loaders/facet.ts'
 import { getRegistryBaseUrl } from '../../registry/index.ts'
 import type { Source } from '../../sources/facet/types.ts'
+import { ownEntry } from '../own-entry.ts'
 import type { RunInstallFailure, StageEvent } from '../types.ts'
 
 /**
@@ -16,7 +18,7 @@ export type LoadFacetContentResult =
       ok: true
       manifest: FacetManifest
       resolved: ResolvedFacetManifest
-      serversDeclared: ReadonlyArray<string>
+      servers: ReadonlyArray<AuthoredServer>
     }
   | { ok: false; failure: RunInstallFailure }
 
@@ -60,7 +62,15 @@ export async function loadFacetContent(
     return { ok: false, failure: { code: 'COMPOSITION_REJECTED', facet: facetName } }
   }
 
-  const serversDeclared = rawManifest.data.servers ? Object.keys(rawManifest.data.servers) : []
+  // Deterministic authored-name order, so the planner's input — and every
+  // report derived from it — does not inherit JSON member order.
+  const declarations = rawManifest.data.servers ?? {}
+  const servers: AuthoredServer[] = Object.keys(declarations)
+    .sort(compareCodeUnits)
+    .flatMap((name) => {
+      const declaration = ownEntry(declarations, name)
+      return declaration === undefined ? [] : [{ name, declaration }]
+    })
 
   const resolved = await resolvePrompts(rawManifest.data, sourceDir)
   if (!resolved.ok) {
@@ -70,7 +80,7 @@ export async function loadFacetContent(
     }
   }
 
-  return { ok: true, manifest: rawManifest.data, resolved: resolved.data, serversDeclared }
+  return { ok: true, manifest: rawManifest.data, resolved: resolved.data, servers }
 }
 
 /**

--- a/packages/engine/src/install/commit/finalize-intent.ts
+++ b/packages/engine/src/install/commit/finalize-intent.ts
@@ -1,15 +1,14 @@
-import type { AssetType } from '@agent-facets/common'
 import {
-  ASSET_DIRECTORY,
   ASSET_TYPES,
   type FacetMaterializationOverrides,
-  overrideFor,
-  overridesForType,
+  type MaterializationOverrideGroup,
+  overrideGroupKey,
   type ProjectAssetOverride,
-  type StaleOverride,
+  SERVER_OVERRIDE_GROUP,
 } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { ownEntry, ownRecord } from '../own-entry.ts'
+import type { ContributionKind, MaterializationOverrideRef, StaleMaterializationOverride } from '../types.ts'
 
 /**
  * Finalize the project's materialization intent for the commit.
@@ -20,29 +19,61 @@ import { ownEntry, ownRecord } from '../own-entry.ts'
  *   1. **Persist the accepted overrides.** They may be the ones already on
  *      disk, or the ones an interactive resolver chose. Compose returns one
  *      map either way, so the writer never has to know which happened.
- *   2. **Prune stale overrides.** An override naming an asset the resolved
- *      facet version no longer contains is dropped — but only here, on the
- *      way into a successful transaction. An override is durable project
- *      intent, so a failed operation must leave it exactly where it was.
+ *   2. **Prune stale overrides.** An override naming an asset or server the
+ *      resolved facet version no longer contains is dropped — but only here,
+ *      on the way into a successful transaction. An override is durable
+ *      project intent, so a failed operation must leave it exactly where it
+ *      was.
  *
  * Both mutate the in-memory desired set only. Nothing reaches disk until the
  * tri-write, which is what makes "pruned only on success" true by
  * construction rather than by remembering to undo something.
  */
 
-/** An override that was dropped, and the identity it named. */
-export interface PrunedOverride {
-  facet: string
-  type: AssetType
-  authoredName: string
+/** An override that was dropped, and the contribution it named. */
+export type PrunedOverride = MaterializationOverrideRef
+
+/**
+ * Every override group, paired with the contribution kind it holds.
+ *
+ * Derived from the published asset-type list plus the server group, exactly
+ * as the schema's group set is, so this cannot describe a different set of
+ * groups than the document accepts. Carrying the contribution kind alongside
+ * the key is what lets the rebuild below report a prune without inferring the
+ * kind back out of a string.
+ */
+const OVERRIDE_GROUPS: readonly {
+  readonly group: MaterializationOverrideGroup
+  readonly contribution: ContributionKind
+}[] = [
+  ...ASSET_TYPES.map((assetType) => ({
+    group: overrideGroupKey(assetType),
+    contribution: { kind: 'asset', assetType } as const,
+  })),
+  { group: SERVER_OVERRIDE_GROUP, contribution: { kind: 'mcp-server' } as const },
+]
+
+/** The document key an override group uses, per contribution kind. */
+function groupKeyOf(contribution: ContributionKind): MaterializationOverrideGroup {
+  switch (contribution.kind) {
+    case 'asset':
+      return overrideGroupKey(contribution.assetType)
+    case 'mcp-server':
+      return SERVER_OVERRIDE_GROUP
+  }
 }
 
-function staleKey(facet: string, type: AssetType, authoredName: string): string {
-  return `${facet}\u0000${type}\u0000${authoredName}`
+function staleKey(facet: string, group: string, authoredName: string): string {
+  return `${facet}\u0000${group}\u0000${authoredName}`
 }
 
 /**
  * Rebuild one facet's override map without its stale entries.
+ *
+ * Iterates every group the schema recognizes rather than only the asset ones:
+ * a group this function does not visit is not merely left unpruned, it is
+ * dropped from the rebuilt object entirely and therefore erased from
+ * `facets.json` by the next successful write.
  *
  * Returns `undefined` when nothing survives: the canonical form of a facet
  * with no overrides is its compact source string, and `applyDesiredFacets`
@@ -55,33 +86,30 @@ function pruneFacetOverrides(
   stale: ReadonlySet<string>,
   pruned: PrunedOverride[],
 ): FacetMaterializationOverrides | undefined {
-  const next: {
-    skills?: Record<string, ProjectAssetOverride>
-    agents?: Record<string, ProjectAssetOverride>
-    commands?: Record<string, ProjectAssetOverride>
-  } = {}
+  const next: Partial<Record<MaterializationOverrideGroup, Record<string, ProjectAssetOverride>>> = {}
   let kept = 0
 
-  for (const type of ASSET_TYPES) {
-    const record = overridesForType(overrides, type)
+  for (const { group, contribution } of OVERRIDE_GROUPS) {
+    const record = overrides[group]
     if (record === undefined) continue
-    // Null-prototype: keyed by authored asset name, which `constructor` and
-    // `__proto__` are both legal values of. A retained override written into a plain
-    // object under the latter would be dropped from the manifest silently.
+    // Null-prototype: keyed by authored name, which `constructor` and
+    // `__proto__` are both legal values of. A retained override written into
+    // a plain object under the latter would be dropped from the manifest
+    // silently.
     const retained = ownRecord<ProjectAssetOverride>()
     let retainedCount = 0
     for (const authoredName of Object.keys(record)) {
-      const disposition = overrideFor(overrides, type, authoredName)
+      const disposition = ownEntry(record, authoredName)
       if (disposition === undefined) continue
-      if (stale.has(staleKey(facet, type, authoredName))) {
-        pruned.push({ facet, type, authoredName })
+      if (stale.has(staleKey(facet, group, authoredName))) {
+        pruned.push({ facet, contribution, authoredName })
         continue
       }
       retained[authoredName] = disposition
       retainedCount += 1
     }
     if (retainedCount > 0) {
-      next[ASSET_DIRECTORY[type]] = retained
+      next[group] = retained
       kept += retainedCount
     }
   }
@@ -103,9 +131,11 @@ function pruneFacetOverrides(
 export function finalizeMaterializationIntent(
   desiredFacets: Record<string, NormalizedFacetEntry>,
   accepted: Readonly<Record<string, FacetMaterializationOverrides>>,
-  staleOverrides: readonly StaleOverride[],
+  staleOverrides: readonly StaleMaterializationOverride[],
 ): readonly PrunedOverride[] {
-  const stale = new Set(staleOverrides.map((s) => staleKey(s.facet, s.type, s.authoredName)))
+  const stale = new Set(
+    staleOverrides.map((entry) => staleKey(entry.facet, groupKeyOf(entry.contribution), entry.authoredName)),
+  )
   const pruned: PrunedOverride[] = []
 
   for (const [facet, entry] of Object.entries(desiredFacets)) {

--- a/packages/engine/src/install/commit/ownership.ts
+++ b/packages/engine/src/install/commit/ownership.ts
@@ -6,7 +6,7 @@ import {
   SKILL_PRIMARY_FILE,
   skillRootPath,
 } from '@agent-facets/protocol'
-import type { ProjectReceiptState } from '../receipt.ts'
+import { assetOwnershipOf, type ProjectReceiptState } from '../receipt.ts'
 
 /**
  * The global ownership index: what this machine has materialized, keyed by
@@ -120,7 +120,10 @@ export function buildPreviousOwnership(state: ProjectReceiptState): Map<string, 
   const index = new Map<string, PreviousOwnership>()
   if (state.kind !== 'loaded') return index
 
-  for (const [facet, entry] of Object.entries(state.receipt.facets)) {
+  // Every readable receipt version records assets identically, so asset
+  // ownership does not discriminate on configuration authority: a pre-`0.4`
+  // record owns exactly as many files as a current one.
+  for (const [facet, entry] of Object.entries(assetOwnershipOf(state.record))) {
     for (const asset of entry.assets) {
       addClaim(index, facet, {
         scope: asset.scope,

--- a/packages/engine/src/install/commit/resolve-all.ts
+++ b/packages/engine/src/install/commit/resolve-all.ts
@@ -102,9 +102,10 @@ export async function resolveAll(args: ResolveAllArgs): Promise<ResolveAllResult
 
     const facetResolution = resolveResult.value
 
-    if (facetResolution.serversDeclared.length > 0) {
-      serverWarnings.push({ facet: facetName, servers: facetResolution.serversDeclared })
-      onStage({ kind: 'server-warning', facet: facetName, servers: facetResolution.serversDeclared })
+    if (facetResolution.servers.length > 0) {
+      const names = facetResolution.servers.map((server) => server.name)
+      serverWarnings.push({ facet: facetName, servers: names })
+      onStage({ kind: 'server-warning', facet: facetName, servers: names })
     }
 
     // Pre-materialization reconciliation (design D10): the previously-locked

--- a/packages/engine/src/install/commit/resolve-git.ts
+++ b/packages/engine/src/install/commit/resolve-git.ts
@@ -218,7 +218,7 @@ export async function resolveGitFacet(args: ResolveGitFacetArgs): Promise<Resolv
         resolved: content.resolved,
         plan: built.plan,
         companionBytes: companionBytes.companions,
-        serversDeclared: content.serversDeclared,
+        servers: content.servers,
       },
     }
   } finally {

--- a/packages/engine/src/install/commit/resolve-local.ts
+++ b/packages/engine/src/install/commit/resolve-local.ts
@@ -115,7 +115,7 @@ export async function resolveLocalFacet(args: ResolveLocalFacetArgs): Promise<Re
       resolved: content.resolved,
       plan: built.plan,
       companionBytes: companionBytes.companions,
-      serversDeclared: content.serversDeclared,
+      servers: content.servers,
     },
   }
 }

--- a/packages/engine/src/install/commit/resolve-registry.ts
+++ b/packages/engine/src/install/commit/resolve-registry.ts
@@ -220,7 +220,7 @@ export async function resolveRegistryFacet(args: ResolveRegistryFacetArgs): Prom
       resolved: content.resolved,
       plan: built.plan,
       companionBytes: companionBytes.companions,
-      serversDeclared: content.serversDeclared,
+      servers: content.servers,
     },
   }
 }

--- a/packages/engine/src/install/commit/server-ownership.ts
+++ b/packages/engine/src/install/commit/server-ownership.ts
@@ -1,0 +1,182 @@
+import {
+  compareCodeUnits,
+  type McpServerFingerprint,
+  type McpServerIdentity,
+  materializedNameOf,
+  mcpServerKey,
+  type PlannedServerConfiguration,
+} from '@agent-facets/protocol'
+import { ownRecord } from '../own-entry.ts'
+import type { ProjectReceiptState, ReceiptConfigurationClaim } from '../receipt.ts'
+
+/**
+ * The MCP configuration ownership index: which effective server identities
+ * this machine has reconciled, and what it approved at each one.
+ *
+ * A sibling of the asset ownership index rather than a widening of it. The
+ * two answer the same two questions — "may this be deleted?" and "which
+ * facets claimed it?" — but over different identity spaces, with different
+ * keys, and with one extra question that only applies here: "was this exact
+ * declaration already approved on this machine?"
+ *
+ * Ownership is project-wide and adapter-agnostic, exactly as it is for
+ * assets. Selecting an adapter delegates management of the identities the
+ * project already owns; it does not create a second ownership axis, and the
+ * key deliberately carries no adapter.
+ */
+
+/** One effective MCP identity this machine previously reconciled. */
+export interface PreviousMcpOwnership {
+  identity: McpServerIdentity
+  /** The addressable ownership key for {@link identity}. */
+  key: string
+  /** The name an adapter can address this configuration by. */
+  effectiveName: string
+  /** Every facet that claimed this identity. Sorted; usually one. */
+  facets: readonly string[]
+  /**
+   * Every declaration fingerprint recorded at this identity. Sorted; usually
+   * one.
+   *
+   * More than one means the receipt recorded claims that disagreed about what
+   * the server IS — historical claims from separate facets, which composition
+   * would now contest. All of them are kept: each is evidence that THAT
+   * declaration was approved here, and discarding any would silently
+   * re-prompt for something the user already accepted.
+   */
+  fingerprints: readonly McpServerFingerprint[]
+}
+
+/** Fold one claim into the index, unioning claimants and fingerprints. */
+function addClaim(index: Map<string, PreviousMcpOwnership>, facet: string, claim: ReceiptConfigurationClaim): void {
+  const effectiveName = materializedNameOf(claim.name, claim.materialization)
+  const key = mcpServerKey(effectiveName)
+  const existing = index.get(key)
+  if (existing === undefined) {
+    index.set(key, {
+      identity: { kind: 'mcp-server', effectiveName },
+      key,
+      effectiveName,
+      facets: [facet],
+      fingerprints: [claim.fingerprint],
+    })
+    return
+  }
+  index.set(key, {
+    ...existing,
+    facets: existing.facets.includes(facet) ? existing.facets : [...existing.facets, facet].sort(compareCodeUnits),
+    fingerprints: existing.fingerprints.includes(claim.fingerprint)
+      ? existing.fingerprints
+      : [...existing.fingerprints, claim.fingerprint].sort(compareCodeUnits),
+  })
+}
+
+/**
+ * Build the global MCP configuration ownership index.
+ *
+ * Takes the receipt STATE, like its asset counterpart, so "no usable account"
+ * and "an account that happens to be empty" cannot be confused at the call
+ * site. A receipt that predates configuration claims yields an EMPTY index —
+ * not because it owns nothing, but because it cannot say. Empty is the safe
+ * answer in both directions: nothing is deleted, and every declaration is
+ * treated as needing approval.
+ */
+export function buildPreviousMcpOwnership(state: ProjectReceiptState): Map<string, PreviousMcpOwnership> {
+  const index = new Map<string, PreviousMcpOwnership>()
+  if (state.kind !== 'loaded') return index
+  if (state.record.authority !== 'assets-and-configuration') return index
+
+  for (const [facet, entry] of Object.entries(state.record.facets)) {
+    for (const claim of entry.configurations) {
+      addClaim(index, facet, claim)
+    }
+  }
+  return index
+}
+
+/**
+ * The effective server identities to remove: previously reconciled per the
+ * receipt, claimed by nothing in the desired set.
+ *
+ * The desired set is the authority for what should exist; this index is the
+ * only authority for what may be removed. An identity the lockfile once
+ * implied but the receipt never recorded is untracked, and stays untouched.
+ *
+ * Deterministically ordered by key so a rollback replays in a stable sequence
+ * and verbose output is reviewable.
+ */
+export function obsoleteMcpOwnership(
+  previous: ReadonlyMap<string, PreviousMcpOwnership>,
+  desired: readonly PlannedServerConfiguration[],
+): PreviousMcpOwnership[] {
+  const claimed = new Set(desired.map((configuration) => configuration.key))
+  const obsolete: PreviousMcpOwnership[] = []
+  for (const [key, ownership] of previous) {
+    if (claimed.has(key)) continue
+    obsolete.push(ownership)
+  }
+  obsolete.sort((a, b) => compareCodeUnits(a.key, b.key))
+  return obsolete
+}
+
+/**
+ * The effective names an adapter may treat as already owned by this project.
+ *
+ * This is the complete extent of what an adapter is permitted to remove, and
+ * it comes from the receipt alone. Deriving it from the lockfile would let a
+ * teammate's commit authorize deleting an entry this machine never wrote.
+ */
+export function previouslyOwnedServerNames(previous: ReadonlyMap<string, PreviousMcpOwnership>): string[] {
+  return [...previous.values()].map((ownership) => ownership.effectiveName).sort(compareCodeUnits)
+}
+
+/**
+ * Whether this machine already approved this exact declaration at this exact
+ * effective identity.
+ *
+ * Keyed on identity AND fingerprint, because either changing is a different
+ * thing to consent to: a new effective name puts a previously approved
+ * command somewhere new, and a new fingerprint runs something else under a
+ * name that was already trusted.
+ */
+export function isDeclarationApproved(
+  previous: ReadonlyMap<string, PreviousMcpOwnership>,
+  configuration: PlannedServerConfiguration,
+): boolean {
+  return previous.get(configuration.key)?.fingerprints.includes(configuration.fingerprint) ?? false
+}
+
+/**
+ * The receipt claims a set of reconciled configurations implies, keyed by
+ * claimant facet.
+ *
+ * Every claimant records its own claim, under its OWN authored name and
+ * disposition: ownership is per project, but a claim has to be attributable
+ * to a facet so that removing one claimant while another remains preserves
+ * the configuration. The effective identity all of them derive is the same,
+ * which is what makes the ownership index above fold them back together.
+ *
+ * Omitted declarations cannot appear: a configuration exists only for an
+ * ACTIVE identity, and a claimant's disposition admits only the arms that
+ * materialize.
+ */
+export function claimsByFacet(
+  configurations: readonly PlannedServerConfiguration[],
+): Record<string, ReceiptConfigurationClaim[]> {
+  // Null-prototype: keyed by facet name from `facets.json`, where
+  // `__proto__` is a legal key and a silent drop would lose a claim.
+  const byFacet: Record<string, ReceiptConfigurationClaim[]> = ownRecord()
+  for (const configuration of configurations) {
+    for (const claimant of configuration.claimants) {
+      const claims = byFacet[claimant.facet] ?? []
+      claims.push({
+        kind: 'mcp-server',
+        name: claimant.authoredName,
+        materialization: claimant.disposition,
+        fingerprint: configuration.fingerprint,
+      })
+      byFacet[claimant.facet] = claims
+    }
+  }
+  return byFacet
+}

--- a/packages/engine/src/install/commit/tri-write.ts
+++ b/packages/engine/src/install/commit/tri-write.ts
@@ -4,9 +4,11 @@ import type { CurrentLockfile, CurrentLockfileFacet } from '@agent-facets/protoc
 import { applyDesiredFacets, type ManifestDocument, type NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { writeProjectManifest } from '../../manifest/project-files.ts'
 import { FACETS_LOCK_FILE, writeLockfile } from '../lockfile-io.ts'
-import { ownRecord } from '../own-entry.ts'
+import { ownEntry, ownRecord } from '../own-entry.ts'
 import {
+  CURRENT_RECEIPT_VERSION,
   type Receipt,
+  type ReceiptConfigurationClaim,
   type ReceiptFacetEntry,
   receiptEntryForLockedFacet,
   receiptPath,
@@ -34,27 +36,42 @@ import type { OnLog, RunInstallFailure } from '../types.ts'
  * the real file permanently.
  */
 export type MaterializedReceiptState =
-  | { kind: 'written'; facetEntries: Readonly<Record<string, CurrentLockfileFacet>> }
+  | {
+      kind: 'written'
+      facetEntries: Readonly<Record<string, CurrentLockfileFacet>>
+      /**
+       * The MCP configuration claims this run reconciled, keyed by facet.
+       * Separate from `facetEntries` because the lockfile records no
+       * declarations, so there is nothing in a locked entry to derive a claim
+       * from — it can only come from what was actually applied.
+       */
+      configurations: Readonly<Record<string, readonly ReceiptConfigurationClaim[]>>
+    }
   | { kind: 'carried-forward'; facets: Readonly<Record<string, ReceiptFacetEntry>> }
 
 /**
  * Derive the new receipt from what this run actually put on disk. The receipt
- * records `{ version, assets[] }` per facet, each asset carrying the owned
- * inner-archive file paths — a self-sufficient, offline-capable deletion
- * record for future drift removal. It mirrors paths, never hashes.
+ * records, per facet, the resolved integrity plus the assets and MCP
+ * configuration claims it owns — a self-sufficient, offline-capable deletion
+ * record for future drift removal. It mirrors asset paths, never hashes, and
+ * declaration fingerprints, never declarations.
+ *
+ * Takes the project PATH rather than a previous receipt: every field of the
+ * new record comes from this run, so a previous one could only contribute
+ * claims this run has no evidence for.
  */
-export function buildUpdatedReceipt(receipt: Receipt, state: MaterializedReceiptState): Receipt {
+export function buildUpdatedReceipt(projectPath: string, state: MaterializedReceiptState): Receipt {
   const facets: Record<string, ReceiptFacetEntry> = ownRecord()
   if (state.kind === 'carried-forward') {
     for (const [name, entry] of Object.entries(state.facets)) {
       facets[name] = entry
     }
-    return { ...receipt, facets }
+    return { version: CURRENT_RECEIPT_VERSION, path: projectPath, facets }
   }
   for (const [name, entry] of Object.entries(state.facetEntries)) {
-    facets[name] = receiptEntryForLockedFacet(entry)
+    facets[name] = receiptEntryForLockedFacet(entry, ownEntry(state.configurations, name) ?? [])
   }
-  return { ...receipt, facets }
+  return { version: CURRENT_RECEIPT_VERSION, path: projectPath, facets }
 }
 
 /**

--- a/packages/engine/src/install/commit/types.ts
+++ b/packages/engine/src/install/commit/types.ts
@@ -1,4 +1,4 @@
-import type { LockfileSource, ResolvedFacetManifest } from '@agent-facets/protocol'
+import type { AuthoredServer, LockfileSource, ResolvedFacetManifest } from '@agent-facets/protocol'
 import type { RunInstallFailure } from '../types.ts'
 import type { SkillCompanionBytes, VerifiedAssetPlan } from '../verified-asset-plan.ts'
 
@@ -36,7 +36,16 @@ export interface ResolvedFacet {
   plan: VerifiedAssetPlan
   /** Keyed by `skill:<name>`; empty map for a companion-less skill. */
   companionBytes: Map<string, SkillCompanionBytes>
-  serversDeclared: ReadonlyArray<string>
+  /**
+   * The facet's authored MCP server declarations, in authored-name order.
+   *
+   * The complete declarations, not their names: a name alone cannot be
+   * fingerprinted, rendered natively, or compared against what a tool's
+   * configuration already says. They arrive verified — a declaration lives
+   * inside the integrity-protected `facet.json`, so anything that reached
+   * this point has already reproduced the locked integrity.
+   */
+  servers: ReadonlyArray<AuthoredServer>
 }
 
 /**

--- a/packages/engine/src/install/frozen-gates.ts
+++ b/packages/engine/src/install/frozen-gates.ts
@@ -104,8 +104,13 @@ export function checkFrozenConsistency(args: FrozenGateArgs): RunInstallFailure 
     // just delivered before anything was downloaded.
     return {
       code: 'MATERIALIZATION_COLLISION',
-      groups: planned.groups,
-      staleOverrides: planned.staleOverrides,
+      groups: planned.groups.map((group) => ({ kind: 'asset' as const, group })),
+      staleOverrides: planned.staleOverrides.map((stale) => ({
+        facet: stale.facet,
+        contribution: { kind: 'asset', assetType: stale.type },
+        authoredName: stale.authoredName,
+        disposition: stale.disposition,
+      })),
     }
   }
 
@@ -114,7 +119,7 @@ export function checkFrozenConsistency(args: FrozenGateArgs): RunInstallFailure 
   const drift: LockfileDriftEntry[] = planned.staleOverrides.map((stale) => ({
     name: stale.facet,
     reason: 'stale-override' as const,
-    assetType: stale.type,
+    contribution: { kind: 'asset', assetType: stale.type },
     authoredName: stale.authoredName,
   }))
 

--- a/packages/engine/src/install/receipt.ts
+++ b/packages/engine/src/install/receipt.ts
@@ -28,11 +28,15 @@ import { type AssetType, atomicWriteFileSync, type Scope, validateAssetName } fr
 import {
   canonicalPrimaryPath,
   isMaterialized,
+  isMcpServerFingerprint,
   lockedDispositionOf,
   type MaterializedDisposition,
   MaterializedDispositionSchema,
+  type McpServerFingerprint,
   type SupportedLockfileAssetEntry,
   type SupportedLockfileFacet,
+  sameDisposition,
+  validateMcpServerName,
 } from '@agent-facets/protocol'
 import { type } from 'arktype'
 import { facetReceiptsDir } from '../facet-dir.ts'
@@ -60,6 +64,14 @@ export const LEGACY_RECEIPT_VERSION = 1
 export const RECEIPT_VERSION_0_2 = 0.2
 
 /**
+ * The preceding receipt schema version. Numeric `0.3` identifies ONLY the
+ * shape with owned-file records and materialization dispositions, but no
+ * facet integrity and no configuration claims: it can witness what this
+ * machine put on disk as FILES, and nothing about MCP configuration.
+ */
+export const RECEIPT_VERSION_0_3 = 0.3
+
+/**
  * The current receipt schema version.
  *
  * A current receipt records, for each asset actually present on disk: its
@@ -73,23 +85,44 @@ export const RECEIPT_VERSION_0_2 = 0.2
  * Omitted assets never appear: a disposition here admits only the two arms
  * that put bytes on disk, which makes "omitted but materialized"
  * unrepresentable rather than merely unlikely.
+ *
+ * `0.4` additionally records, per facet, the resolved facet integrity that
+ * witnessed the entry and the MCP configuration claims this machine
+ * successfully reconciled. Those claims are simultaneously keyed deletion
+ * authority and this machine's evidence of prior approval, and they carry a
+ * fingerprint rather than a declaration, so the record proves what was
+ * approved without storing a command, URL, or environment data.
  */
-export const CURRENT_RECEIPT_VERSION = 0.3
+export const CURRENT_RECEIPT_VERSION = 0.4
+
+/**
+ * Every readable version that predates configuration claims.
+ *
+ * Derived from the constants rather than restated, so adding a version
+ * cannot leave this union describing a set that no longer exists.
+ */
+export type PreConfigurationReceiptVersion =
+  | typeof LEGACY_RECEIPT_VERSION
+  | typeof RECEIPT_VERSION_0_2
+  | typeof RECEIPT_VERSION_0_3
 
 // ---------------------------------------------------------------------------
 // Schema
 // ---------------------------------------------------------------------------
 
 /**
- * A current (`0.3`) receipt asset record: authored identity, the complete
- * set of owned authored inner-archive file paths, and the materialization
- * disposition. A skill owns `skills/<name>/SKILL.md` plus every materialized
- * companion; an agent or command owns exactly its single conventional
- * primary file. Companion paths are the engine-supplied
- * `ownedCompanionPaths` handed to the adapter delete request, so offline
- * multi-file cleanup is exact.
+ * A receipt asset record: authored identity, the complete set of owned
+ * authored inner-archive file paths, and the materialization disposition. A
+ * skill owns `skills/<name>/SKILL.md` plus every materialized companion; an
+ * agent or command owns exactly its single conventional primary file.
+ * Companion paths are the engine-supplied `ownedCompanionPaths` handed to the
+ * adapter delete request, so offline multi-file cleanup is exact.
+ *
+ * Shared by `0.3` and `0.4`: configuration claims were added beside asset
+ * ownership, not on top of it, so the asset shape is identical in both and
+ * restating it would let the two drift.
  */
-const CurrentReceiptAssetSchema = type({
+const ReceiptAssetSchema = type({
   scope: "'system' | 'user' | 'project'",
   type: "'skill' | 'agent' | 'command'",
   name: 'string',
@@ -97,15 +130,63 @@ const CurrentReceiptAssetSchema = type({
   files: 'string[]',
 })
 
+/** The members a configuration claim may carry, and nothing else. */
+const CONFIGURATION_CLAIM_MEMBERS: ReadonlySet<string> = new Set(['kind', 'name', 'materialization', 'fingerprint'])
+
+/**
+ * A current (`0.4`) MCP configuration claim.
+ *
+ * Closed, unlike most schemas in this repository: an unrecognized member here
+ * would be a place for a command, a URL, or an environment value to live in a
+ * file whose entire contract is that it holds none of them. Arktype tolerates
+ * extra keys by default, so the closure is explicit.
+ *
+ * `name` is AUTHORED and `materialization` derives the effective identity,
+ * exactly as for assets. `fingerprint` stands in for the declaration itself;
+ * its spelling is validated with the declaration's own semantic checks during
+ * entry validation, where a bad value drops one claim rather than the
+ * document.
+ */
+const ReceiptConfigurationClaimSchema = type({
+  kind: "'mcp-server'",
+  name: 'string',
+  materialization: MaterializedDispositionSchema,
+  fingerprint: 'string',
+}).narrow((data, ctx) => {
+  const stray = Object.keys(data).filter((key) => !CONFIGURATION_CLAIM_MEMBERS.has(key))
+  if (stray.length > 0) {
+    return ctx.mustBe(`a configuration claim without the unrecognized member "${stray[0]}"`)
+  }
+  return true
+})
+
 const CurrentReceiptFacetEntrySchema = type({
   version: 'string',
-  assets: CurrentReceiptAssetSchema.array(),
+  /** The resolved facet integrity that witnessed this entry's claims. */
+  integrity: 'string',
+  assets: ReceiptAssetSchema.array(),
+  configurations: ReceiptConfigurationClaimSchema.array(),
 })
 
 const CurrentReceiptSchema = type({
   version: type.unit(CURRENT_RECEIPT_VERSION),
   path: 'string',
   facets: type.Record('string', CurrentReceiptFacetEntrySchema),
+})
+
+/**
+ * Preceding (`0.3`) receipt: complete asset ownership with dispositions, no
+ * facet integrity and no configuration claims.
+ */
+const Receipt03FacetEntrySchema = type({
+  version: 'string',
+  assets: ReceiptAssetSchema.array(),
+})
+
+const Receipt03Schema = type({
+  version: type.unit(RECEIPT_VERSION_0_3),
+  path: 'string',
+  facets: type.Record('string', Receipt03FacetEntrySchema),
 })
 
 /**
@@ -178,11 +259,64 @@ export interface ReceiptAsset {
   files: string[]
 }
 
-export interface ReceiptFacetEntry {
+/**
+ * One MCP configuration claim: an active declaration this machine
+ * successfully reconciled into every selected adapter.
+ *
+ * The claim is deliberately two things at once. It is keyed deletion
+ * authority — the effective identity derived from `name` and
+ * `materialization` may be removed when nothing desires it any more — and it
+ * is this machine's evidence that the declaration behind `fingerprint` was
+ * approved here. Neither may be inferred from the lockfile, which is shared
+ * state that a teammate's commit rewrites.
+ *
+ * What it is NOT is a copy of the declaration. The fingerprint answers "is
+ * this the same launch or connection behavior?" without the receipt ever
+ * holding a command, its arguments, a URL, or an environment name or value.
+ */
+export interface ReceiptConfigurationClaim {
+  kind: 'mcp-server'
+  /** The AUTHORED server name. The effective one derives from `materialization`. */
+  name: string
+  materialization: MaterializedDisposition
+  fingerprint: McpServerFingerprint
+}
+
+/**
+ * Asset ownership for one facet — the part every readable receipt version can
+ * express, and therefore the part every version confers full authority over.
+ */
+export interface ReceiptAssetOwnership {
   version: string
   assets: ReceiptAsset[]
 }
 
+/**
+ * A current (`0.4`) facet record: asset ownership, plus the facet integrity
+ * that witnessed it, plus the configuration claims reconciled alongside it.
+ *
+ * `integrity` is what makes an offline proof possible later: declarations
+ * live inside the integrity-protected `facet.json` and deliberately not in
+ * the lockfile, so "are this facet's claims still about the same
+ * declarations?" is answerable without a fetch only by comparing the recorded
+ * integrity against the locked one.
+ *
+ * Extends {@link ReceiptAssetOwnership} rather than restating it, so every
+ * consumer that only needs assets accepts a current record unchanged while
+ * nothing can read claims off a record that has none.
+ */
+export interface ReceiptFacetEntry extends ReceiptAssetOwnership {
+  integrity: string
+  configurations: ReceiptConfigurationClaim[]
+}
+
+/**
+ * The receipt this machine writes. Always the current version: every earlier
+ * format refines into memory on load and the next successful write emits
+ * `0.4`, never an intermediate writer format. That is a property of the type
+ * rather than of remembering to set a field — `version` admits one value, and
+ * {@link writeReceipt} accepts nothing else.
+ */
 export interface Receipt {
   version: typeof CURRENT_RECEIPT_VERSION
   path: string
@@ -190,26 +324,91 @@ export interface Receipt {
 }
 
 /**
- * A receipt asset entry rejected during load because its name or one of its
- * owned file paths failed validation (path traversal, backslashes, empty
- * segments). Reported — never acted on — while the facet's remaining valid
- * entries still load (D6: a corrupted receipt may cause a skipped cleanup; it
- * must never poison the rest of the record). Because an invalid path could
- * escape the adapter's storage root, the whole asset record is dropped rather
- * than partially trusted — an unowned or escaping path is never deleted.
+ * What a receipt file that LOADED proves, and how much of it.
+ *
+ * Two arms, because there are exactly two answers and they differ in kind
+ * rather than in degree. A `0.4` document witnessed both what this machine
+ * put on disk and what it configured. Every earlier document witnessed the
+ * files and could not have witnessed configuration, because the concept did
+ * not exist when it was written.
+ *
+ * The distinction is represented rather than flattened, deliberately. A
+ * refined pre-`0.4` record carrying `configurations: []` would be
+ * indistinguishable from a current record whose facet genuinely reconciled no
+ * declarations — and those two states must diverge: the first can prove
+ * nothing and forces ordinary resolution, while the second is positive
+ * evidence, anchored by `integrity`, that a successful operation left no
+ * active configuration behind.
+ *
+ * Tagged at the document rather than per facet, because that is where the
+ * fact lives: version dispatch is exact and refinement is whole-document, so
+ * a receipt in which some facets are witnessed and others are not is not a
+ * state this system can produce.
  */
-export interface InvalidReceiptAsset {
-  facet: string
-  asset: string
-  reason: string
+export type LoadedReceipt =
+  /** Every readable pre-`0.4` document. Full asset authority, no configuration authority. */
+  | {
+      authority: 'assets-only'
+      refinedFrom: PreConfigurationReceiptVersion
+      path: string
+      facets: Readonly<Record<string, ReceiptAssetOwnership>>
+    }
+  /** A current document. Asset authority plus witnessed configuration claims. */
+  | {
+      authority: 'assets-and-configuration'
+      path: string
+      facets: Readonly<Record<string, ReceiptFacetEntry>>
+    }
+
+/**
+ * The asset ownership a loaded record proves, whatever configuration
+ * authority it carries.
+ *
+ * Every readable version records assets identically, so asset consumers
+ * should not have to discriminate — and must not, because branching would
+ * invite one of them to treat a pre-`0.4` record as owning less than it does.
+ */
+export function assetOwnershipOf(record: LoadedReceipt): Readonly<Record<string, ReceiptAssetOwnership>> {
+  return record.facets
 }
 
+/**
+ * A receipt record rejected during load. Reported — never acted on — while
+ * the facet's remaining valid records still load (D6: a corrupted receipt may
+ * cause a skipped cleanup; it must never poison the rest of the file).
+ *
+ * Tagged because the two kinds name different things and are recovered from
+ * differently: an asset names a path this machine will now never clean up, a
+ * configuration claim names a server entry that reverts to untracked and
+ * unapproved. A single shape with an `asset` field holding a server name
+ * would read as the former while meaning the latter.
+ */
+export type InvalidReceiptEntry =
+  /**
+   * The asset's name or one of its owned file paths failed validation (path
+   * traversal, backslashes). Because an invalid path could escape the
+   * adapter's storage root, the whole asset record is dropped rather than
+   * partially trusted — an unowned or escaping path is never deleted.
+   */
+  | { kind: 'asset'; facet: string; asset: string; reason: string }
+  /**
+   * The claim's server name or fingerprint was malformed, or the facet made
+   * two contradictory claims about one authored name. Dropping it withdraws
+   * both of the things a claim confers: the entry becomes untracked native
+   * occupancy, and its declaration needs approval again. Both are the safe
+   * direction — nothing is deleted and nothing is assumed consented.
+   */
+  | { kind: 'configuration'; facet: string; server: string; reason: string }
+
 export type LoadReceiptResult =
-  | { ok: true; receipt: Receipt; invalidEntries: ReadonlyArray<InvalidReceiptAsset> }
+  | { ok: true; record: LoadedReceipt; invalidEntries: ReadonlyArray<InvalidReceiptEntry> }
   | { ok: false; reason: 'missing' | 'corrupt' | 'path-mismatch' }
 
-/** Why this machine has no usable account of what it materialized. */
-export type ReceiptUnavailableReason = 'missing' | 'corrupt' | 'path-mismatch'
+/**
+ * Why this machine has no usable account of what it materialized. Derived
+ * from the failure arm rather than restated, so the two cannot diverge.
+ */
+export type ReceiptUnavailableReason = Extract<LoadReceiptResult, { ok: false }>['reason']
 
 /**
  * What this machine can prove it materialized.
@@ -222,17 +421,16 @@ export type ReceiptUnavailableReason = 'missing' | 'corrupt' | 'path-mismatch'
  * nothing, and the lockfile cannot stand in for either, because it is shared
  * state that a `git pull` rewrites without touching a single file on disk.
  *
- * The `unavailable` arm carries NO `Receipt`, deliberately. Every claim in a
+ * The `unavailable` arm carries NO record, deliberately. Every claim in a
  * receipt is a licence to delete, so a state that means "no claims" must not
- * be able to hold any: an empty-by-convention `Receipt` here would put the
+ * be able to hold any: an empty-by-convention record here would put the
  * whole guarantee on one constructor remembering to leave a field empty.
  * `canonicalProjectPath` is all the arm needs, because the only other use for
- * a receipt value is as the base a commit builds its NEW record on — and that
- * base is derived at commit time from the path (see `emptyReceiptFor`).
+ * a loaded record is as the location a commit writes its NEW one to.
  */
 export type ProjectReceiptState =
   /** Read from this machine's receipt file, and free to contradict the lockfile. */
-  | { kind: 'loaded'; receipt: Receipt; invalidEntries: ReadonlyArray<InvalidReceiptAsset> }
+  | { kind: 'loaded'; record: LoadedReceipt; invalidEntries: ReadonlyArray<InvalidReceiptEntry> }
   /** No trustworthy local account. Proven ownership is empty by construction. */
   | { kind: 'unavailable'; reason: ReceiptUnavailableReason; projectPath: string }
 
@@ -324,114 +522,45 @@ export function loadReceipt(projectDir: string): LoadReceiptResult {
     return { ok: false, reason: 'corrupt' }
   }
 
-  // Exact version dispatch (design D10), mirroring the lockfile. Any
-  // other/absent version is corrupt — the shape is never sniffed to guess a
-  // schema. Each earlier version refines losslessly into the current shape:
-  //
-  //   `1`   — identity only. Refined to primary-only ownership, which is
-  //           exact rather than a guess: legacy installs could not
-  //           materialize companions, so there were none to record.
-  //   `0.2` — complete ownership, no disposition. Refined to authored
-  //           materialization, the only meaning a pre-disposition receipt
-  //           could have had.
-  const observedVersion =
-    typeof parsed === 'object' && parsed !== null && 'version' in parsed
-      ? (parsed as { version?: unknown }).version
-      : undefined
-
-  const authored = { kind: 'authored' } as const
-
-  let embeddedPath: string
-  let rawFacets: Record<string, { version: string; assets: ReadonlyArray<RawReceiptAsset> }>
-  if (observedVersion === CURRENT_RECEIPT_VERSION) {
-    const validated = CurrentReceiptSchema(parsed)
-    if (validated instanceof type.errors) return { ok: false, reason: 'corrupt' }
-    embeddedPath = validated.path
-    rawFacets = validated.facets
-  } else if (observedVersion === RECEIPT_VERSION_0_2) {
-    const validated = Receipt02Schema(parsed)
-    if (validated instanceof type.errors) return { ok: false, reason: 'corrupt' }
-    embeddedPath = validated.path
-    rawFacets = ownRecord()
-    for (const [name, entry] of Object.entries(validated.facets)) {
-      rawFacets[name] = {
-        version: entry.version,
-        assets: entry.assets.map((a) => ({ ...a, materialization: authored })),
-      }
-    }
-  } else if (observedVersion === LEGACY_RECEIPT_VERSION) {
-    const validated = LegacyReceiptSchema(parsed)
-    if (validated instanceof type.errors) return { ok: false, reason: 'corrupt' }
-    embeddedPath = validated.path
-    rawFacets = ownRecord()
-    for (const [name, entry] of Object.entries(validated.facets)) {
-      rawFacets[name] = {
-        version: entry.version,
-        assets: entry.assets.map((a) => ({
-          ...a,
-          materialization: authored,
-          files: [canonicalPrimaryPath(a.type, a.name)],
-        })),
-      }
-    }
-  } else {
-    return { ok: false, reason: 'corrupt' }
-  }
+  const dispatched = dispatchReceiptVersion(parsed)
+  if (dispatched === null) return { ok: false, reason: 'corrupt' }
 
   // Self-identification check: the embedded path must match the
   // project being operated on.
-  if (embeddedPath !== canonical) {
+  if (dispatched.path !== canonical) {
     return { ok: false, reason: 'path-mismatch' }
   }
 
-  // Validate every asset name AND every owned file path — receipt data is
-  // untrusted. A crafted name or a path that could traverse outside the
-  // adapter's storage drops the whole asset record (reported, never
-  // deleted), while the facet's remaining valid entries still load (D6).
   // Null-prototype throughout: a receipt facet key is an arbitrary string
   // from a file on disk, and dropping a `__proto__`-named facet here would
   // erase an ownership claim silently — the one outcome D6 rules out, since
   // the assets it covers would then never be deleted OR re-tracked.
-  const invalidEntries: InvalidReceiptAsset[] = []
-  const facets: Record<string, ReceiptFacetEntry> = ownRecord()
-  for (const [facetName, entry] of Object.entries(rawFacets)) {
-    const validAssets: ReceiptAsset[] = []
-    for (const asset of entry.assets) {
-      const nameCheck = validateAssetName(asset.name)
-      if (!nameCheck.ok) {
-        invalidEntries.push({ facet: facetName, asset: asset.name, reason: nameCheck.reason })
-        continue
-      }
-      let badPath: { path: string; reason: string } | undefined
-      for (const p of asset.files) {
-        const check = validateAssetName(p)
-        if (!check.ok) {
-          badPath = { path: p, reason: check.reason }
-          break
-        }
-      }
-      if (badPath !== undefined) {
-        invalidEntries.push({
-          facet: facetName,
-          asset: asset.name,
-          reason: `owned path "${badPath.path}" ${badPath.reason}`,
-        })
-        continue
-      }
-      validAssets.push({
-        scope: asset.scope,
-        type: asset.type,
-        name: asset.name,
-        materialization: asset.materialization,
-        files: [...asset.files],
-      })
+  const invalidEntries: InvalidReceiptEntry[] = []
+
+  if (dispatched.authority === 'assets-only') {
+    const facets: Record<string, ReceiptAssetOwnership> = ownRecord()
+    for (const [facetName, entry] of Object.entries(dispatched.facets)) {
+      facets[facetName] = { version: entry.version, assets: validatedAssets(facetName, entry.assets, invalidEntries) }
     }
-    facets[facetName] = { version: entry.version, assets: validAssets }
+    return {
+      ok: true,
+      record: { authority: 'assets-only', refinedFrom: dispatched.refinedFrom, path: canonical, facets },
+      invalidEntries,
+    }
   }
 
+  const facets: Record<string, ReceiptFacetEntry> = ownRecord()
+  for (const [facetName, entry] of Object.entries(dispatched.facets)) {
+    facets[facetName] = {
+      version: entry.version,
+      integrity: entry.integrity,
+      assets: validatedAssets(facetName, entry.assets, invalidEntries),
+      configurations: validatedClaims(facetName, entry.configurations, invalidEntries),
+    }
+  }
   return {
     ok: true,
-    receipt: { version: CURRENT_RECEIPT_VERSION, path: canonical, facets },
+    record: { authority: 'assets-and-configuration', path: canonical, facets },
     invalidEntries,
   }
 }
@@ -443,6 +572,230 @@ interface RawReceiptAsset {
   name: string
   materialization: MaterializedDisposition
   files: ReadonlyArray<string>
+}
+
+/** One facet's asset ownership as dispatch produced it. */
+interface RawAssetFacet {
+  version: string
+  assets: ReadonlyArray<RawReceiptAsset>
+}
+
+/** One current facet record as dispatch produced it, claims not yet checked. */
+interface RawCurrentFacet extends RawAssetFacet {
+  integrity: string
+  configurations: ReadonlyArray<{
+    kind: 'mcp-server'
+    name: string
+    materialization: MaterializedDisposition
+    fingerprint: string
+  }>
+}
+
+/** What exact version dispatch establishes, before the path check. */
+type DispatchedReceipt =
+  | {
+      authority: 'assets-only'
+      refinedFrom: PreConfigurationReceiptVersion
+      path: string
+      facets: Readonly<Record<string, RawAssetFacet>>
+    }
+  | { authority: 'assets-and-configuration'; path: string; facets: Readonly<Record<string, RawCurrentFacet>> }
+
+/**
+ * Exact version dispatch (design D10), mirroring the lockfile. Any other or
+ * absent version is corrupt — the shape is never sniffed to guess a schema.
+ *
+ * Each earlier version refines losslessly into the current ASSET shape, and
+ * none of them gains configuration authority by doing so:
+ *
+ *   `1`   — identity only. Refined to primary-only ownership, which is exact
+ *           rather than a guess: legacy installs could not materialize
+ *           companions, so there were none to record.
+ *   `0.2` — complete ownership, no disposition. Refined to authored
+ *           materialization, the only meaning a pre-disposition receipt could
+ *           have had.
+ *   `0.3` — complete ownership with dispositions. Nothing to refine.
+ *
+ * Returns `null` for an unreadable document rather than a reason, because
+ * every way this step can fail is the same reason.
+ */
+function dispatchReceiptVersion(parsed: unknown): DispatchedReceipt | null {
+  const observedVersion =
+    typeof parsed === 'object' && parsed !== null && 'version' in parsed
+      ? (parsed as { version?: unknown }).version
+      : undefined
+
+  const authored = { kind: 'authored' } as const
+
+  if (observedVersion === CURRENT_RECEIPT_VERSION) {
+    const validated = CurrentReceiptSchema(parsed)
+    if (validated instanceof type.errors) return null
+    return { authority: 'assets-and-configuration', path: validated.path, facets: validated.facets }
+  }
+
+  if (observedVersion === RECEIPT_VERSION_0_3) {
+    const validated = Receipt03Schema(parsed)
+    if (validated instanceof type.errors) return null
+    return {
+      authority: 'assets-only',
+      refinedFrom: RECEIPT_VERSION_0_3,
+      path: validated.path,
+      facets: validated.facets,
+    }
+  }
+
+  if (observedVersion === RECEIPT_VERSION_0_2) {
+    const validated = Receipt02Schema(parsed)
+    if (validated instanceof type.errors) return null
+    const facets: Record<string, RawAssetFacet> = ownRecord()
+    for (const [name, entry] of Object.entries(validated.facets)) {
+      facets[name] = {
+        version: entry.version,
+        assets: entry.assets.map((a) => ({ ...a, materialization: authored })),
+      }
+    }
+    return { authority: 'assets-only', refinedFrom: RECEIPT_VERSION_0_2, path: validated.path, facets }
+  }
+
+  if (observedVersion === LEGACY_RECEIPT_VERSION) {
+    const validated = LegacyReceiptSchema(parsed)
+    if (validated instanceof type.errors) return null
+    const facets: Record<string, RawAssetFacet> = ownRecord()
+    for (const [name, entry] of Object.entries(validated.facets)) {
+      facets[name] = {
+        version: entry.version,
+        assets: entry.assets.map((a) => ({
+          ...a,
+          materialization: authored,
+          files: [canonicalPrimaryPath(a.type, a.name)],
+        })),
+      }
+    }
+    return { authority: 'assets-only', refinedFrom: LEGACY_RECEIPT_VERSION, path: validated.path, facets }
+  }
+
+  return null
+}
+
+/**
+ * Validate every asset name AND every owned file path — receipt data is
+ * untrusted. A crafted name or a path that could traverse outside the
+ * adapter's storage drops the whole asset record (reported, never deleted),
+ * while the facet's remaining valid entries still load (D6).
+ */
+function validatedAssets(
+  facetName: string,
+  assets: ReadonlyArray<RawReceiptAsset>,
+  invalidEntries: InvalidReceiptEntry[],
+): ReceiptAsset[] {
+  const valid: ReceiptAsset[] = []
+  for (const asset of assets) {
+    const nameCheck = validateAssetName(asset.name)
+    if (!nameCheck.ok) {
+      invalidEntries.push({ kind: 'asset', facet: facetName, asset: asset.name, reason: nameCheck.reason })
+      continue
+    }
+    let badPath: { path: string; reason: string } | undefined
+    for (const p of asset.files) {
+      const check = validateAssetName(p)
+      if (!check.ok) {
+        badPath = { path: p, reason: check.reason }
+        break
+      }
+    }
+    if (badPath !== undefined) {
+      invalidEntries.push({
+        kind: 'asset',
+        facet: facetName,
+        asset: asset.name,
+        reason: `owned path "${badPath.path}" ${badPath.reason}`,
+      })
+      continue
+    }
+    valid.push({
+      scope: asset.scope,
+      type: asset.type,
+      name: asset.name,
+      materialization: asset.materialization,
+      files: [...asset.files],
+    })
+  }
+  return valid
+}
+
+/**
+ * Validate one facet's configuration claims, dropping and reporting the ones
+ * this machine cannot act on.
+ *
+ * Per-entry containment, exactly as for assets: a claim the file got wrong
+ * must not withdraw authority over every other claim in it. Dropping is
+ * always the safe direction — a dropped claim deletes nothing and consents to
+ * nothing.
+ *
+ * The server-name grammar and the fingerprint spelling are protocol
+ * contracts, so they are checked with the protocol's own predicates rather
+ * than re-expressed here. `isMcpServerFingerprint` narrows, which is what
+ * turns a `string` read off disk into a fingerprint without a cast.
+ *
+ * A facet claiming one authored name twice is resolved by what the two claims
+ * say. Byte-identical repetition is redundancy and collapses to one claim.
+ * Two claims that DISAGREE about the disposition or the declaration are a
+ * record contradicting itself about a single server, so neither survives:
+ * keeping the first would let file order decide which effective entry this
+ * machine believes it owns, and which declaration it believes was approved.
+ */
+function validatedClaims(
+  facetName: string,
+  claims: RawCurrentFacet['configurations'],
+  invalidEntries: InvalidReceiptEntry[],
+): ReceiptConfigurationClaim[] {
+  const byName = new Map<string, ReceiptConfigurationClaim>()
+  const contradicted = new Set<string>()
+
+  for (const claim of claims) {
+    const { fingerprint } = claim
+    const nameCheck = validateMcpServerName(claim.name)
+    if (!nameCheck.ok) {
+      invalidEntries.push({ kind: 'configuration', facet: facetName, server: claim.name, reason: nameCheck.reason })
+      continue
+    }
+    if (!isMcpServerFingerprint(fingerprint)) {
+      invalidEntries.push({
+        kind: 'configuration',
+        facet: facetName,
+        server: claim.name,
+        reason: `fingerprint "${fingerprint}" is not a sha256 digest`,
+      })
+      continue
+    }
+    const candidate: ReceiptConfigurationClaim = {
+      kind: 'mcp-server',
+      name: claim.name,
+      materialization: claim.materialization,
+      fingerprint,
+    }
+    const existing = byName.get(claim.name)
+    if (existing === undefined) {
+      byName.set(claim.name, candidate)
+      continue
+    }
+    if (sameDisposition(existing.materialization, candidate.materialization) && existing.fingerprint === fingerprint) {
+      continue
+    }
+    contradicted.add(claim.name)
+  }
+
+  for (const name of contradicted) {
+    byName.delete(name)
+    invalidEntries.push({
+      kind: 'configuration',
+      facet: facetName,
+      server: name,
+      reason: 'the receipt records two conflicting claims for this server',
+    })
+  }
+
+  return [...byName.values()]
 }
 
 // ---------------------------------------------------------------------------
@@ -499,24 +852,21 @@ export function materializedDispositionOf(asset: SupportedLockfileAssetEntry): M
  */
 export function resolveProjectReceipt(projectDir: string): ProjectReceiptState {
   const result = loadReceipt(projectDir)
-  if (result.ok) return { kind: 'loaded', receipt: result.receipt, invalidEntries: result.invalidEntries }
+  if (result.ok) return { kind: 'loaded', record: result.record, invalidEntries: result.invalidEntries }
   return { kind: 'unavailable', reason: result.reason, projectPath: bestEffortPath(projectDir) }
 }
 
 /**
- * The base a commit builds its new receipt on when there was no readable one.
- * Claims nothing: this run's writes are the only thing that may fill it.
+ * The canonical project path a commit writes this run's receipt to.
+ *
+ * The commit needs the LOCATION and nothing else: the record it writes is
+ * built entirely from what this run reconciled, so handing it a previous
+ * receipt to build "on top of" would offer it claims it has no business
+ * inheriting — including, for a pre-`0.4` record, claims of a shape it cannot
+ * even express.
  */
-export function emptyReceiptFor(projectPath: string): Receipt {
-  return { version: CURRENT_RECEIPT_VERSION, path: projectPath, facets: ownRecord() }
-}
-
-/**
- * The receipt base for whatever provenance a run has — the loaded record, or
- * an empty one. Never an ownership claim in the `unavailable` case.
- */
-export function receiptBaseFor(state: ProjectReceiptState): Receipt {
-  return state.kind === 'loaded' ? state.receipt : emptyReceiptFor(state.projectPath)
+export function receiptProjectPath(state: ProjectReceiptState): string {
+  return state.kind === 'loaded' ? state.record.path : state.projectPath
 }
 
 /**
@@ -545,8 +895,17 @@ function bestEffortPath(projectDir: string): string {
  *
  * Omitted assets are excluded: the lockfile records the resolved SET, the
  * receipt records what is on disk, and an omitted asset was never written.
+ *
+ * `configurations` arrives separately because the lockfile has nowhere to
+ * derive it from — declarations live in the integrity-protected `facet.json`,
+ * deliberately not in the lockfile — so the claims can only come from what
+ * this run actually reconciled. `integrity` anchors them to the exact
+ * resolved facet they were witnessed against.
  */
-export function receiptEntryForLockedFacet(entry: SupportedLockfileFacet): ReceiptFacetEntry {
+export function receiptEntryForLockedFacet(
+  entry: SupportedLockfileFacet,
+  configurations: readonly ReceiptConfigurationClaim[],
+): ReceiptFacetEntry {
   const assets: ReceiptAsset[] = []
   for (const asset of entry.assets) {
     const materialization = materializedDispositionOf(asset)
@@ -559,7 +918,7 @@ export function receiptEntryForLockedFacet(entry: SupportedLockfileFacet): Recei
       files: ownedPathsForLockedAsset(asset),
     })
   }
-  return { version: entry.version, assets }
+  return { version: entry.version, integrity: entry.integrity, assets, configurations: [...configurations] }
 }
 
 /**

--- a/packages/engine/src/install/remove/refine.ts
+++ b/packages/engine/src/install/remove/refine.ts
@@ -4,7 +4,6 @@ import type {
   FacetContribution,
   FacetMaterializationOverrides,
   MaterializedAsset,
-  StaleOverride,
   SupportedLockfile,
   SupportedLockfileFacet,
 } from '@agent-facets/protocol'
@@ -22,11 +21,12 @@ import { ownEntry, ownRecord } from '../own-entry.ts'
 import {
   materializedDispositionOf,
   ownedPathsForLockedAsset,
+  type PreConfigurationReceiptVersion,
   type ProjectReceiptState,
   type ReceiptAsset,
   type ReceiptFacetEntry,
 } from '../receipt.ts'
-import type { FacetOutcome, LockfileDriftEntry } from '../types.ts'
+import type { FacetOutcome, LockfileDriftEntry, StaleMaterializationOverride } from '../types.ts'
 
 /**
  * Removal without resolution.
@@ -77,6 +77,14 @@ import type { FacetOutcome, LockfileDriftEntry } from '../types.ts'
 export type RemainingReceiptDisagreement =
   /** The receipt records a different resolved version than the lockfile. */
   | { kind: 'version'; recorded: string; locked: string }
+  /**
+   * The receipt records different facet content than the lockfile pins. The
+   * version string can repeat across a `git pull` or a mutated local path;
+   * integrity cannot, and it is the only offline evidence that this facet's
+   * declarations are still the ones the recorded claims were witnessed
+   * against.
+   */
+  | { kind: 'integrity'; recorded: string; locked: string }
   /** The lockfile says this asset is materialized; the receipt never saw it. */
   | { kind: 'asset-unrecorded'; scope: Scope; assetType: AssetType; authoredName: string }
   /** Both know the asset, but disagree about the name it was written under. */
@@ -109,6 +117,16 @@ export type RefineNotApplicable =
     }
   /** No receipt to witness with, so nothing on disk is tracked. */
   | { code: 'receipt-unwitnessable'; reason: 'missing' | 'corrupt' | 'path-mismatch' }
+  /**
+   * The receipt predates configuration claims. Its asset ownership is intact,
+   * but it cannot say whether a remaining facet declares MCP servers, because
+   * declarations live only inside the integrity-protected `facet.json` this
+   * path deliberately does not fetch. Carrying it forward would commit a
+   * record asserting that nothing is configured, which is a claim rather than
+   * an observation. One ordinary operation rewrites the receipt at the
+   * current version and this stops applying.
+   */
+  | { code: 'configuration-unwitnessed'; refinedFrom: PreConfigurationReceiptVersion }
   /**
    * A remaining facet's materialization is untracked: the receipt says nothing
    * about it. Its assets must be written before they can be claimed, so the
@@ -147,8 +165,8 @@ export interface RefinedRemoval {
   receiptFacets: Record<string, ReceiptFacetEntry>
   /** The remaining facets' persisted intent, unchanged. */
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>
-  /** Remaining overrides naming assets the locked content no longer has. */
-  staleOverrides: readonly StaleOverride[]
+  /** Remaining overrides naming contributions the locked content no longer has. */
+  staleOverrides: readonly StaleMaterializationOverride[]
   /** Remaining facets, reported as untouched. */
   outcomes: readonly FacetOutcome[]
 }
@@ -177,7 +195,14 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
   if (receiptState.kind === 'unavailable') {
     return { kind: 'not-applicable', reason: { code: 'receipt-unwitnessable', reason: receiptState.reason } }
   }
-  const receipt = receiptState.receipt
+  // Only a record that could have witnessed configuration may be carried
+  // forward. The type enforces it: an `assets-only` record has no claim field
+  // to copy, so there is no way to write one from here even by mistake.
+  const record = receiptState.record
+  if (record.authority !== 'assets-and-configuration') {
+    return { kind: 'not-applicable', reason: { code: 'configuration-unwitnessed', refinedFrom: record.refinedFrom } }
+  }
+  const witnessedFacets = record.facets
 
   // Collect the remaining entries up front. Doing it here rather than during
   // the rebuild means every later step holds a real entry, so there is no
@@ -269,7 +294,7 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
     // one from the locked entry would claim files this machine has no evidence
     // it wrote — which the next run would then read as permission to delete
     // them. A facet it DOES mention must agree exactly.
-    const recorded = ownEntry(receipt.facets, name)
+    const recorded = ownEntry(witnessedFacets, name)
     if (recorded === undefined) {
       return { kind: 'not-applicable', reason: { code: 'remaining-untracked', facet: name } }
     }
@@ -307,7 +332,12 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
       previousOwnership,
       receiptFacets,
       overrides,
-      staleOverrides: planned.staleOverrides,
+      staleOverrides: planned.staleOverrides.map((stale) => ({
+        facet: stale.facet,
+        contribution: { kind: 'asset', assetType: stale.type },
+        authoredName: stale.authoredName,
+        disposition: stale.disposition,
+      })),
       outcomes,
     },
   }
@@ -367,6 +397,9 @@ function witnessRemaining(recorded: ReceiptFacetEntry, locked: SupportedLockfile
   if (recorded.version !== locked.version) {
     return { ok: false, disagreement: { kind: 'version', recorded: recorded.version, locked: locked.version } }
   }
+  if (recorded.integrity !== locked.integrity) {
+    return { ok: false, disagreement: { kind: 'integrity', recorded: recorded.integrity, locked: locked.integrity } }
+  }
   const assets: ReceiptAsset[] = []
   for (const asset of locked.assets) {
     const disposition = materializedDispositionOf(asset)
@@ -384,7 +417,19 @@ function witnessRemaining(recorded: ReceiptFacetEntry, locked: SupportedLockfile
     }
     assets.push(witnessed)
   }
-  return { ok: true, entry: { version: recorded.version, assets } }
+  // Claims are carried verbatim. The facet remains desired and its integrity
+  // matches the locked entry, so the declarations behind these fingerprints
+  // are provably the ones that were reconciled — which is exactly the proof
+  // that makes carrying them forward an observation rather than a guess.
+  return {
+    ok: true,
+    entry: {
+      version: recorded.version,
+      integrity: recorded.integrity,
+      assets,
+      configurations: recorded.configurations,
+    },
+  }
 }
 
 /** Set equality over owned paths. Order is not part of what either side means. */

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import type { PlannedServerConfiguration } from '@agent-facets/protocol'
 import { CURRENT_LOCKFILE_VERSION, preserveLockfileExtensions } from '@agent-facets/protocol'
 import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
 import { FACETS_JSON_FILE, type NormalizedProjectManifest } from '../manifest/mutations.ts'
@@ -10,6 +11,7 @@ import { finalizeMaterializationIntent } from './commit/finalize-intent.ts'
 import { installFacets } from './commit/install-loop.ts'
 import { buildPreviousOwnership, obsoleteOwnership } from './commit/ownership.ts'
 import { resolveAll } from './commit/resolve-all.ts'
+import { claimsByFacet } from './commit/server-ownership.ts'
 import { buildUpdatedReceipt, commitProjectFiles, type LockedSetCommit } from './commit/tri-write.ts'
 import { checkFrozenConsistency } from './frozen-gates.ts'
 import { InstallJournal } from './journal.ts'
@@ -18,7 +20,7 @@ import { FACETS_LOCK_FILE, loadLockfile } from './lockfile-io.ts'
 import { deleteObsoleteAssets, type RetainedObsoleteBundle } from './materialize.ts'
 import { materializeFailureToRunInstall } from './materialize-failure.ts'
 import { ownEntry } from './own-entry.ts'
-import { type Receipt, receiptBaseFor, resolveProjectReceipt } from './receipt.ts'
+import { receiptProjectPath, resolveProjectReceipt } from './receipt.ts'
 import { refineRemoval } from './remove/refine.ts'
 import { rollbackAndFail, summarize } from './run-install-support.ts'
 import type { InstallDelta, RunInstallFailure, RunInstallOptions, RunInstallResult, StageEvent } from './types.ts'
@@ -127,11 +129,25 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     // lockfile's claims. Invalid asset entries (escape paths) are reported and
     // skipped — the rest of the receipt is still processed (W2 / design D6).
     const receiptState = resolveProjectReceipt(projectRoot)
-    const receipt: Receipt = receiptBaseFor(receiptState)
+    const receiptPath = receiptProjectPath(receiptState)
     if (receiptState.kind === 'loaded') {
       for (const invalid of receiptState.invalidEntries) {
-        onLog(() => `[warn] receipt asset entry rejected for ${invalid.facet}: "${invalid.asset}" (${invalid.reason})`)
-        onStage({ kind: 'receipt-invalid-asset', ...invalid })
+        if (invalid.kind === 'asset') {
+          onLog(
+            () => `[warn] receipt asset entry rejected for ${invalid.facet}: "${invalid.asset}" (${invalid.reason})`,
+          )
+          onStage({ kind: 'receipt-invalid-asset', facet: invalid.facet, asset: invalid.asset, reason: invalid.reason })
+          continue
+        }
+        onLog(
+          () => `[warn] receipt server claim rejected for ${invalid.facet}: "${invalid.server}" (${invalid.reason})`,
+        )
+        onStage({
+          kind: 'receipt-invalid-configuration',
+          facet: invalid.facet,
+          server: invalid.server,
+          reason: invalid.reason,
+        })
       }
     } else if (receiptState.reason !== 'missing') {
       // A receipt that exists but cannot be read is an anomaly with a large
@@ -306,7 +322,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         lockedSet: { kind: 'write', newLockfile },
         // Nothing was written, so the receipt can only be PRUNED — never
         // re-derived from lockfile entries this run did not apply.
-        newReceipt: buildUpdatedReceipt(receipt, { kind: 'carried-forward', facets: refined.receiptFacets }),
+        newReceipt: buildUpdatedReceipt(receiptPath, { kind: 'carried-forward', facets: refined.receiptFacets }),
         onLog,
       })
       if (!committed.ok) {
@@ -318,7 +334,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         onStage({
           kind: 'stale-override-pruned',
           facet: entry.facet,
-          assetType: entry.type,
+          contribution: entry.contribution,
           authoredName: entry.authoredName,
         })
       }
@@ -370,6 +386,11 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       return failureNoMutation(composed.failure)
     }
     const plan = composed.plan
+
+    // The MCP configurations this run reconciled into native tool state.
+    // Empty until the native apply step exists: the composed plan says what
+    // SHOULD be configured, and a receipt claim may only record what was.
+    const reconciledServerConfigurations: readonly PlannedServerConfiguration[] = []
 
     // 7. The first mutation is now imminent, so the rollback ledger opens
     //    here. Every entry it accumulates corresponds to a write that
@@ -463,7 +484,16 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
             facets: newFacetEntries,
           }),
         }
-    const newReceipt = buildUpdatedReceipt(receipt, { kind: 'written', facetEntries: newFacetEntries })
+    // The claims this run reconciled. Nothing in this pipeline applies native
+    // MCP configuration yet, so it reconciled none — and a claim asserts BOTH
+    // that an identity was reconciled and that its declaration was approved
+    // here, so recording one from the composed plan alone would assert two
+    // things that have not happened.
+    const newReceipt = buildUpdatedReceipt(receiptPath, {
+      kind: 'written',
+      facetEntries: newFacetEntries,
+      configurations: claimsByFacet(reconciledServerConfigurations),
+    })
     if (!frozenLockfile && merged.hasDelta) {
       applyManifestWritePolicy(merged.desiredFacets, delta.additions, newFacetEntries)
     }
@@ -503,7 +533,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       onStage({
         kind: 'stale-override-pruned',
         facet: entry.facet,
-        assetType: entry.type,
+        contribution: entry.contribution,
         authoredName: entry.authoredName,
       })
     }

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -4,7 +4,8 @@ import type {
   CollisionGroup,
   IntegrityFailure,
   MaterializationDisposition,
-  StaleOverride,
+  ProjectAssetOverride,
+  ServerCollisionGroup,
   SupportedLockfile,
 } from '@agent-facets/protocol'
 import type { AdapterCompatibilityFailure } from '../adapters/api-compatibility.ts'
@@ -12,6 +13,48 @@ import type { UnsupportedManifestVersion } from '../manifest/project-files.ts'
 import type { RegistryError } from '../registry/index.ts'
 import type { ParseError, Source } from '../sources/facet/types.ts'
 import type { CollisionResolver } from './commit/compose.ts'
+
+/**
+ * Which kind of contribution a materialization override names.
+ *
+ * Tagged rather than an `AssetType` widened with a `'server'` member: servers
+ * occupy their own identity space and carry no asset type at all, so the
+ * asset arm is the only one that can hold one. Every consumer that has to
+ * name an override — a prune report, a frozen drift entry, a collision
+ * location — needs exactly this distinction and nothing more.
+ */
+export type ContributionKind = { kind: 'asset'; assetType: AssetType } | { kind: 'mcp-server' }
+
+/** One override, identified by the facet and authored contribution it names. */
+export interface MaterializationOverrideRef {
+  facet: string
+  contribution: ContributionKind
+  /** The AUTHORED name, which is what `facets.json` keys the override by. */
+  authoredName: string
+}
+
+/**
+ * An override naming a contribution the resolved facet no longer has.
+ *
+ * Reported, never fatal: an override is durable project intent, so it
+ * survives a failed operation and is dropped only by a successful commit.
+ */
+export interface StaleMaterializationOverride extends MaterializationOverrideRef {
+  disposition: ProjectAssetOverride
+}
+
+/**
+ * One unresolved effective-name collision, from either identity space.
+ *
+ * Tagged rather than flattened into a single member shape: an asset claimant
+ * has a scope, an asset type, and a materialization namespace, while a server
+ * claimant has a declaration and a fingerprint. A union of those fields with
+ * everything optional would let a renderer read a namespace off a server
+ * group and print nothing where a reason belongs.
+ */
+export type MaterializationCollisionGroup =
+  | { kind: 'asset'; group: CollisionGroup }
+  | { kind: 'mcp-server'; group: ServerCollisionGroup }
 
 declare const EFFECTIVE_NAME: unique symbol
 
@@ -151,6 +194,14 @@ export type StageEvent =
    */
   | { kind: 'receipt-invalid-asset'; facet: string; asset: string; reason: string }
   /**
+   * A receipt MCP configuration claim was rejected during load (malformed
+   * server name or fingerprint, or two conflicting claims for one server).
+   * The claim is dropped, so its native entry reverts to untracked occupancy
+   * and its declaration needs approval again — neither of which a user could
+   * deduce from a run that otherwise looks routine.
+   */
+  | { kind: 'receipt-invalid-configuration'; facet: string; server: string; reason: string }
+  /**
    * A receipt file exists for this project but could not be used — unreadable,
    * or self-identifying as a different project. Every identity it had tracked
    * is therefore untracked for this run: nothing can be cleaned up, and this
@@ -205,14 +256,14 @@ export type StageEvent =
     }
   /**
    * A materialization override was dropped because the resolved facet version
-   * no longer contains the asset it named.
+   * no longer contains the asset or server it named.
    *
    * A dedicated event rather than a verbose log line: this silently changes
    * what `facets.json` says, so a user who never passes `--verbose` still has
    * to be told. Emitted only after the transaction commits — the prune is not
    * real until then.
    */
-  | { kind: 'stale-override-pruned'; facet: string; assetType: AssetType; authoredName: string }
+  | ({ kind: 'stale-override-pruned' } & MaterializationOverrideRef)
   | { kind: 'adapter-complete'; facet: string; adapter: string }
   | { kind: 'asset-installed'; facet: string; adapter: string; asset: AssetIdentity }
   | { kind: 'asset-deleted'; facet: string; adapter: string; asset: AssetIdentity }
@@ -256,11 +307,11 @@ export type LockfileDriftEntry =
       locked: MaterializationDisposition
     }
   /**
-   * An override names an asset the locked content does not contain. A normal
-   * install prunes it inside its transaction; frozen mode writes nothing, so
-   * it can only report it.
+   * An override names an asset or server the locked content does not contain.
+   * A normal install prunes it inside its transaction; frozen mode writes
+   * nothing, so it can only report it.
    */
-  | { name: string; reason: 'stale-override'; assetType: AssetType; authoredName: string }
+  | { name: string; reason: 'stale-override'; contribution: ContributionKind; authoredName: string }
   /**
    * The manifest records materialization intent the loaded lockfile format
    * cannot express. Reproduction would have to invent the missing half.
@@ -458,8 +509,8 @@ export type RunInstallFailure =
    */
   | {
       code: 'MATERIALIZATION_COLLISION'
-      groups: ReadonlyArray<CollisionGroup>
-      staleOverrides: ReadonlyArray<StaleOverride>
+      groups: ReadonlyArray<MaterializationCollisionGroup>
+      staleOverrides: ReadonlyArray<StaleMaterializationOverride>
     }
   /**
    * An interactive resolver returned choices that still do not compose. The
@@ -468,7 +519,7 @@ export type RunInstallFailure =
    */
   | {
       code: 'MATERIALIZATION_RESOLUTION_INVALID'
-      groups: ReadonlyArray<CollisionGroup>
+      groups: ReadonlyArray<MaterializationCollisionGroup>
       problems: ReadonlyArray<{ facet: string; alias: string; reason: string }>
     }
   /** The user dismissed collision resolution. No state was mutated. */

--- a/packages/engine/src/manifest/mutations.ts
+++ b/packages/engine/src/manifest/mutations.ts
@@ -1,11 +1,10 @@
 import {
-  ASSET_DIRECTORY,
-  ASSET_TYPES,
   CURRENT_PROJECT_MANIFEST_VERSION,
   type FacetMaterializationOverrides,
   facetEntryOverrides,
   facetEntrySource,
   type LEGACY_PROJECT_MANIFEST_VERSION,
+  MATERIALIZATION_OVERRIDE_GROUPS,
   type PROJECT_MANIFEST_VERSION_0_1,
   type ProjectAssetOverride,
   type ProjectManifestParseFailure,
@@ -245,18 +244,10 @@ export function emptyProjectManifest(): NormalizedProjectManifest {
   }
 }
 
-/**
- * The manifest override groups, in canonical asset-type order.
- *
- * Derived from the published asset-type list rather than written out, so a
- * new asset type cannot gain a group that this module then fails to iterate.
- */
-const OVERRIDE_GROUPS = ASSET_TYPES.map((type) => ASSET_DIRECTORY[type])
-
-/** How many overrides an entry declares across every asset type. */
+/** How many overrides an entry declares across every recognized group. */
 export function countOverrides(overrides: FacetMaterializationOverrides | undefined): number {
   if (overrides === undefined) return 0
-  return OVERRIDE_GROUPS.reduce((total, group) => total + Object.keys(overrides[group] ?? {}).length, 0)
+  return MATERIALIZATION_OVERRIDE_GROUPS.reduce((total, group) => total + Object.keys(overrides[group] ?? {}).length, 0)
 }
 
 /**
@@ -345,7 +336,7 @@ function reconcileOverrides(expanded: { materialization?: unknown }, desired: Fa
   }
   const document = expanded.materialization as Record<string, unknown>
 
-  for (const group of OVERRIDE_GROUPS) {
+  for (const group of MATERIALIZATION_OVERRIDE_GROUPS) {
     const desiredGroup = desired[group]
     if (desiredGroup === undefined || Object.keys(desiredGroup).length === 0) {
       // The canonical form of "no overrides of this type" is an absent group,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -194,7 +194,7 @@ export { mcpServerKey, planServerMaterialization } from './materialization/serve
 // stores in place of the declaration, so prior approval can be proven without
 // recording a command, URL, or environment data.
 export type { McpServerFingerprint } from './mcp/fingerprint.ts'
-export { canonicalMcpServerEncoding, computeMcpServerFingerprint } from './mcp/fingerprint.ts'
+export { canonicalMcpServerEncoding, computeMcpServerFingerprint, isMcpServerFingerprint } from './mcp/fingerprint.ts'
 // deterministic ordering — one comparator for every artifact and report whose
 // order is part of its contract, so planner output, the removal-refinement
 // rebuild, and the lockfile writer cannot disagree.
@@ -299,6 +299,7 @@ export type {
   FacetMaterializationOverrides,
   FacetMaterializationOverrides01,
   LegacyProjectManifest,
+  MaterializationOverrideGroup,
   ProjectFacetEntry,
   ProjectFacetEntry01,
   ProjectManifest01,
@@ -310,6 +311,7 @@ export {
   facetEntrySource,
   LEGACY_PROJECT_MANIFEST_VERSION,
   LegacyProjectManifestSchema,
+  MATERIALIZATION_OVERRIDE_GROUPS,
   PROJECT_MANIFEST_VERSION_0_1,
   ProjectManifest01Schema,
   SERVER_OVERRIDE_GROUP,

--- a/packages/protocol/src/mcp/fingerprint.ts
+++ b/packages/protocol/src/mcp/fingerprint.ts
@@ -47,6 +47,21 @@ const FINGERPRINT_ENCODING_TAG = 'facets:mcp-server:v1'
 /** A declaration fingerprint, in the repository-wide `sha256:<hex>` form. */
 export type McpServerFingerprint = `sha256:${string}`
 
+/** The exact spelling {@link computeMcpServerFingerprint} emits. */
+const FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{64}$/
+
+/**
+ * Whether a string is a well-formed declaration fingerprint.
+ *
+ * The template-literal type alone accepts `sha256:` followed by anything, so a
+ * value read back from a file needs this narrower check before it may be
+ * treated as one. Kept beside the encoder so the accepted spelling and the
+ * emitted spelling cannot drift.
+ */
+export function isMcpServerFingerprint(value: string): value is McpServerFingerprint {
+  return FINGERPRINT_PATTERN.test(value)
+}
+
 /**
  * The exact bytes hashed for a declaration. Exported for tests and for any
  * other implementation of the specification that needs to reproduce the

--- a/packages/protocol/src/schemas/project-manifest.ts
+++ b/packages/protocol/src/schemas/project-manifest.ts
@@ -1,6 +1,6 @@
-import { validateAssetName } from '@agent-facets/common'
+import { type AssetType, validateAssetName } from '@agent-facets/common'
 import { type } from 'arktype'
-import { ASSET_DIRECTORY } from '../materialization/identity.ts'
+import { ASSET_DIRECTORY, ASSET_TYPES } from '../materialization/identity.ts'
 import { ProjectAssetOverrideSchema } from './materialization.ts'
 import { validateMcpServerName } from './mcp-server.ts'
 
@@ -56,6 +56,23 @@ export const SUPPORTED_PROJECT_MANIFEST_VERSIONS: readonly number[] = [
  * non-interactive collision report all point users at the same location.
  */
 export const SERVER_OVERRIDE_GROUP = 'servers'
+
+/**
+ * Every override group the current schema recognizes, in document order.
+ *
+ * Derived from the asset-type list plus the server group rather than written
+ * out, so a producer that iterates this cannot fail to visit a group the
+ * schema accepts. That failure mode is not hypothetical: counting, pruning,
+ * and comment-preserving reconciliation all iterate groups, and a group
+ * missing from that iteration is silently dropped from the document on the
+ * next successful write.
+ */
+export type MaterializationOverrideGroup = (typeof ASSET_DIRECTORY)[AssetType] | typeof SERVER_OVERRIDE_GROUP
+
+export const MATERIALIZATION_OVERRIDE_GROUPS: readonly MaterializationOverrideGroup[] = [
+  ...ASSET_TYPES.map((type) => ASSET_DIRECTORY[type]),
+  SERVER_OVERRIDE_GROUP,
+]
 
 // --- Materialization overrides ---
 


### PR DESCRIPTION
### Why

MCP server declarations need to participate in the same materialization pipeline as assets: collision detection, override persistence, stale-override pruning, receipt ownership, and drift reporting. Previously, server declarations were noted as warnings but otherwise ignored by the composition and ownership machinery.

### Details

**Receipt version `0.4`** is introduced alongside the existing `0.3`. The new version adds two fields per facet entry: `integrity` (the resolved facet integrity that witnessed the entry) and `configurations` (MCP configuration claims). A claim records the authored server name, its materialization disposition, and a declaration fingerprint — never a command, URL, or environment data. Every pre-`0.4` receipt refines into an `assets-only` loaded record on read, which explicitly withholds configuration authority. A `0.4` receipt produces an `assets-and-configuration` record. The distinction is represented in the type rather than by convention, so a pre-`0.4` record cannot accidentally carry an empty `configurations` field that would be indistinguishable from a current record that genuinely reconciled nothing.

**`ContributionKind`** is a new tagged union (`{ kind: 'asset'; assetType }` | `{ kind: 'mcp-server' }`) that replaces bare `AssetType` wherever an override or stale report needs to name either kind of contribution. `StaleMaterializationOverride`, `MaterializationOverrideRef`, and `MaterializationCollisionGroup` are built on top of it. The `stale-override-pruned` stage event, `LockfileDriftEntry`, and `RunInstallFailure` all adopt these types.

**Collision detection** now runs both the asset planner and the new server planner against the same override map in separate identity spaces. Asset and server collisions are gathered into one `MaterializationCollisionGroup[]` and reported together. A server collision currently reports rather than opening the interactive resolver, because the resolver workspace speaks only about assets; handing it a mixed set would let a user confirm a draft that resolves nothing.

**`finalizeMaterializationIntent`** now iterates every override group the schema recognizes — asset types plus `servers` — rather than only asset types. A group not visited was previously dropped from the rebuilt object and erased from `facets.json` on the next successful write, which is what caused server-only entries to collapse to their compact source string.

**`countOverrides`** and the comment-preserving reconciliation loop in `applyDesiredFacets` both switch from a locally-derived asset-only group list to the new `MATERIALIZATION_OVERRIDE_GROUPS` constant exported from the protocol package, which includes the server group.

**`buildUpdatedReceipt`** now takes a project path rather than a previous receipt. The previous receipt could only contribute claims this run has no evidence for, and handing it in offered a path for pre-`0.4` claims to ride forward into a current record.

**`refineRemoval`** gains an integrity check alongside the existing version check, and returns `configuration-unwitnessed` for any pre-`0.4` receipt rather than carrying it forward — a record that could not have witnessed configuration cannot safely assert that nothing is configured.

**`collisionClaimants`** and `describeCollisionGroup`** are extracted into `collision-report.ts` so the Ink failure block and the stderr collision report render from the same derived data and cannot disagree about which claimants exist or where a user edits them.

**`contribution.ts`** is a new utility module with `describeContribution` and `contributionKey`, used in every surface that names a materialization override — pruned-intent notices, frozen drift lists, the collision workspace, the non-interactive collision report, and the install view — so a server reads as "MCP server" everywhere rather than varying by surface.

### Verification

The new and updated tests cover: MCP server composition (identical declarations compose, differing ones collide, asset and server collisions report together), receipt `0.4` round-trips, configuration claim validation (malformed names, bad fingerprints, contradictory claims, unrecognized members), server ownership indexing and obsolescence, `claimsByFacet` round-tripping through the receipt back into the ownership index, stale server override pruning and reporting, server-only entries surviving manifest canonicalization, and the receipt upgrade path from every pre-`0.4` version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes install receipts, deletion authority, and approval semantics for MCP configuration—security-sensitive orchestration with broad engine and CLI impact.
> 
> **Overview**
> Wires **MCP server declarations** into the same materialization path as assets: compose runs asset and server planners on one override map (separate identity spaces), reports **asset and MCP collisions together**, and carries planned server configurations through resolution. Server-only facets can install with empty asset lists; identical declarations compose instead of colliding.
> 
> Introduces **receipt `0.4`** with per-facet `integrity` and **configuration claims** (name, disposition, fingerprint only—no commands/URLs/env). Older receipts load as **`assets-only`** with no configuration authority; successful writes always emit `0.4`. **`buildUpdatedReceipt`** now builds from the project path and reconciled state only, not a prior receipt.
> 
> Adds **`ContributionKind`** and tagged types (`StaleMaterializationOverride`, `MaterializationCollisionGroup`, etc.) so overrides, drift, stage events, and failures name assets or MCP servers consistently. **`finalizeMaterializationIntent`** and manifest **`countOverrides` / `reconcileOverrides`** include the **`servers`** override group so server-only intent is not collapsed away.
> 
> New **`server-ownership`** indexing drives obsolete server removal and declaration approval from receipt claims. CLI surfaces use **`contribution.ts`** and shared **`collision-report`** helpers for MCP-aware messaging; invalid configuration claims surface via **`receipt-invalid-configuration`**.
> 
> OpenSpec tasks mark section 8 (receipt 0.4 / manifest / composition / ownership) complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25443305a898acfc7622238f17791b30660ce9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->