### PR TITLE
Replace flat `InstallSummary` and `serverWarnings` with structured `mcp` outcomes, dispositions, and configuration counts

### DIFF
--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -103,16 +103,16 @@
 
 ## 11. Engine outcomes and obsolete warning path — Research
 
-- [ ] 11.1 Explore: Map stage events, install failures, facet classification, summaries, stale-intent reporting, and every `server-warning`/`serverWarnings` producer and consumer.
-- [ ] 11.2 Propose: Define structured MCP outcomes and aggregate result shapes that distinguish intent updates, native drift repair, semantic no-op, takeover, unsupported adapters, and text-asset counts without carrying declaration secrets.
+- [x] 11.1 Explore: Map stage events, install failures, facet classification, summaries, stale-intent reporting, and every `server-warning`/`serverWarnings` producer and consumer.
+- [x] 11.2 Propose: Define structured MCP outcomes and aggregate result shapes that distinguish intent updates, native drift repair, semantic no-op, takeover, unsupported adapters, and text-asset counts without carrying declaration secrets.
 
 ## 12. Engine outcomes and obsolete warning path — Implementation
 
-- [ ] 12.1 Implement: Add typed MCP consent, configuration, collision, takeover, stale-intent, and unsupported-adapter events/failures/results, with exhaustive switches and pure-data failure contracts.
-- [ ] 12.2 Implement: Extend facet classification and summaries so declaration/alias/omission changes are updated, native drift is repaired, semantic matches are unchanged, and server-only facets report configuration work with zero assets.
-- [ ] 12.3 Implement: Remove `server-warning`, `serverWarnings`, `serversDeclared`, warn-and-skip plumbing, and associated success-path tests now that obsolete references fail validation.
-- [ ] 12.4 Implement: Add focused outcome, summary, failure aggregation, stale-intent, and secret-redaction tests.
-- [ ] 12.5 Verify: Run focused engine outcome tests and type checks.
+- [x] 12.1 Implement: Add typed MCP consent, configuration, collision, takeover, stale-intent, and unsupported-adapter events/failures/results, with exhaustive switches and pure-data failure contracts.
+- [x] 12.2 Implement: Extend facet classification and summaries so declaration/alias/omission changes are updated, native drift is repaired, semantic matches are unchanged, and server-only facets report configuration work with zero assets.
+- [x] 12.3 Implement: Remove `server-warning`, `serverWarnings`, `serversDeclared`, warn-and-skip plumbing, and associated success-path tests now that obsolete references fail validation.
+- [x] 12.4 Implement: Add focused outcome, summary, failure aggregation, stale-intent, and secret-redaction tests.
+- [x] 12.5 Verify: Run focused engine outcome tests and type checks.
 
 ## 13. Collision resolution UI — Research
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -3,6 +3,8 @@ import type {
   CollisionResolution,
   CollisionResolutionRequest,
   CollisionResolver,
+  InstallSummary,
+  McpInstallOutcomes,
   RollbackOutcome,
   RunInstallFailure,
   RunInstallResult,
@@ -21,6 +23,20 @@ import {
   UNSUPPORTED_MANIFEST_VERSION_WHAT,
 } from '../util/unsupported-manifest-version.ts'
 import { visibleContentFrame, visibleTerminalText } from './helpers/terminal-output.ts'
+
+/** An operation with no MCP work at all, which is every fixture below. */
+const NO_MCP: McpInstallOutcomes = {
+  consent: { kind: 'not-required' },
+  dispositions: [],
+  configurations: [],
+  prunedIntent: [],
+}
+
+const NO_MCP_COUNTS: InstallSummary['mcp'] = {
+  configurations: { added: 0, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+  declarations: { aliased: 0, omitted: 0 },
+  takeovers: { accepted: 0 },
+}
 
 /**
  * Wait long enough for the view's `useEffect` chain to finish (run the
@@ -48,14 +64,18 @@ function makeFakeRun(
   }
 }
 
-/** A no-op successful run, for tests whose subject is a warning event. */
+/** A no-op successful run, for tests whose subject is an event rather than a result. */
 function emptySuccess(): RunInstallResult {
   return {
     ok: true,
     lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
-    summary: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 0, totalAssets: 0, removedAssets: 0 },
+    summary: {
+      facets: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+      textAssets: { written: 0, removed: 0 },
+      mcp: NO_MCP_COUNTS,
+    },
     perFacet: [],
-    serverWarnings: [],
+    mcp: NO_MCP,
   }
 }
 
@@ -72,52 +92,40 @@ const successResultSingle: RunInstallResult = {
   ok: true,
   lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
   summary: {
-    installed: 1,
-    updated: 0,
-    repaired: 0,
-    unchanged: 0,
-    removed: 0,
-    totalAssets: 3,
-    removedAssets: 0,
+    facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+    textAssets: { written: 3, removed: 0 },
+    mcp: NO_MCP_COUNTS,
   },
   perFacet: [{ kind: 'installed', name: 'viper-plans', version: '1.2.3' }],
-  serverWarnings: [],
+  mcp: NO_MCP,
 }
 
 const successResultMulti: RunInstallResult = {
   ok: true,
   lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
   summary: {
-    installed: 2,
-    updated: 1,
-    repaired: 0,
-    unchanged: 0,
-    removed: 0,
-    totalAssets: 9,
-    removedAssets: 0,
+    facets: { installed: 2, updated: 1, repaired: 0, unchanged: 0, removed: 0 },
+    textAssets: { written: 9, removed: 0 },
+    mcp: NO_MCP_COUNTS,
   },
   perFacet: [
     { kind: 'installed', name: 'viper-plans', version: '1.2.3' },
     { kind: 'installed', name: 'rezi', version: '0.5.0' },
     { kind: 'updated', name: 'planner', oldVersion: '1.0.0', newVersion: '2.0.0' },
   ],
-  serverWarnings: [],
+  mcp: NO_MCP,
 }
 
 const successResultNoOp: RunInstallResult = {
   ok: true,
   lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
   summary: {
-    installed: 0,
-    updated: 0,
-    repaired: 0,
-    unchanged: 0,
-    removed: 0,
-    totalAssets: 0,
-    removedAssets: 0,
+    facets: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+    textAssets: { written: 0, removed: 0 },
+    mcp: NO_MCP_COUNTS,
   },
   perFacet: [],
-  serverWarnings: [],
+  mcp: NO_MCP,
 }
 
 describe('InstallView — single-facet success', () => {
@@ -186,42 +194,6 @@ describe('InstallView — multi-facet success with update', () => {
   })
 })
 
-describe('InstallView — server warnings', () => {
-  test('renders a warning line when servers are declared', async () => {
-    const events: StageEvent[] = [
-      { kind: 'install-start', totalFacets: 1 },
-      { kind: 'facet-start', facet: 'with-servers', specifier: './fixture' },
-      {
-        kind: 'server-warning',
-        facet: 'with-servers',
-        servers: ['inline-server', 'remote-server'],
-      },
-      {
-        kind: 'facet-success',
-        facet: 'with-servers',
-        outcome: { kind: 'installed', name: 'with-servers', version: '0.1.0' },
-      },
-      { kind: 'install-complete', outcome: 'success' },
-    ]
-    const instance = render(
-      createElement(InstallView, {
-        mode: 'add',
-        run: makeFakeRun(events, successResultSingle),
-      }),
-    )
-    await settle()
-    const frame = visibleContentFrame(instance.frames)
-    expect(frame).toContain('with-servers')
-    expect(frame).toContain('2 servers declared')
-    expect(frame).toContain('inline-server')
-    expect(frame).toContain('remote-server')
-    // Ink wraps the warning message across lines in the test terminal width,
-    // so we check for a substring that survives wrapping.
-    expect(frame).toContain('not yet')
-    instance.unmount()
-  })
-})
-
 describe('InstallView — drift removal', () => {
   test('renders a removal line when a facet is dropped from facets.json', async () => {
     const events: StageEvent[] = [
@@ -233,16 +205,12 @@ describe('InstallView — drift removal', () => {
       ok: true,
       lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
       summary: {
-        installed: 0,
-        updated: 0,
-        repaired: 0,
-        unchanged: 0,
-        removed: 1,
-        totalAssets: 0,
-        removedAssets: 2,
+        facets: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 1 },
+        textAssets: { written: 0, removed: 2 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [{ kind: 'removed', name: 'orphan', oldVersion: '1.0.0' }],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(
       createElement(InstallView, {
@@ -267,16 +235,12 @@ describe('InstallView — drift removal', () => {
       ok: true,
       lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
       summary: {
-        installed: 0,
-        updated: 0,
-        repaired: 0,
-        unchanged: 0,
-        removed: 1,
-        totalAssets: 0,
-        removedAssets: 0,
+        facets: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 1 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [{ kind: 'removed-untracked', name: 'orphan', oldVersion: '1.0.0' }],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(createElement(InstallView, { mode: 'remove', run: makeFakeRun(events, result) }))
     await settle()
@@ -302,16 +266,12 @@ describe('InstallView — drift removal', () => {
       ok: true,
       lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
       summary: {
-        installed: 0,
-        updated: 0,
-        repaired: 0,
-        unchanged: 0,
-        removed: 0,
-        totalAssets: 0,
-        removedAssets: 0,
+        facets: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(createElement(InstallView, { mode: 'install', run: makeFakeRun(events, result) }))
     await settle()
@@ -500,16 +460,12 @@ describe('InstallView — marketing aesthetic on `add`', () => {
         },
       },
       summary: {
-        installed: 1,
-        updated: 0,
-        repaired: 0,
-        unchanged: 0,
-        removed: 0,
-        totalAssets: 2,
-        removedAssets: 0,
+        facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 2, removed: 0 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [{ kind: 'installed', name: 'cowsay', version: '0.1.0' }],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(
       createElement(InstallView, {
@@ -559,16 +515,12 @@ describe('InstallView — marketing aesthetic on `add`', () => {
         },
       },
       summary: {
-        installed: 1,
-        updated: 0,
-        repaired: 0,
-        unchanged: 0,
-        removed: 0,
-        totalAssets: 1,
-        removedAssets: 0,
+        facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 1, removed: 0 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [{ kind: 'installed', name: 'pure-skills', version: '1.0.0' }],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(
       createElement(InstallView, {
@@ -649,20 +601,16 @@ describe('InstallView — marketing aesthetic on `add`', () => {
         },
       },
       summary: {
-        installed: 1,
-        updated: 0,
-        repaired: 0,
-        unchanged: 1,
-        removed: 0,
-        totalAssets: 1,
-        removedAssets: 0,
+        facets: { installed: 1, updated: 0, repaired: 0, unchanged: 1, removed: 0 },
+        textAssets: { written: 1, removed: 0 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [
         { kind: 'installed', name: 'cowsay', version: '0.1.0' },
         // pre-existing — `unchanged` must NOT contribute to the bundle viz
         { kind: 'unchanged', name: 'existing-skill', version: '1.0.0' },
       ],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(
       createElement(InstallView, {
@@ -713,16 +661,12 @@ describe('InstallView — marketing aesthetic on `add`', () => {
         },
       },
       summary: {
-        installed: 1,
-        updated: 0,
-        repaired: 0,
-        unchanged: 0,
-        removed: 0,
-        totalAssets: 1,
-        removedAssets: 0,
+        facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 1, removed: 0 },
+        mcp: NO_MCP_COUNTS,
       },
       perFacet: [{ kind: 'installed', name: 'cowsay', version: '0.1.0' }],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(
       createElement(InstallView, {
@@ -1309,9 +1253,13 @@ describe('InstallView — materialization reporting', () => {
         },
       },
     },
-    summary: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0, totalAssets: 1, removedAssets: 0 },
+    summary: {
+      facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+      textAssets: { written: 1, removed: 0 },
+      mcp: NO_MCP_COUNTS,
+    },
     perFacet: [{ kind: 'installed', name: 'alpha', version: '1.0.0' }],
-    serverWarnings: [],
+    mcp: NO_MCP,
   }
 
   test('shows the authored name beside the effective name, and marks omissions', async () => {
@@ -1387,9 +1335,13 @@ describe('InstallView — disposition-only change', () => {
     const result: RunInstallResult = {
       ok: true,
       lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
-      summary: { installed: 0, updated: 1, repaired: 0, unchanged: 0, removed: 0, totalAssets: 1, removedAssets: 0 },
+      summary: {
+        facets: { installed: 0, updated: 1, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 1, removed: 0 },
+        mcp: NO_MCP_COUNTS,
+      },
       perFacet: [{ kind: 'updated', name: 'alpha', oldVersion: '1.0.0', newVersion: '1.0.0' }],
-      serverWarnings: [],
+      mcp: NO_MCP,
     }
     const instance = render(
       createElement(InstallView, {

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -4,6 +4,7 @@ import type {
   CollisionResolution,
   CollisionResolutionRequest,
   CollisionResolver,
+  InstallSummary,
   MaterializationOverrideRef,
   RemovePrepareFailure,
   RunInstallResult,
@@ -94,11 +95,6 @@ function isInstallFailure(r: InstallViewResult): r is Extract<RunInstallResult, 
   return !r.ok && !isPrepareFailure(r) && !isRemovePrepareFailure(r)
 }
 
-interface ServerWarning {
-  facet: string
-  servers: ReadonlyArray<string>
-}
-
 /** A materialization choice dropped because its contribution no longer exists. */
 type PrunedOverride = MaterializationOverrideRef
 
@@ -150,7 +146,6 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
   const [totalFacets, setTotalFacets] = useState(0)
   const [facetOrder, setFacetOrder] = useState<string[]>([])
   const [facets, setFacets] = useState<Record<string, FacetState>>({})
-  const [serverWarnings, setServerWarnings] = useState<ServerWarning[]>([])
 
   /** Per-facet adapter completions: facetName → list of adapter names done. */
   const [adaptersByFacet, setAdaptersByFacet] = useState<Record<string, string[]>>({})
@@ -234,9 +229,6 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         })
         setFacetOrder((prev) => (prev.includes(event.facet) ? prev : [...prev, event.facet]))
         return
-      case 'server-warning':
-        setServerWarnings((prev) => [...prev, { facet: event.facet, servers: event.servers }])
-        return
       case 'adapter-complete':
         setAdaptersByFacet((prev) => {
           const existing = prev[event.facet] ?? []
@@ -297,6 +289,19 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         // No per-event UI for these; the final result render covers them.
         // A drift removal in particular is already named in the summary,
         // where it can also say whether anything was actually cleaned up.
+        return
+      case 'mcp-consent-required':
+      case 'mcp-consent-accepted':
+      case 'mcp-consent-declined':
+      case 'asset-takeover-required':
+      case 'asset-takeover-accepted':
+      case 'asset-takeover-cancelled':
+      case 'mcp-configured':
+        // Deliberately unrendered for now. This view cannot yet reach any of
+        // them: no command supplies a consent policy or a takeover resolver,
+        // so the engine settles both without asking. The approval and
+        // takeover screens, and the MCP half of the summary, arrive together
+        // with that plumbing rather than as a half-wired preview of it.
         return
       default: {
         // Exhaustiveness guard. Without it a newly added stage event
@@ -479,17 +484,6 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         </Box>
       )}
 
-      {serverWarnings.length > 0 && (
-        <Box flexDirection="column" marginLeft={2}>
-          {serverWarnings.map((w) => (
-            <Text key={w.facet} color={THEME.warning}>
-              ⚠ {w.facet}: {w.servers.length} server{w.servers.length === 1 ? '' : 's'} declared ({w.servers.join(', ')}
-              ) — server installation not yet supported, skipping.
-            </Text>
-          ))}
-        </Box>
-      )}
-
       {prunedOverrides.length > 0 && (
         <Box flexDirection="column" marginLeft={2}>
           {prunedOverrides.map((pruned) => (
@@ -600,7 +594,21 @@ function SuccessSummary({
   elapsedMs: number
 }) {
   const { summary } = result
-  const isNoOp = summary.installed === 0 && summary.updated === 0 && summary.repaired === 0 && summary.removed === 0
+  // MCP configuration counts on its own: a run whose only work was removing a
+  // receipt-owned server orphan leaves every facet `unchanged`, and reporting
+  // "no changes" over a native file this run rewrote is exactly the lie the
+  // separate counts exist to prevent.
+  const configurationWork =
+    summary.mcp.configurations.added +
+    summary.mcp.configurations.updated +
+    summary.mcp.configurations.repaired +
+    summary.mcp.configurations.removed
+  const isNoOp =
+    summary.facets.installed === 0 &&
+    summary.facets.updated === 0 &&
+    summary.facets.repaired === 0 &&
+    summary.facets.removed === 0 &&
+    configurationWork === 0
   const elapsed = `${(elapsedMs / 1000).toFixed(2)}s`
 
   if (isNoOp) {
@@ -807,20 +815,25 @@ function formatColoredBundleViz(counts: AssetCounts): React.ReactNode {
   )
 }
 
-function summaryLine(summary: {
-  installed: number
-  updated: number
-  repaired: number
-  unchanged: number
-  removed: number
-  totalAssets: number
-}): string {
+/**
+ * Takes the whole {@link InstallSummary} rather than the six fields it reads,
+ * so a count added to the engine's shape is at least visible here instead of
+ * being structurally invisible to this file.
+ */
+function summaryLine(summary: InstallSummary): string {
+  const { facets, textAssets, mcp } = summary
   const parts: string[] = []
-  if (summary.installed > 0) parts.push(`${summary.installed} installed`)
-  if (summary.updated > 0) parts.push(`${summary.updated} updated`)
-  if (summary.repaired > 0) parts.push(`${summary.repaired} repaired`)
-  if (summary.unchanged > 0) parts.push(`${summary.unchanged} unchanged`)
-  if (summary.removed > 0) parts.push(`${summary.removed} removed`)
-  parts.push(`${summary.totalAssets} asset${summary.totalAssets === 1 ? '' : 's'} written`)
+  if (facets.installed > 0) parts.push(`${facets.installed} installed`)
+  if (facets.updated > 0) parts.push(`${facets.updated} updated`)
+  if (facets.repaired > 0) parts.push(`${facets.repaired} repaired`)
+  if (facets.unchanged > 0) parts.push(`${facets.unchanged} unchanged`)
+  if (facets.removed > 0) parts.push(`${facets.removed} removed`)
+  parts.push(`${textAssets.written} asset${textAssets.written === 1 ? '' : 's'} written`)
+
+  // Counted separately from assets, because they are: a server-only facet
+  // writes no file and would otherwise summarize as having done nothing.
+  const configured = mcp.configurations.added + mcp.configurations.updated + mcp.configurations.repaired
+  if (configured > 0) parts.push(`${configured} server config${configured === 1 ? '' : 's'} written`)
+  if (mcp.configurations.removed > 0) parts.push(`${mcp.configurations.removed} server config removed`)
   return parts.join(' · ')
 }

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -301,7 +301,7 @@ describe('runInstall — local source success path with events', () => {
 
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(result.summary.installed).toBe(1)
+    expect(result.summary.facets.installed).toBe(1)
     expect(result.lockfile.facets['viper-plans']?.version).toBe('0.1.0')
     expect(events.find((e) => e.kind === 'install-start')).toBeDefined()
     expect(events.find((e) => e.kind === 'facet-success')).toBeDefined()
@@ -321,7 +321,7 @@ describe('runInstall — local source success path', () => {
     })
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(result.summary.installed).toBe(1)
+    expect(result.summary.facets.installed).toBe(1)
     expect(result.lockfile.facets['viper-plans']?.version).toBe('0.1.0')
   })
 
@@ -598,7 +598,7 @@ describe('runInstall — drift removal', () => {
     })
     expect(second.ok).toBe(true)
     if (!second.ok) expect.unreachable()
-    expect(second.summary.removed).toBe(1)
+    expect(second.summary.facets.removed).toBe(1)
     expect(second.lockfile.facets.orphan).toBeUndefined()
     expect(second.lockfile.facets.keeper).toBeDefined()
     expect(events.find((e) => e.kind === 'drift-removal')).toBeDefined()
@@ -643,8 +643,8 @@ describe('runInstall — lockfile bootstrap and reuse', () => {
     expect(result.lockfile.facets['viper-plans']?.version).toBe('0.1.0')
     // Same content + metadata on disk → skip-if-identical kicks in:
     // the facet reports as unchanged with zero new writes.
-    expect(result.summary.unchanged).toBe(1)
-    expect(result.summary.totalAssets).toBe(0)
+    expect(result.summary.facets.unchanged).toBe(1)
+    expect(result.summary.textAssets.written).toBe(0)
   })
 
   test('repaired: deleted asset is re-written and reported as repaired', async () => {
@@ -671,9 +671,9 @@ describe('runInstall — lockfile bootstrap and reuse', () => {
     })
     expect(result.ok).toBe(true)
     if (!result.ok) expect.unreachable()
-    expect(result.summary.repaired).toBe(1)
-    expect(result.summary.unchanged).toBe(0)
-    expect(result.summary.totalAssets).toBe(1)
+    expect(result.summary.facets.repaired).toBe(1)
+    expect(result.summary.facets.unchanged).toBe(0)
+    expect(result.summary.textAssets.written).toBe(1)
     expect(existsSync(skillPath)).toBe(true)
   })
 })
@@ -1220,12 +1220,12 @@ describe('runInstall — multi-file skill materialization', () => {
 
     const first = await runInstall({ projectRoot, adapters })
     if (!first.ok) expect.unreachable()
-    expect(first.summary.totalAssets).toBe(1)
+    expect(first.summary.textAssets.written).toBe(1)
 
     // Second install with no changes: the whole bundle is identical → skipped.
     const second = await runInstall({ projectRoot, adapters })
     if (!second.ok) expect.unreachable()
-    expect(second.summary.totalAssets).toBe(0)
+    expect(second.summary.textAssets.written).toBe(0)
 
     // Drift a single companion on disk, then reinstall: the bundle is
     // repaired (one write) and the drifted file is restored from source. The
@@ -1235,7 +1235,7 @@ describe('runInstall — multi-file skill materialization', () => {
     const logs: string[] = []
     const third = await runInstall({ projectRoot, adapters, onLog: (b) => logs.push(b()) })
     if (!third.ok) expect.unreachable()
-    expect(third.summary.totalAssets).toBe(1)
+    expect(third.summary.textAssets.written).toBe(1)
     expect(readFileSync(apiPath, 'utf8')).toBe('# api reference\n')
     expect(logs.some((l) => l.includes('drift: skills/planning/references/api.md'))).toBe(true)
   })
@@ -1366,7 +1366,7 @@ describe('runInstall — multi-file skill materialization', () => {
     // survives, and the install reports the bundle as repaired (one write).
     const second = await runInstall({ projectRoot, adapters })
     if (!second.ok) expect.unreachable()
-    expect(second.summary.totalAssets).toBe(1)
+    expect(second.summary.textAssets.written).toBe(1)
     expect(readFileSync(join(skillDir, 'references/api.md'), 'utf8')).toBe('# api reference\n')
     expect(readFileSync(notePath, 'utf8')).toBe('keep me\n')
   })
@@ -1391,7 +1391,7 @@ describe('runInstall — multi-file skill materialization', () => {
     if (!frozen.ok) expect.unreachable()
 
     // Nothing written, and every companion survives.
-    expect(frozen.summary.totalAssets).toBe(0)
+    expect(frozen.summary.textAssets.written).toBe(0)
     expect(frozen.perFacet).toEqual([{ kind: 'unchanged', name: 'viper-plans', version: '0.1.0' }])
     const skillDir = join(projectRoot, '.bundle/skills/planning')
     expect(readFileSync(join(skillDir, 'references/api.md'), 'utf8')).toBe('# api reference\n')

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -182,6 +182,19 @@ export type {
   McpDeclarationApproval,
   McpNativeTakeover,
 } from './install/mcp/consent.ts'
+// MCP outcomes. The CLI renders these; the engine decides them.
+export type {
+  McpActiveConfigurationStatus,
+  McpApprovalSummary,
+  McpConfigurationOutcome,
+  McpConsentOutcome,
+  McpConsentRequestSummary,
+  McpDispositionOutcome,
+  McpInstallOutcomes,
+  McpIntentChange,
+  McpTakeoverSummary,
+  PrunedServerIntent,
+} from './install/mcp/outcomes.ts'
 export type { McpContractViolation } from './install/mcp/prepare.ts'
 // Prototype-safe access to records keyed by user-authored names. The CLI's
 // collision draft builds and rewrites exactly such a record before handing it

--- a/packages/engine/src/install/__tests__/apply-ownership.test.ts
+++ b/packages/engine/src/install/__tests__/apply-ownership.test.ts
@@ -226,7 +226,7 @@ describe('apply — aliased assets materialize under the effective name', () => 
 
     // If the companion lookup keyed off the effective name, the bundle would
     // read as "companions missing" and be rewritten every single run.
-    expect(second.summary.totalAssets).toBe(0)
+    expect(second.summary.textAssets.written).toBe(0)
     expect(second.perFacet).toEqual([{ kind: 'unchanged', name: 'alpha', version: '1.0.0' }])
   })
 })
@@ -304,7 +304,7 @@ describe('apply — global ownership reconciliation', () => {
     // Both claimants' companions were removed — the union, not just one set.
     expect(existsSync(skillRoot('shared'))).toBe(false)
     // Counted once, not once per claim.
-    expect(result.summary.removedAssets).toBe(1)
+    expect(result.summary.textAssets.removed).toBe(1)
   })
 
   test('changing an alias deletes the old identity and writes the new one', async () => {
@@ -645,11 +645,11 @@ describe('apply — global ownership reconciliation', () => {
     // ...and nothing on disk is touched, because nothing proved ownership.
     expect(io.some((call) => call.startsWith('delete:'))).toBe(false)
     expect(readFileSync(join(skillRoot('review'), 'SKILL.md'), 'utf8')).toContain('# review from alpha')
-    expect(result.summary.removedAssets).toBe(0)
+    expect(result.summary.textAssets.removed).toBe(0)
     // Reported as its own outcome: "removed" would claim the files are gone.
     expect(result.perFacet).toEqual([{ kind: 'removed-untracked', name: 'alpha', oldVersion: '1.0.0' }])
     // Still counted as a removal — a declaration really did leave the project.
-    expect(result.summary.removed).toBe(1)
+    expect(result.summary.facets.removed).toBe(1)
   })
 
   test('a tracked removal reports removed, not removed-untracked', async () => {
@@ -670,7 +670,7 @@ describe('apply — global ownership reconciliation', () => {
 
     expect(result.perFacet).toContainEqual({ kind: 'removed', name: 'alpha', oldVersion: '1.0.0' })
     expect(existsSync(skillRoot('review'))).toBe(false)
-    expect(result.summary.removedAssets).toBe(1)
+    expect(result.summary.textAssets.removed).toBe(1)
   })
 
   test('an obsolete bundle whose primary is gone keeps its companions and says so', async () => {
@@ -712,7 +712,7 @@ describe('apply — global ownership reconciliation', () => {
       companionPaths: ['refs/api.md'],
     })
     // Nothing left disk, so the asset count must not claim otherwise.
-    expect(result.summary.removedAssets).toBe(0)
+    expect(result.summary.textAssets.removed).toBe(0)
   })
 
   test('a failure after a skipped bundle delete needs no inverse and loses nothing', async () => {
@@ -871,7 +871,7 @@ describe('apply — frozen reproduction of recorded intent', () => {
     })
     if (!result.ok) expect.unreachable()
     expect(prompted).toBe(false)
-    expect(result.summary.totalAssets).toBe(0)
+    expect(result.summary.textAssets.written).toBe(0)
     expect(existsSync(join(skillRoot('vendor-review'), 'refs/api.md'))).toBe(true)
     expectUntouched(lock, manifestText)
   })

--- a/packages/engine/src/install/__tests__/mcp-outcomes.test.ts
+++ b/packages/engine/src/install/__tests__/mcp-outcomes.test.ts
@@ -1,0 +1,567 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Adapter } from '@agent-facets/adapter'
+import { ADAPTER_API_VERSION, deleteAssetFile, installAssetFile, readAssetFile } from '@agent-facets/adapter'
+import { receiptPath } from '../receipt.ts'
+import { runRemove } from '../remove/index.ts'
+import { runInstall } from '../run-install.ts'
+import type { RunInstallOptions, RunInstallResult, StageEvent } from '../types.ts'
+import { type RecordingMcpOptions, recordingMcpCapability } from './helpers/mcp-adapter.ts'
+
+/**
+ * What a run REPORTS about MCP configuration: per-facet classification,
+ * separate summary counts, outcome events, and what those surfaces are
+ * allowed to carry.
+ *
+ * Kept apart from `mcp-install.test.ts`, which is about ordering — what has
+ * and has not happened when a run refuses. These tests almost all succeed;
+ * the subject is the account the operation gives of itself afterwards.
+ */
+
+let projectRoot: string
+let originalCwd: string
+let originalFacetDir: string | undefined
+let fakeHome: string
+
+const STDIO = { type: 'stdio', command: 'npx', args: ['-y', 'server-filesystem'], env: { TOKEN: 'hunter2' } }
+const OTHER = { type: 'http', url: 'https://example.test/mcp' }
+const ACCEPT: RunInstallOptions['mcpConsent'] = { kind: 'preapproved' }
+
+interface TestAdapter {
+  adapter: Adapter
+  documentPath: string
+}
+
+function mcpAdapter(name: string, options: RecordingMcpOptions = {}): TestAdapter {
+  const baseDir = () => join(projectRoot, `.${name}`)
+  const file = (type: string, assetName: string) => join(baseDir(), `${type}s`, `${assetName}.md`)
+  const document = () => join(baseDir(), 'mcp.json')
+  const mcp = recordingMcpCapability(document, options)
+  return {
+    get documentPath() {
+      return document()
+    },
+    adapter: {
+      name,
+      apiVersion: ADAPTER_API_VERSION,
+      supportsInstall: true,
+      mcpServers: mcp.capability,
+      buildAssetMetadata: (data) => ({ ok: true, data: (data ?? {}) as Record<string, unknown> }),
+      async installAsset(request) {
+        const p = { file: file(request.assetType, request.name) }
+        await installAssetFile(p, request.content, request.metadata as Record<string, unknown> | undefined)
+        return { ok: true, primaryPath: p.file }
+      },
+      async readAsset(request) {
+        try {
+          const { content, metadata } = await readAssetFile({ file: file(request.assetType, request.name) })
+          return request.assetType === 'skill'
+            ? { ok: true, asset: { assetType: 'skill', content, metadata, companions: {} } }
+            : { ok: true, asset: { assetType: request.assetType, content, metadata } }
+        } catch {
+          return { ok: false, failure: { code: 'not-found' } }
+        }
+      },
+      async deleteAsset(request) {
+        const p = { file: file(request.assetType, request.name) }
+        await deleteAssetFile(p)
+        return { ok: true, existed: true, deletedPaths: [p.file] }
+      },
+    },
+  }
+}
+
+function serverFixture(facet: string, server: string, declaration: unknown, version = '1.0.0'): string {
+  const dir = join(projectRoot, 'vendor', facet)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'facet.json'), JSON.stringify({ name: facet, version, servers: { [server]: declaration } }))
+  return `./vendor/${facet}`
+}
+
+function skillFixture(facet: string, skill: string): string {
+  const dir = join(projectRoot, 'vendor', facet)
+  mkdirSync(join(dir, `skills/${skill}`), { recursive: true })
+  writeFileSync(
+    join(dir, 'facet.json'),
+    JSON.stringify({ name: facet, version: '1.0.0', skills: { [skill]: { description: `${skill} skill` } } }),
+  )
+  writeFileSync(join(dir, `skills/${skill}/SKILL.md`), `# ${skill} from ${facet}\n`)
+  return `./vendor/${facet}`
+}
+
+function writeManifest(value: unknown): void {
+  writeFileSync(join(projectRoot, 'facets.json'), `${JSON.stringify(value, null, 2)}\n`)
+}
+
+/** Run an install, collecting every stage event it emits. */
+async function install(
+  options: Partial<RunInstallOptions> & { adapters: Adapter[] },
+): Promise<{ result: RunInstallResult; events: StageEvent[] }> {
+  const events: StageEvent[] = []
+  const result = await runInstall({
+    projectRoot,
+    mcpConsent: ACCEPT,
+    ...options,
+    onStage: (event) => events.push(event),
+  })
+  return { result, events }
+}
+
+/** Narrow to a successful run. */
+function succeeded(result: RunInstallResult): Extract<RunInstallResult, { ok: true }> {
+  if (!result.ok) expect.unreachable()
+  return result
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd()
+  originalFacetDir = process.env.FACET_DIR
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mcp-out-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mcp-out-home-')))
+  process.env.FACET_DIR = join(fakeHome, '.facet')
+  process.chdir(projectRoot)
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (originalFacetDir === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = originalFacetDir
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('mcp outcomes — a server-only facet reports its work', () => {
+  test('a first install reports one configuration added and zero assets', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.summary.facets.installed).toBe(1)
+    expect(success.summary.textAssets.written).toBe(0)
+    expect(success.summary.mcp.configurations.added).toBe(1)
+    expect(success.perFacet).toEqual([{ kind: 'installed', name: 'alpha', version: '1.0.0' }])
+    expect(success.mcp.configurations).toEqual([
+      {
+        kind: 'active',
+        adapter: 'rec',
+        effectiveName: 'filesystem',
+        claimants: ['alpha'],
+        status: 'added',
+        takenOver: false,
+      },
+    ])
+  })
+
+  test('a second install with nothing changed is unchanged, not repaired', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.perFacet).toEqual([{ kind: 'unchanged', name: 'alpha', version: '1.0.0' }])
+    expect(success.summary.mcp.configurations).toEqual({
+      added: 0,
+      updated: 0,
+      repaired: 0,
+      unchanged: 1,
+      removed: 0,
+    })
+    expect(success.mcp.dispositions).toEqual([
+      { kind: 'authored', facet: 'alpha', authoredName: 'filesystem', change: 'unchanged' },
+    ])
+  })
+
+  test('native drift at an approved identity is repaired', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    // Someone deleted the tool's configuration. The declaration this machine
+    // approved has not changed — only the file has.
+    rmSync(rec.documentPath, { force: true })
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.perFacet).toEqual([{ kind: 'repaired', name: 'alpha', version: '1.0.0' }])
+    expect(success.summary.mcp.configurations.repaired).toBe(1)
+    // The project asked for exactly what it asked for last time.
+    expect(success.mcp.dispositions[0]?.change).toBe('unchanged')
+  })
+})
+
+describe('mcp outcomes — intent changes are updates, not repairs', () => {
+  test('aliasing a server at an unchanged facet version is updated', async () => {
+    const source = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: source } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source, materialization: { servers: { filesystem: { kind: 'aliased', as: 'fs' } } } } },
+    })
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.perFacet).toEqual([{ kind: 'updated', name: 'alpha', oldVersion: '1.0.0', newVersion: '1.0.0' }])
+    expect(success.summary.mcp.declarations).toEqual({ aliased: 1, omitted: 0 })
+    expect(success.mcp.dispositions).toEqual([
+      { kind: 'aliased', facet: 'alpha', authoredName: 'filesystem', effectiveName: 'fs', change: 'updated' },
+    ])
+  })
+
+  test('omitting a previously configured server is updated and removes the entry', async () => {
+    const source = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: source } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source, materialization: { servers: { filesystem: { kind: 'omitted' } } } } },
+    })
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.perFacet).toEqual([{ kind: 'updated', name: 'alpha', oldVersion: '1.0.0', newVersion: '1.0.0' }])
+    expect(success.summary.mcp.declarations).toEqual({ aliased: 0, omitted: 1 })
+    expect(success.summary.mcp.configurations.removed).toBe(1)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({})
+  })
+
+  test('an omission that was already there stays unchanged', async () => {
+    const source = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source, materialization: { servers: { filesystem: { kind: 'omitted' } } } } },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    // Nothing was ever configured, so there is nothing to have changed.
+    expect(success.perFacet).toEqual([{ kind: 'unchanged', name: 'alpha', version: '1.0.0' }])
+    expect(success.mcp.dispositions).toEqual([
+      { kind: 'omitted', facet: 'alpha', authoredName: 'filesystem', change: 'unchanged' },
+    ])
+  })
+})
+
+describe('mcp outcomes — evidence this machine does not have', () => {
+  test('a receipt that predates configuration claims reports intent as unwitnessed', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    // Rewrite the receipt at the version that cannot express a claim.
+    const receipt = JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8'))
+    receipt.version = 0.3
+    for (const facet of Object.values(receipt.facets) as Array<Record<string, unknown>>) {
+      delete facet.configurations
+      delete facet.integrity
+    }
+    writeFileSync(receiptPath(projectRoot), `${JSON.stringify(receipt, null, 2)}\n`)
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    // It does not claim the declaration is new, and it does not claim it is
+    // unchanged. It says it cannot tell.
+    expect(success.mcp.dispositions).toEqual([
+      { kind: 'authored', facet: 'alpha', authoredName: 'filesystem', change: 'unwitnessed' },
+    ])
+    // And an unwitnessed intent never fabricates an update on its own.
+    expect(success.perFacet).toEqual([{ kind: 'unchanged', name: 'alpha', version: '1.0.0' }])
+  })
+})
+
+describe('mcp outcomes — takeover', () => {
+  test('an equivalent untracked entry is adopted as unchanged plus a takeover', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    // Forget the identity while leaving the file: the entry is now untracked
+    // AND already exactly right.
+    rmSync(receiptPath(projectRoot), { force: true })
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.perFacet).toEqual([{ kind: 'unchanged', name: 'alpha', version: '1.0.0' }])
+    expect(success.summary.mcp.configurations.unchanged).toBe(1)
+    expect(success.summary.mcp.takeovers.accepted).toBe(1)
+    expect(success.mcp.configurations[0]).toMatchObject({ status: 'unchanged', takenOver: true })
+  })
+
+  test('a divergent untracked entry is repaired plus a takeover', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    mkdirSync(join(projectRoot, '.rec'), { recursive: true })
+    writeFileSync(rec.documentPath, `${JSON.stringify({ filesystem: OTHER }, null, 2)}\n`)
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.summary.mcp.configurations.repaired).toBe(1)
+    expect(success.summary.mcp.takeovers.accepted).toBe(1)
+    expect(success.mcp.configurations[0]).toMatchObject({ status: 'repaired', takenOver: true })
+  })
+})
+
+describe('mcp outcomes — counting', () => {
+  test('every adapter contributes its own reconciliation', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const one = mcpAdapter('one')
+    const two = mcpAdapter('two')
+
+    const { result } = await install({ adapters: [one.adapter, two.adapter] })
+    const success = succeeded(result)
+
+    // The same unit as text assets, which also count per adapter.
+    expect(success.summary.mcp.configurations.added).toBe(2)
+    expect(success.mcp.configurations.map((o) => o.adapter)).toEqual(['one', 'two'])
+  })
+
+  test('two facets declaring the same server both claim the one configuration', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: serverFixture('beta', 'filesystem', STDIO),
+      },
+    })
+    const rec = mcpAdapter('rec')
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.summary.mcp.configurations.added).toBe(1)
+    expect(success.mcp.configurations[0]).toMatchObject({ claimants: ['alpha', 'beta'] })
+    // Reconciling a shared identity is work on behalf of every claimant, so
+    // neither facet is reported as having had nothing done for it.
+    expect(success.perFacet.map((o) => o.kind)).toEqual(['installed', 'installed'])
+  })
+
+  test('an entry someone already deleted is not counted as a removal', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    // The user removed the entry by hand before asking to remove the facet.
+    writeFileSync(rec.documentPath, '{}\n')
+    rmSync(join(projectRoot, 'vendor/alpha'), { recursive: true, force: true })
+
+    const removed = await runRemove({ projectRoot, names: ['alpha'], adapters: [rec.adapter] })
+    if (!removed.ok) expect.unreachable()
+
+    expect(removed.install.summary.mcp.configurations.removed).toBe(0)
+    expect(removed.install.mcp.configurations).toEqual([
+      {
+        kind: 'obsolete',
+        adapter: 'rec',
+        effectiveName: 'filesystem',
+        previousClaimants: ['alpha'],
+        status: 'already-absent',
+      },
+    ])
+  })
+
+  test('removing the last claimant reports the removal', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+    rmSync(join(projectRoot, 'vendor/alpha'), { recursive: true, force: true })
+
+    const removed = await runRemove({ projectRoot, names: ['alpha'], adapters: [rec.adapter] })
+    if (!removed.ok) expect.unreachable()
+
+    expect(removed.install.summary.mcp.configurations.removed).toBe(1)
+    expect(removed.install.mcp.configurations[0]).toMatchObject({ kind: 'obsolete', status: 'removed' })
+  })
+})
+
+describe('mcp outcomes — events', () => {
+  test('consent and configuration events bracket the work', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const { events } = await install({ adapters: [rec.adapter] })
+    const kinds = events.map((event) => event.kind)
+
+    expect(kinds).toContain('mcp-consent-required')
+    expect(kinds).toContain('mcp-consent-accepted')
+    // Committed outcomes come after the lockfile write, because until then
+    // the configuration is still a candidate for rollback.
+    expect(kinds.indexOf('mcp-configured')).toBeGreaterThan(kinds.indexOf('lockfile-write'))
+    expect(kinds.indexOf('mcp-consent-accepted')).toBeLessThan(kinds.indexOf('mcp-configured'))
+  })
+
+  test('a preapproved run says so', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const { events, result } = await install({ adapters: [rec.adapter] })
+
+    const accepted = events.find((event) => event.kind === 'mcp-consent-accepted')
+    expect(accepted).toEqual({ kind: 'mcp-consent-accepted', via: 'preapproved' })
+    const success = succeeded(result)
+    if (success.mcp.consent.kind !== 'accepted') expect.unreachable()
+    expect(success.mcp.consent.via).toBe('preapproved')
+  })
+
+  test('a rolled-back run announces no configuration at all', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const first = mcpAdapter('first')
+    // The second adapter writes nothing and fails, AFTER the first has already
+    // written its document — so this is a real rollback, not a refusal before
+    // the first mutation.
+    const second = mcpAdapter('second', {
+      failApply: { code: 'io-failed', operation: 'write', path: '/nope', message: 'disk on fire' },
+    })
+
+    const { result, events } = await install({ adapters: [first.adapter, second.adapter] })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MCP_APPLY_FAILED')
+    expect(result.rollback.kind).toBe('succeeded')
+    expect(events.map((event) => event.kind)).not.toContain('mcp-configured')
+    // The restore put the first adapter's document back to not existing.
+    expect(existsSync(first.documentPath)).toBe(false)
+  })
+
+  test('a declined request is reported as declined and carries the identities', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const { result, events } = await install({
+      adapters: [rec.adapter],
+      mcpConsent: { kind: 'interactive', resolve: async () => ({ kind: 'declined' }) },
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_CONSENT_DECLINED') expect.unreachable()
+    expect(result.failure.request.declarations).toEqual([
+      { effectiveName: 'filesystem', claimants: ['alpha'], standing: { kind: 'unknown-identity' } },
+    ])
+    expect(events.map((event) => event.kind)).toContain('mcp-consent-declined')
+  })
+
+  test('an asset takeover is announced and then accepted', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+    const rec = mcpAdapter('rec')
+    mkdirSync(join(projectRoot, '.rec', 'skills'), { recursive: true })
+    writeFileSync(join(projectRoot, '.rec', 'skills', 'review.md'), '# hand written\n')
+
+    const { events } = await install({
+      adapters: [rec.adapter],
+      resolveAssetTakeover: async () => ({ kind: 'continue' }),
+    })
+
+    const kinds = events.map((event) => event.kind)
+    expect(kinds).toContain('asset-takeover-required')
+    expect(kinds).toContain('asset-takeover-accepted')
+    expect(kinds).not.toContain('asset-takeover-cancelled')
+  })
+
+  test('a cancelled asset takeover is announced as cancelled', async () => {
+    writeManifest({ facets: { alpha: skillFixture('alpha', 'review') } })
+    const rec = mcpAdapter('rec')
+    mkdirSync(join(projectRoot, '.rec', 'skills'), { recursive: true })
+    writeFileSync(join(projectRoot, '.rec', 'skills', 'review.md'), '# hand written\n')
+
+    const { events } = await install({
+      adapters: [rec.adapter],
+      resolveAssetTakeover: async () => ({ kind: 'cancelled' }),
+    })
+
+    const kinds = events.map((event) => event.kind)
+    expect(kinds).toContain('asset-takeover-cancelled')
+    expect(kinds).not.toContain('asset-takeover-accepted')
+  })
+})
+
+describe('mcp outcomes — what routine surfaces carry', () => {
+  const SECRETS = ['npx', 'server-filesystem', 'hunter2', 'TOKEN', 'example.test']
+
+  test('outcomes and events name identities, not declarations', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    const { result, events } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    const reported = JSON.stringify({ mcp: success.mcp, summary: success.summary, events })
+    for (const secret of SECRETS) {
+      expect(reported).not.toContain(secret)
+    }
+    // What they DO carry is enough to report the work.
+    expect(reported).toContain('filesystem')
+  })
+
+  test('the approval surface still receives the exact declaration', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+
+    let shown = ''
+    const { result } = await install({
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async (request) => {
+          shown = JSON.stringify(request)
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    // A user cannot authorize a command they were not shown.
+    for (const secret of SECRETS.filter((s) => s !== 'example.test')) {
+      expect(shown).toContain(secret)
+    }
+  })
+})
+
+describe('mcp outcomes — stale server intent', () => {
+  test('a pruned server override is reported and makes the facet updated', async () => {
+    const source = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: source } })
+    const rec = mcpAdapter('rec')
+    expect((await install({ adapters: [rec.adapter] })).result.ok).toBe(true)
+
+    // An override naming a declaration the facet does not publish.
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source, materialization: { servers: { gone: { kind: 'omitted' } } } } },
+    })
+
+    const { result } = await install({ adapters: [rec.adapter] })
+    const success = succeeded(result)
+
+    expect(success.mcp.prunedIntent).toEqual([{ facet: 'alpha', authoredName: 'gone' }])
+    // `facets.json` is materially different afterwards, so the facet is not
+    // unchanged — even though nothing about its declarations moved.
+    expect(success.perFacet).toEqual([{ kind: 'updated', name: 'alpha', oldVersion: '1.0.0', newVersion: '1.0.0' }])
+  })
+})

--- a/packages/engine/src/install/__tests__/run-install.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.test.ts
@@ -339,7 +339,7 @@ describe('runInstall — a facet named after an Object.prototype member', () => 
     const result = await install()
 
     if (!result.ok) expect.unreachable('a facet named `constructor` should install like any other')
-    expect(result.summary.installed).toBe(1)
+    expect(result.summary.facets.installed).toBe(1)
     expect(Object.hasOwn(readLock().facets, 'constructor')).toBe(true)
   })
 
@@ -355,7 +355,7 @@ describe('runInstall — a facet named after an Object.prototype member', () => 
     const second = await install()
 
     if (!second.ok) expect.unreachable()
-    expect(second.summary.unchanged).toBe(1)
+    expect(second.summary.facets.unchanged).toBe(1)
   })
 })
 

--- a/packages/engine/src/install/__tests__/run-remove.test.ts
+++ b/packages/engine/src/install/__tests__/run-remove.test.ts
@@ -493,7 +493,7 @@ describe('runRemove — a remaining facet is unavailable', () => {
       name: 'cowsay',
       oldVersion: '0.1.1',
     })
-    expect(result.install.summary.removedAssets).toBe(0)
+    expect(result.install.summary.textAssets.removed).toBe(0)
     // The facet that stays was rewritten, and is tracked from now on.
     expect(existsSync(assetPath('test-adapter', 'planner'))).toBe(true)
     const receipt = JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8'))

--- a/packages/engine/src/install/classify-outcome.ts
+++ b/packages/engine/src/install/classify-outcome.ts
@@ -4,6 +4,7 @@ import {
   type SupportedLockfileFacet,
   sameDisposition,
 } from '@agent-facets/protocol'
+import type { McpInstallOutcomes } from './mcp/outcomes.ts'
 import type { FacetOutcome } from './types.ts'
 
 function identityKey(asset: { scope: string; type: string; name: string }): string {
@@ -29,24 +30,88 @@ function dispositionsChanged(previous: SupportedLockfileFacet, current: CurrentL
 }
 
 /**
+ * What reconciling one facet's MCP declarations amounted to.
+ *
+ * Two independent booleans rather than one status, because they answer
+ * different questions and can both be true: the project can change what it
+ * asks for at the same moment a tool's config file turns out to have drifted.
+ * Neither can be derived from the lockfile — servers are deliberately absent
+ * from it — so both arrive from the MCP outcomes.
+ */
+export interface FacetConfigurationWork {
+  /**
+   * The project's intent changed: a different declaration, a new or removed
+   * alias, or an omission that was not there before.
+   */
+  intentChanged: boolean
+  /** Reconciling this facet's declarations had to write native configuration. */
+  reconciled: boolean
+}
+
+/** A facet with no server declarations at all, which is most of them. */
+export const NO_CONFIGURATION_WORK: FacetConfigurationWork = { intentChanged: false, reconciled: false }
+
+/**
+ * Attribute this run's MCP work back to the facets that asked for it.
+ *
+ * An effective configuration can be claimed by several facets at once — that
+ * is what identical declarations compose INTO — so reconciling it is work on
+ * behalf of every one of them. Splitting the credit would mean picking a
+ * winner among claimants that are, by construction, indistinguishable.
+ *
+ * `introduced` deliberately does not count as an intent change: a declaration
+ * this machine has no record of is either a brand-new facet (already
+ * `installed`) or one whose configuration never landed, and the second is a
+ * repair rather than a change of mind. `unwitnessed` claims nothing at all.
+ */
+export function facetConfigurationWork(mcp: McpInstallOutcomes): Map<string, FacetConfigurationWork> {
+  const work = new Map<string, FacetConfigurationWork>()
+  const mark = (facet: string, change: Partial<FacetConfigurationWork>): void => {
+    const existing = work.get(facet) ?? NO_CONFIGURATION_WORK
+    work.set(facet, { ...existing, ...change })
+  }
+
+  for (const disposition of mcp.dispositions) {
+    if (disposition.change === 'updated') mark(disposition.facet, { intentChanged: true })
+  }
+  // A pruned override is intent that changed too: the project stopped saying
+  // something about a declaration, and the facet's entry in `facets.json` is
+  // materially different afterwards.
+  for (const pruned of mcp.prunedIntent) {
+    mark(pruned.facet, { intentChanged: true })
+  }
+  for (const configuration of mcp.configurations) {
+    if (configuration.kind !== 'active' || configuration.status === 'unchanged') continue
+    for (const facet of configuration.claimants) mark(facet, { reconciled: true })
+  }
+  return work
+}
+
+/**
  * Classify a per-facet outcome by comparing the previous lockfile entry (if
- * any) against what this run resolved and composed.
+ * any) against what this run resolved, composed, and reconciled.
  *
  *   - `installed` — the facet was not in the previous lockfile.
  *   - `updated`   — a different version, OR the same version with different
- *     materialization intent. Aliasing or omitting an asset changes what is
- *     on disk and what the lockfile records, so reporting it as `unchanged`
- *     would describe a real change as a no-op. It is not `repaired` either:
- *     nothing drifted, the project asked for something different.
- *   - `repaired`  — same version and same intent, but at least one asset had
- *     to be rewritten because on-disk state had drifted.
+ *     materialization intent. Aliasing or omitting an asset or a server
+ *     changes what is on disk and what the project records, so reporting it
+ *     as `unchanged` would describe a real change as a no-op. It is not
+ *     `repaired` either: nothing drifted, the project asked for something
+ *     different.
+ *   - `repaired`  — same version and same intent, but an asset or a native
+ *     MCP entry had to be rewritten because the state on disk had drifted.
  *   - `unchanged` — same version, same intent, nothing written.
+ *
+ * A facet that publishes only servers reaches the same four answers on the
+ * strength of `configuration` alone, which is what keeps it from reporting
+ * itself as a no-op every time.
  */
 export function classifyOutcome(
   name: string,
   previous: SupportedLockfileFacet | undefined,
   current: CurrentLockfileFacet,
   assetsWritten: number,
+  configuration: FacetConfigurationWork = NO_CONFIGURATION_WORK,
 ): FacetOutcome {
   if (previous === undefined) {
     return { kind: 'installed', name, version: current.version }
@@ -59,7 +124,7 @@ export function classifyOutcome(
       newVersion: current.version,
     }
   }
-  if (dispositionsChanged(previous, current)) {
+  if (dispositionsChanged(previous, current) || configuration.intentChanged) {
     return {
       kind: 'updated',
       name,
@@ -67,7 +132,7 @@ export function classifyOutcome(
       newVersion: current.version,
     }
   }
-  if (assetsWritten > 0) {
+  if (assetsWritten > 0 || configuration.reconciled) {
     return { kind: 'repaired', name, version: current.version }
   }
   return { kind: 'unchanged', name, version: current.version }

--- a/packages/engine/src/install/commit/install-loop.ts
+++ b/packages/engine/src/install/commit/install-loop.ts
@@ -1,11 +1,10 @@
 import type { Adapter } from '@agent-facets/adapter'
 import type { CurrentLockfileFacet, MaterializedAsset } from '@agent-facets/protocol'
 import type { AssetTakeoverResolver } from '../asset-takeover.ts'
-import { classifyOutcome } from '../classify-outcome.ts'
 import type { InstallJournal } from '../journal.ts'
 import { materialize } from '../materialize.ts'
 import { materializeFailureToRunInstall } from '../materialize-failure.ts'
-import type { FacetOutcome, OnLog, RunInstallFailure, StageEvent } from '../types.ts'
+import type { OnLog, RunInstallFailure, StageEvent } from '../types.ts'
 import type { ComposedPlan } from './compose.ts'
 import type { PreviousOwnership } from './ownership.ts'
 import type { ResolvedFacetRecord } from './resolve-all.ts'
@@ -13,7 +12,15 @@ import type { ResolvedFacetRecord } from './resolve-all.ts'
 export interface InstallLoopSuccess {
   /** The lockfile entries resolved this run, keyed by facet name. */
   newFacetEntries: Record<string, CurrentLockfileFacet>
-  perFacet: FacetOutcome[]
+  /**
+   * Assets written per facet, keyed by facet name.
+   *
+   * Evidence rather than a verdict. A facet's outcome also depends on whether
+   * its MCP declarations had to be reconciled, and that happens after every
+   * asset is on disk — so this loop reports what it did and the orchestrator
+   * classifies once both halves are known.
+   */
+  assetWrites: ReadonlyMap<string, number>
   /** Assets actually written across all facets (skipped no-ops don't count). */
   totalAssets: number
 }
@@ -61,7 +68,7 @@ export async function installFacets(args: InstallLoopArgs): Promise<InstallLoopR
   // Entries come from Compose, which is where dispositions were decided.
   // Apply reports what it wrote; it does not re-derive what should be locked.
   const newFacetEntries: Record<string, CurrentLockfileFacet> = { ...plan.facetEntries }
-  const perFacet: FacetOutcome[] = []
+  const assetWrites = new Map<string, number>()
   let totalAssets = 0
 
   // Assets to write, per facet, carrying both identities. Omitted assets are
@@ -80,7 +87,7 @@ export async function installFacets(args: InstallLoopArgs): Promise<InstallLoopR
   }
 
   for (const record of resolved) {
-    const { facet: facetName, previousEntry } = record
+    const facetName = record.facet
     if (signal?.aborted) {
       return { ok: false, failure: { code: 'ABORTED' } }
     }
@@ -105,16 +112,8 @@ export async function installFacets(args: InstallLoopArgs): Promise<InstallLoopR
     }
 
     totalAssets += materializeResult.written
-
-    // Classify against the COMPOSED entry, not the resolved version alone:
-    // an alias or omission changes the facet's state at an unchanged
-    // version, and only the composed entry carries that.
-    const composedEntry = plan.facetEntries[facetName]
-    if (composedEntry === undefined) continue
-    const outcome = classifyOutcome(facetName, previousEntry, composedEntry, materializeResult.written)
-    perFacet.push(outcome)
-    onStage({ kind: 'facet-success', facet: facetName, outcome })
+    assetWrites.set(facetName, materializeResult.written)
   }
 
-  return { ok: true, value: { newFacetEntries, perFacet, totalAssets } }
+  return { ok: true, value: { newFacetEntries, assetWrites, totalAssets } }
 }

--- a/packages/engine/src/install/commit/resolve-all.ts
+++ b/packages/engine/src/install/commit/resolve-all.ts
@@ -26,7 +26,6 @@ export interface ResolvedFacetRecord extends ResolvedFacet {
 export interface ResolveAllSuccess {
   /** Sorted by facet name. See the ordering note on {@link resolveAll}. */
   resolved: readonly ResolvedFacetRecord[]
-  serverWarnings: { facet: string; servers: ReadonlyArray<string> }[]
 }
 
 export type ResolveAllResult = { ok: true; value: ResolveAllSuccess } | { ok: false; failure: RunInstallFailure }
@@ -71,7 +70,6 @@ export async function resolveAll(args: ResolveAllArgs): Promise<ResolveAllResult
   const { desiredFacets, previousLockfile, adapters, signal, onStage, onLog } = args
 
   const resolved: ResolvedFacetRecord[] = []
-  const serverWarnings: { facet: string; servers: ReadonlyArray<string> }[] = []
 
   const facetNames = Object.keys(desiredFacets).sort(compareCodeUnits)
 
@@ -102,12 +100,6 @@ export async function resolveAll(args: ResolveAllArgs): Promise<ResolveAllResult
 
     const facetResolution = resolveResult.value
 
-    if (facetResolution.servers.length > 0) {
-      const names = facetResolution.servers.map((server) => server.name)
-      serverWarnings.push({ facet: facetName, servers: names })
-      onStage({ kind: 'server-warning', facet: facetName, servers: names })
-    }
-
     // Pre-materialization reconciliation (design D10): the previously-locked
     // entry MUST agree with the freshly derived plan before any adapter
     // write. It lives here rather than in the materialize pass because it is
@@ -132,5 +124,5 @@ export async function resolveAll(args: ResolveAllArgs): Promise<ResolveAllResult
     resolved.push({ ...facetResolution, facet: facetName, previousEntry })
   }
 
-  return { ok: true, value: { resolved, serverWarnings } }
+  return { ok: true, value: { resolved } }
 }

--- a/packages/engine/src/install/materialize.ts
+++ b/packages/engine/src/install/materialize.ts
@@ -227,18 +227,38 @@ export async function materialize(opts: MaterializeOptions): Promise<Materialize
       // still being adopted: the bytes do not change, but this machine is
       // about to start claiming a file someone else put there.
       if (previous !== null && ownershipFor(opts.previousOwnership, asset) === undefined) {
+        const occupancy = identical ? 'equivalent' : 'divergent'
+        opts.onStage?.({
+          kind: 'asset-takeover-required',
+          facet: opts.facetName,
+          adapter: adapter.name,
+          asset: target,
+          occupancy,
+        })
         const decision = opts.resolveAssetTakeover
           ? await opts.resolveAssetTakeover({
               facet: opts.facetName,
               adapter: adapter.name,
               asset: target,
               authoredName: asset.authoredName,
-              occupancy: identical ? 'equivalent' : 'divergent',
+              occupancy,
             })
           : { kind: 'continue' as const }
         if (decision.kind === 'cancelled') {
+          opts.onStage?.({
+            kind: 'asset-takeover-cancelled',
+            facet: opts.facetName,
+            adapter: adapter.name,
+            asset: target,
+          })
           return { ok: false, failure: { kind: 'takeover-cancelled', adapter: adapter.name, asset: target } }
         }
+        opts.onStage?.({
+          kind: 'asset-takeover-accepted',
+          facet: opts.facetName,
+          adapter: adapter.name,
+          asset: target,
+        })
       }
 
       if (identical) {

--- a/packages/engine/src/install/mcp/outcomes.ts
+++ b/packages/engine/src/install/mcp/outcomes.ts
@@ -1,0 +1,358 @@
+import type { McpServerPreparationOutcome } from '@agent-facets/adapter'
+import {
+  compareCodeUnits,
+  mcpServerKey,
+  type PlannedServer,
+  type PlannedServerConfiguration,
+  sameDisposition,
+} from '@agent-facets/protocol'
+import { isDeclarationApproved, type PreviousMcpOwnership } from '../commit/server-ownership.ts'
+import type { ProjectReceiptState, ReceiptConfigurationClaim } from '../receipt.ts'
+import type { McpApprovalStanding, McpConsentRequest } from './consent.ts'
+import type { PreparedMcpAdapter } from './prepare.ts'
+
+/**
+ * What an operation did to this project's MCP configuration.
+ *
+ * Two independent axes, deliberately not collapsed into one status. INTENT is
+ * what the project asked for — a declaration, an alias, an omission — and
+ * lives in `facets.json` plus the facet's manifest. NATIVE STATE is what a
+ * tool's own configuration file holds. They move independently: a changed
+ * declaration whose native rendering happens to match is an intent update and
+ * a native no-op, and a native file someone edited by hand is a repair with no
+ * intent change at all. One status field would have to pick a winner.
+ *
+ * These types carry identities, adapters, and statuses. The declarations
+ * themselves stay in the consent request, which is the surface whose whole
+ * purpose is showing a user the exact command they are authorizing; routine
+ * outcomes need names and never the payload.
+ */
+
+// ---------------------------------------------------------------------------
+// Intent
+// ---------------------------------------------------------------------------
+
+/**
+ * How this project's intent for one authored declaration compares with what
+ * this machine last reconciled.
+ *
+ *   - `introduced` — nothing was recorded here for it before.
+ *   - `updated`    — the declaration, its alias, or its omission changed.
+ *   - `unchanged`  — same declaration, same disposition.
+ *   - `unwitnessed`— this machine has no usable record of what it last did, so
+ *     the comparison is genuinely unanswerable. Distinct from `introduced`,
+ *     which asserts something a corrupt or pre-`0.4` receipt cannot support.
+ */
+export type McpIntentChange = 'introduced' | 'updated' | 'unchanged' | 'unwitnessed'
+
+/**
+ * One authored declaration and what the project decided about it.
+ *
+ * Tagged by disposition so an effective name exists exactly where one is
+ * meaningful: an omitted declaration has no effective identity at all, and an
+ * authored one's effective name IS its authored name.
+ */
+export type McpDispositionOutcome =
+  | { kind: 'authored'; facet: string; authoredName: string; change: McpIntentChange }
+  | { kind: 'aliased'; facet: string; authoredName: string; effectiveName: string; change: McpIntentChange }
+  | { kind: 'omitted'; facet: string; authoredName: string; change: McpIntentChange }
+
+/**
+ * What this machine can prove about its own previous MCP intent.
+ *
+ * `witnessed` with an empty map is a real and common answer — a project whose
+ * receipt is simply absent has definitively never reconciled anything here.
+ * `unwitnessed` is the narrower case where a record exists but cannot speak:
+ * a pre-`0.4` receipt, or one too damaged to read.
+ */
+export type McpIntentBaseline =
+  | { kind: 'witnessed'; claims: ReadonlyMap<string, ReadonlyMap<string, ReceiptConfigurationClaim>> }
+  | { kind: 'unwitnessed' }
+
+/** Derive the intent baseline from this machine's receipt state. */
+export function mcpIntentBaseline(state: ProjectReceiptState): McpIntentBaseline {
+  if (state.kind === 'unavailable') {
+    // A missing receipt proves absence: this machine has reconciled nothing
+    // for this project. A corrupt or foreign one proves nothing at all.
+    return state.reason === 'missing' ? { kind: 'witnessed', claims: new Map() } : { kind: 'unwitnessed' }
+  }
+  if (state.record.authority !== 'assets-and-configuration') return { kind: 'unwitnessed' }
+
+  const claims = new Map<string, Map<string, ReceiptConfigurationClaim>>()
+  for (const [facet, entry] of Object.entries(state.record.facets)) {
+    const byName = new Map<string, ReceiptConfigurationClaim>()
+    for (const claim of entry.configurations) byName.set(claim.name, claim)
+    claims.set(facet, byName)
+  }
+  return { kind: 'witnessed', claims }
+}
+
+function intentChangeOf(baseline: McpIntentBaseline, planned: PlannedServer): McpIntentChange {
+  if (baseline.kind === 'unwitnessed') return 'unwitnessed'
+  const prior = baseline.claims.get(planned.facet)?.get(planned.authoredName)
+
+  if (planned.disposition.kind === 'omitted') {
+    // A receipt records only what it reconciled, so an omission is witnessed
+    // by the ABSENCE of a claim. Having one means this machine configured the
+    // server and the project has since withdrawn it.
+    return prior === undefined ? 'unchanged' : 'updated'
+  }
+  if (prior === undefined) return 'introduced'
+  const same = sameDisposition(prior.materialization, planned.disposition) && prior.fingerprint === planned.fingerprint
+  return same ? 'unchanged' : 'updated'
+}
+
+/**
+ * Classify every authored declaration's intent, including omitted ones.
+ *
+ * Omissions are the reason this reads `planned` rather than the active
+ * configuration set: "the project omits this server" is unanswerable from the
+ * identities that survived planning.
+ */
+export function classifyMcpDispositions(
+  planned: readonly PlannedServer[],
+  baseline: McpIntentBaseline,
+): McpDispositionOutcome[] {
+  const outcomes = planned.map((entry) => dispositionOutcomeOf(entry, intentChangeOf(baseline, entry)))
+  outcomes.sort((a, b) => compareCodeUnits(a.facet, b.facet) || compareCodeUnits(a.authoredName, b.authoredName))
+  return outcomes
+}
+
+function dispositionOutcomeOf(entry: PlannedServer, change: McpIntentChange): McpDispositionOutcome {
+  const common = { facet: entry.facet, authoredName: entry.authoredName, change }
+  switch (entry.disposition.kind) {
+    case 'authored':
+      return { kind: 'authored', ...common }
+    case 'aliased':
+      return { kind: 'aliased', ...common, effectiveName: entry.disposition.as }
+    case 'omitted':
+      return { kind: 'omitted', ...common }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Native reconciliation
+// ---------------------------------------------------------------------------
+
+/**
+ * What reconciling one effective identity did to one adapter's native file.
+ *
+ *   - `added`     — nothing was there and this run created it.
+ *   - `updated`   — the entry changed because the DECLARATION changed.
+ *   - `repaired`  — the entry changed because the NATIVE state had drifted, or
+ *     because an untracked entry was overwritten. The desired declaration was
+ *     already what this project wanted.
+ *   - `unchanged` — the adapter proved the native entry already matched, so
+ *     nothing was written.
+ */
+export type McpActiveConfigurationStatus = 'added' | 'updated' | 'repaired' | 'unchanged'
+
+/**
+ * One adapter's reconciliation of one effective server identity.
+ *
+ * Tagged on whether the identity is still desired, because the two arms name
+ * different facts: an active outcome's claimants are the facets that want it
+ * NOW, while an obsolete one's are the facets that used to — a single
+ * `claimants` field would read as the former while meaning the latter.
+ */
+export type McpConfigurationOutcome =
+  | {
+      kind: 'active'
+      adapter: string
+      effectiveName: string
+      /** Every facet claiming this identity, in the planner's order. */
+      claimants: readonly string[]
+      status: McpActiveConfigurationStatus
+      /** Whether this identity was occupied by an entry this machine did not own. */
+      takenOver: boolean
+    }
+  | {
+      kind: 'obsolete'
+      adapter: string
+      effectiveName: string
+      /** Every facet that claimed this identity per the receipt. */
+      previousClaimants: readonly string[]
+      /**
+       * `removed` deleted an entry that was there; `already-absent` dropped a
+       * claim whose entry someone had already deleted by hand. Both end with
+       * the identity unowned, and only the first is work a user did not do.
+       */
+      status: 'removed' | 'already-absent'
+    }
+
+export interface ClassifyMcpConfigurationsArgs {
+  /** The active effective configurations this run reconciled. */
+  configurations: readonly PlannedServerConfiguration[]
+  /** Approval and ownership evidence from the receipt, as it was BEFORE this run. */
+  previousOwnership: ReadonlyMap<string, PreviousMcpOwnership>
+  /** Every adapter's read-only preparation — where occupancy and equality were decided. */
+  prepared: readonly PreparedMcpAdapter[]
+}
+
+/**
+ * Classify what each adapter's application did, from the evidence its
+ * preparation already produced.
+ *
+ * Preparation is the authority rather than the apply result: it reports per
+ * SERVER, while `apply` reports per document, so a mixed document ("one entry
+ * added, one already correct") is only decomposable here. Applying a prepared
+ * plan is defined to do exactly what preparation said it would, which is what
+ * makes reading the earlier of the two sound.
+ */
+export function classifyMcpConfigurations(args: ClassifyMcpConfigurationsArgs): McpConfigurationOutcome[] {
+  const byName = new Map(
+    args.configurations.map((configuration) => [configuration.identity.effectiveName, configuration]),
+  )
+  const outcomes: McpConfigurationOutcome[] = []
+
+  for (const { adapter, preparation } of args.prepared) {
+    for (const outcome of preparation.outcomes) {
+      if (outcome.kind === 'obsolete-owned') {
+        const ownership = args.previousOwnership.get(mcpServerKey(outcome.name))
+        outcomes.push({
+          kind: 'obsolete',
+          adapter,
+          effectiveName: outcome.name,
+          previousClaimants: ownership?.facets ?? [],
+          status: outcome.occupancy === 'present' ? 'removed' : 'already-absent',
+        })
+        continue
+      }
+
+      const configuration = byName.get(outcome.name)
+      // An outcome naming something the desired set does not contain would be
+      // an adapter reporting on an entry it was never asked about. Skipped for
+      // the same reason consent skips it: nothing was authorized, so nothing
+      // is claimed here either.
+      if (configuration === undefined) continue
+
+      outcomes.push({
+        kind: 'active',
+        adapter,
+        effectiveName: outcome.name,
+        claimants: configuration.claimants.map((claimant) => claimant.facet),
+        status: activeStatusOf(outcome, isDeclarationApproved(args.previousOwnership, configuration)),
+        takenOver: outcome.ownership === 'untracked' && outcome.kind !== 'absent',
+      })
+    }
+  }
+
+  outcomes.sort((a, b) => compareCodeUnits(a.adapter, b.adapter) || compareCodeUnits(a.effectiveName, b.effectiveName))
+  return outcomes
+}
+
+/**
+ * Whether a write happened, and why.
+ *
+ * `approved` is the discriminator between the two reasons a tracked entry gets
+ * rewritten: this machine already reconciled this exact declaration here, so a
+ * difference on disk is drift someone introduced (`repaired`); a fingerprint it
+ * has never approved means the project asked for something else (`updated`).
+ */
+function activeStatusOf(
+  outcome: Exclude<McpServerPreparationOutcome, { kind: 'obsolete-owned' }>,
+  approved: boolean,
+): McpActiveConfigurationStatus {
+  switch (outcome.kind) {
+    case 'absent':
+      // Untracked and absent is a plain creation. Tracked and absent means the
+      // entry this machine owns is gone from the file.
+      if (outcome.ownership === 'untracked') return 'added'
+      return approved ? 'repaired' : 'updated'
+    case 'equivalent':
+      return 'unchanged'
+    case 'divergent':
+      // An untracked destination has no approved declaration to compare
+      // against, so the rewrite is always a repair of state this project did
+      // not put there.
+      if (outcome.ownership === 'untracked') return 'repaired'
+      return approved ? 'repaired' : 'updated'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Consent
+// ---------------------------------------------------------------------------
+
+/** One approval, without the declaration that was displayed to obtain it. */
+export interface McpApprovalSummary {
+  effectiveName: string
+  claimants: readonly string[]
+  standing: McpApprovalStanding
+}
+
+/** One disclosed untracked native entry, without the declaration. */
+export interface McpTakeoverSummary {
+  adapter: string
+  effectiveName: string
+  existing: 'equivalent' | 'divergent'
+}
+
+/**
+ * What a user was asked to approve, in the form the rest of the system needs
+ * afterwards.
+ *
+ * The full {@link McpConsentRequest} exists so a user can read the exact
+ * command before authorizing it. Once that decision is made, every downstream
+ * consumer — summaries, events, the success result — needs only which
+ * identities were involved, so this is what travels.
+ */
+export interface McpConsentRequestSummary {
+  declarations: readonly McpApprovalSummary[]
+  takeovers: readonly McpTakeoverSummary[]
+}
+
+export function summarizeMcpConsentRequest(request: McpConsentRequest): McpConsentRequestSummary {
+  return {
+    declarations: request.declarations.map((approval) => ({
+      effectiveName: approval.identity.effectiveName,
+      claimants: approval.claimants.map((claimant) => claimant.facet),
+      standing: approval.standing,
+    })),
+    takeovers: request.takeovers.map((takeover) => ({
+      adapter: takeover.adapter,
+      effectiveName: takeover.identity.effectiveName,
+      existing: takeover.existing,
+    })),
+  }
+}
+
+/**
+ * Whether this run needed approval, and how it got it.
+ *
+ * `via` distinguishes a decision a human made from one a flag supplied. Both
+ * authorize the same work, but only one of them means someone read the
+ * commands, which is exactly the distinction an audit of a CI run wants.
+ */
+export type McpConsentOutcome =
+  | { kind: 'not-required' }
+  | { kind: 'accepted'; via: 'interactive' | 'preapproved'; request: McpConsentRequestSummary }
+
+// ---------------------------------------------------------------------------
+// Aggregate
+// ---------------------------------------------------------------------------
+
+/** A server override the successful commit dropped. */
+export interface PrunedServerIntent {
+  facet: string
+  authoredName: string
+}
+
+/** Everything an operation did to MCP configuration, for the success result. */
+export interface McpInstallOutcomes {
+  consent: McpConsentOutcome
+  /** Every authored declaration's disposition and intent change. */
+  dispositions: readonly McpDispositionOutcome[]
+  /** Per adapter, per effective identity: what reconciliation did. */
+  configurations: readonly McpConfigurationOutcome[]
+  /** Server overrides this commit pruned because the facet no longer declares them. */
+  prunedIntent: readonly PrunedServerIntent[]
+}
+
+/** The outcome of an operation that had no MCP work at all. */
+export const NO_MCP_OUTCOMES: McpInstallOutcomes = {
+  consent: { kind: 'not-required' },
+  dispositions: [],
+  configurations: [],
+  prunedIntent: [],
+}

--- a/packages/engine/src/install/run-install-support.ts
+++ b/packages/engine/src/install/run-install-support.ts
@@ -1,24 +1,58 @@
 import type { InstallJournal } from './journal.ts'
+import type { McpInstallOutcomes } from './mcp/outcomes.ts'
 import type { FacetOutcome, InstallSummary, OnLog, RunInstallFailure, RunInstallResult } from './types.ts'
 
-/** Aggregate per-facet outcomes into the post-install summary counts. */
+/** Aggregate per-facet outcomes and MCP work into the post-install summary. */
 export function summarize(
   perFacet: ReadonlyArray<FacetOutcome>,
   totalAssets: number,
   removedAssets: number,
+  mcp: McpInstallOutcomes,
 ): InstallSummary {
   const count = (kind: FacetOutcome['kind']) => perFacet.filter((o) => o.kind === kind).length
   return {
-    installed: count('installed'),
-    updated: count('updated'),
-    repaired: count('repaired'),
-    unchanged: count('unchanged'),
-    // Both kinds dropped a declaration, which is what this count means. How
-    // many ASSETS left disk is `removedAssets`, and for an untracked removal
-    // that is zero — the two numbers disagreeing is the signal, not a bug.
-    removed: count('removed') + count('removed-untracked'),
-    totalAssets,
-    removedAssets,
+    facets: {
+      installed: count('installed'),
+      updated: count('updated'),
+      repaired: count('repaired'),
+      unchanged: count('unchanged'),
+      // Both kinds dropped a declaration, which is what this count means. How
+      // many ASSETS left disk is `textAssets.removed`, and for an untracked
+      // removal that is zero — the two disagreeing is the signal, not a bug.
+      removed: count('removed') + count('removed-untracked'),
+    },
+    textAssets: { written: totalAssets, removed: removedAssets },
+    mcp: summarizeMcp(mcp),
+  }
+}
+
+function summarizeMcp(mcp: McpInstallOutcomes): InstallSummary['mcp'] {
+  const configurations = { added: 0, updated: 0, repaired: 0, unchanged: 0, removed: 0 }
+  for (const outcome of mcp.configurations) {
+    if (outcome.kind === 'active') {
+      configurations[outcome.status]++
+      continue
+    }
+    // An entry someone had already deleted by hand leaves nothing for this
+    // run to do, so counting it as a removal would credit the operation with
+    // work it did not perform. The claim still goes; the native file does not
+    // change, which is what `unchanged` says.
+    if (outcome.status === 'removed') configurations.removed++
+    else configurations.unchanged++
+  }
+
+  const declarations = { aliased: 0, omitted: 0 }
+  for (const disposition of mcp.dispositions) {
+    if (disposition.kind === 'aliased') declarations.aliased++
+    else if (disposition.kind === 'omitted') declarations.omitted++
+  }
+
+  return {
+    configurations,
+    declarations,
+    // Only an accepted request can have adopted anything: a declined one
+    // fails the operation before the journal opens.
+    takeovers: { accepted: mcp.consent.kind === 'accepted' ? mcp.consent.request.takeovers.length : 0 },
   }
 }
 

--- a/packages/engine/src/install/run-install.ts
+++ b/packages/engine/src/install/run-install.ts
@@ -4,10 +4,11 @@ import { CURRENT_LOCKFILE_VERSION, preserveLockfileExtensions } from '@agent-fac
 import { type AdapterCompatibilityFailure, compatibilityFailureFor } from '../adapters/api-compatibility.ts'
 import { FACETS_JSON_FILE, type NormalizedProjectManifest } from '../manifest/mutations.ts'
 import { loadProjectManifest, manifestLoadFailure } from '../manifest/project-files.ts'
+import { classifyOutcome, facetConfigurationWork, NO_CONFIGURATION_WORK } from './classify-outcome.ts'
 import { compose } from './commit/compose.ts'
 import { applyManifestWritePolicy, mergeDeltaIntoManifest } from './commit/delta.ts'
 import { removedFacetOutcomes } from './commit/drift-removal.ts'
-import { finalizeMaterializationIntent } from './commit/finalize-intent.ts'
+import { finalizeMaterializationIntent, type PrunedOverride } from './commit/finalize-intent.ts'
 import { installFacets } from './commit/install-loop.ts'
 import { buildPreviousOwnership, obsoleteOwnership } from './commit/ownership.ts'
 import { resolveAll } from './commit/resolve-all.ts'
@@ -26,12 +27,30 @@ import { deleteObsoleteAssets, type RetainedObsoleteBundle } from './materialize
 import { materializeFailureToRunInstall } from './materialize-failure.ts'
 import { applyMcpServers } from './mcp/apply.ts'
 import { deriveMcpConsent, type McpConsentPolicy, settleMcpConsent } from './mcp/consent.ts'
+import {
+  classifyMcpConfigurations,
+  classifyMcpDispositions,
+  type McpConfigurationOutcome,
+  type McpConsentOutcome,
+  type McpInstallOutcomes,
+  mcpIntentBaseline,
+  NO_MCP_OUTCOMES,
+  type PrunedServerIntent,
+  summarizeMcpConsentRequest,
+} from './mcp/outcomes.ts'
 import { prepareMcpServers } from './mcp/prepare.ts'
 import { ownEntry } from './own-entry.ts'
 import { receiptProjectPath, resolveProjectReceipt } from './receipt.ts'
 import { refineRemoval } from './remove/refine.ts'
 import { rollbackAndFail, summarize } from './run-install-support.ts'
-import type { InstallDelta, RunInstallFailure, RunInstallOptions, RunInstallResult, StageEvent } from './types.ts'
+import type {
+  FacetOutcome,
+  InstallDelta,
+  RunInstallFailure,
+  RunInstallOptions,
+  RunInstallResult,
+  StageEvent,
+} from './types.ts'
 
 /**
  * Run the install pipeline for a project — the commit orchestrator.
@@ -383,15 +402,29 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
           authoredName: entry.authoredName,
         })
       }
+
+      // Removal reconciles ownership without resolving anything, so it has no
+      // declarations to report a disposition for and no approval to record.
+      // What it does have is the native entries it just dropped.
+      const refinedOutcomes: McpInstallOutcomes = {
+        ...NO_MCP_OUTCOMES,
+        configurations: classifyMcpConfigurations({
+          configurations: [],
+          previousOwnership: refined.previousMcpOwnership,
+          prepared: refinedMcp.prepared,
+        }),
+        prunedIntent: prunedServerIntent(prunedIntent),
+      }
+      reportMcpConfigured(refinedOutcomes.configurations)
       onStage({ kind: 'install-complete', outcome: 'success' })
 
       const perFacetOutcomes = [...refined.outcomes, ...removed]
       return {
         ok: true,
         lockfile: newLockfile,
-        summary: summarize(perFacetOutcomes, 0, deletion.deleted),
+        summary: summarize(perFacetOutcomes, 0, deletion.deleted, refinedOutcomes),
         perFacet: perFacetOutcomes,
-        serverWarnings: [],
+        mcp: refinedOutcomes,
       }
     }
 
@@ -415,7 +448,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     if (!resolution.ok) {
       return failureNoMutation(resolution.failure)
     }
-    const { resolved, serverWarnings } = resolution.value
+    const { resolved } = resolution.value
 
     // 7. Compose the global plan. Still no journal and still nothing
     //    written: a collision, an invalid alias, or a cancelled resolution
@@ -483,6 +516,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       previousOwnership: previousMcpOwnership,
       prepared: preparedMcp.prepared,
     })
+    let mcpConsentOutcome: McpConsentOutcome = { kind: 'not-required' }
     if (consent.kind === 'required') {
       // Frozen mode reproduces recorded intent and must never collect a new
       // decision, not even from a human at a terminal. The CLI already
@@ -490,6 +524,8 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       // the collision resolver's own frozen guard.
       const policy: McpConsentPolicy =
         frozenLockfile && mcpConsent.kind === 'interactive' ? { kind: 'unavailable' } : mcpConsent
+      const summary = summarizeMcpConsentRequest(consent.request)
+      onStage({ kind: 'mcp-consent-required', request: summary })
       const settled = await settleMcpConsent(policy, consent.request)
       if (settled.kind === 'unavailable') {
         return failureNoMutation({ code: 'MCP_CONSENT_REQUIRED', request: consent.request })
@@ -501,8 +537,14 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         return failureNoMutation({ code: 'ABORTED' })
       }
       if (settled.kind === 'declined') {
-        return failureNoMutation({ code: 'MCP_CONSENT_DECLINED' })
+        onStage({ kind: 'mcp-consent-declined' })
+        return failureNoMutation({ code: 'MCP_CONSENT_DECLINED', request: summary })
       }
+      // `preapproved` is the only arm that answers without asking, so it is
+      // the only one that can report an approval nobody read.
+      const via = policy.kind === 'preapproved' ? 'preapproved' : 'interactive'
+      onStage({ kind: 'mcp-consent-accepted', via })
+      mcpConsentOutcome = { kind: 'accepted', via, request: summary }
     }
 
     // 7. The first mutation is now imminent, so the rollback ledger opens
@@ -572,8 +614,7 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
     if (!loop.ok) {
       return await rollbackAndFail(journal, loop.failure, onLog)
     }
-    const { newFacetEntries, perFacet, totalAssets } = loop.value
-    perFacet.push(...removedOutcomes)
+    const { newFacetEntries, assetWrites, totalAssets } = loop.value
 
     // 10. Apply every prepared native MCP plan, last of the mutations and
     //     immediately before the transaction commits. Each changed document
@@ -680,6 +721,44 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       })
     }
 
+    // Same rule for configuration outcomes: the reconciliation is not real
+    // until the tri-write above commits, so nothing is announced before it.
+    const mcp: McpInstallOutcomes = {
+      consent: mcpConsentOutcome,
+      dispositions: classifyMcpDispositions(plan.mcpServers.planned, mcpIntentBaseline(receiptState)),
+      configurations: classifyMcpConfigurations({
+        configurations: reconciledServerConfigurations,
+        previousOwnership: previousMcpOwnership,
+        prepared: preparedMcp.prepared,
+      }),
+      prunedIntent: prunedServerIntent(pruned),
+    }
+    reportMcpConfigured(mcp.configurations)
+
+    // Classified here rather than inside the write loop, because a facet's
+    // outcome is not knowable until its configuration has been reconciled
+    // too: a server-only facet writes no asset at all, and a declaration
+    // whose native entry had drifted is a repair the loop cannot see.
+    const configurationWork = facetConfigurationWork(mcp)
+    const perFacet: FacetOutcome[] = []
+    for (const record of resolved) {
+      // Composed entries are the authority on what was locked, including the
+      // dispositions this run applied. A facet the plan does not carry was
+      // never composed and so has nothing to classify.
+      const composedEntry = plan.facetEntries[record.facet]
+      if (composedEntry === undefined) continue
+      const outcome = classifyOutcome(
+        record.facet,
+        record.previousEntry,
+        composedEntry,
+        assetWrites.get(record.facet) ?? 0,
+        configurationWork.get(record.facet) ?? NO_CONFIGURATION_WORK,
+      )
+      perFacet.push(outcome)
+      onStage({ kind: 'facet-success', facet: record.facet, outcome })
+    }
+    perFacet.push(...removedOutcomes)
+
     onStage({ kind: 'install-complete', outcome: 'success' })
 
     return {
@@ -690,9 +769,9 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
       lockfile: lockedSet.kind === 'write' ? lockedSet.newLockfile : previousLockfile,
       // `deletion.deleted` counts identities that actually existed on disk,
       // across every adapter — not a per-facet estimate multiplied out.
-      summary: summarize(perFacet, totalAssets, deletion.deleted),
+      summary: summarize(perFacet, totalAssets, deletion.deleted, mcp),
       perFacet,
-      serverWarnings,
+      mcp,
     }
   } finally {
     await installLock.release()
@@ -700,6 +779,19 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
 
   function noopStage(_event: StageEvent): void {}
   function noopLog(_build: () => string): void {}
+
+  /**
+   * The server half of what a successful commit pruned.
+   *
+   * Both domains prune through one pass over one override document, so the
+   * split happens here rather than by running the prune twice. Assets already
+   * have somewhere to be reported; servers did not until now.
+   */
+  function prunedServerIntent(pruned: readonly PrunedOverride[]): PrunedServerIntent[] {
+    return pruned
+      .filter((entry) => entry.contribution.kind === 'mcp-server')
+      .map((entry) => ({ facet: entry.facet, authoredName: entry.authoredName }))
+  }
 
   /**
    * Announce obsolete bundles whose cleanup was skipped because their primary
@@ -716,6 +808,18 @@ export async function runInstall(opts: RunInstallOptions): Promise<RunInstallRes
         facets: bundle.facets,
         companionPaths: bundle.companionPaths,
       })
+    }
+  }
+
+  /**
+   * Announce every effective identity this operation reconciled, after the
+   * transaction has committed. Same rule as the retained-bundle and
+   * stale-override reports: until the tri-write succeeds, a configuration
+   * write is still a candidate for rollback.
+   */
+  function reportMcpConfigured(outcomes: readonly McpConfigurationOutcome[]): void {
+    for (const outcome of outcomes) {
+      onStage({ kind: 'mcp-configured', outcome })
     }
   }
 

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -16,6 +16,7 @@ import type { ParseError, Source } from '../sources/facet/types.ts'
 import type { AssetTakeoverResolver } from './asset-takeover.ts'
 import type { CollisionResolver } from './commit/compose.ts'
 import type { McpConsentPolicy, McpConsentRequest } from './mcp/consent.ts'
+import type { McpConfigurationOutcome, McpConsentRequestSummary, McpInstallOutcomes } from './mcp/outcomes.ts'
 import type { McpContractViolation } from './mcp/prepare.ts'
 
 /**
@@ -139,16 +140,54 @@ export type FacetOutcome =
 
 /**
  * Aggregate counts for the post-install summary line.
+ *
+ * Grouped by domain rather than flattened. Text assets and MCP configurations
+ * are different work in different places, and a flat shape made one of them
+ * the default: `totalAssets` beside the facet counts read as "everything this
+ * run did", so a facet that configured three servers and wrote no file
+ * summarized as nothing happening. Naming the domain forces every reader to
+ * say which one it means.
  */
 export interface InstallSummary {
-  installed: number
-  updated: number
-  repaired: number
-  unchanged: number
-  removed: number
-  /** Assets actually written across all facets (excludes skipped no-ops). */
-  totalAssets: number
-  removedAssets: number
+  /** Per-facet outcomes, counted by kind. `removed` includes untracked removals. */
+  facets: {
+    installed: number
+    updated: number
+    repaired: number
+    unchanged: number
+    removed: number
+  }
+  /**
+   * Files. Counted per adapter and asset, so one skill across three adapters
+   * is three writes — the same unit the adapters actually worked in.
+   */
+  textAssets: {
+    /** Assets actually written (excludes skipped no-ops). */
+    written: number
+    removed: number
+  }
+  mcp: {
+    /**
+     * Native reconciliation, counted per adapter and effective identity —
+     * the same unit as {@link textAssets}, for the same reason.
+     */
+    configurations: {
+      added: number
+      updated: number
+      repaired: number
+      unchanged: number
+      removed: number
+    }
+    /** Authored declarations by disposition. Counted once, not per adapter. */
+    declarations: {
+      aliased: number
+      omitted: number
+    }
+    /** Untracked native entries this run adopted or replaced with approval. */
+    takeovers: {
+      accepted: number
+    }
+  }
 }
 
 /**
@@ -189,7 +228,6 @@ export type StageEvent =
   | { kind: 'facet-stage'; facet: string; stage: FacetStage }
   | { kind: 'facet-success'; facet: string; outcome: FacetOutcome }
   | { kind: 'facet-failure'; facet: string; failure: RunInstallFailure }
-  | { kind: 'server-warning'; facet: string; servers: ReadonlyArray<string> }
   | { kind: 'drift-removal'; facet: string; oldVersion: string }
   /**
    * A receipt asset entry was rejected during load (path traversal,
@@ -268,6 +306,50 @@ export type StageEvent =
    * real until then.
    */
   | ({ kind: 'stale-override-pruned' } & MaterializationOverrideRef)
+  /**
+   * MCP configuration needs approval, and this run is about to ask for it.
+   *
+   * Carries the summary rather than the request: the exact declarations go to
+   * the approval surface, which is the one place whose purpose is showing them.
+   * A progress event describes what is being decided, not its payload.
+   */
+  | { kind: 'mcp-consent-required'; request: McpConsentRequestSummary }
+  /**
+   * Approval was obtained. `via` separates a human who read the commands from
+   * a flag that stood in for one — the same set of work, authorized two
+   * materially different ways.
+   */
+  | { kind: 'mcp-consent-accepted'; via: 'interactive' | 'preapproved' }
+  /**
+   * The user refused. Emitted before the journal opens, so nothing needs
+   * undoing and the operation ends with every file as it was.
+   */
+  | { kind: 'mcp-consent-declined' }
+  /**
+   * An asset write reached an occupied destination this machine does not own,
+   * and the just-in-time gate is about to ask about it.
+   */
+  | {
+      kind: 'asset-takeover-required'
+      facet: string
+      adapter: string
+      asset: AssetIdentity
+      occupancy: 'equivalent' | 'divergent'
+    }
+  /** The occupied destination was adopted or overwritten. */
+  | { kind: 'asset-takeover-accepted'; facet: string; adapter: string; asset: AssetIdentity }
+  /** The user refused mid-application; the caller rolls the journal back. */
+  | { kind: 'asset-takeover-cancelled'; facet: string; adapter: string; asset: AssetIdentity }
+  /**
+   * One effective MCP identity was reconciled into one adapter's native
+   * configuration.
+   *
+   * Emitted only after the transaction commits, like `stale-override-pruned`
+   * and for the same reason: until the tri-write succeeds the write is still
+   * a candidate for rollback, and reporting it earlier would announce work
+   * that may be undone a moment later.
+   */
+  | { kind: 'mcp-configured'; outcome: McpConfigurationOutcome }
   | { kind: 'adapter-complete'; facet: string; adapter: string }
   | { kind: 'asset-installed'; facet: string; adapter: string; asset: AssetIdentity }
   | { kind: 'asset-deleted'; facet: string; adapter: string; asset: AssetIdentity }
@@ -595,11 +677,12 @@ export type RunInstallFailure =
   /**
    * The user declined the MCP configuration request.
    *
-   * Payload-free, unlike `MCP_CONSENT_REQUIRED`: re-printing declarations the
-   * user just refused would push them onto a persistent surface for no
-   * benefit. Nothing was mutated — consent settles before the journal opens.
+   * Carries the SUMMARY, not the request: the user just read the declarations
+   * and said no, so reprinting them helps nobody, while the identities are
+   * what a report needs to say which servers were left unconfigured. Nothing
+   * was mutated — consent settles before the journal opens.
    */
-  | { code: 'MCP_CONSENT_DECLINED' }
+  | { code: 'MCP_CONSENT_DECLINED'; request: McpConsentRequestSummary }
   | { code: 'ABORTED' }
 
 /**
@@ -632,8 +715,8 @@ export type RollbackOutcome =
  * Result of a `runInstall` invocation. Discriminated by `ok`.
  *
  * On success, callers receive the new lockfile (already written to
- * disk), a summary of counts, per-facet outcomes, and any server
- * warnings collected during install.
+ * disk), a summary of counts, per-facet outcomes, and what the run did
+ * to this project's MCP configuration.
  *
  * On failure, callers receive the structured failure plus the
  * `RollbackOutcome` — view layers branch on `rollback.kind`.
@@ -644,7 +727,11 @@ export type RunInstallResult =
       lockfile: SupportedLockfile
       summary: InstallSummary
       perFacet: ReadonlyArray<FacetOutcome>
-      serverWarnings: ReadonlyArray<{ facet: string; servers: ReadonlyArray<string> }>
+      /**
+       * What this operation did to MCP configuration: intent, native
+       * reconciliation, and the approval that authorized it.
+       */
+      mcp: McpInstallOutcomes
     }
   | {
       ok: false


### PR DESCRIPTION
### Why

The old `server-warning` / `serverWarnings` surface treated MCP server declarations as a warn-and-skip concern rather than a first-class outcome. That made it impossible to report what a run actually did to native configuration files, left server-only facets summarizing as no-ops, and gave the rest of the system no structured way to distinguish intent changes from native drift repairs.

### Details

`serverWarnings` and the `server-warning` stage event are removed entirely. In their place, `RunInstallResult` gains an `mcp` field of type `McpInstallOutcomes`, which carries:

- **`consent`** — whether approval was required and how it was obtained (`interactive` vs `preapproved`), without the declarations themselves.
- **`dispositions`** — every authored declaration's intent change (`introduced`, `updated`, `unchanged`, `unwitnessed`), tagged by disposition kind so an effective name appears only where one exists.
- **`configurations`** — per-adapter, per-effective-identity reconciliation outcomes (`added`, `updated`, `repaired`, `unchanged`, `removed`), with a `takenOver` flag for entries this machine did not previously own.
- **`prunedIntent`** — server overrides that were dropped because the facet no longer declares them.

`InstallSummary` is restructured from a flat set of counts into three named groups — `facets`, `textAssets`, and `mcp` — so a server-only facet's configuration work is counted separately from file writes and cannot be mistaken for a no-op.

Facet outcome classification (`classifyOutcome`) now accepts a `FacetConfigurationWork` argument derived from the MCP outcomes, so a facet that only configures servers can still be reported as `repaired` or `updated` rather than always `unchanged`. Classification is deferred until after MCP reconciliation completes, which is why the install loop now returns raw `assetWrites` counts instead of pre-classified `FacetOutcome` values.

Six new stage events replace `server-warning`: `mcp-consent-required`, `mcp-consent-accepted`, `mcp-consent-declined`, `asset-takeover-required`, `asset-takeover-accepted`, `asset-takeover-cancelled`, and `mcp-configured`. All are handled in an exhaustive switch so a future addition cannot be silently ignored. The `mcp-configured` event, like `stale-override-pruned`, is emitted only after the transaction commits.

`MCP_CONSENT_DECLINED` now carries a `McpConsentRequestSummary` (identities and standings, not declarations) so a failure report can name which servers were left unconfigured without reprinting the commands the user just refused.

### Verification

New focused test file `mcp-outcomes.test.ts` covers: server-only facet counts, unchanged vs repaired vs updated classification, unwitnessed intent, takeover scenarios, multi-adapter and multi-claimant counting, already-absent removal, event ordering, secret redaction from routine surfaces (declarations must not appear in `mcp`, `summary`, or events), and stale server intent pruning. Existing engine and CLI tests are updated to the new summary shape. CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install orchestration, result contracts, and facet classification across engine and CLI; behavior changes are well-tested but affect every install success/failure surface.
> 
> **Overview**
> Replaces the warn-and-skip **`server-warning` / `serverWarnings`** path with first-class MCP reporting on successful installs.
> 
> **Engine:** Successful **`RunInstallResult`** now includes **`mcp: McpInstallOutcomes`** (consent, per-declaration dispositions, per-adapter configuration outcomes, pruned server intent). **`InstallSummary`** is grouped into **`facets`**, **`textAssets`**, and **`mcp`** counts. Facet **`installed` / `updated` / `repaired` / `unchanged`** classification runs **after** MCP reconciliation via **`facetConfigurationWork`**, so server-only facets and native config drift are not mislabeled as no-ops. New stage events (**`mcp-consent-*`**, **`asset-takeover-*`**, **`mcp-configured`**) replace **`server-warning`**; **`MCP_CONSENT_DECLINED`** carries a summary (identities only, not declarations). **`mcp/outcomes.ts`** and **`mcp-outcomes.test.ts`** cover classification, counting, events, and secret redaction.
> 
> **CLI:** **`InstallView`** drops server-warning UI, updates fixtures to the new summary shape, treats MCP configuration counts in no-op detection and **`summaryLine`**, and exhaustively handles new events (MCP UI still deferred until consent/takeover plumbing exists).
> 
> OpenSpec tasks **11–12** are marked complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c218c39cd72f4a6818c221fd96bcdf68391216fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->