### PR TITLE
Implement MCP consent, asset takeover, journaled apply, and offline removal

### DIFF
--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -84,22 +84,22 @@
 
 ## 9. Transaction, consent, frozen, removal, and takeover — Research
 
-- [ ] 9.1 Explore: Trace install ordering, journal semantics, byte-preimage helpers, rollback error reporting, and the first mutation boundary for normal and removal-only paths.
-- [ ] 9.2 Explore: Trace interactive resolver plumbing and define MCP consent/failure values for new or changed declarations, native takeovers, non-interactive opt-in, and unsupported selected adapters.
-- [ ] 9.3 Explore: Trace frozen post-resolution checks and removal refinement proofs needed for integrity-anchored configuration claims and receipt-only server-orphan cleanup.
-- [ ] 9.4 Explore: Trace asset previous-state reads and ownership lookup to place the just-in-time takeover gate without an eager scan or coupling it to MCP consent.
-- [ ] 9.5 Propose: Define the complete orchestration change from preflight through prepare, consent, journaled asset work, native apply, receipt commit, rollback, and offline removal fallback.
+- [x] 9.1 Explore: Trace install ordering, journal semantics, byte-preimage helpers, rollback error reporting, and the first mutation boundary for normal and removal-only paths.
+- [x] 9.2 Explore: Trace interactive resolver plumbing and define MCP consent/failure values for new or changed declarations, native takeovers, non-interactive opt-in, and unsupported selected adapters.
+- [x] 9.3 Explore: Trace frozen post-resolution checks and removal refinement proofs needed for integrity-anchored configuration claims and receipt-only server-orphan cleanup.
+- [x] 9.4 Explore: Trace asset previous-state reads and ownership lookup to place the just-in-time takeover gate without an eager scan or coupling it to MCP consent.
+- [x] 9.5 Propose: Define the complete orchestration change from preflight through prepare, consent, journaled asset work, native apply, receipt commit, rollback, and offline removal fallback.
 
 ## 10. Transaction, consent, frozen, removal, and takeover — Implementation
 
-- [ ] 10.1 Implement: Add the post-compose collective MCP-support preflight and batch read-only preparation for every selected adapter before prompting or mutation.
-- [ ] 10.2 Implement: Derive machine-local approval from effective identity plus fingerprint, combine unapproved declarations and untracked native occupancy into one MCP-only request, and enforce `--accept-mcp` for non-interactive/frozen callers without banking failed approval.
-- [ ] 10.3 Implement: Capture each prepared document's byte preimage, journal throwing restore operations, apply native MCP plans after asset writes, and restore every document exactly on later adapter, cancellation, or tri-write failure.
-- [ ] 10.4 Implement: Add the separate just-in-time asset takeover resolver at the existing previous-state read, default to continue, adopt equivalent bytes without rewriting, overwrite divergent content transactionally, and roll back all prior work on cancellation.
-- [ ] 10.5 Implement: Add post-resolution frozen MCP gates for collision, stale intent, support, parse, integrity, and approval while allowing receipt/native reconciliation only after every consistency check passes.
-- [ ] 10.6 Implement: Extend removal-only refinement to carry integrity-witnessed configuration claims offline, fall back for pre-`0.4` or unprovable state, preserve remaining claimants, and delete only obsolete receipt-owned server identities.
-- [ ] 10.7 Implement: Add ordering, no-mutation, no-reprompt, teammate-consent, takeover, byte-restore, frozen-orphan, offline-removal, and fallback tests across successful, declined, failed, and interrupted operations.
-- [ ] 10.8 Verify: Run focused install, frozen, removal, materialization, journal, and rollback tests and type checks.
+- [x] 10.1 Implement: Add the post-compose collective MCP-support preflight and batch read-only preparation for every selected adapter before prompting or mutation.
+- [x] 10.2 Implement: Derive machine-local approval from effective identity plus fingerprint, combine unapproved declarations and untracked native occupancy into one MCP-only request, and enforce `--accept-mcp` for non-interactive/frozen callers without banking failed approval.
+- [x] 10.3 Implement: Capture each prepared document's byte preimage, journal throwing restore operations, apply native MCP plans after asset writes, and restore every document exactly on later adapter, cancellation, or tri-write failure.
+- [x] 10.4 Implement: Add the separate just-in-time asset takeover resolver at the existing previous-state read, default to continue, adopt equivalent bytes without rewriting, overwrite divergent content transactionally, and roll back all prior work on cancellation.
+- [x] 10.5 Implement: Add post-resolution frozen MCP gates for collision, stale intent, support, parse, integrity, and approval while allowing receipt/native reconciliation only after every consistency check passes.
+- [x] 10.6 Implement: Extend removal-only refinement to carry integrity-witnessed configuration claims offline, fall back for pre-`0.4` or unprovable state, preserve remaining claimants, and delete only obsolete receipt-owned server identities.
+- [x] 10.7 Implement: Add ordering, no-mutation, no-reprompt, teammate-consent, takeover, byte-restore, frozen-orphan, offline-removal, and fallback tests across successful, declined, failed, and interrupted operations.
+- [x] 10.8 Verify: Run focused install, frozen, removal, materialization, journal, and rollback tests and type checks.
 
 ## 11. Engine outcomes and obsolete warning path — Research
 

--- a/packages/cli/src/commands/shared/install-failure.ts
+++ b/packages/cli/src/commands/shared/install-failure.ts
@@ -65,6 +65,28 @@ export function installFailureFix(
       return UNSUPPORTED_MANIFEST_VERSION_FIX
     case 'LOCKFILE_DRIFT':
       return "lockfile is out of date; run 'facet install' (without --frozen-lockfile) or 'facet add' to update it"
+    case 'MCP_ADAPTERS_UNSUPPORTED':
+      // Two remedies, and which one applies is per adapter — the detail block
+      // above names each. This line says only that both exist, so a user who
+      // reads it alone does not conclude that upgrading is always the answer.
+      return `upgrade the adapters listed above, or omit their server declarations in facets.json, then re-run 'facet ${command}'`
+    case 'ASSET_TAKEOVER_CANCELLED':
+      // The disk state is the point: this cancellation happened after writes,
+      // so "nothing happened" would be wrong and "re-run" alone would be
+      // unhelpful without saying what state the tree is in.
+      return `${describeDiskState(rollback)}. Re-run 'facet ${command}' and continue, or move the existing file aside first`
+    case 'MCP_CONSENT_REQUIRED':
+      return `review the servers listed above, then re-run 'facet ${command} --accept-mcp' to approve them, or omit them in facets.json`
+    case 'MCP_CONSENT_DECLINED':
+      return `${describeDiskState(rollback)}. Re-run 'facet ${command}' to review the servers again, or omit them in facets.json`
+    case 'MCP_PREPARE_FAILED':
+    case 'MCP_APPLY_FAILED':
+    case 'MCP_DOCUMENT_UNREADABLE':
+      return `${describeDiskState(rollback)}; repair the configuration document named above, then re-run 'facet ${command}'`
+    case 'MCP_CONTRACT_VIOLATION':
+      // Nothing the user can edit; sending them to their own files would be
+      // a wild goose chase.
+      return 'report this to the adapter’s author; no project file needs changing'
     default:
       // Most codes that land here failed BEFORE the journal opened —
       // `LOCK_HELD`, `FACETS_JSON_NOT_FOUND`, `FROZEN_WITH_DELTA`,

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -5,6 +5,14 @@ import { describeCompatibilityFailure } from '../../../util/adapter-install-erro
 import { collisionClaimants, collisionGroupKey, describeCollisionGroup } from '../../../util/collision-report.ts'
 import { contributionKey, describeContribution } from '../../../util/contribution.ts'
 import { diskStateSentence } from '../../../util/install-outcome.ts'
+import {
+  describeApprovalHeading,
+  describeDeclarationInFull,
+  describeMcpCapabilityFailure,
+  describeMcpContractViolation,
+  describeTakeoverHeading,
+  describeUnsupportedMcpAdapter,
+} from '../../../util/mcp-report.ts'
 import { THEME } from '../../theme.ts'
 import { UnsupportedManifestVersionBlock } from './unsupported-version-block.tsx'
 
@@ -584,6 +592,100 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
       return (
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.hint}>Cancelled.</Text>
+        </Box>
+      )
+    case 'MCP_ADAPTERS_UNSUPPORTED':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ {failure.adapters.length !== 1 ? 'selected adapters cannot' : 'a selected adapter cannot'} configure MCP
+            servers — nothing was changed
+          </Text>
+          {failure.adapters.map((entry) => {
+            const described = describeUnsupportedMcpAdapter(entry)
+            return (
+              <Box key={entry.adapter} flexDirection="column">
+                <Text> {described.what}</Text>
+                <Text color={THEME.hint}> {described.fix}</Text>
+              </Box>
+            )
+          })}
+          <Text color={THEME.hint}> servers: {failure.servers.join(', ')}</Text>
+        </Box>
+      )
+    case 'MCP_PREPARE_FAILED':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ {failure.adapter} could not plan its MCP configuration — nothing was changed
+          </Text>
+          <Text> {describeMcpCapabilityFailure(failure.failure)}</Text>
+        </Box>
+      )
+    case 'ASSET_TAKEOVER_CANCELLED':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.hint}>
+            Cancelled at {failure.adapter}: {failure.asset.type} “{failure.asset.name}” was already there and is not
+            tracked by this project.
+          </Text>
+        </Box>
+      )
+    case 'MCP_APPLY_FAILED':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ {failure.adapter} could not write its MCP configuration
+          </Text>
+          <Text> {describeMcpCapabilityFailure(failure.failure)}</Text>
+        </Box>
+      )
+    case 'MCP_DOCUMENT_UNREADABLE':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ could not read {failure.path} before changing it
+          </Text>
+          <Text> {failure.cause}</Text>
+          <Text color={THEME.hint}> {failure.adapter}'s configuration was left alone rather than written back</Text>
+        </Box>
+      )
+    case 'MCP_CONSENT_REQUIRED':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ MCP server configuration needs your approval — nothing was changed
+          </Text>
+          {failure.request.declarations.map((entry) => (
+            <Box key={entry.identity.effectiveName} flexDirection="column">
+              <Text> {describeApprovalHeading(entry)}</Text>
+              {describeDeclarationInFull(entry.declaration).map((line) => (
+                <Text key={line} color={THEME.hint}>
+                  {'   '}
+                  {line}
+                </Text>
+              ))}
+            </Box>
+          ))}
+          {failure.request.takeovers.map((entry) => (
+            <Text key={`${entry.adapter}:${entry.identity.effectiveName}`}> {describeTakeoverHeading(entry)}</Text>
+          ))}
+        </Box>
+      )
+    case 'MCP_CONSENT_DECLINED':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.hint}>Declined. No MCP server configuration was written.</Text>
+        </Box>
+      )
+    case 'MCP_CONTRACT_VIOLATION':
+      return (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={THEME.warning} bold>
+            ✕ an adapter broke the MCP configuration contract
+          </Text>
+          <Text> {describeMcpContractViolation(failure.violation)}</Text>
+          <Text color={THEME.hint}> this is an adapter bug; report it to the adapter's author</Text>
         </Box>
       )
     default: {

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -18,7 +18,7 @@ import { quoteShellArg } from './shell-quote.ts'
  * fix lines. Targets are user/source-derived (receipt specifiers, local
  * paths, package names) and must paste back into a shell safely.
  */
-function adapterInstallCommand(target: string): string {
+export function adapterInstallCommand(target: string): string {
   return `facet adapter install ${quoteShellArg(target)}`
 }
 

--- a/packages/cli/src/util/mcp-report.ts
+++ b/packages/cli/src/util/mcp-report.ts
@@ -1,0 +1,105 @@
+import type { McpServerCapabilityFailure, McpServerDeclaration } from '@agent-facets/adapter'
+import type {
+  McpConsentRequest,
+  McpContractViolation,
+  McpDeclarationApproval,
+  McpNativeTakeover,
+  McpUnsupportedAdapter,
+} from '@agent-facets/engine'
+import { adapterInstallCommand } from './adapter-install-errors.ts'
+
+/**
+ * Shared renderings for MCP configuration failures.
+ *
+ * Lives here rather than inside one view because the same three values reach
+ * three surfaces — the Ink failure block, the `fix:` line, and the
+ * non-interactive stderr report — and a user comparing them should not find
+ * three different descriptions of one condition.
+ *
+ * Nothing here renders a declaration. Commands, arguments, environment
+ * assignments, and URLs belong only on the approval surface a user is
+ * actively reading; every path through this module can end up in a CI log.
+ */
+
+/** What an unsupported adapter means, and what to do about it. */
+export interface UnsupportedMcpAdapterDescription {
+  what: string
+  fix: string
+}
+
+export function describeUnsupportedMcpAdapter(entry: McpUnsupportedAdapter): UnsupportedMcpAdapterDescription {
+  switch (entry.kind) {
+    case 'asset-only-api':
+      return {
+        what: `${entry.adapter} implements adapter API ${entry.apiVersion}, which has no MCP server support`,
+        fix: `upgrade it: ${adapterInstallCommand(entry.adapter)}`,
+      }
+    case 'capability-declined':
+      return {
+        what: `${entry.adapter} declares no MCP server support`,
+        // Deliberately not "upgrade": this adapter answered the question, and
+        // the answer will not change with a newer release.
+        fix: 'omit the server declarations in facets.json, or deselect this adapter',
+      }
+  }
+}
+
+/** One line naming what an adapter's MCP preparation or application hit. */
+export function describeMcpCapabilityFailure(failure: McpServerCapabilityFailure): string {
+  switch (failure.code) {
+    case 'io-failed':
+      return `could not ${failure.operation} ${failure.path}: ${failure.message}`
+    case 'parse-failed':
+      return `${failure.path} could not be parsed: ${failure.message}`
+    case 'validation-failed':
+      return `${failure.path} is not in a shape it can safely edit: ${failure.message}`
+    case 'conflict':
+      return `${failure.path} cannot hold the desired servers without destroying native state: ${failure.message}`
+  }
+}
+
+/**
+ * The exact thing a declaration would run or connect to.
+ *
+ * Complete and unredacted, unlike the collision report's summary: this is
+ * only ever rendered on a consent surface — the approval screen, or the
+ * failure that exists to tell a non-interactive caller what `--accept-mcp`
+ * would authorize. A user cannot approve execution from an elision.
+ */
+export function describeDeclarationInFull(declaration: McpServerDeclaration): string[] {
+  if (declaration.type === 'http') return [`http ${declaration.url}`]
+  const lines = [`stdio ${[declaration.command, ...(declaration.args ?? [])].join(' ')}`]
+  for (const [key, value] of Object.entries(declaration.env ?? {})) {
+    lines.push(`env ${key}=${value}`)
+  }
+  return lines
+}
+
+/** The heading line for one unapproved declaration. */
+export function describeApprovalHeading(entry: McpDeclarationApproval): string {
+  const claimants = entry.claimants.map((claimant) => claimant.facet).join(', ')
+  const reason = entry.standing.kind === 'declaration-changed' ? 'changed since it was approved' : 'not yet approved'
+  return `${entry.identity.effectiveName} (${reason}) — from ${claimants}`
+}
+
+/** The heading line for one untracked native entry a plan would take over. */
+export function describeTakeoverHeading(entry: McpNativeTakeover): string {
+  const verb =
+    entry.existing === 'equivalent' ? 'already matches and would be adopted' : 'differs and would be replaced'
+  return `${entry.adapter}: ${entry.identity.effectiveName} ${verb}`
+}
+
+/** Whether a request has anything to say in each of its two sections. */
+export function consentRequestCounts(request: McpConsentRequest): { declarations: number; takeovers: number } {
+  return { declarations: request.declarations.length, takeovers: request.takeovers.length }
+}
+
+/** One line naming an adapter's breach of the MCP capability contract. */
+export function describeMcpContractViolation(violation: McpContractViolation): string {
+  switch (violation.kind) {
+    case 'document-outside-project':
+      return `${violation.adapter} disclosed a configuration document outside the project: ${violation.path}`
+    case 'undisclosed-changed-path':
+      return `${violation.adapter} changed a document it never disclosed: ${violation.path}`
+  }
+}

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@agent-facets/protocol'
 import { type } from 'arktype'
 import { type CacheIdentity, cachePath, cachePutVerified, computeDirIntegrity } from '../cache/index.ts'
+import { recordingMcpCapability } from '../install/__tests__/helpers/mcp-adapter.ts'
 import { loadLockfile } from '../install/lockfile-io.ts'
 import { runInstall } from '../install/run-install.ts'
 import type { StageEvent } from '../install/types.ts'
@@ -61,7 +62,10 @@ function buildFakeAdapter(name: string): Adapter {
     name,
     apiVersion: ADAPTER_API_VERSION,
     supportsInstall: true,
-    mcpServers: false,
+    // A declared capability rather than `false`: a project with an active
+    // server declaration now requires one, and an adapter that declines is a
+    // different scenario with its own tests.
+    mcpServers: recordingMcpCapability(() => join(baseDir, 'mcp.json')).capability,
     buildAssetMetadata: (data) => ({
       ok: true,
       data: (data ?? {}) as Record<string, unknown>,
@@ -528,6 +532,10 @@ describe('runInstall — concrete MCP declarations', () => {
     const result = await runInstall({
       projectRoot,
       adapters: [buildFakeAdapter('test')],
+      // A declaration authorizes execution, so an unapproved one now stops
+      // the run. This test is about the declaration not *degrading* the
+      // install; approval is exercised on its own.
+      mcpConsent: { kind: 'preapproved' },
     })
     expect(result.ok).toBe(true)
   })

--- a/packages/engine/src/adapters/mcp-support.ts
+++ b/packages/engine/src/adapters/mcp-support.ts
@@ -1,0 +1,80 @@
+import type { Adapter, AdapterApiVersionAssetsOnly, McpServerCapability } from '@agent-facets/adapter'
+// Subpath import: dependency-free, so this stays out of the full SDK runtime
+// graph for the same reason `api-compatibility.ts` does.
+import { ADAPTER_API_VERSION_ASSETS_ONLY } from '@agent-facets/adapter/api-version'
+
+/**
+ * Whether a selected adapter can reconcile MCP configuration.
+ *
+ * A different question from `api-compatibility.ts`, which answers "is this
+ * adapter loadable at all?" That one is unconditional and its remedy is
+ * always "install a compatible release". This one is conditional on the
+ * project actually having MCP work to do, and its two answers have two
+ * different remedies — which is why widening `AdapterCompatibilityFailure`
+ * would have been wrong.
+ */
+
+/**
+ * Why one selected adapter cannot do MCP work.
+ *
+ * Two arms rather than one shape with an optional API token, because the
+ * remedies genuinely differ: an asset-only adapter predates the question and
+ * may gain support in a later release, while `mcpServers: false` is a
+ * deliberate statement that this tool has no MCP configuration to write.
+ * Upgrading the second one will never help.
+ */
+export type McpUnsupportedAdapter =
+  /** Published against the superseded asset-only contract. */
+  | { kind: 'asset-only-api'; adapter: string; apiVersion: AdapterApiVersionAssetsOnly }
+  /** Current contract, explicitly declining MCP support. */
+  | { kind: 'capability-declined'; adapter: string }
+
+/** One selected adapter that can reconcile MCP configuration. */
+export interface McpCapableSelection {
+  adapter: string
+  capability: McpServerCapability
+}
+
+/**
+ * The result of classifying the complete selected set.
+ *
+ * All-or-nothing: MCP configuration is project state, and reconciling it
+ * into some tools but not others would leave the project in a condition no
+ * subsequent run could describe. So a single unsupported adapter fails the
+ * whole operation, and the failure names every one of them rather than the
+ * first.
+ */
+export type McpAdapterSupport =
+  | { ok: true; capable: readonly McpCapableSelection[] }
+  | { ok: false; unsupported: readonly McpUnsupportedAdapter[] }
+
+/**
+ * Classify every selected adapter's MCP support.
+ *
+ * Narrows on the `apiVersion` tag rather than probing for an `mcpServers`
+ * field: the adapter union is tagged precisely so this question is answered
+ * by the type system, and a structural probe would silently accept a `0.1`
+ * adapter that happened to carry an unrelated member of that name.
+ *
+ * Selection order is preserved, so a report lists adapters in the order the
+ * caller chose them.
+ */
+export function classifyMcpSupport(adapters: readonly Adapter[]): McpAdapterSupport {
+  const capable: McpCapableSelection[] = []
+  const unsupported: McpUnsupportedAdapter[] = []
+
+  for (const adapter of adapters) {
+    if (adapter.apiVersion === ADAPTER_API_VERSION_ASSETS_ONLY) {
+      unsupported.push({ kind: 'asset-only-api', adapter: adapter.name, apiVersion: adapter.apiVersion })
+      continue
+    }
+    if (adapter.mcpServers === false) {
+      unsupported.push({ kind: 'capability-declined', adapter: adapter.name })
+      continue
+    }
+    capable.push({ adapter: adapter.name, capability: adapter.mcpServers })
+  }
+
+  if (unsupported.length > 0) return { ok: false, unsupported }
+  return { ok: true, capable }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -36,6 +36,7 @@ export {
 } from './adapters/installation.ts'
 export type { InstalledAdapterFailure, LoadAdaptersResult } from './adapters/loader.ts'
 export { loadInstalledAdapters } from './adapters/loader.ts'
+export type { McpUnsupportedAdapter } from './adapters/mcp-support.ts'
 export type {
   PlaceAdapterFailure,
   PlaceAdapterResult,
@@ -146,6 +147,11 @@ export {
   facetReceiptsDir,
   resolveFacetDir,
 } from './facet-dir.ts'
+export type {
+  AssetTakeoverDecision,
+  AssetTakeoverRequest,
+  AssetTakeoverResolver,
+} from './install/asset-takeover.ts'
 // install machinery
 // The collision-resolver contract. Exported because the interactive
 // workspace lives in the CLI (TTY detection and prompting are display
@@ -164,6 +170,19 @@ export type { LoadLockfileResult } from './install/lockfile-io.ts'
 export { emptyLockfile, FACETS_LOCK_FILE, loadLockfile, writeLockfile } from './install/lockfile-io.ts'
 export type { MaterializeOptions, MaterializeResult } from './install/materialize.ts'
 export { materialize } from './install/materialize.ts'
+// MCP configuration consent. Exported for the same reason the collision
+// resolver is: the screen is a display concern the CLI owns, while what
+// needs approving — and what an approval means — is an engine rule.
+export type {
+  McpApprovalStanding,
+  McpConsentDecision,
+  McpConsentPolicy,
+  McpConsentRequest,
+  McpConsentResolver,
+  McpDeclarationApproval,
+  McpNativeTakeover,
+} from './install/mcp/consent.ts'
+export type { McpContractViolation } from './install/mcp/prepare.ts'
 // Prototype-safe access to records keyed by user-authored names. The CLI's
 // collision draft builds and rewrites exactly such a record before handing it
 // back as the resolver's answer, so it needs the same two primitives the

--- a/packages/engine/src/install/__tests__/compose.test.ts
+++ b/packages/engine/src/install/__tests__/compose.test.ts
@@ -8,6 +8,7 @@ import type { CollisionResolution, CollisionResolutionRequest } from '../commit/
 import { receiptPath } from '../receipt.ts'
 import { runInstall } from '../run-install.ts'
 import type { StageEvent } from '../types.ts'
+import { recordingMcpCapability } from './helpers/mcp-adapter.ts'
 
 /**
  * Cross-facet collision detection and resolution, exercised through the real
@@ -25,17 +26,24 @@ let originalFacetDir: string | undefined
 let fakeHome: string
 
 /** Adapter that records every I/O call so "never invoked" is provable. */
-function recordingAdapter(name: string): { adapter: Adapter; io: string[] } {
+function recordingAdapter(name: string): { adapter: Adapter; io: string[]; mcpDocument: string } {
   const io: string[] = []
   const baseDir = () => join(projectRoot, `.${name}`)
   const file = (type: string, assetName: string) => join(baseDir(), `${type}s`, `${assetName}.md`)
+  const mcpDocument = () => join(baseDir(), 'mcp.json')
+  const mcp = recordingMcpCapability(mcpDocument)
   return {
     io,
+    // Resolved lazily by the caller only after `projectRoot` exists; exposed
+    // as a getter so the literal above stays a plain object.
+    get mcpDocument() {
+      return mcpDocument()
+    },
     adapter: {
       name,
       apiVersion: ADAPTER_API_VERSION,
       supportsInstall: true,
-      mcpServers: false,
+      mcpServers: mcp.capability,
       buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
       async installAsset(request) {
         io.push(`install:${request.assetType}:${request.name}`)
@@ -86,6 +94,14 @@ function serverFixture(facet: string, server: string, declaration: unknown, vers
 }
 
 const STDIO = { type: 'stdio', command: 'npx', args: ['-y', 'server-filesystem'] }
+
+/**
+ * These tests are about composition, not consent: every declaration they
+ * install is approved up front so the pipeline reaches the planner. Consent
+ * itself — who may approve, and what happens when nobody can — has its own
+ * suite.
+ */
+const ACCEPT_MCP = { kind: 'preapproved' } as const
 
 function writeManifest(value: unknown): string {
   const text = `${JSON.stringify(value, null, 2)}\n`
@@ -188,7 +204,7 @@ describe('compose — MCP server composition', () => {
 
     // Same declaration, same effective name: one configuration, two
     // claimants. Contesting here would block an install over an agreement.
-    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    const result = await runInstall({ projectRoot, adapters: [adapter], mcpConsent: ACCEPT_MCP })
     expect(result.ok).toBe(true)
   })
 
@@ -217,7 +233,7 @@ describe('compose — MCP server composition', () => {
     const { adapter } = recordingAdapter('rec')
 
     // Separate identity spaces, so there is no shared key to contend in.
-    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    const result = await runInstall({ projectRoot, adapters: [adapter], mcpConsent: ACCEPT_MCP })
     expect(result.ok).toBe(true)
   })
 
@@ -233,7 +249,7 @@ describe('compose — MCP server composition', () => {
     })
     const { adapter } = recordingAdapter('rec')
 
-    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    const result = await runInstall({ projectRoot, adapters: [adapter], mcpConsent: ACCEPT_MCP })
     expect(result.ok).toBe(true)
   })
 
@@ -249,7 +265,7 @@ describe('compose — MCP server composition', () => {
     })
     const { adapter } = recordingAdapter('rec')
 
-    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    const result = await runInstall({ projectRoot, adapters: [adapter], mcpConsent: ACCEPT_MCP })
     expect(result.ok).toBe(true)
   })
 
@@ -258,7 +274,7 @@ describe('compose — MCP server composition', () => {
     writeManifest({ facets: { alpha: a } })
     const { adapter, io } = recordingAdapter('rec')
 
-    const result = await runInstall({ projectRoot, adapters: [adapter] })
+    const result = await runInstall({ projectRoot, adapters: [adapter], mcpConsent: ACCEPT_MCP })
 
     if (!result.ok) expect.unreachable()
     // The lockfile records the facet with an empty asset list; no adapter
@@ -290,7 +306,7 @@ describe('compose — MCP server composition', () => {
     writeManifest({ facets: { alpha: a } })
     const { adapter } = recordingAdapter('rec')
 
-    expect((await runInstall({ projectRoot, adapters: [adapter] })).ok).toBe(true)
+    expect((await runInstall({ projectRoot, adapters: [adapter], mcpConsent: ACCEPT_MCP })).ok).toBe(true)
 
     // The lockfile is unchanged by MCP support: a declaration travels inside
     // the integrity-pinned `facet.json`, so duplicating it here would give a
@@ -313,7 +329,12 @@ describe('compose — MCP server composition', () => {
     const { adapter } = recordingAdapter('rec')
     const events: StageEvent[] = []
 
-    const result = await runInstall({ projectRoot, adapters: [adapter], onStage: (e) => events.push(e) })
+    const result = await runInstall({
+      projectRoot,
+      adapters: [adapter],
+      mcpConsent: ACCEPT_MCP,
+      onStage: (e) => events.push(e),
+    })
 
     expect(result.ok).toBe(true)
     expect(events.filter((e) => e.kind === 'stale-override-pruned')).toEqual([

--- a/packages/engine/src/install/__tests__/helpers/mcp-adapter.ts
+++ b/packages/engine/src/install/__tests__/helpers/mcp-adapter.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import type {
+  ApplyMcpServersResult,
+  McpServerCapability,
+  McpServerCapabilityFailure,
+  McpServerDeclaration,
+  PrepareMcpServersRequest,
+  PrepareMcpServersResult,
+} from '@agent-facets/adapter'
+import { mcpOutcomesRequireWrite, reconcileMcpServers } from '@agent-facets/adapter'
+
+/**
+ * A minimal but honest MCP capability for engine tests.
+ *
+ * Honest in the ways the engine actually depends on: it prepares read-only,
+ * discloses the one document it would touch before writing it, reports
+ * `unchanged` when nothing needs to move, and derives ownership strictly from
+ * `previouslyOwnedNames`. That makes it usable as a stand-in wherever a test
+ * needs a `0.2` adapter that can carry MCP work, without importing a
+ * first-party adapter's native format into engine's test suite.
+ *
+ * The document is deliberately a plain JSON map of name to declaration. The
+ * native shape is each adapter's business; what engine tests care about is
+ * that a document exists, that its bytes change only when they should, and
+ * that a rollback can put the old ones back.
+ */
+
+/** What the fake wrote, so a test can assert on the sequence. */
+export interface McpCapabilityRecorder {
+  capability: McpServerCapability
+  /** `prepare:<n desired>` / `apply:changed` / `apply:unchanged`, in order. */
+  calls: string[]
+}
+
+type FakePlan =
+  | { kind: 'unchanged'; path: string }
+  | { kind: 'write'; path: string; servers: Record<string, McpServerDeclaration> }
+
+/**
+ * Build a capability whose document lives at `documentPath()`.
+ *
+ * The path is a thunk because engine tests create their project root in
+ * `beforeEach`, after the adapter literal has already been written.
+ */
+export interface RecordingMcpOptions {
+  /** Make `prepare` report this failure instead of planning. */
+  failPrepare?: McpServerCapabilityFailure
+  /** Make `apply` report this failure instead of writing. */
+  failApply?: McpServerCapabilityFailure
+  /**
+   * Report a changed path `prepare` never disclosed — the contract breach the
+   * engine refuses because it has no preimage for it.
+   */
+  applyUndisclosedPath?: () => string
+}
+
+export function recordingMcpCapability(
+  documentPath: () => string,
+  options: RecordingMcpOptions = {},
+): McpCapabilityRecorder {
+  const calls: string[] = []
+
+  const capability: McpServerCapability<FakePlan> = {
+    async prepare(request: PrepareMcpServersRequest): Promise<PrepareMcpServersResult<FakePlan>> {
+      const path = documentPath()
+      calls.push(`prepare:${request.desired.length}`)
+      if (options.failPrepare !== undefined) return { ok: false, failure: options.failPrepare }
+
+      const servers = readServers(path)
+      if (!servers.ok) {
+        return { ok: false, failure: { code: 'parse-failed', path, message: servers.message } }
+      }
+
+      const outcomes = reconcileMcpServers({
+        desired: request.desired,
+        previouslyOwnedNames: request.previouslyOwnedNames,
+        presentNames: new Set(Object.keys(servers.value)),
+        // Byte equality of the serialized declaration stands in for an
+        // adapter's native comparison: this fake's "native format" IS the
+        // portable one, so anything else would be pretending.
+        compare: (contribution) =>
+          JSON.stringify(servers.value[contribution.name]) === JSON.stringify(contribution.declaration)
+            ? 'equivalent'
+            : 'divergent',
+      })
+
+      if (!mcpOutcomesRequireWrite(outcomes)) {
+        return { ok: true, preparation: { plan: { kind: 'unchanged', path }, documentPaths: [path], outcomes } }
+      }
+
+      const next: Record<string, McpServerDeclaration> = { ...servers.value }
+      for (const outcome of outcomes) {
+        if (outcome.kind === 'obsolete-owned') {
+          delete next[outcome.name]
+          continue
+        }
+        const contribution = request.desired.find((entry) => entry.name === outcome.name)
+        if (contribution !== undefined) next[outcome.name] = contribution.declaration
+      }
+
+      return {
+        ok: true,
+        preparation: { plan: { kind: 'write', path, servers: next }, documentPaths: [path], outcomes },
+      }
+    },
+
+    async apply(request: { plan: FakePlan }): Promise<ApplyMcpServersResult> {
+      const plan = request.plan
+      if (plan.kind === 'unchanged') {
+        calls.push('apply:unchanged')
+        return { ok: true, status: 'unchanged' }
+      }
+      if (options.failApply !== undefined) {
+        calls.push('apply:failed')
+        return { ok: false, failure: options.failApply }
+      }
+      calls.push('apply:changed')
+      mkdirSync(dirname(plan.path), { recursive: true })
+      writeFileSync(plan.path, `${JSON.stringify(plan.servers, null, 2)}\n`)
+      const undisclosed = options.applyUndisclosedPath?.()
+      if (undisclosed !== undefined) {
+        return { ok: true, status: 'changed', changedPaths: [undisclosed] }
+      }
+      return { ok: true, status: 'changed', changedPaths: [plan.path] }
+    },
+  }
+
+  return { capability, calls }
+}
+
+function readServers(
+  path: string,
+): { ok: true; value: Record<string, McpServerDeclaration> } | { ok: false; message: string } {
+  let text: string
+  try {
+    text = readFileSync(path, 'utf8')
+  } catch {
+    return { ok: true, value: {} }
+  }
+  try {
+    return { ok: true, value: JSON.parse(text) as Record<string, McpServerDeclaration> }
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/packages/engine/src/install/__tests__/mcp-install.test.ts
+++ b/packages/engine/src/install/__tests__/mcp-install.test.ts
@@ -1,0 +1,853 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
+import {
+  ADAPTER_API_VERSION,
+  ADAPTER_API_VERSION_ASSETS_ONLY,
+  deleteAssetFile,
+  installAssetFile,
+  readAssetFile,
+} from '@agent-facets/adapter'
+import type { AssetTakeoverRequest } from '../asset-takeover.ts'
+import type { McpConsentRequest } from '../mcp/consent.ts'
+import { receiptPath } from '../receipt.ts'
+import { runRemove } from '../remove/index.ts'
+import { runInstall } from '../run-install.ts'
+import { assetIdentity, type RunInstallOptions } from '../types.ts'
+import { type RecordingMcpOptions, recordingMcpCapability } from './helpers/mcp-adapter.ts'
+
+/**
+ * MCP configuration through the real install pipeline: support, preparation,
+ * consent, application, rollback, frozen reproduction, and offline removal.
+ *
+ * The properties under test are almost all ORDERING properties — what has and
+ * has not happened at the moment a run refuses. So nearly every failing case
+ * also asserts what is on disk, and the successful ones assert what is not.
+ */
+
+let projectRoot: string
+let originalCwd: string
+let originalFacetDir: string | undefined
+let fakeHome: string
+
+const STDIO = { type: 'stdio', command: 'npx', args: ['-y', 'server-filesystem'] }
+const HTTP = { type: 'http', url: 'https://example.test/mcp' }
+const ACCEPT: RunInstallOptions['mcpConsent'] = { kind: 'preapproved' }
+
+interface TestAdapter {
+  adapter: Adapter
+  io: string[]
+  mcpCalls: string[]
+  documentPath: string
+}
+
+/** A `0.2` adapter with a working MCP capability, recording every call. */
+function mcpAdapter(name: string, options: RecordingMcpOptions = {}): TestAdapter {
+  const io: string[] = []
+  const baseDir = () => join(projectRoot, `.${name}`)
+  const file = (type: string, assetName: string) => join(baseDir(), `${type}s`, `${assetName}.md`)
+  const document = () => join(baseDir(), 'mcp.json')
+  const mcp = recordingMcpCapability(document, options)
+  return {
+    io,
+    mcpCalls: mcp.calls,
+    get documentPath() {
+      return document()
+    },
+    adapter: {
+      name,
+      apiVersion: ADAPTER_API_VERSION,
+      supportsInstall: true,
+      mcpServers: mcp.capability,
+      buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
+      // The SDK helpers verbatim, so the assemble → write → read → split
+      // round trip matches every real adapter. A hand-rolled store that drops
+      // metadata can never report an asset as unchanged, which would make the
+      // equivalent-takeover case untestable.
+      async installAsset(request) {
+        io.push(`install:${request.assetType}:${request.name}`)
+        const p = { file: file(request.assetType, request.name) }
+        await installAssetFile(p, request.content, request.metadata as Record<string, unknown> | undefined)
+        return { ok: true, primaryPath: p.file }
+      },
+      async readAsset(request) {
+        io.push(`read:${request.assetType}:${request.name}`)
+        try {
+          const { content, metadata } = await readAssetFile({ file: file(request.assetType, request.name) })
+          return request.assetType === 'skill'
+            ? { ok: true, asset: { assetType: 'skill', content, metadata, companions: {} } }
+            : { ok: true, asset: { assetType: request.assetType, content, metadata } }
+        } catch {
+          return { ok: false, failure: { code: 'not-found' } }
+        }
+      },
+      async deleteAsset(request) {
+        io.push(`delete:${request.assetType}:${request.name}`)
+        const p = { file: file(request.assetType, request.name) }
+        await deleteAssetFile(p)
+        return { ok: true, existed: true, deletedPaths: [p.file] }
+      },
+    },
+  }
+}
+
+/** An adapter that declares the current API but no MCP support. */
+function decliningAdapter(name: string): Adapter {
+  const built = mcpAdapter(name)
+  return { ...built.adapter, apiVersion: ADAPTER_API_VERSION, mcpServers: false }
+}
+
+/** An adapter published against the superseded asset-only contract. */
+function assetOnlyAdapter(name: string): Adapter {
+  const built = mcpAdapter(name)
+  const { mcpServers: _dropped, ...rest } = built.adapter as Adapter & { mcpServers?: unknown }
+  return { ...rest, apiVersion: ADAPTER_API_VERSION_ASSETS_ONLY } as Adapter
+}
+
+function serverFixture(facet: string, server: string, declaration: unknown, version = '1.0.0'): string {
+  const dir = join(projectRoot, 'vendor', facet)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'facet.json'), JSON.stringify({ name: facet, version, servers: { [server]: declaration } }))
+  return `./vendor/${facet}`
+}
+
+function skillFixture(facet: string, skill: string, version = '1.0.0'): string {
+  const dir = join(projectRoot, 'vendor', facet)
+  mkdirSync(join(dir, `skills/${skill}`), { recursive: true })
+  writeFileSync(
+    join(dir, 'facet.json'),
+    JSON.stringify({ name: facet, version, skills: { [skill]: { description: `${skill} skill` } } }),
+  )
+  writeFileSync(join(dir, `skills/${skill}/SKILL.md`), `# ${skill} from ${facet}\n`)
+  return `./vendor/${facet}`
+}
+
+function writeManifest(value: unknown): string {
+  const text = `${JSON.stringify(value, null, 2)}\n`
+  writeFileSync(join(projectRoot, 'facets.json'), text)
+  return text
+}
+
+function readIfPresent(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mcp-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mcp-home-')))
+  process.env.FACET_DIR = join(fakeHome, '.facet')
+  process.chdir(projectRoot)
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('mcp — adapter support preflight', () => {
+  test('an adapter declining MCP fails the run before anything is prepared or written', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const declining = decliningAdapter('declines')
+
+    const result = await runInstall({ projectRoot, adapters: [declining], mcpConsent: ACCEPT })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_ADAPTERS_UNSUPPORTED') expect.unreachable()
+    expect(result.failure.adapters).toEqual([{ kind: 'capability-declined', adapter: 'declines' }])
+    expect(result.failure.servers).toEqual(['filesystem'])
+    // Before the journal: the operation never reached a mutation at all.
+    expect(result.rollback.kind).toBe('not-needed')
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    expect(existsSync(receiptPath(projectRoot))).toBe(false)
+  })
+
+  test('every unsupported adapter is named, not just the first', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [assetOnlyAdapter('old'), decliningAdapter('declines'), mcpAdapter('good').adapter],
+      mcpConsent: ACCEPT,
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_ADAPTERS_UNSUPPORTED') expect.unreachable()
+    expect(result.failure.adapters).toEqual([
+      { kind: 'asset-only-api', adapter: 'old', apiVersion: ADAPTER_API_VERSION_ASSETS_ONLY },
+      { kind: 'capability-declined', adapter: 'declines' },
+    ])
+  })
+
+  test('a text-only project keeps an asset-only adapter usable', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+
+    const result = await runInstall({ projectRoot, adapters: [assetOnlyAdapter('old')] })
+
+    // No declarations means no MCP work, so support is never required and no
+    // capability method is invoked. This is the whole point of the window.
+    expect(result.ok).toBe(true)
+  })
+
+  test('an omitted declaration is not active, so it requires no MCP support', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source: a, materialization: { servers: { filesystem: { kind: 'omitted' } } } } },
+    })
+
+    expect((await runInstall({ projectRoot, adapters: [decliningAdapter('declines')] })).ok).toBe(true)
+  })
+})
+
+describe('mcp — consent', () => {
+  test('a non-interactive caller fails with the complete request and changes nothing', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const result = await runInstall({ projectRoot, adapters: [rec.adapter] })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_CONSENT_REQUIRED') expect.unreachable()
+    const [declaration] = result.failure.request.declarations
+    expect(declaration?.identity.effectiveName).toBe('filesystem')
+    expect(declaration?.standing).toEqual({ kind: 'unknown-identity' })
+    expect(declaration?.claimants.map((c) => c.facet)).toEqual(['alpha'])
+    // The exact command is in the request: a user deciding whether to pass
+    // --accept-mcp is deciding whether to let this run.
+    expect(declaration?.declaration).toEqual(STDIO as never)
+
+    // Prepared, never applied.
+    expect(rec.mcpCalls).toEqual(['prepare:1'])
+    expect(existsSync(rec.documentPath)).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  test('a declined request writes no configuration and records no approval', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: { kind: 'interactive', resolve: async () => ({ kind: 'declined' }) },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MCP_CONSENT_DECLINED')
+    expect(result.rollback.kind).toBe('not-needed')
+    expect(existsSync(rec.documentPath)).toBe(false)
+    expect(existsSync(receiptPath(projectRoot))).toBe(false)
+  })
+
+  test('approval applies the configuration and records the claim', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    let asked = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async () => {
+          asked++
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(asked).toBe(1)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+
+    // The receipt records the claim by fingerprint — never the command.
+    const receipt = readFileSync(receiptPath(projectRoot), 'utf8')
+    expect(JSON.parse(receipt).facets.alpha.configurations).toEqual([
+      {
+        kind: 'mcp-server',
+        name: 'filesystem',
+        materialization: { kind: 'authored' },
+        fingerprint: expect.any(String),
+      },
+    ])
+    for (const secret of ['npx', 'server-filesystem']) {
+      expect(receipt).not.toContain(secret)
+    }
+  })
+
+  test('an approved declaration is not asked about again', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    let asked = 0
+    const again = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async () => {
+          asked++
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(again.ok).toBe(true)
+    expect(asked).toBe(0)
+  })
+
+  test('a changed declaration is asked about again, and says so', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // Same facet, same name, different command: a name the user already
+    // trusted now runs something else.
+    serverFixture('alpha', 'filesystem', { type: 'stdio', command: 'other-mcp' }, '1.0.1')
+
+    let seen: McpConsentRequest | undefined
+    const again = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async (request) => {
+          seen = request
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(again.ok).toBe(true)
+    expect(seen?.declarations[0]?.standing).toEqual({ kind: 'declaration-changed' })
+  })
+
+  test('approval is machine-local: a teammate with the same files is asked', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // The receipt is machine-local and never committed, so a teammate's clone
+    // has the same manifest, lockfile, and configuration document — and no
+    // approval evidence at all.
+    rmSync(receiptPath(projectRoot), { force: true })
+
+    const teammate = await runInstall({ projectRoot, adapters: [rec.adapter] })
+    if (teammate.ok) expect.unreachable()
+    expect(teammate.failure.code).toBe('MCP_CONSENT_REQUIRED')
+  })
+
+  test('an untracked native entry is disclosed as a takeover', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    // Someone configured this server by hand, differently.
+    mkdirSync(join(projectRoot, '.rec'), { recursive: true })
+    writeFileSync(rec.documentPath, `${JSON.stringify({ filesystem: HTTP }, null, 2)}\n`)
+
+    let seen: McpConsentRequest | undefined
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async (request) => {
+          seen = request
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(seen?.takeovers).toEqual([
+      {
+        adapter: 'rec',
+        identity: { kind: 'mcp-server', effectiveName: 'filesystem' },
+        existing: 'divergent',
+        declaration: STDIO as never,
+      },
+    ])
+  })
+})
+
+describe('mcp — application and rollback', () => {
+  test('a later adapter failure restores the earlier document byte-for-byte', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const first = mcpAdapter('first')
+    const second = mcpAdapter('second', {
+      failApply: { code: 'io-failed', operation: 'write', path: '/nope', message: 'disk on fire' },
+    })
+
+    // A pre-existing document with formatting the engine has no way to
+    // reproduce semantically — which is exactly why rollback restores bytes.
+    mkdirSync(join(projectRoot, '.first'), { recursive: true })
+    const before = '{\n\t"legacy": {"type":"stdio","command":"keep-me"}\n}\n'
+    writeFileSync(first.documentPath, before)
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [first.adapter, second.adapter],
+      mcpConsent: ACCEPT,
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_APPLY_FAILED') expect.unreachable()
+    expect(result.failure.adapter).toBe('second')
+    expect(result.rollback.kind).toBe('succeeded')
+    expect(readFileSync(first.documentPath, 'utf8')).toBe(before)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  test('a document created by the run is deleted again on rollback', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const first = mcpAdapter('first')
+    const second = mcpAdapter('second', {
+      failApply: { code: 'conflict', path: '/nope', message: 'cannot represent' },
+    })
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [first.adapter, second.adapter],
+      mcpConsent: ACCEPT,
+    })
+
+    if (result.ok) expect.unreachable()
+    // "Absent" is a preimage too: restoring it removes the file this run made.
+    expect(existsSync(first.documentPath)).toBe(false)
+  })
+
+  test('a preparation failure stops the run before any asset is written', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec', {
+      failPrepare: { code: 'parse-failed', path: '/project/.rec/mcp.json', message: 'unexpected token' },
+    })
+
+    const result = await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MCP_PREPARE_FAILED')
+    // No asset write, no asset read: preparation precedes the journal.
+    expect(rec.io).toEqual([])
+  })
+
+  test('a write to an undisclosed path is refused as a contract breach', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec', { applyUndisclosedPath: () => join(projectRoot, 'elsewhere.json') })
+
+    const result = await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_CONTRACT_VIOLATION') expect.unreachable()
+    expect(result.failure.violation.kind).toBe('undisclosed-changed-path')
+  })
+})
+
+describe('mcp — frozen reproduction', () => {
+  test('frozen never opens a prompt, even with a resolver in hand', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+    rmSync(receiptPath(projectRoot), { force: true })
+
+    let asked = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async () => {
+          asked++
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MCP_CONSENT_REQUIRED')
+    expect(asked).toBe(0)
+  })
+
+  test('frozen honors a pre-supplied approval and still writes only the receipt', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    const manifestBefore = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+    const lockBefore = readFileSync(join(projectRoot, 'facets.lock'), 'utf8')
+    rmSync(rec.documentPath, { force: true })
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: ACCEPT,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+  })
+
+  test('frozen reports a stale server override instead of pruning it', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    const manifestBefore = writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source: a, materialization: { servers: { gone: { kind: 'omitted' } } } } },
+    })
+    const documentBefore = readFileSync(rec.documentPath, 'utf8')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: ACCEPT,
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'LOCKFILE_DRIFT') expect.unreachable()
+    const entry = result.failure.facets[0]
+    if (entry?.reason !== 'stale-override') expect.unreachable()
+    expect(entry.contribution).toEqual({ kind: 'mcp-server' })
+    expect(entry.authoredName).toBe('gone')
+    // A normal install prunes this inside its transaction; frozen has no
+    // transaction, so it must leave the intent exactly where it found it.
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBefore)
+    expect(readFileSync(rec.documentPath, 'utf8')).toBe(documentBefore)
+  })
+
+  test('a server-only override does not make an older lockfile unrepresentable', async () => {
+    // Servers have no lockfile representation at any version, so an entry
+    // whose only override is a server alias asks nothing of the lockfile
+    // format. Reporting a migration here would name a fix that changes
+    // nothing.
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    const lockfile = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    lockfile.lockfileVersion = 0.2
+    for (const facet of Object.values(lockfile.facets) as Array<Record<string, unknown>>) {
+      facet.assets = []
+    }
+    writeFileSync(join(projectRoot, 'facets.lock'), `${JSON.stringify(lockfile, null, 2)}\n`)
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source: a, materialization: { servers: { filesystem: { kind: 'aliased', as: 'fs' } } } } },
+    })
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: ACCEPT,
+    })
+
+    // It may still fail for a reason of its own, but never for this one.
+    if (!result.ok && result.failure.code === 'LOCKFILE_DRIFT') {
+      expect(result.failure.facets.map((f) => f.reason)).not.toContain('materialization-unrepresentable')
+    }
+  })
+})
+
+describe('mcp — offline removal', () => {
+  test('removing the last claimant deletes the owned server entry offline', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+
+    // The facet's source is gone: nothing may be fetched or rebuilt.
+    rmSync(join(projectRoot, 'vendor/alpha'), { recursive: true, force: true })
+
+    const removed = await runRemove({ projectRoot, names: ['alpha'], adapters: [rec.adapter] })
+
+    expect(removed.ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({})
+    expect(JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8')).facets.alpha).toBeUndefined()
+  })
+
+  test('a remaining claimant preserves the server', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: serverFixture('beta', 'filesystem', STDIO),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    rmSync(join(projectRoot, 'vendor/alpha'), { recursive: true, force: true })
+    const removed = await runRemove({ projectRoot, names: ['alpha'], adapters: [rec.adapter] })
+
+    expect(removed.ok).toBe(true)
+    // beta still claims it, so the entry stays exactly as it is.
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+  })
+
+  test('a pre-configuration receipt falls back to ordinary resolution', async () => {
+    writeManifest({
+      facets: {
+        alpha: skillFixture('alpha', 'review'),
+        beta: skillFixture('beta', 'other'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter] })).ok).toBe(true)
+
+    // Rewrite the receipt at the version that predates configuration claims.
+    const receipt = JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8'))
+    receipt.version = 0.3
+    for (const facet of Object.values(receipt.facets) as Array<Record<string, unknown>>) {
+      delete facet.configurations
+      delete facet.integrity
+    }
+    writeFileSync(receiptPath(projectRoot), `${JSON.stringify(receipt, null, 2)}\n`)
+
+    const reasons: string[] = []
+    const removed = await runRemove({
+      projectRoot,
+      names: ['alpha'],
+      adapters: [rec.adapter],
+      onStage: (event) => {
+        if (event.kind === 'removal-resolution-required') reasons.push(event.reason)
+      },
+    })
+
+    // It falls back rather than guessing; the sources are still present, so
+    // the ordinary pipeline then succeeds.
+    expect(reasons).toEqual(['configuration-unwitnessed'])
+    expect(removed.ok).toBe(true)
+  })
+})
+
+describe('asset takeover', () => {
+  /** Put an untracked file exactly where the desired skill will land. */
+  function occupy(adapterName: string, skill: string, body: string): string {
+    const path = join(projectRoot, `.${adapterName}`, 'skills', `${skill}.md`)
+    mkdirSync(join(path, '..'), { recursive: true })
+    writeFileSync(path, body)
+    return path
+  }
+
+  test('an occupied untracked destination is disclosed before it is replaced', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+    const rec = mcpAdapter('rec')
+    const path = occupy('rec', 'review', '# hand written\n')
+
+    const seen: AssetTakeoverRequest[] = []
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      resolveAssetTakeover: async (request) => {
+        seen.push(request)
+        return { kind: 'continue' }
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(seen).toEqual([
+      {
+        facet: 'alpha',
+        adapter: 'rec',
+        asset: assetIdentity('project', 'skill', 'review'),
+        authoredName: 'review',
+        occupancy: 'divergent',
+      },
+    ])
+    expect(readFileSync(path, 'utf8')).toContain('review from alpha')
+  })
+
+  test('cancelling restores every prior mutation and commits nothing', async () => {
+    writeManifest({
+      facets: {
+        alpha: skillFixture('alpha', 'a-review'),
+        beta: skillFixture('beta', 'b-review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    occupy('rec', 'b-review', '# hand written\n')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      resolveAssetTakeover: async () => ({ kind: 'cancelled' }),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'ASSET_TAKEOVER_CANCELLED') expect.unreachable()
+    expect(String(result.failure.asset.name)).toBe('b-review')
+    expect(result.rollback.kind).toBe('succeeded')
+    // The facet written before the gate was reached is gone again, and the
+    // project files were never committed.
+    expect(existsSync(join(projectRoot, '.rec', 'skills', 'a-review.md'))).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  test('an owned destination reconciles without asking', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter] })).ok).toBe(true)
+
+    // Drift it, so the second run has real work to do at an owned identity.
+    writeFileSync(join(projectRoot, '.rec', 'skills', 'review.md'), '# drifted\n')
+
+    let asked = 0
+    const again = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      resolveAssetTakeover: async () => {
+        asked++
+        return { kind: 'continue' }
+      },
+    })
+
+    expect(again.ok).toBe(true)
+    expect(asked).toBe(0)
+  })
+
+  test('an equivalent untracked destination is adopted without rewriting it', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter] })).ok).toBe(true)
+
+    // Forget the identity while leaving the bytes: a clone whose receipt is
+    // machine-local, or a project whose receipt was lost. The destination is
+    // now untracked AND already exactly right.
+    rmSync(receiptPath(projectRoot), { force: true })
+    const before = rec.io.length
+
+    const seen: AssetTakeoverRequest[] = []
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      resolveAssetTakeover: async (request) => {
+        seen.push(request)
+        return { kind: 'continue' }
+      },
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(seen[0]?.occupancy).toBe('equivalent')
+    // Adopted: nothing was written, and the identity is tracked again.
+    expect(rec.io.slice(before).filter((call) => call.startsWith('install:'))).toEqual([])
+    expect(JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8')).facets.alpha.assets).toHaveLength(1)
+  })
+
+  test('a non-interactive run continues automatically', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+    const rec = mcpAdapter('rec')
+    const path = occupy('rec', 'review', '# hand written\n')
+
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter] })).ok).toBe(true)
+    expect(readFileSync(path, 'utf8')).toContain('review from alpha')
+  })
+
+  test('frozen mode never opens the gate', async () => {
+    const a = skillFixture('alpha', 'review')
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter] })).ok).toBe(true)
+
+    // Forget the identity, so the destination reads as untracked again.
+    rmSync(receiptPath(projectRoot), { force: true })
+
+    let asked = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      resolveAssetTakeover: async () => {
+        asked++
+        return { kind: 'continue' }
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(asked).toBe(0)
+  })
+
+  test('MCP approval does not accept an asset takeover', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    occupy('rec', 'review', '# hand written\n')
+
+    let asked = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      // Pre-supplied MCP approval, which must say nothing about assets.
+      mcpConsent: ACCEPT,
+      resolveAssetTakeover: async () => {
+        asked++
+        return { kind: 'cancelled' }
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(asked).toBe(1)
+    expect(result.failure.code).toBe('ASSET_TAKEOVER_CANCELLED')
+  })
+})
+
+describe('mcp — interruption', () => {
+  test('an abort after approval rolls the operation back', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    const controller = new AbortController()
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      signal: controller.signal,
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async () => {
+          controller.abort()
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    // The signal is the honest account of what happened, even though the
+    // screen settled as approved.
+    expect(result.failure.code).toBe('ABORTED')
+    expect(readIfPresent(rec.documentPath)).toBeNull()
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+})

--- a/packages/engine/src/install/__tests__/refine-removal.test.ts
+++ b/packages/engine/src/install/__tests__/refine-removal.test.ts
@@ -3,6 +3,7 @@ import {
   CURRENT_LOCKFILE_VERSION,
   type CurrentLockfileFacet,
   canonicalPrimaryPath,
+  type McpServerFingerprint,
   type SupportedLockfile,
 } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
@@ -513,5 +514,221 @@ describe('refineRemoval — a receipt that cannot witness anything', () => {
     if (result.kind !== 'not-applicable') expect.unreachable()
     if (result.reason.code !== 'receipt-unwitnessable') expect.unreachable()
     expect(result.reason.reason).toBe(reason)
+  })
+})
+
+/**
+ * The configuration half of the same proof.
+ *
+ * A removal writes nothing, so every question it asks about MCP servers has
+ * to be answerable from the receipt's own claims. Where it is not — the
+ * receipt predates claims, the manifest asks for something the claims do not
+ * record, or the claims disagree with each other — the operation falls back
+ * to ordinary resolution rather than guessing.
+ */
+describe('refineRemoval — configuration claims', () => {
+  const FINGERPRINT: McpServerFingerprint = `sha256:${'b'.repeat(64)}`
+
+  function withClaims(
+    entry: CurrentLockfileFacet,
+    claims: ReadonlyArray<{
+      name: string
+      materialization: ReceiptFacetEntry['configurations'][number]['materialization']
+    }>,
+  ): ReceiptFacetEntry {
+    return receiptEntryForLockedFacet(
+      entry,
+      claims.map((claim) => ({
+        kind: 'mcp-server' as const,
+        name: claim.name,
+        materialization: claim.materialization,
+        fingerprint: FINGERPRINT,
+      })),
+    )
+  }
+
+  const previousLockfile = lockfileOf([
+    ['keep', entryWith([{ name: 'review' }])],
+    ['gone', entryWith([{ name: 'dropped' }])],
+  ])
+
+  function stateOf(keep: ReceiptFacetEntry, gone?: ReceiptFacetEntry): ProjectReceiptState {
+    const entries: Array<[string, ReceiptFacetEntry]> = [['keep', keep]]
+    if (gone !== undefined) entries.push(['gone', gone])
+    return loaded({ version: CURRENT_RECEIPT_VERSION, path: '/tmp/project', facets: record(entries) })
+  }
+
+  test('carries a remaining facet’s claims forward verbatim', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [
+      { name: 'filesystem', materialization: { kind: 'authored' } },
+    ])
+    const result = refineRemoval({
+      desiredFacets: desiredOnly(['keep']),
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep),
+    })
+
+    if (result.kind !== 'refined') expect.unreachable()
+    expect(result.refinement.receiptFacets.keep?.configurations).toEqual(keep.configurations)
+    // Still claimed, so nothing may be deleted.
+    expect(result.refinement.obsoleteConfigurations).toEqual([])
+    expect(result.refinement.retainedConfigurations.map((c) => c.identity.effectiveName)).toEqual(['filesystem'])
+  })
+
+  test('a claim only the dropped facet held becomes deletable', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [])
+    const gone = withClaims(previousLockfile.facets.gone as CurrentLockfileFacet, [
+      { name: 'filesystem', materialization: { kind: 'authored' } },
+    ])
+    const result = refineRemoval({
+      desiredFacets: desiredOnly(['keep']),
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep, gone),
+    })
+
+    if (result.kind !== 'refined') expect.unreachable()
+    expect(result.refinement.obsoleteConfigurations.map((o) => o.effectiveName)).toEqual(['filesystem'])
+  })
+
+  test('a claim a remaining facet shares with the dropped one is retained', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [
+      { name: 'filesystem', materialization: { kind: 'authored' } },
+    ])
+    const gone = withClaims(previousLockfile.facets.gone as CurrentLockfileFacet, [
+      { name: 'filesystem', materialization: { kind: 'authored' } },
+    ])
+    const result = refineRemoval({
+      desiredFacets: desiredOnly(['keep']),
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep, gone),
+    })
+
+    if (result.kind !== 'refined') expect.unreachable()
+    expect(result.refinement.obsoleteConfigurations).toEqual([])
+  })
+
+  test('an alias the manifest asks for but the claims do not record falls back', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [])
+    const desiredFacets = record<NormalizedFacetEntry>([
+      ['keep', { source: './vendor/keep', overrides: { servers: { filesystem: { kind: 'aliased', as: 'fs' } } } }],
+    ])
+
+    const result = refineRemoval({
+      desiredFacets,
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep),
+    })
+
+    if (result.kind !== 'not-applicable') expect.unreachable()
+    if (result.reason.code !== 'remaining-server-intent-unwitnessed') expect.unreachable()
+    expect(result.reason.authoredName).toBe('filesystem')
+  })
+
+  test('a claim the manifest now aliases differently falls back', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [
+      { name: 'filesystem', materialization: { kind: 'authored' } },
+    ])
+    const desiredFacets = record<NormalizedFacetEntry>([
+      ['keep', { source: './vendor/keep', overrides: { servers: { filesystem: { kind: 'aliased', as: 'fs' } } } }],
+    ])
+
+    const result = refineRemoval({
+      desiredFacets,
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep),
+    })
+
+    if (result.kind !== 'not-applicable') expect.unreachable()
+    expect(result.reason.code).toBe('remaining-server-intent-unrecorded')
+  })
+
+  test('a claim the manifest now omits falls back', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [
+      { name: 'filesystem', materialization: { kind: 'authored' } },
+    ])
+    const desiredFacets = record<NormalizedFacetEntry>([
+      ['keep', { source: './vendor/keep', overrides: { servers: { filesystem: { kind: 'omitted' } } } }],
+    ])
+
+    const result = refineRemoval({
+      desiredFacets,
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep),
+    })
+
+    if (result.kind !== 'not-applicable') expect.unreachable()
+    expect(result.reason.code).toBe('remaining-server-intent-unrecorded')
+  })
+
+  test('an omission with no claim is consistent', () => {
+    const keep = withClaims(previousLockfile.facets.keep as CurrentLockfileFacet, [])
+    const desiredFacets = record<NormalizedFacetEntry>([
+      ['keep', { source: './vendor/keep', overrides: { servers: { filesystem: { kind: 'omitted' } } } }],
+    ])
+
+    const result = refineRemoval({
+      desiredFacets,
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep),
+    })
+
+    expect(result.kind).toBe('refined')
+  })
+
+  test('a retained identity the receipt recorded twice, differently, falls back', () => {
+    // Two claims at one effective name with different fingerprints: the entry
+    // on disk says whatever the last write said, and nothing here can put the
+    // remaining claimant's version back.
+    const keep = receiptEntryForLockedFacet(previousLockfile.facets.keep as CurrentLockfileFacet, [
+      { kind: 'mcp-server', name: 'filesystem', materialization: { kind: 'authored' }, fingerprint: FINGERPRINT },
+    ])
+    const gone = receiptEntryForLockedFacet(previousLockfile.facets.gone as CurrentLockfileFacet, [
+      {
+        kind: 'mcp-server',
+        name: 'filesystem',
+        materialization: { kind: 'authored' },
+        fingerprint: `sha256:${'c'.repeat(64)}` as McpServerFingerprint,
+      },
+    ])
+
+    const result = refineRemoval({
+      desiredFacets: desiredOnly(['keep']),
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: stateOf(keep, gone),
+    })
+
+    if (result.kind !== 'not-applicable') expect.unreachable()
+    if (result.reason.code !== 'retained-server-identity-contested') expect.unreachable()
+    expect(result.reason.effectiveName).toBe('filesystem')
+  })
+
+  test.each([1, 0.2, 0.3] as const)('a receipt at version %p cannot witness configuration', (version) => {
+    const result = refineRemoval({
+      desiredFacets: desiredOnly(['keep']),
+      previousLockfile,
+      lockfileExisted: true,
+      receiptState: {
+        kind: 'loaded',
+        record: {
+          authority: 'assets-only',
+          refinedFrom: version,
+          path: '/tmp/project',
+          facets: record([['keep', { version: '1.0.0', assets: [] }]]),
+        },
+        invalidEntries: [],
+      },
+    })
+
+    if (result.kind !== 'not-applicable') expect.unreachable()
+    if (result.reason.code !== 'configuration-unwitnessed') expect.unreachable()
+    expect(result.reason.refinedFrom).toBe(version)
   })
 })

--- a/packages/engine/src/install/add/index.ts
+++ b/packages/engine/src/install/add/index.ts
@@ -1,5 +1,7 @@
 import type { Adapter } from '@agent-facets/adapter'
+import type { AssetTakeoverResolver } from '../asset-takeover.ts'
 import type { CollisionResolver } from '../commit/compose.ts'
+import type { McpConsentPolicy } from '../mcp/consent.ts'
 import { runInstall } from '../run-install.ts'
 import type { OnLog, RunInstallResult, StageEvent } from '../types.ts'
 import { type AddPrepareFailure, type AddSource, type PrepareAddResult, prepareAdd } from './prepare.ts'
@@ -33,6 +35,18 @@ export interface RunAddOptions {
    * most needed.
    */
   resolveCollisions?: CollisionResolver
+  /**
+   * How this invocation may obtain MCP configuration approval, forwarded to
+   * `runInstall`. Present on all three front doors because all three enter
+   * the same commit pipeline and reconcile the same remaining facets.
+   */
+  mcpConsent?: McpConsentPolicy
+  /**
+   * Just-in-time gate for an occupied asset destination this machine does not
+   * own, forwarded to `runInstall`. Absence continues, preserving existing
+   * non-interactive behavior.
+   */
+  resolveAssetTakeover?: AssetTakeoverResolver
 }
 
 /**
@@ -80,6 +94,8 @@ export async function runAdd(opts: RunAddOptions): Promise<RunAddResult> {
     ...(onLog ? { onLog } : {}),
     ...(signal ? { signal } : {}),
     ...(opts.resolveCollisions ? { resolveCollisions: opts.resolveCollisions } : {}),
+    ...(opts.mcpConsent ? { mcpConsent: opts.mcpConsent } : {}),
+    ...(opts.resolveAssetTakeover ? { resolveAssetTakeover: opts.resolveAssetTakeover } : {}),
   })
 
   if (!install.ok) {

--- a/packages/engine/src/install/asset-takeover.ts
+++ b/packages/engine/src/install/asset-takeover.ts
@@ -1,0 +1,52 @@
+import type { AssetIdentity } from './types.ts'
+
+/**
+ * The just-in-time asset takeover gate.
+ *
+ * Desired project state authorizes reconciling an effective identity even
+ * when something is already sitting there — but "something is already sitting
+ * there and this machine did not put it there" is worth saying out loud
+ * before it is adopted or replaced.
+ *
+ * Just-in-time, and deliberately so: the question is asked from the
+ * previous-state read that no-op detection and rollback already require, at
+ * the moment that identity is reached. Nothing else is inspected. A file at a
+ * destination the desired set never names is not looked at, let alone
+ * mentioned — searching for takeovers would turn a targeted operation into a
+ * survey of the user's project.
+ *
+ * Entirely separate from MCP configuration consent. Approving a server's
+ * command says nothing about overwriting a hand-written skill, and the type
+ * system keeps them apart: no MCP value is in scope where this gate runs.
+ */
+
+/** One occupied, untracked destination the desired set names. */
+export interface AssetTakeoverRequest {
+  /** The facet whose desired asset reached this destination. */
+  facet: string
+  /** The adapter whose storage is occupied — the file lives in ITS tree. */
+  adapter: string
+  /** The EFFECTIVE identity being taken over. */
+  asset: AssetIdentity
+  /** The authored name, so an alias reads as "authored → effective". */
+  authoredName: string
+  /**
+   * What is already there, relative to the desired state.
+   *
+   * Never "absent": an empty destination is a creation, not a takeover, and
+   * the gate is not reached for one. `equivalent` is adopted with no write at
+   * all; `divergent` is overwritten.
+   */
+  occupancy: 'equivalent' | 'divergent'
+}
+
+/**
+ * The answer.
+ *
+ * Two arms only. "Continue by default" is expressed by the ABSENCE of a
+ * resolver rather than a third arm, so a non-interactive run has nothing to
+ * answer and "asked but undecided" is not representable.
+ */
+export type AssetTakeoverDecision = { kind: 'continue' } | { kind: 'cancelled' }
+
+export type AssetTakeoverResolver = (request: AssetTakeoverRequest) => Promise<AssetTakeoverDecision>

--- a/packages/engine/src/install/commit/install-loop.ts
+++ b/packages/engine/src/install/commit/install-loop.ts
@@ -1,5 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import type { CurrentLockfileFacet, MaterializedAsset } from '@agent-facets/protocol'
+import type { AssetTakeoverResolver } from '../asset-takeover.ts'
 import { classifyOutcome } from '../classify-outcome.ts'
 import type { InstallJournal } from '../journal.ts'
 import { materialize } from '../materialize.ts'
@@ -32,6 +33,11 @@ export interface InstallLoopArgs {
   previousOwnership: ReadonlyMap<string, PreviousOwnership>
   adapters: ReadonlyArray<Adapter>
   journal: InstallJournal
+  /**
+   * Interactive gate for an occupied destination this machine does not own.
+   * Forwarded verbatim; absence means continue.
+   */
+  resolveAssetTakeover?: AssetTakeoverResolver
   signal?: AbortSignal
   onStage: (event: StageEvent) => void
   onLog: OnLog
@@ -50,7 +56,7 @@ export interface InstallLoopArgs {
  * only reports; it never unwinds.
  */
 export async function installFacets(args: InstallLoopArgs): Promise<InstallLoopResult> {
-  const { resolved, plan, previousOwnership, adapters, journal, signal, onStage, onLog } = args
+  const { resolved, plan, previousOwnership, adapters, journal, resolveAssetTakeover, signal, onStage, onLog } = args
 
   // Entries come from Compose, which is where dispositions were decided.
   // Apply reports what it wrote; it does not re-derive what should be locked.
@@ -88,6 +94,7 @@ export async function installFacets(args: InstallLoopArgs): Promise<InstallLoopR
       previousOwnership,
       companionBytes: record.companionBytes,
       journal,
+      ...(resolveAssetTakeover ? { resolveAssetTakeover } : {}),
       onLog,
       onStage,
     })

--- a/packages/engine/src/install/commit/ownership.ts
+++ b/packages/engine/src/install/commit/ownership.ts
@@ -176,5 +176,22 @@ export function ownedCompanionPathsFor(
   previous: ReadonlyMap<string, PreviousOwnership>,
   asset: MaterializedAsset,
 ): readonly string[] {
-  return previous.get(asset.adapterKey)?.ownedCompanionPaths ?? []
+  return ownershipFor(previous, asset)?.ownedCompanionPaths ?? []
+}
+
+/**
+ * This machine's record for a desired asset's effective identity, or
+ * `undefined` when it has none.
+ *
+ * The tracked/untracked distinction has to come from here rather than from
+ * {@link ownedCompanionPathsFor}, which collapses "no record" and "a record
+ * with no companions" into the same empty array — and the second is every
+ * agent, every command, and every companion-less skill this machine already
+ * owns. A takeover gate keyed on that emptiness would prompt for all of them.
+ */
+export function ownershipFor(
+  previous: ReadonlyMap<string, PreviousOwnership>,
+  asset: MaterializedAsset,
+): PreviousOwnership | undefined {
+  return previous.get(asset.adapterKey)
 }

--- a/packages/engine/src/install/commit/server-ownership.ts
+++ b/packages/engine/src/install/commit/server-ownership.ts
@@ -107,7 +107,11 @@ export function buildPreviousMcpOwnership(state: ProjectReceiptState): Map<strin
  */
 export function obsoleteMcpOwnership(
   previous: ReadonlyMap<string, PreviousMcpOwnership>,
-  desired: readonly PlannedServerConfiguration[],
+  // Only the key is read, and only the key can be: the removal path proves
+  // what remains from carried receipt claims, which carry no declaration
+  // because no fetch happened. Demanding a `PlannedServerConfiguration` there
+  // would force it to invent one.
+  desired: readonly { readonly key: string }[],
 ): PreviousMcpOwnership[] {
   const claimed = new Set(desired.map((configuration) => configuration.key))
   const obsolete: PreviousMcpOwnership[] = []

--- a/packages/engine/src/install/commit/tri-write.ts
+++ b/packages/engine/src/install/commit/tri-write.ts
@@ -1,8 +1,8 @@
-import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { CurrentLockfile, CurrentLockfileFacet } from '@agent-facets/protocol'
 import { applyDesiredFacets, type ManifestDocument, type NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { writeProjectManifest } from '../../manifest/project-files.ts'
+import { capturePreimage, describeError, type FilePreimage, restorePreimage } from '../file-preimage.ts'
 import { FACETS_LOCK_FILE, writeLockfile } from '../lockfile-io.ts'
 import { ownEntry, ownRecord } from '../own-entry.ts'
 import {
@@ -205,7 +205,12 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
       args.onLog?.(() => `[verbose]   wrote ${write.file} (${write.path})`)
     } catch (error) {
       for (const image of preImages) {
-        restorePreImage(image)
+        // Best-effort: this restore runs on a disk that just failed a write,
+        // so it may fail too. The structured failure below still reports the
+        // commit as failed and the caller still replays the journal, and a
+        // partially-restored file is no worse than the mid-trio state the
+        // restore is repairing.
+        restorePreimage(image)
       }
       return {
         ok: false,
@@ -221,21 +226,12 @@ export function commitProjectFiles(args: TriWriteArgs): TriWriteResult {
 }
 
 /**
- * Byte pre-image of a project file. `bytes: null` records absence —
- * restoring an absent pre-image deletes the file.
- */
-interface FilePreImage {
-  path: string
-  bytes: Buffer | null
-}
-
-/**
  * Everything the trio needs that can fail before its first write: the
  * receipt's location, and a pre-image of each of the three files.
  */
 function prepareTriWrite(
   projectRoot: string,
-): { ok: true; receiptFile: string; preImages: FilePreImage[] } | { ok: false; failure: RunInstallFailure } {
+): { ok: true; receiptFile: string; preImages: FilePreimage[] } | { ok: false; failure: RunInstallFailure } {
   let receiptFile: string
   try {
     receiptFile = receiptPath(projectRoot)
@@ -250,60 +246,13 @@ function prepareTriWrite(
     }
   }
 
-  const preImages: FilePreImage[] = []
+  const preImages: FilePreimage[] = []
   for (const path of [join(projectRoot, 'facets.json'), join(projectRoot, FACETS_LOCK_FILE), receiptFile]) {
-    const captured = capturePreImage(path)
+    const captured = capturePreimage(path)
     if (!captured.ok) {
       return { ok: false, failure: { code: 'LOCKFILE_WRITE_FAILED', path, cause: captured.cause } }
     }
-    preImages.push(captured.image)
+    preImages.push(captured.preimage)
   }
   return { ok: true, receiptFile, preImages }
-}
-
-/**
- * Read a file's current bytes, or record that it does not exist.
- *
- * Only the "not there" errno family means absence. Every other read failure —
- * EACCES, EIO, a path that turned into a directory — is reported, because
- * treating it as absence would arm a restore that DELETES a file this run
- * could not read, turning an unreadable manifest into a lost one.
- */
-function capturePreImage(path: string): { ok: true; image: FilePreImage } | { ok: false; cause: string } {
-  try {
-    return { ok: true, image: { path, bytes: readFileSync(path) } }
-  } catch (error) {
-    if (isMissingFile(error)) return { ok: true, image: { path, bytes: null } }
-    return { ok: false, cause: `could not read the current contents: ${describeError(error)}` }
-  }
-}
-
-/** ENOENT/ENOTDIR — the "file is not there" errno family. */
-function isMissingFile(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null || !('code' in error)) return false
-  const code = (error as NodeJS.ErrnoException).code
-  return code === 'ENOENT' || code === 'ENOTDIR'
-}
-
-function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
-}
-
-/**
- * Best-effort restore. The restore runs on a disk that just failed a
- * write, so it may fail too; swallowing here is deliberate — the
- * journal rollback and the structured failure still report the commit
- * as failed, and a partially-restored file is no worse than the
- * mid-trio state the restore is repairing.
- */
-function restorePreImage(image: FilePreImage): void {
-  try {
-    if (image.bytes === null) {
-      rmSync(image.path, { force: true })
-    } else {
-      writeFileSync(image.path, image.bytes)
-    }
-  } catch {
-    // Best-effort by design (see doc comment).
-  }
 }

--- a/packages/engine/src/install/file-preimage.ts
+++ b/packages/engine/src/install/file-preimage.ts
@@ -1,0 +1,79 @@
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+
+/**
+ * Byte preimages: the engine's own record of what a file looked like before
+ * it touched it.
+ *
+ * Used wherever a rollback has to put bytes back exactly — the project-file
+ * trio, and every native configuration document an adapter discloses. It is
+ * one module rather than one copy per call site because the rule that makes
+ * it safe is subtle and asymmetric: getting "the file is absent" wrong in one
+ * direction loses a file, and in the other leaves one behind.
+ *
+ * Deliberately not in `@agent-facets/common`: only the engine rolls back.
+ * Adapters supply no inverse operations at all.
+ */
+
+/**
+ * A file's prior state.
+ *
+ * Tagged rather than `bytes: Buffer | null`, because `null` is doing real
+ * work here — it means "restore by deleting" — and a nullable field invites a
+ * caller to reach for `.bytes` and write `null` into a file.
+ */
+export type FilePreimage = { kind: 'absent'; path: string } | { kind: 'present'; path: string; bytes: Buffer }
+
+export type CapturePreimageResult = { ok: true; preimage: FilePreimage } | { ok: false; cause: string }
+
+export type RestorePreimageResult = { ok: true } | { ok: false; cause: string }
+
+/**
+ * Read a file's current bytes, or record that it does not exist.
+ *
+ * Only the "not there" errno family counts as absence. Every other read
+ * failure — EACCES, EIO, a path that turned into a directory — is reported,
+ * because treating it as absence would arm a restore that DELETES a file this
+ * run could not read, turning an unreadable document into a lost one.
+ */
+export function capturePreimage(path: string): CapturePreimageResult {
+  try {
+    return { ok: true, preimage: { kind: 'present', path, bytes: readFileSync(path) } }
+  } catch (error) {
+    if (isMissingFile(error)) return { ok: true, preimage: { kind: 'absent', path } }
+    return { ok: false, cause: `could not read the current contents: ${describeError(error)}` }
+  }
+}
+
+/**
+ * Put a file back exactly as it was, or report why it could not be.
+ *
+ * Returns rather than throws so each caller can choose: the tri-write's
+ * restore is best-effort (it runs on a disk that just failed a write, and a
+ * structured failure already reports the commit as failed), while a journal
+ * inverse must convert a failure into a throw — the journal counts an undo as
+ * failed only when it throws, so a swallowed restore would be reported as a
+ * clean rollback while a document stayed changed.
+ */
+export function restorePreimage(preimage: FilePreimage): RestorePreimageResult {
+  try {
+    if (preimage.kind === 'absent') {
+      rmSync(preimage.path, { force: true })
+    } else {
+      writeFileSync(preimage.path, preimage.bytes)
+    }
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, cause: describeError(error) }
+  }
+}
+
+/** ENOENT/ENOTDIR — the "file is not there" errno family. */
+export function isMissingFile(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+export function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/engine/src/install/frozen-gates.ts
+++ b/packages/engine/src/install/frozen-gates.ts
@@ -7,10 +7,10 @@ import {
   type SupportedLockfileVersion,
   sameDisposition,
 } from '@agent-facets/protocol'
-import { countOverrides, type NormalizedFacetEntry } from '../manifest/mutations.ts'
+import { countAssetOverrides, type NormalizedFacetEntry } from '../manifest/mutations.ts'
 import { detectLockfileDrift } from './detect-lockfile-drift.ts'
 import { ownEntry } from './own-entry.ts'
-import type { LockfileDriftEntry, RunInstallFailure } from './types.ts'
+import type { LockfileDriftEntry, RunInstallFailure, StaleMaterializationOverride } from './types.ts'
 
 /**
  * The frozen-lockfile consistency gate.
@@ -62,7 +62,11 @@ export function checkFrozenConsistency(args: FrozenGateArgs): RunInstallFailure 
   if (lockfileVersion !== LOCKFILE_VERSION_0_3) {
     const unrepresentable: LockfileDriftEntry[] = []
     for (const [name, entry] of Object.entries(facets)) {
-      if (countOverrides(entry.overrides) === 0) continue
+      // Asset groups only: this gate asks whether the lockfile VERSION can
+      // record what the entry declares, and no lockfile version records a
+      // server disposition. Counting one here reported an unrepresentable
+      // materialization whose "fix" — migrate to `0.3` — would change nothing.
+      if (countAssetOverrides(entry.overrides) === 0) continue
       unrepresentable.push({
         name,
         reason: 'materialization-unrepresentable',
@@ -147,4 +151,36 @@ export function checkFrozenConsistency(args: FrozenGateArgs): RunInstallFailure 
   }
 
   return null
+}
+
+/**
+ * The frozen server-intent gate, run after resolution.
+ *
+ * It cannot join {@link checkFrozenConsistency}: that gate answers from the
+ * manifest and lockfile alone, and a server declaration lives inside the
+ * integrity-pinned `facet.json`. Whether an override still names something
+ * the facet declares is simply unanswerable before the archive is fetched and
+ * verified — the price of keeping declarations out of a shared lockfile.
+ *
+ * What it must preserve is the ordering: this runs before the journal opens
+ * and before any cleanup, so a frozen run that is going to refuse has not
+ * deleted anything first. A normal install prunes a stale override inside its
+ * transaction; frozen mode has no transaction to prune in, so it reports.
+ */
+export function checkFrozenServerIntent(
+  staleOverrides: readonly StaleMaterializationOverride[],
+): RunInstallFailure | null {
+  const drift: LockfileDriftEntry[] = staleOverrides
+    // Asset staleness is already reported by the pre-fetch gate above, from
+    // the locked set. Reporting it again here would double-count it.
+    .filter((stale) => stale.contribution.kind === 'mcp-server')
+    .map((stale) => ({
+      name: stale.facet,
+      reason: 'stale-override' as const,
+      contribution: stale.contribution,
+      authoredName: stale.authoredName,
+    }))
+
+  if (drift.length === 0) return null
+  return { code: 'LOCKFILE_DRIFT', facets: drift }
 }

--- a/packages/engine/src/install/materialize-failure.ts
+++ b/packages/engine/src/install/materialize-failure.ts
@@ -31,6 +31,13 @@ export function materializeFailureToRunInstall(facet: string, failure: Materiali
         asset: failure.asset,
         cause: failure.cause,
       }
+    case 'takeover-cancelled':
+      return {
+        code: 'ASSET_TAKEOVER_CANCELLED',
+        facet,
+        adapter: failure.adapter,
+        asset: failure.asset,
+      }
     case 'delete-failed':
       return {
         code: 'ADAPTER_DELETE_FAILED',

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -9,7 +9,8 @@ import type {
 import { type Scope, splitFrontMatter } from '@agent-facets/common'
 import { type MaterializedAsset, type ResolvedFacetManifest, skillRootPath } from '@agent-facets/protocol'
 import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
-import { ownedCompanionPathsFor, type PreviousOwnership } from './commit/ownership.ts'
+import type { AssetTakeoverResolver } from './asset-takeover.ts'
+import { ownedCompanionPathsFor, ownershipFor, type PreviousOwnership } from './commit/ownership.ts'
 import type { InstallJournal } from './journal.ts'
 import { type AssetIdentity, assetIdentity, type OnLog, type StageEvent } from './types.ts'
 import { authoredCompanionKey, type SkillCompanionBytes } from './verified-asset-plan.ts'
@@ -42,6 +43,16 @@ export interface MaterializeOptions {
    */
   companionBytes?: Map<string, SkillCompanionBytes>
   journal: InstallJournal
+  /**
+   * Interactive gate for an occupied destination this machine does not own.
+   *
+   * Absent means continue — the opposite default from the collision
+   * resolver, and deliberately so: a collision has no correct answer without
+   * the user, while a takeover has one that preserves existing behavior.
+   * Frozen mode and non-interactive callers therefore reconcile exactly as
+   * they always have, by never being handed one.
+   */
+  resolveAssetTakeover?: AssetTakeoverResolver
   onLog?: OnLog
   /** Structured progress events for view layers. */
   onStage?: (event: StageEvent) => void
@@ -87,6 +98,13 @@ export type MaterializeFailure =
   | { kind: 'read-failed'; adapter: string; asset: AssetIdentity; cause: string }
   | { kind: 'install-failed'; adapter: string; asset: AssetIdentity; cause: string }
   | { kind: 'delete-failed'; adapter: string; asset: AssetIdentity; cause: string }
+  /**
+   * The user declined to take over an occupied, untracked destination.
+   * Unlike a collision cancellation this lands mid-journal, so the caller
+   * replays it — the rollback outcome is half of what the user needs to be
+   * told.
+   */
+  | { kind: 'takeover-cancelled'; adapter: string; asset: AssetIdentity }
 
 /**
  * Result of one `materialize` call. Errors are values, not control
@@ -193,12 +211,37 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
       // Skip only when the primary AND every companion already match on disk.
       // A single drifted companion (or a changed companion set) forces a
       // repair through the atomic bundle replacement below.
-      if (
-        previous &&
+      const identical =
+        previous !== null &&
         previous.content === candidateSplit.content &&
         JSON.stringify(previous.metadata ?? {}) === JSON.stringify(mergedCandidateMetadata) &&
         companionsIdentical(previous.companions, companions)
-      ) {
+
+      // The just-in-time takeover gate. Reached only when something is
+      // already at this destination AND this machine's receipt does not own
+      // it — an owned identity reconciles without a warning, and an empty one
+      // is a creation. Both facts are already in hand from the read above and
+      // the ownership index, so nothing extra is inspected.
+      //
+      // Placed before the skip because an equivalent untracked destination is
+      // still being adopted: the bytes do not change, but this machine is
+      // about to start claiming a file someone else put there.
+      if (previous !== null && ownershipFor(opts.previousOwnership, asset) === undefined) {
+        const decision = opts.resolveAssetTakeover
+          ? await opts.resolveAssetTakeover({
+              facet: opts.facetName,
+              adapter: adapter.name,
+              asset: target,
+              authoredName: asset.authoredName,
+              occupancy: identical ? 'equivalent' : 'divergent',
+            })
+          : { kind: 'continue' as const }
+        if (decision.kind === 'cancelled') {
+          return { ok: false, failure: { kind: 'takeover-cancelled', adapter: adapter.name, asset: target } }
+        }
+      }
+
+      if (identical) {
         opts.onLog?.(() => `[verbose]     =${describeTarget(asset)} (skipped)`)
         skipped++
         continue

--- a/packages/engine/src/install/mcp/apply.ts
+++ b/packages/engine/src/install/mcp/apply.ts
@@ -1,0 +1,104 @@
+import { capturePreimage, type FilePreimage, restorePreimage } from '../file-preimage.ts'
+import type { InstallJournal } from '../journal.ts'
+import type { OnLog, RunInstallFailure } from '../types.ts'
+import { insideProject, type PreparedMcpAdapter } from './prepare.ts'
+
+/**
+ * Apply prepared MCP plans, with a byte-exact undo for every document
+ * actually changed.
+ *
+ * Runs after every asset write and immediately before the tri-write. That
+ * ordering is deliberate: a tool watching its own configuration should see a
+ * server appear as late as possible in an operation that might still fail,
+ * and the assets a server's tooling might reference are already on disk by
+ * the time it does.
+ *
+ * Adapters supply no inverse operations. Rollback fidelity is the engine's:
+ * it captures each disclosed document's exact prior bytes before the write
+ * and journals a restore, so putting a JSONC file back does not depend on an
+ * adapter reproducing comments it never saw.
+ */
+
+export interface ApplyMcpArgs {
+  prepared: readonly PreparedMcpAdapter[]
+  projectRoot: string
+  journal: InstallJournal
+  signal?: AbortSignal | undefined
+  onLog: OnLog
+}
+
+export type ApplyMcpResult = { ok: true } | { ok: false; failure: RunInstallFailure }
+
+export async function applyMcpServers(args: ApplyMcpArgs): Promise<ApplyMcpResult> {
+  const { prepared, projectRoot, journal, signal, onLog } = args
+
+  for (const { adapter, capability, preparation } of prepared) {
+    // Checked per adapter, mirroring the per-facet checkpoint in the write
+    // pass: an interrupt during a three-adapter apply must not write all
+    // three before anyone notices.
+    if (signal?.aborted) return { ok: false, failure: { code: 'ABORTED' } }
+
+    // Capture every DISCLOSED document, not just the ones that will change:
+    // which ones change is only known after `apply` returns, and a preimage
+    // read afterwards would record the post-write bytes.
+    //
+    // Deliberately not deduplicated across adapters. If two adapters disclose
+    // one path, the second capture holds the first adapter's written bytes,
+    // and LIFO replay walks back through them to the original — which is the
+    // correct final state, arrived at without the engine having to model
+    // shared documents.
+    const preimages = new Map<string, FilePreimage>()
+    for (const path of preparation.documentPaths) {
+      if (preimages.has(path)) continue
+      const captured = capturePreimage(path)
+      if (!captured.ok) {
+        // Refuse to let the adapter write. A document this run cannot read is
+        // one it cannot put back, and an unrestorable write is worse than a
+        // failed operation.
+        return { ok: false, failure: { code: 'MCP_DOCUMENT_UNREADABLE', adapter, path, cause: captured.cause } }
+      }
+      preimages.set(path, captured.preimage)
+    }
+
+    const applied = await capability.apply({ plan: preparation.plan })
+    if (!applied.ok) {
+      return { ok: false, failure: { code: 'MCP_APPLY_FAILED', adapter, failure: applied.failure } }
+    }
+    if (applied.status === 'unchanged') {
+      onLog(() => `[verbose] ${adapter}: MCP configuration already matched; nothing written`)
+      continue
+    }
+
+    for (const path of applied.changedPaths) {
+      const preimage = preimages.get(path)
+      if (preimage === undefined || !insideProject(projectRoot, path)) {
+        // The adapter wrote somewhere it never disclosed, so no preimage
+        // exists for it. Reported rather than journaled: the caller rolls
+        // back everything that IS restorable, and the failure names the one
+        // thing that is not.
+        return {
+          ok: false,
+          failure: {
+            code: 'MCP_CONTRACT_VIOLATION',
+            violation: { kind: 'undisclosed-changed-path', adapter, path },
+          },
+        }
+      }
+      journal.record({
+        label: `mcp ${adapter}:${path}`,
+        undo: async () => {
+          const restored = restorePreimage(preimage)
+          if (!restored.ok) {
+            // Must throw: the journal counts an undo as failed only when it
+            // throws, so returning here would report a clean rollback while a
+            // tool's configuration stayed changed.
+            throw new Error(`failed to restore ${path}: ${restored.cause}`)
+          }
+        },
+      })
+      onLog(() => `[verbose] ${adapter}: wrote MCP configuration (${path})`)
+    }
+  }
+
+  return { ok: true }
+}

--- a/packages/engine/src/install/mcp/consent.ts
+++ b/packages/engine/src/install/mcp/consent.ts
@@ -1,0 +1,224 @@
+import type { McpServerPreparationOutcome } from '@agent-facets/adapter'
+import {
+  compareCodeUnits,
+  type McpServerDeclaration,
+  type McpServerFingerprint,
+  type McpServerIdentity,
+  type PlannedServerConfiguration,
+  type ServerClaimant,
+} from '@agent-facets/protocol'
+import { isDeclarationApproved, type PreviousMcpOwnership } from '../commit/server-ownership.ts'
+import type { PreparedMcpAdapter } from './prepare.ts'
+
+/**
+ * MCP configuration consent: what a user is being asked to authorize, and how
+ * this invocation is allowed to obtain that authorization.
+ *
+ * The thing being authorized is execution. A declaration names a command this
+ * machine will hand to a tool to run, or an endpoint it will connect to, so
+ * the decision cannot be derived from a fingerprint, inherited from a
+ * teammate's commit, or implied by having installed a facet. It is answered
+ * per machine, recorded only in the machine-local receipt, and only by a
+ * successful commit.
+ */
+
+/** Why a declaration needs approval now. */
+export type McpApprovalStanding =
+  /** Nothing on this machine has ever owned this effective identity. */
+  | { kind: 'unknown-identity' }
+  /**
+   * This identity is owned, but under a different declaration.
+   *
+   * Tagged rather than carrying the previous declaration: the receipt stores
+   * fingerprints only, so what it changed *from* is genuinely unavailable. A
+   * field for it would be permanently empty or permanently a guess.
+   */
+  | { kind: 'declaration-changed' }
+
+/** One effective declaration this machine has not approved. */
+export interface McpDeclarationApproval {
+  identity: McpServerIdentity
+  fingerprint: McpServerFingerprint
+  /**
+   * The exact declaration. This is the consent payload — a user cannot
+   * authorize a command from a hash — and one of only two places a
+   * declaration is allowed to travel outward.
+   */
+  declaration: McpServerDeclaration
+  /** Every facet claiming this identity, in the planner's order. */
+  claimants: readonly ServerClaimant[]
+  standing: McpApprovalStanding
+}
+
+/** One untracked native entry an approved plan would adopt or replace. */
+export interface McpNativeTakeover {
+  adapter: string
+  identity: McpServerIdentity
+  /**
+   * What the adapter proved about the entry already there. Two literals
+   * rather than a boolean: `equivalent` means it is adopted with no write at
+   * all, `divergent` means it is overwritten — different things to tell a
+   * user, and a boolean would read the same for a field added later.
+   */
+  existing: 'equivalent' | 'divergent'
+  /** The declaration that would be adopted or written at this identity. */
+  declaration: McpServerDeclaration
+}
+
+/**
+ * The single MCP-configuration-only request.
+ *
+ * Never empty. That is refined at the boundary rather than encoded in the
+ * type: "at least one across two lists" is not expressible without a third
+ * tag, and {@link deriveMcpConsent} is the only constructor — it answers
+ * `satisfied` instead of handing back an empty request.
+ *
+ * It carries only MCP declarations and MCP native takeovers. Asset collision
+ * resolution and asset takeover are separate decisions with separate screens,
+ * and approving execution must never be the act that also accepts overwriting
+ * someone's hand-written file.
+ */
+export interface McpConsentRequest {
+  declarations: readonly McpDeclarationApproval[]
+  takeovers: readonly McpNativeTakeover[]
+}
+
+export type McpConsentRequirement = { kind: 'satisfied' } | { kind: 'required'; request: McpConsentRequest }
+
+/**
+ * The answer. Payload-free on purpose: approval accepts the complete
+ * displayed set, so a partial answer is not a thing a user can give and not a
+ * thing this type should be able to represent.
+ */
+export type McpConsentDecision = { kind: 'approved' } | { kind: 'declined' }
+
+export type McpConsentResolver = (request: McpConsentRequest) => Promise<McpConsentDecision>
+
+/**
+ * How this invocation may obtain approval.
+ *
+ * One tagged field rather than an `acceptMcp` boolean beside an optional
+ * resolver, which would make four combinations representable for three real
+ * states and leave "flag set AND resolver supplied" to a comment. It also
+ * keeps frozen mode expressible without a special case: frozen resolves to
+ * `preapproved` when the flag was supplied and `unavailable` otherwise, and
+ * never reaches the arm that can prompt.
+ */
+export type McpConsentPolicy =
+  /** `--accept-mcp`. Never prompts; the only arm frozen mode may use. */
+  | { kind: 'preapproved' }
+  /** An interactive, non-frozen caller. */
+  | { kind: 'interactive'; resolve: McpConsentResolver }
+  /** Non-interactive with no opt-in: fail before mutation with the full list. */
+  | { kind: 'unavailable' }
+
+/**
+ * What a policy produced for a request.
+ *
+ * `unavailable` is a third arm here but not on {@link McpConsentDecision}:
+ * "this caller had no way to answer" is a property of the invocation, not an
+ * answer a user gave, and the two lead to different failures — one tells you
+ * to pass a flag, the other tells you nothing was approved.
+ */
+export type McpConsentSettlement = McpConsentDecision | { kind: 'unavailable' }
+
+/** Obtain approval under a policy. Prompts only on the `interactive` arm. */
+export async function settleMcpConsent(
+  policy: McpConsentPolicy,
+  request: McpConsentRequest,
+): Promise<McpConsentSettlement> {
+  switch (policy.kind) {
+    case 'preapproved':
+      return { kind: 'approved' }
+    case 'unavailable':
+      return { kind: 'unavailable' }
+    case 'interactive':
+      return await policy.resolve(request)
+  }
+}
+
+export interface DeriveMcpConsentArgs {
+  /** The active effective configurations this run would reconcile. */
+  configurations: readonly PlannedServerConfiguration[]
+  /** Approval evidence from the receipt. Empty for a pre-`0.4` receipt. */
+  previousOwnership: ReadonlyMap<string, PreviousMcpOwnership>
+  /** Every adapter's read-only preparation, which is where occupancy is known. */
+  prepared: readonly PreparedMcpAdapter[]
+}
+
+/**
+ * Compute what still needs approving.
+ *
+ * Two independent questions, deliberately not collapsed: whether this machine
+ * has approved a declaration (asked of the receipt) and whether a native
+ * entry it does not own is already sitting at that name (asked of the
+ * adapter's preparation). A declaration can be approved while its destination
+ * is occupied by something else, and an unapproved declaration can be landing
+ * somewhere empty.
+ */
+export function deriveMcpConsent(args: DeriveMcpConsentArgs): McpConsentRequirement {
+  const declarations: McpDeclarationApproval[] = []
+  for (const configuration of args.configurations) {
+    if (isDeclarationApproved(args.previousOwnership, configuration)) continue
+    declarations.push({
+      identity: configuration.identity,
+      fingerprint: configuration.fingerprint,
+      declaration: configuration.declaration,
+      claimants: configuration.claimants,
+      standing: args.previousOwnership.has(configuration.key)
+        ? { kind: 'declaration-changed' }
+        : { kind: 'unknown-identity' },
+    })
+  }
+  declarations.sort((a, b) => compareCodeUnits(a.identity.effectiveName, b.identity.effectiveName))
+
+  const byName = new Map(args.configurations.map((c) => [c.identity.effectiveName, c]))
+  const takeovers: McpNativeTakeover[] = []
+  for (const { adapter, preparation } of args.prepared) {
+    for (const outcome of preparation.outcomes) {
+      const existing = untrackedOccupancy(outcome)
+      if (existing === null) continue
+      const configuration = byName.get(outcome.name)
+      // An outcome naming something the desired set does not contain would be
+      // an adapter reporting on an entry it was never asked about. Skipping
+      // is the conservative reading: nothing is disclosed, so nothing is
+      // authorized, and the entry is left alone.
+      if (configuration === undefined) continue
+      takeovers.push({
+        adapter,
+        identity: configuration.identity,
+        existing,
+        declaration: configuration.declaration,
+      })
+    }
+  }
+  takeovers.sort(
+    (a, b) =>
+      compareCodeUnits(a.adapter, b.adapter) || compareCodeUnits(a.identity.effectiveName, b.identity.effectiveName),
+  )
+
+  if (declarations.length === 0 && takeovers.length === 0) return { kind: 'satisfied' }
+  return { kind: 'required', request: { declarations, takeovers } }
+}
+
+/**
+ * Whether one outcome describes an untracked entry that is actually there.
+ *
+ * An exhaustive switch rather than a filter: `absent` and `untracked` is a
+ * pure addition with nothing to take over, and that is exactly the
+ * distinction a predicate would be free to get wrong. A new outcome kind
+ * fails to compile here, which is the point.
+ */
+function untrackedOccupancy(outcome: McpServerPreparationOutcome): 'equivalent' | 'divergent' | null {
+  switch (outcome.kind) {
+    case 'absent':
+      return null
+    case 'equivalent':
+      return outcome.ownership === 'untracked' ? 'equivalent' : null
+    case 'divergent':
+      return outcome.ownership === 'untracked' ? 'divergent' : null
+    case 'obsolete-owned':
+      // Owned by definition — removing it needs no new approval.
+      return null
+  }
+}

--- a/packages/engine/src/install/mcp/prepare.ts
+++ b/packages/engine/src/install/mcp/prepare.ts
@@ -1,0 +1,162 @@
+import { isAbsolute, relative, resolve } from 'node:path'
+import type { Adapter, McpServerCapability, McpServerContribution, McpServerPreparation } from '@agent-facets/adapter'
+import { compareCodeUnits, type PlannedServerConfiguration } from '@agent-facets/protocol'
+import { classifyMcpSupport } from '../../adapters/mcp-support.ts'
+import type { PreviousMcpOwnership } from '../commit/server-ownership.ts'
+import type { OnLog, RunInstallFailure } from '../types.ts'
+
+/**
+ * Read-only MCP preparation: ask every selected adapter what it *would*
+ * change, before anything is prompted for or written.
+ *
+ * This is the step that makes consent honest. The adapter parses its native
+ * document once and reports occupancy and equality, so the engine can show a
+ * user exactly what an approval authorizes — and can discover an untracked
+ * entry it is about to adopt — without a second scan and without having
+ * mutated anything it might have to undo.
+ */
+
+/**
+ * An engine-observable breach of the MCP capability contract.
+ *
+ * Kept separate from {@link McpServerCapabilityFailure}: those describe the
+ * adapter's world failing (unparseable document, unwritable file) and are
+ * expected. These describe the adapter itself misbehaving in a way that would
+ * make rollback unsound — a document outside the project, or a write to a
+ * path whose preimage was never disclosed. Reporting the second as the first
+ * would tell a user to fix their config file when the bug is in an adapter.
+ */
+export type McpContractViolation =
+  /** A disclosed document path escapes the project tree. */
+  | { kind: 'document-outside-project'; adapter: string; path: string }
+  /** `apply` changed a path `prepare` never disclosed, so no preimage exists. */
+  | { kind: 'undisclosed-changed-path'; adapter: string; path: string }
+
+/** One adapter's prepared plan, held opaquely until the apply step. */
+export interface PreparedMcpAdapter {
+  adapter: string
+  capability: McpServerCapability
+  /**
+   * The adapter's own plan and disclosures. `plan` is deliberately `unknown`:
+   * the engine stores it and hands it back, and cannot read it.
+   */
+  preparation: McpServerPreparation<unknown>
+}
+
+export type PrepareMcpResult =
+  | { ok: true; prepared: readonly PreparedMcpAdapter[] }
+  | { ok: false; failure: RunInstallFailure }
+
+export interface PrepareMcpArgs {
+  projectRoot: string
+  /** Every selected adapter, in selection order. */
+  adapters: readonly Adapter[]
+  /** The active effective configurations this run wants reconciled. */
+  configurations: readonly PlannedServerConfiguration[]
+  /**
+   * Receipt-owned identities nothing desires any more.
+   *
+   * Passed separately from {@link configurations} because it is half of the
+   * answer to "is there MCP work at all?": a project whose desired state
+   * declares no server still has work to do if this machine owns an entry
+   * that must now be removed.
+   */
+  obsolete: readonly PreviousMcpOwnership[]
+  /**
+   * The complete set of effective names the receipt authorizes an adapter to
+   * remove. Derived from the receipt alone — never the lockfile, which would
+   * let a teammate's commit authorize deleting an entry this machine never
+   * wrote.
+   */
+  previouslyOwnedNames: readonly string[]
+  onLog: OnLog
+}
+
+/**
+ * Verify support and prepare every adapter, or fail before any mutation.
+ *
+ * Returns an empty set — invoking no capability method at all — when the
+ * project has neither an active declaration nor an owned identity to remove.
+ * That is what keeps an asset-only adapter usable for a text-only project:
+ * support is only required for work that actually exists.
+ */
+export async function prepareMcpServers(args: PrepareMcpArgs): Promise<PrepareMcpResult> {
+  const { projectRoot, adapters, configurations, obsolete, previouslyOwnedNames, onLog } = args
+
+  // No declarations and nothing owned to remove: this project has no MCP
+  // state, so no adapter is asked about it and none needs to support it.
+  if (configurations.length === 0 && obsolete.length === 0) {
+    return { ok: true, prepared: [] }
+  }
+
+  const support = classifyMcpSupport(adapters)
+  if (!support.ok) {
+    return {
+      ok: false,
+      failure: {
+        code: 'MCP_ADAPTERS_UNSUPPORTED',
+        adapters: support.unsupported,
+        servers: involvedServerNames(configurations, obsolete),
+      },
+    }
+  }
+
+  const desired: McpServerContribution[] = configurations.map((configuration) => ({
+    name: configuration.identity.effectiveName,
+    declaration: configuration.declaration,
+  }))
+
+  const prepared: PreparedMcpAdapter[] = []
+  for (const { adapter, capability } of support.capable) {
+    const result = await capability.prepare({ projectRoot, desired, previouslyOwnedNames })
+    if (!result.ok) {
+      return { ok: false, failure: { code: 'MCP_PREPARE_FAILED', adapter, failure: result.failure } }
+    }
+
+    // Every disclosed path is a document this run may later restore by
+    // writing bytes to it. One that escapes the project turns a rollback into
+    // an arbitrary write, so it is refused here — while nothing has been
+    // prepared for application and nothing has been mutated.
+    for (const path of result.preparation.documentPaths) {
+      if (insideProject(projectRoot, path)) continue
+      return {
+        ok: false,
+        failure: {
+          code: 'MCP_CONTRACT_VIOLATION',
+          violation: { kind: 'document-outside-project', adapter, path },
+        },
+      }
+    }
+
+    onLog(
+      () =>
+        `[verbose] ${adapter}: prepared ${result.preparation.outcomes.length} MCP outcome(s) across ${result.preparation.documentPaths.length} document(s)`,
+    )
+    prepared.push({ adapter, capability, preparation: result.preparation })
+  }
+
+  return { ok: true, prepared }
+}
+
+/**
+ * Every effective server name this operation involves, for the
+ * unsupported-adapter report.
+ *
+ * Names only: the remedy is to upgrade an adapter or omit a declaration, and
+ * neither needs the command a server would run.
+ */
+function involvedServerNames(
+  configurations: readonly PlannedServerConfiguration[],
+  obsolete: readonly PreviousMcpOwnership[],
+): string[] {
+  const names = new Set<string>()
+  for (const configuration of configurations) names.add(configuration.identity.effectiveName)
+  for (const ownership of obsolete) names.add(ownership.effectiveName)
+  return [...names].sort(compareCodeUnits)
+}
+
+/** Whether an absolute path resolves to somewhere strictly inside the project. */
+export function insideProject(projectRoot: string, path: string): boolean {
+  const rel = relative(resolve(projectRoot), resolve(path))
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+}

--- a/packages/engine/src/install/remove/index.ts
+++ b/packages/engine/src/install/remove/index.ts
@@ -1,5 +1,7 @@
 import type { Adapter } from '@agent-facets/adapter'
+import type { AssetTakeoverResolver } from '../asset-takeover.ts'
 import type { CollisionResolver } from '../commit/compose.ts'
+import type { McpConsentPolicy } from '../mcp/consent.ts'
 import { runInstall } from '../run-install.ts'
 import type { OnLog, Removal, RunInstallResult, StageEvent } from '../types.ts'
 import { prepareRemove, type RemovePrepareFailure, type RemovePrepareResult } from './prepare.ts'
@@ -33,6 +35,19 @@ export interface RunRemoveOptions {
    * dead-ending the user in a command that can only report.
    */
   resolveCollisions?: CollisionResolver
+  /**
+   * How this invocation may obtain MCP configuration approval, forwarded to
+   * `runInstall`. A removal that falls back to ordinary resolution
+   * reconciles every remaining facet, which can include configuration this
+   * machine has not approved.
+   */
+  mcpConsent?: McpConsentPolicy
+  /**
+   * Just-in-time gate for an occupied asset destination this machine does not
+   * own, forwarded to `runInstall`. Absence continues, preserving existing
+   * non-interactive behavior.
+   */
+  resolveAssetTakeover?: AssetTakeoverResolver
 }
 
 /**
@@ -83,6 +98,8 @@ export async function runRemove(opts: RunRemoveOptions): Promise<RunRemoveResult
     ...(onLog ? { onLog } : {}),
     ...(signal ? { signal } : {}),
     ...(opts.resolveCollisions ? { resolveCollisions: opts.resolveCollisions } : {}),
+    ...(opts.mcpConsent ? { mcpConsent: opts.mcpConsent } : {}),
+    ...(opts.resolveAssetTakeover ? { resolveAssetTakeover: opts.resolveAssetTakeover } : {}),
   })
 
   if (!install.ok) {

--- a/packages/engine/src/install/remove/refine.ts
+++ b/packages/engine/src/install/remove/refine.ts
@@ -4,6 +4,9 @@ import type {
   FacetContribution,
   FacetMaterializationOverrides,
   MaterializedAsset,
+  McpServerIdentity,
+  ProjectAssetOverride,
+  ServerClaimant,
   SupportedLockfile,
   SupportedLockfileFacet,
 } from '@agent-facets/protocol'
@@ -11,11 +14,19 @@ import {
   collisionKey,
   compareCodeUnits,
   lockedDispositionOf,
+  materializedNameOf,
+  mcpServerKey,
   planMaterialization,
+  SERVER_OVERRIDE_GROUP,
   sameDisposition,
 } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
 import { buildPreviousOwnership, type PreviousOwnership } from '../commit/ownership.ts'
+import {
+  buildPreviousMcpOwnership,
+  obsoleteMcpOwnership,
+  type PreviousMcpOwnership,
+} from '../commit/server-ownership.ts'
 import { detectLockfileDrift } from '../detect-lockfile-drift.ts'
 import { ownEntry, ownRecord } from '../own-entry.ts'
 import {
@@ -144,6 +155,43 @@ export type RefineNotApplicable =
    * record. Honoring it means writing assets, which removal does not do.
    */
   | { code: 'remaining-intent-unrecorded'; facet: string; assetType: AssetType; authoredName: string }
+  /**
+   * A remaining facet's server intent disagrees with what this machine
+   * recorded configuring. Honoring it means renaming or removing a native
+   * entry, which is a write — so it belongs on the ordinary path.
+   */
+  | { code: 'remaining-server-intent-unrecorded'; facet: string; authoredName: string }
+  /**
+   * A remaining facet declares a server alias the receipt has no claim for.
+   * Whether that is stale intent (the facet no longer declares the server) or
+   * an alias never reconciled is only answerable from the facet's manifest,
+   * which this path does not fetch.
+   */
+  | { code: 'remaining-server-intent-unwitnessed'; facet: string; authoredName: string }
+  /**
+   * The receipt recorded more than one declaration at an effective server
+   * identity a remaining claimant keeps. The native entry belongs to whichever
+   * claim was written last, and this path has no way to write the remaining
+   * one over it.
+   */
+  | { code: 'retained-server-identity-contested'; effectiveName: string; remaining: readonly string[] }
+
+/**
+ * An effective MCP identity this removal keeps, proven from local state.
+ *
+ * Deliberately NOT a `PlannedServerConfiguration`: that type carries the
+ * declaration, and only a fetch can supply one. Reusing it here would force
+ * this path to invent a declaration or cast one into existence, turning
+ * "offline removal never reads a manifest" from a fact the types enforce into
+ * a convention a future edit could break.
+ */
+export interface RetainedServerConfiguration {
+  identity: McpServerIdentity
+  /** The addressable ownership key for {@link identity}. */
+  key: string
+  /** Every remaining facet that still claims it. */
+  claimants: readonly ServerClaimant[]
+}
 
 /** Everything the commit needs, derived without a single fetch. */
 export interface RefinedRemoval {
@@ -167,6 +215,21 @@ export interface RefinedRemoval {
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>
   /** Remaining overrides naming contributions the locked content no longer has. */
   staleOverrides: readonly StaleMaterializationOverride[]
+  /**
+   * What this machine had configured before the removal. Returned for the
+   * same reason `previousOwnership` is: the gates were checked against this
+   * index, and rebuilding it in the caller could only differ by disagreeing
+   * with a decision already made.
+   */
+  previousMcpOwnership: ReadonlyMap<string, PreviousMcpOwnership>
+  /** The effective server identities remaining claims still cover. */
+  retainedConfigurations: readonly RetainedServerConfiguration[]
+  /**
+   * The receipt-owned server identities this removal is authorized to delete
+   * — computed here, from the same two proven values, so the caller cannot
+   * widen it into something the gates never checked.
+   */
+  obsoleteConfigurations: readonly PreviousMcpOwnership[]
   /** Remaining facets, reported as untouched. */
   outcomes: readonly FacetOutcome[]
 }
@@ -305,6 +368,14 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
         reason: { code: 'remaining-receipt-disagrees', facet: name, disagreement: witnessed.disagreement },
       }
     }
+    // Server intent must already BE the recorded intent, for the same reason
+    // asset intent must: renaming or withdrawing a native entry is a write,
+    // and this path performs none. Checked against the receipt CLAIM rather
+    // than the lockfile, because the lockfile records no server at any
+    // version — the claim is the only local witness there is.
+    const serverIntent = witnessServerIntent(name, ownEntry(desiredFacets, name)?.overrides, witnessed.entry)
+    if (serverIntent !== null) return { kind: 'not-applicable', reason: serverIntent }
+
     receiptFacets[name] = witnessed.entry
 
     facetEntries[name] = {
@@ -324,6 +395,17 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
     outcomes.push({ kind: 'unchanged', name, version: entry.version })
   }
 
+  // The configuration half of the same proof. Retained identities come from
+  // the carried claims — the only offline evidence of what is configured —
+  // and everything the receipt owns that no retained claim covers is what may
+  // be deleted. Both are derived here so the delete pass diffs exactly what
+  // the gates above accepted.
+  const previousMcpOwnership = buildPreviousMcpOwnership(receiptState)
+  const retainedConfigurations = retainedServerConfigurations(receiptFacets)
+  const contestedServer = contestedRetainedServer(previousMcpOwnership, retainedConfigurations)
+  if (contestedServer !== null) return { kind: 'not-applicable', reason: contestedServer }
+  const obsoleteConfigurations = obsoleteMcpOwnership(previousMcpOwnership, retainedConfigurations)
+
   return {
     kind: 'refined',
     refinement: {
@@ -331,6 +413,9 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
       materialized: planned.plan.materialized,
       previousOwnership,
       receiptFacets,
+      previousMcpOwnership,
+      retainedConfigurations,
+      obsoleteConfigurations,
       overrides,
       staleOverrides: planned.staleOverrides.map((stale) => ({
         facet: stale.facet,
@@ -341,6 +426,107 @@ export function refineRemoval(args: RefineRemovalArgs): RefineRemovalResult {
       outcomes,
     },
   }
+}
+
+/**
+ * Check one remaining facet's declared server intent against the claims this
+ * machine recorded for it.
+ *
+ * Both directions matter. An override the receipt cannot account for might be
+ * stale intent or an alias that was never reconciled, and telling those apart
+ * needs the facet's manifest. A claim the manifest no longer asks for means
+ * the user changed their mind about a name that is currently on disk. Neither
+ * is answerable — or actionable — without writing, so both take the ordinary
+ * path.
+ */
+function witnessServerIntent(
+  facet: string,
+  overrides: FacetMaterializationOverrides | undefined,
+  recorded: ReceiptFacetEntry,
+): RefineNotApplicable | null {
+  const declared = overrides?.[SERVER_OVERRIDE_GROUP] ?? {}
+  const claims = new Map(recorded.configurations.map((claim) => [claim.name, claim]))
+
+  for (const claim of recorded.configurations) {
+    const override = ownEntry(declared, claim.name)
+    if (override === undefined) {
+      // No override means authored materialization; a claim recorded under an
+      // alias therefore disagrees with what the manifest now asks for.
+      if (claim.materialization.kind === 'authored') continue
+      return { code: 'remaining-server-intent-unrecorded', facet, authoredName: claim.name }
+    }
+    if (override.kind === 'omitted' || !sameDisposition(claim.materialization, override)) {
+      return { code: 'remaining-server-intent-unrecorded', facet, authoredName: claim.name }
+    }
+  }
+
+  for (const authoredName of Object.keys(declared).sort(compareCodeUnits)) {
+    const override = ownEntry(declared, authoredName) as ProjectAssetOverride | undefined
+    // An omission with no claim is consistent: an omitted server is never
+    // recorded, so its absence is exactly what the manifest asks for.
+    if (override === undefined || override.kind === 'omitted') continue
+    if (claims.has(authoredName)) continue
+    return { code: 'remaining-server-intent-unwitnessed', facet, authoredName }
+  }
+
+  return null
+}
+
+/**
+ * Fold the carried claims of every remaining facet into effective identities.
+ *
+ * This is the desired set for a removal: derived from what the receipt
+ * witnesses, never from a declaration this run did not read.
+ */
+function retainedServerConfigurations(
+  receiptFacets: Readonly<Record<string, ReceiptFacetEntry>>,
+): RetainedServerConfiguration[] {
+  const byKey = new Map<string, { identity: McpServerIdentity; key: string; claimants: ServerClaimant[] }>()
+  for (const facet of Object.keys(receiptFacets).sort(compareCodeUnits)) {
+    const entry = ownEntry(receiptFacets, facet)
+    if (entry === undefined) continue
+    for (const claim of entry.configurations) {
+      const effectiveName = materializedNameOf(claim.name, claim.materialization)
+      const key = mcpServerKey(effectiveName)
+      const existing = byKey.get(key)
+      const claimant: ServerClaimant = {
+        facet,
+        authoredName: claim.name,
+        disposition: claim.materialization,
+      }
+      if (existing === undefined) {
+        byKey.set(key, { identity: { kind: 'mcp-server', effectiveName }, key, claimants: [claimant] })
+        continue
+      }
+      existing.claimants.push(claimant)
+    }
+  }
+  return [...byKey.values()].sort((a, b) => compareCodeUnits(a.key, b.key))
+}
+
+/**
+ * A retained effective server identity the receipt recorded disagreeing
+ * declarations at, or `null` when every retained identity was recorded once.
+ *
+ * Identical declarations compose — that is the whole reason two facets may
+ * claim one server name — so several claimants are not a problem. Several
+ * FINGERPRINTS are: the native entry says whatever the last claim written
+ * said, and this path cannot write the remaining one over it.
+ */
+function contestedRetainedServer(
+  previous: ReadonlyMap<string, PreviousMcpOwnership>,
+  retained: readonly RetainedServerConfiguration[],
+): RefineNotApplicable | null {
+  for (const configuration of retained) {
+    const ownership = previous.get(configuration.key)
+    if (ownership === undefined || ownership.fingerprints.length <= 1) continue
+    return {
+      code: 'retained-server-identity-contested',
+      effectiveName: configuration.identity.effectiveName,
+      remaining: configuration.claimants.map((claimant) => claimant.facet),
+    }
+  }
+  return null
 }
 
 /**

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -11,14 +11,22 @@ import { finalizeMaterializationIntent } from './commit/finalize-intent.ts'
 import { installFacets } from './commit/install-loop.ts'
 import { buildPreviousOwnership, obsoleteOwnership } from './commit/ownership.ts'
 import { resolveAll } from './commit/resolve-all.ts'
-import { claimsByFacet } from './commit/server-ownership.ts'
+import {
+  buildPreviousMcpOwnership,
+  claimsByFacet,
+  obsoleteMcpOwnership,
+  previouslyOwnedServerNames,
+} from './commit/server-ownership.ts'
 import { buildUpdatedReceipt, commitProjectFiles, type LockedSetCommit } from './commit/tri-write.ts'
-import { checkFrozenConsistency } from './frozen-gates.ts'
+import { checkFrozenConsistency, checkFrozenServerIntent } from './frozen-gates.ts'
 import { InstallJournal } from './journal.ts'
 import { acquireInstallLock } from './lockfile-guard.ts'
 import { FACETS_LOCK_FILE, loadLockfile } from './lockfile-io.ts'
 import { deleteObsoleteAssets, type RetainedObsoleteBundle } from './materialize.ts'
 import { materializeFailureToRunInstall } from './materialize-failure.ts'
+import { applyMcpServers } from './mcp/apply.ts'
+import { deriveMcpConsent, type McpConsentPolicy, settleMcpConsent } from './mcp/consent.ts'
+import { prepareMcpServers } from './mcp/prepare.ts'
 import { ownEntry } from './own-entry.ts'
 import { receiptProjectPath, resolveProjectReceipt } from './receipt.ts'
 import { refineRemoval } from './remove/refine.ts'
@@ -43,11 +51,14 @@ import type { InstallDelta, RunInstallFailure, RunInstallOptions, RunInstallResu
  * `result.failure`; rollback status via `result.rollback`.
  */
 export async function runInstall(opts: RunInstallOptions): Promise<RunInstallResult> {
-  const { projectRoot, adapters, signal, resolveCollisions } = opts
+  const { projectRoot, adapters, signal, resolveCollisions, resolveAssetTakeover } = opts
   const delta: InstallDelta = opts.delta ?? { additions: [], removals: [] }
   const onStage = opts.onStage ?? noopStage
   const onLog = opts.onLog ?? noopLog
   const frozenLockfile = opts.frozenLockfile === true
+  // Absent means "this caller cannot answer", which is what makes failing
+  // with the complete request the default rather than a special case.
+  const mcpConsent: McpConsentPolicy = opts.mcpConsent ?? { kind: 'unavailable' }
 
   // 1. Acquire the install lock BEFORE reading anything a commit is derived
   //    from. Reading first left a window in which a concurrent operation
@@ -272,6 +283,27 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         return failureNoMutation({ code: 'ABORTED' })
       }
 
+      // Configuration cleanup is prepared here, on the no-mutation path, for
+      // the same reason the resolve path prepares before its journal opens.
+      //
+      // The request is deliberately asymmetric: nothing is desired, and the
+      // owned set is narrowed to exactly the identities this removal is
+      // authorized to delete. A retained identity therefore appears in
+      // neither list, which is how an adapter is told to leave it alone. No
+      // consent is asked for either — removal withdraws authorization, it
+      // never grants it.
+      const refinedMcp = await prepareMcpServers({
+        projectRoot,
+        adapters,
+        configurations: [],
+        obsolete: refined.obsoleteConfigurations,
+        previouslyOwnedNames: refined.obsoleteConfigurations.map((ownership) => ownership.effectiveName),
+        onLog,
+      })
+      if (!refinedMcp.ok) {
+        return failureNoMutation(refinedMcp.failure)
+      }
+
       // The steps below mirror the resolve path's Apply and commit, minus the
       // write pass: nothing is materialized, because refinement has confirmed
       // every remaining asset is already on disk under the identity it keeps.
@@ -296,6 +328,19 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       if (!deletion.ok) {
         const failure = materializeFailureToRunInstall(deletion.facets[0] ?? '', deletion.failure)
         return await rollbackAndFail(journal, failure, onLog)
+      }
+
+      // Remove the obsolete native entries, journaled with their exact prior
+      // bytes like every other configuration write.
+      const refinedApplied = await applyMcpServers({
+        prepared: refinedMcp.prepared,
+        projectRoot,
+        journal,
+        signal,
+        onLog,
+      })
+      if (!refinedApplied.ok) {
+        return await rollbackAndFail(journal, refinedApplied.failure, onLog)
       }
 
       // Second checkpoint: the deletes are done and the tri-write is next, so
@@ -387,10 +432,78 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     }
     const plan = composed.plan
 
-    // The MCP configurations this run reconciled into native tool state.
-    // Empty until the native apply step exists: the composed plan says what
-    // SHOULD be configured, and a receipt claim may only record what was.
-    const reconciledServerConfigurations: readonly PlannedServerConfiguration[] = []
+    // 7a0. Frozen server intent. Runs here rather than in the pre-fetch gate
+    //      because whether an override still names a declaration the facet
+    //      publishes is only knowable from the verified archive. Still ahead
+    //      of everything that mutates: a frozen run that refuses has not
+    //      deleted, written, or reconciled anything first.
+    if (frozenLockfile) {
+      const staleServerIntent = checkFrozenServerIntent(plan.staleOverrides)
+      if (staleServerIntent !== null) {
+        return failureNoMutation(staleServerIntent)
+      }
+    }
+
+    // 7a. The MCP configuration ownership index, built from the receipt
+    //     STATE. Needed here — before the journal — because both remaining
+    //     pre-mutation steps read it: preparation needs the exact set of
+    //     effective names an adapter is authorized to remove, and consent
+    //     needs the approval evidence recorded at each identity. A receipt
+    //     that predates configuration claims yields an empty index, which is
+    //     the safe answer in both directions: nothing is deletable, and every
+    //     declaration needs approval.
+    const previousMcpOwnership = buildPreviousMcpOwnership(receiptState)
+    const obsoleteConfigurations = obsoleteMcpOwnership(previousMcpOwnership, plan.mcpServers.configurations)
+
+    // 7b. Verify every selected adapter can do this project's MCP work, then
+    //     ask each to prepare its complete native change read-only. Both run
+    //     on the no-mutation path, before the journal and before any prompt:
+    //     an unsupported adapter must not consume an approval it cannot
+    //     honor, and a user cannot be asked to approve a change nothing has
+    //     computed yet.
+    const preparedMcp = await prepareMcpServers({
+      projectRoot,
+      adapters,
+      configurations: plan.mcpServers.configurations,
+      obsolete: obsoleteConfigurations,
+      previouslyOwnedNames: previouslyOwnedServerNames(previousMcpOwnership),
+      onLog,
+    })
+    if (!preparedMcp.ok) {
+      return failureNoMutation(preparedMcp.failure)
+    }
+
+    // 7c. MCP configuration consent. Approval authorizes execution — a
+    //     command this machine will hand a tool to run, or an endpoint it
+    //     will connect to — so it is asked per machine, from the receipt's
+    //     own approval evidence, and never inherited from a teammate's
+    //     commit. Still before the journal: declining costs nothing to undo.
+    const consent = deriveMcpConsent({
+      configurations: plan.mcpServers.configurations,
+      previousOwnership: previousMcpOwnership,
+      prepared: preparedMcp.prepared,
+    })
+    if (consent.kind === 'required') {
+      // Frozen mode reproduces recorded intent and must never collect a new
+      // decision, not even from a human at a terminal. The CLI already
+      // withholds the resolver; this is the defense-in-depth half, mirroring
+      // the collision resolver's own frozen guard.
+      const policy: McpConsentPolicy =
+        frozenLockfile && mcpConsent.kind === 'interactive' ? { kind: 'unavailable' } : mcpConsent
+      const settled = await settleMcpConsent(policy, consent.request)
+      if (settled.kind === 'unavailable') {
+        return failureNoMutation({ code: 'MCP_CONSENT_REQUIRED', request: consent.request })
+      }
+      // An abort arriving while the screen was open settles it as declined;
+      // the signal is the honest account of what happened, so it is read
+      // first rather than adding a third decision arm for the same fact.
+      if (signal?.aborted) {
+        return failureNoMutation({ code: 'ABORTED' })
+      }
+      if (settled.kind === 'declined') {
+        return failureNoMutation({ code: 'MCP_CONSENT_DECLINED' })
+      }
+    }
 
     // 7. The first mutation is now imminent, so the rollback ledger opens
     //    here. Every entry it accumulates corresponds to a write that
@@ -447,6 +560,11 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       previousOwnership,
       adapters,
       journal,
+      // Frozen mode reproduces recorded intent and never collects a new
+      // decision, so the gate is withheld and reconciliation continues
+      // exactly as it did before — the same rule the collision resolver and
+      // MCP consent follow.
+      ...(resolveAssetTakeover && !frozenLockfile ? { resolveAssetTakeover } : {}),
       signal,
       onStage,
       onLog,
@@ -456,6 +574,32 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     }
     const { newFacetEntries, perFacet, totalAssets } = loop.value
     perFacet.push(...removedOutcomes)
+
+    // 10. Apply every prepared native MCP plan, last of the mutations and
+    //     immediately before the transaction commits. Each changed document
+    //     is journaled with its exact prior bytes, so a tri-write failure or
+    //     an abort arriving now walks configuration and assets back together
+    //     in one LIFO replay.
+    const appliedMcp = await applyMcpServers({
+      prepared: preparedMcp.prepared,
+      projectRoot,
+      journal,
+      signal,
+      onLog,
+    })
+    if (!appliedMcp.ok) {
+      return await rollbackAndFail(journal, appliedMcp.failure, onLog)
+    }
+
+    // What this run actually reconciled. Every active configuration was —
+    // each adapter either wrote it or proved the native state already matched
+    // — and approval for all of them was obtained above, which is what makes
+    // a claim assert two true things rather than one.
+    //
+    // Zero capable adapters with a non-empty desired set is not that: nothing
+    // reconciled it, so nothing may claim it.
+    const reconciledServerConfigurations: readonly PlannedServerConfiguration[] =
+      preparedMcp.prepared.length > 0 ? plan.mcpServers.configurations : []
 
     if (signal?.aborted) {
       return await rollbackAndFail(journal, { code: 'ABORTED' }, onLog)
@@ -484,11 +628,9 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
             facets: newFacetEntries,
           }),
         }
-    // The claims this run reconciled. Nothing in this pipeline applies native
-    // MCP configuration yet, so it reconciled none — and a claim asserts BOTH
-    // that an identity was reconciled and that its declaration was approved
-    // here, so recording one from the composed plan alone would assert two
-    // things that have not happened.
+    // A claim asserts BOTH that an identity was reconciled and that its
+    // declaration was approved here, which is why it is derived from what the
+    // apply step did rather than from the composed plan.
     const newReceipt = buildUpdatedReceipt(receiptPath, {
       kind: 'written',
       facetEntries: newFacetEntries,

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -1,4 +1,4 @@
-import type { Adapter } from '@agent-facets/adapter'
+import type { Adapter, McpServerCapabilityFailure } from '@agent-facets/adapter'
 import type { AssetType, Scope, ValidationError } from '@agent-facets/common'
 import type {
   CollisionGroup,
@@ -9,10 +9,14 @@ import type {
   SupportedLockfile,
 } from '@agent-facets/protocol'
 import type { AdapterCompatibilityFailure } from '../adapters/api-compatibility.ts'
+import type { McpUnsupportedAdapter } from '../adapters/mcp-support.ts'
 import type { UnsupportedManifestVersion } from '../manifest/project-files.ts'
 import type { RegistryError } from '../registry/index.ts'
 import type { ParseError, Source } from '../sources/facet/types.ts'
+import type { AssetTakeoverResolver } from './asset-takeover.ts'
 import type { CollisionResolver } from './commit/compose.ts'
+import type { McpConsentPolicy, McpConsentRequest } from './mcp/consent.ts'
+import type { McpContractViolation } from './mcp/prepare.ts'
 
 /**
  * Which kind of contribution a materialization override names.
@@ -524,6 +528,78 @@ export type RunInstallFailure =
     }
   /** The user dismissed collision resolution. No state was mutated. */
   | { code: 'MATERIALIZATION_CANCELLED' }
+  /**
+   * The user declined to take over an occupied destination this machine does
+   * not own.
+   *
+   * Distinct from `MATERIALIZATION_CANCELLED`, which settles before the
+   * journal opens and has nothing to undo. This one lands mid-application, so
+   * the rollback outcome is the load-bearing half of the report: whether the
+   * work already done was fully restored.
+   */
+  | { code: 'ASSET_TAKEOVER_CANCELLED'; facet: string; adapter: string; asset: AssetIdentity }
+  /**
+   * This operation has MCP configuration work — an active declaration to
+   * reconcile, or a receipt-owned entry to remove — and at least one selected
+   * adapter cannot do it.
+   *
+   * Raised after composition (which is what makes the active set knowable)
+   * and before preparation, consent, or any mutation. Carries every
+   * unsupported adapter, because upgrading one at a time to discover the next
+   * teaches a user nothing about the shape of the problem, and the effective
+   * server names so the remedy can point at the declarations to omit. It
+   * deliberately carries no declaration: neither remedy needs the command a
+   * server would run.
+   */
+  | {
+      code: 'MCP_ADAPTERS_UNSUPPORTED'
+      adapters: ReadonlyArray<McpUnsupportedAdapter>
+      servers: ReadonlyArray<string>
+    }
+  /**
+   * An adapter's read-only MCP preparation reported a structured failure —
+   * an unparseable or unsafely-shaped native document, or a read it could not
+   * perform. Preparation writes nothing, so every inspected document is
+   * unchanged.
+   */
+  | { code: 'MCP_PREPARE_FAILED'; adapter: string; failure: McpServerCapabilityFailure }
+  /**
+   * An adapter's MCP application reported a structured failure. Its own
+   * documents are unchanged (the capability is atomic per document); every
+   * earlier document this run changed is restored from its byte preimage.
+   */
+  | { code: 'MCP_APPLY_FAILED'; adapter: string; failure: McpServerCapabilityFailure }
+  /**
+   * A disclosed configuration document could not be read for its byte
+   * preimage, so the write was refused rather than performed without an undo.
+   * Distinct from a read failure inside preparation: the adapter did nothing
+   * wrong, and the document is one the engine — not the adapter — was reading.
+   */
+  | { code: 'MCP_DOCUMENT_UNREADABLE'; adapter: string; path: string; cause: string }
+  /**
+   * An adapter broke the MCP capability contract in a way that would make
+   * rollback unsound. Distinct from `MCP_PREPARE_FAILED`: the fault is in the
+   * adapter, not in the project's configuration, and no user edit fixes it.
+   */
+  | { code: 'MCP_CONTRACT_VIOLATION'; violation: McpContractViolation }
+  /**
+   * MCP configuration needs approval and this caller cannot give it: a
+   * non-interactive command without `--accept-mcp`, or frozen mode, which
+   * reproduces recorded intent and never collects a new decision.
+   *
+   * Carries the complete request because the remedy is to read it: a user
+   * deciding whether to pass `--accept-mcp` needs the exact commands and URLs
+   * it would authorize. Raised before the journal opens, so nothing changed.
+   */
+  | { code: 'MCP_CONSENT_REQUIRED'; request: McpConsentRequest }
+  /**
+   * The user declined the MCP configuration request.
+   *
+   * Payload-free, unlike `MCP_CONSENT_REQUIRED`: re-printing declarations the
+   * user just refused would push them onto a persistent surface for no
+   * benefit. Nothing was mutated — consent settles before the journal opens.
+   */
+  | { code: 'MCP_CONSENT_DECLINED' }
   | { code: 'ABORTED' }
 
 /**
@@ -663,4 +739,26 @@ export interface RunInstallOptions {
    * new decisions.
    */
   resolveCollisions?: CollisionResolver
+  /**
+   * How this invocation may obtain MCP configuration approval.
+   *
+   * Defaults to `unavailable`, which makes "fail with the complete request"
+   * the default rather than a special case — the same discipline that makes
+   * an omitted `resolveCollisions` report instead of guess. Frozen mode may
+   * use `preapproved` but never `interactive`.
+   */
+  mcpConsent?: McpConsentPolicy
+  /**
+   * Optional just-in-time gate for an occupied asset destination this machine
+   * does not own.
+   *
+   * Note the deliberate asymmetry with `resolveCollisions`: an absent
+   * collision resolver FAILS, because a collision has no correct answer
+   * without the user. An absent takeover resolver CONTINUES, because a
+   * takeover does — the behavior every non-interactive caller has today.
+   *
+   * Independent of `mcpConsent` by construction. Approving a server's command
+   * must never be the act that also accepts overwriting a file.
+   */
+  resolveAssetTakeover?: AssetTakeoverResolver
 }

--- a/packages/engine/src/manifest/mutations.ts
+++ b/packages/engine/src/manifest/mutations.ts
@@ -5,10 +5,12 @@ import {
   facetEntrySource,
   type LEGACY_PROJECT_MANIFEST_VERSION,
   MATERIALIZATION_OVERRIDE_GROUPS,
+  type MaterializationOverrideGroup,
   type PROJECT_MANIFEST_VERSION_0_1,
   type ProjectAssetOverride,
   type ProjectManifestParseFailure,
   parseProjectManifestDocument,
+  SERVER_OVERRIDE_GROUP,
 } from '@agent-facets/protocol'
 import { parse as parseCommentJson, stringify as stringifyCommentJson } from 'comment-json'
 
@@ -246,8 +248,35 @@ export function emptyProjectManifest(): NormalizedProjectManifest {
 
 /** How many overrides an entry declares across every recognized group. */
 export function countOverrides(overrides: FacetMaterializationOverrides | undefined): number {
+  return countOverridesIn(overrides, MATERIALIZATION_OVERRIDE_GROUPS)
+}
+
+/**
+ * How many overrides an entry declares in its ASSET groups only.
+ *
+ * Separate from {@link countOverrides} because one caller — the frozen
+ * lockfile-format gate — is asking a narrower question: can this lockfile
+ * VERSION record the dispositions this entry declares? Servers are absent
+ * from the lockfile at every version by design, so a server alias is not
+ * something an older lockfile fails to express; counting it there reported a
+ * migration the user could not perform and that would not have helped.
+ */
+export function countAssetOverrides(overrides: FacetMaterializationOverrides | undefined): number {
+  return countOverridesIn(overrides, ASSET_OVERRIDE_GROUPS)
+}
+
+/**
+ * The asset half of the override groups, derived from the full list so a new
+ * asset type joins it automatically and a new non-asset group cannot.
+ */
+const ASSET_OVERRIDE_GROUPS = MATERIALIZATION_OVERRIDE_GROUPS.filter((group) => group !== SERVER_OVERRIDE_GROUP)
+
+function countOverridesIn(
+  overrides: FacetMaterializationOverrides | undefined,
+  groups: readonly MaterializationOverrideGroup[],
+): number {
   if (overrides === undefined) return 0
-  return MATERIALIZATION_OVERRIDE_GROUPS.reduce((total, group) => total + Object.keys(overrides[group] ?? {}).length, 0)
+  return groups.reduce((total, group) => total + Object.keys(overrides[group] ?? {}).length, 0)
 }
 
 /**


### PR DESCRIPTION
### Why

MCP server configuration requires user approval before any command or endpoint is handed to a tool to run. Without this, a facet could silently configure arbitrary execution on a machine that never consented to it. This implements the full consent, application, and rollback pipeline for MCP configuration across all three install entry points (`runInstall`, `runAdd`, `runRemove`).

### Details

**Ordering guarantees.** The pipeline is structured so that a run that will refuse has not mutated anything first. Support classification and read-only preparation happen before the journal opens, consent is settled before the first write, and application happens after all asset writes and immediately before the tri-write commit. A failure at any point rolls back exactly what that point had written.

**Consent is machine-local.** Approval is derived from the machine-local receipt's fingerprint evidence, never from a teammate's commit or the shared lockfile. A declaration that changed since it was last approved is re-presented. Frozen mode may use `--accept-mcp` but never opens an interactive prompt, mirroring the same rule the collision resolver follows.

**Rollback fidelity is the engine's responsibility.** Adapters supply no inverse operations. Before calling `apply`, the engine captures the exact prior bytes of every disclosed document. Each changed path is journaled with a restore that writes those bytes back, so putting a JSONC file back does not depend on an adapter reproducing comments it never saw. A document the engine cannot read before writing is refused rather than written without an undo.

**Contract enforcement.** Two adapter breaches are detected and refused: a disclosed document path that escapes the project tree (which would turn a rollback into an arbitrary write), and a path reported as changed by `apply` that `prepare` never disclosed (for which no preimage exists). Both are reported as `MCP_CONTRACT_VIOLATION` rather than as capability failures, because the fault is in the adapter, not in the project's configuration.

**Offline removal.** `refineRemoval` now carries configuration claims forward from the receipt, computes which effective server identities are retained by remaining claimants and which are obsolete, and checks that the manifest's declared intent matches what the receipt recorded — falling back to ordinary resolution when it does not. The delete pass then removes only the obsolete entries, journaled with their prior bytes.

**Asset takeover gate.** A separate just-in-time gate is introduced for occupied asset destinations this machine does not own. It is deliberately independent of MCP consent: approving a server's command must never be the act that also accepts overwriting a hand-written file. Absent a resolver, the gate continues — preserving existing non-interactive behavior. Frozen mode withholds the gate entirely.

**`filePreimage` extracted.** The byte-preimage helpers previously inlined in `tri-write.ts` are extracted to `file-preimage.ts` so the MCP apply step can use the same capture-and-restore logic without duplicating the subtle asymmetry around "absent" vs. unreadable.

**`countAssetOverrides` split from `countOverrides`.** The frozen lockfile-format gate asks whether the lockfile version can represent an entry's dispositions. Servers are absent from the lockfile at every version by design, so counting a server alias there reported a migration the user could not perform. The new function counts only asset override groups.

### Verification

A new test suite (`mcp-install.test.ts`) covers the properties under test, which are almost all ordering properties — what has and has not happened at the moment a run refuses. Failing cases assert disk state. The suite covers: adapter support preflight, consent (non-interactive failure, decline, approval, re-approval, changed declarations, machine-local scope, native takeover disclosure), application and rollback (byte-exact restore, creation-then-delete, preparation failure ordering, contract breach), frozen reproduction (no prompt, pre-supplied approval, stale server override, server-only overrides and lockfile format), offline removal (last claimant, shared claimant, pre-configuration receipt fallback), asset takeover (disclosure, cancellation and rollback, owned destination, equivalent adoption, non-interactive default, frozen suppression, independence from MCP approval), and interruption. Tasks 9 and 10 in the planning document are marked complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core install orchestration around consent, native config writes, journaling/rollback, and removal refinement—mistakes could mutate tool configs or delete servers incorrectly; scope is large with many failure paths.
> 
> **Overview**
> Wires **machine-local MCP configuration consent** into the install pipeline: after compose, adapters are classified and prepared read-only, unapproved declarations and untracked native occupancy are combined into one request, and nothing mutates until approval (or `--accept-mcp` / frozen preapproval). Native MCP plans run **after asset writes** and before the tri-write, with **byte-exact document preimages** journaled for rollback and **contract violations** when adapters disclose or change paths outside the agreed set.
> 
> Adds a **separate just-in-time asset takeover** gate at materialization (default continue; cancellation rolls back mid-journal work) and extends **offline removal** so receipt configuration claims drive retained vs obsolete server identities, with fallback when intent cannot be witnessed.
> 
> **CLI** gains shared `mcp-report` rendering, Ink failure blocks, and `install-failure` fix lines for the new failure codes. **`file-preimage`** is extracted from tri-write for shared restore logic; frozen lockfile checks use **`countAssetOverrides`** so server-only overrides do not trigger false “unrepresentable” drift.
> 
> Large **`mcp-install.test.ts`** (and related test updates) lock in ordering, consent locality, rollback, frozen behavior, removal, and takeover. OpenSpec tasks **9–10** are marked complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a9bab79931962e1a2de0a7200777eefd43f0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->