### PR TITLE
Extend collision resolution UI and workspace to MCP server claimants

### DIFF
--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -116,15 +116,15 @@
 
 ## 13. Collision resolution UI — Research
 
-- [ ] 13.1 Explore: Inspect the collision draft/workspace, claimant identity, alias validation, cancellation, non-interactive report, and prototype-safety tests that currently assume asset-only claimants.
-- [ ] 13.2 Propose: Define tagged asset/MCP claimant models and a complete-draft re-planning approach that preserves separate namespaces, accessible statuses, durable server dispositions, and no-winner behavior.
+- [x] 13.1 Explore: Inspect the collision draft/workspace, claimant identity, alias validation, cancellation, non-interactive report, and prototype-safety tests that currently assume asset-only claimants.
+- [x] 13.2 Propose: Define tagged asset/MCP claimant models and a complete-draft re-planning approach that preserves separate namespaces, accessible statuses, durable server dispositions, and no-winner behavior.
 
 ## 14. Collision resolution UI — Implementation
 
-- [ ] 14.1 Implement: Extend the interactive overview, focused workspace, draft model, and Keep/Alias/Omit controls to MCP claimants with declaration summaries and complete global revalidation.
-- [ ] 14.2 Implement: Extend non-interactive collision failures with every MCP claimant, exact `materialization.servers` locations, valid alias/omission examples, no invented winner, and explicit no-mutation reporting.
-- [ ] 14.3 Implement: Add UI/model/report tests for mixed asset/server groups, every-claimant omission, alias conflicts, invalid aliases, cancellation/interruption, accessible status labels, and prototype-pollution keys.
-- [ ] 14.4 Verify: Run focused collision workspace, report, CLI integration, and type checks.
+- [x] 14.1 Implement: Extend the interactive overview, focused workspace, draft model, and Keep/Alias/Omit controls to MCP claimants with declaration summaries and complete global revalidation.
+- [x] 14.2 Implement: Extend non-interactive collision failures with every MCP claimant, exact `materialization.servers` locations, valid alias/omission examples, no invented winner, and explicit no-mutation reporting.
+- [x] 14.3 Implement: Add UI/model/report tests for mixed asset/server groups, every-claimant omission, alias conflicts, invalid aliases, cancellation/interruption, accessible status labels, and prototype-pollution keys.
+- [x] 14.4 Verify: Run focused collision workspace, report, CLI integration, and type checks.
 
 ## 15. Consent, takeover, flags, and command output — Research
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type {
+  CollisionFacetContribution,
   CollisionResolution,
   CollisionResolutionRequest,
   CollisionResolver,
@@ -10,9 +11,9 @@ import type {
   RunInstallResult,
   StageEvent,
 } from '@agent-facets/engine'
-import { assetIdentity } from '@agent-facets/engine'
-import type { FacetContribution, IntegrityFailure } from '@agent-facets/protocol'
-import { CURRENT_LOCKFILE_VERSION, LOCKFILE_VERSION_0_3, planMaterialization } from '@agent-facets/protocol'
+import { assetIdentity, planCollisionIntent } from '@agent-facets/engine'
+import type { IntegrityFailure } from '@agent-facets/protocol'
+import { CURRENT_LOCKFILE_VERSION, LOCKFILE_VERSION_0_3 } from '@agent-facets/protocol'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
 import { InstallView, type InstallViewResult } from '../tui/views/install/install-view.tsx'
@@ -1014,13 +1015,13 @@ const KEY = { down: '\u001B[B', right: '\u001B[C', enter: '\r', escape: '\u001B'
 function collisionRequest(): CollisionResolutionRequest {
   // Planner contributions are AUTHORED assets — identity only. They carry no
   // disposition or file records, unlike a lockfile entry.
-  const contributions: FacetContribution[] = [
-    { facet: 'alpha', assets: [{ scope: 'project', type: 'skill', name: 'review' }] },
-    { facet: 'beta', assets: [{ scope: 'project', type: 'skill', name: 'review' }] },
+  const facets: CollisionFacetContribution[] = [
+    { facet: 'alpha', assets: [{ scope: 'project', type: 'skill', name: 'review' }], servers: [] },
+    { facet: 'beta', assets: [{ scope: 'project', type: 'skill', name: 'review' }], servers: [] },
   ]
-  const planned = planMaterialization(contributions)
+  const planned = planCollisionIntent(facets, {})
   if (planned.ok || planned.reason !== 'collision') expect.unreachable()
-  return { groups: planned.groups, contributions, staleOverrides: [] }
+  return { groups: planned.groups, facets, overrides: {}, staleOverrides: [] }
 }
 
 const CANCELLED_RESULT: RunInstallResult = {

--- a/packages/cli/src/commands/shared/__tests__/install-failure.test.ts
+++ b/packages/cli/src/commands/shared/__tests__/install-failure.test.ts
@@ -123,7 +123,19 @@ describe('installFailureDetail', () => {
 
 describe('installFailureFix — actionable failures name their command', () => {
   const actionable: RunInstallFailure[] = [
-    { code: 'MATERIALIZATION_ALIAS_INVALID', problems: [{ facet: 'a', alias: 'Bad', reason: 'must be lowercase' }] },
+    {
+      code: 'MATERIALIZATION_ALIAS_INVALID',
+      problems: [
+        {
+          kind: 'asset',
+          facet: 'a',
+          assetType: 'skill',
+          authoredName: 'review',
+          alias: 'Bad',
+          reason: 'must be lowercase',
+        },
+      ],
+    },
     { code: 'MATERIALIZATION_COLLISION', groups: [], staleOverrides: [] },
     { code: 'MATERIALIZATION_CANCELLED' },
   ]

--- a/packages/cli/src/tui/views/install/collision/__tests__/draft.test.ts
+++ b/packages/cli/src/tui/views/install/collision/__tests__/draft.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import type { CollisionResolutionRequest } from '@agent-facets/engine'
-import type { FacetContribution } from '@agent-facets/protocol'
-import { planMaterialization } from '@agent-facets/protocol'
+import type { CollisionFacetContribution, CollisionResolutionRequest } from '@agent-facets/engine'
+import { planCollisionIntent } from '@agent-facets/engine'
+import type { FacetMaterializationOverrides, McpServerDeclaration } from '@agent-facets/protocol'
 import {
   type ClaimantModel,
   createDraft,
@@ -17,24 +17,35 @@ import {
  * A fixture that disagreed with the planner would let these tests pass
  * while the real workspace showed something else.
  */
-function requestFor(contributions: FacetContribution[]): CollisionResolutionRequest {
-  const planned = planMaterialization(contributions)
+function requestFor(
+  facets: CollisionFacetContribution[],
+  overrides: Readonly<Record<string, FacetMaterializationOverrides>> = {},
+): CollisionResolutionRequest {
+  const planned = planCollisionIntent(facets, overrides)
   if (planned.ok) expect.unreachable()
   if (planned.reason !== 'collision') expect.unreachable()
-  return {
-    groups: planned.groups,
-    contributions,
-    staleOverrides: planned.staleOverrides.map((stale) => ({
-      facet: stale.facet,
-      contribution: { kind: 'asset' as const, assetType: stale.type },
-      authoredName: stale.authoredName,
-      disposition: stale.disposition,
-    })),
-  }
+  return { groups: planned.groups, facets, overrides, staleOverrides: planned.staleOverrides }
 }
 
-function skill(facet: string, ...names: string[]): FacetContribution {
-  return { facet, assets: names.map((name) => ({ scope: 'project', type: 'skill', name })) }
+function skill(facet: string, ...names: string[]): CollisionFacetContribution {
+  return { facet, assets: names.map((name) => ({ scope: 'project', type: 'skill', name })), servers: [] }
+}
+
+/**
+ * A facet declaring servers, each with a command derived from the facet so
+ * two facets declaring the same NAME disagree about what it is. Identical
+ * declarations compose rather than collide, so a fixture meant to produce a
+ * collision has to actually differ.
+ */
+function server(facet: string, ...names: string[]): CollisionFacetContribution {
+  return {
+    facet,
+    assets: [],
+    servers: names.map((name) => ({
+      name,
+      declaration: { type: 'stdio', command: `${facet}-${name}` } as McpServerDeclaration,
+    })),
+  }
 }
 
 function memberOf(model: WorkspaceModel, facet: string, authoredName: string): ClaimantModel {
@@ -43,6 +54,10 @@ function memberOf(model: WorkspaceModel, facet: string, authoredName: string): C
     if (found) return found
   }
   expect.unreachable()
+}
+
+function refOf(model: WorkspaceModel, facet: string, authoredName: string) {
+  return memberOf(model, facet, authoredName).ref
 }
 
 function statusOf(model: WorkspaceModel, facet: string, authoredName: string): string {
@@ -67,11 +82,8 @@ describe('collision draft — initial state', () => {
     // `gamma` already has an alias recorded. It is not part of the
     // collision, so nothing in the workspace will touch it — but it must
     // survive into what gets submitted.
-    const contributions: FacetContribution[] = [
-      ...TWO_WAY,
-      { ...skill('gamma', 'audit'), overrides: { skills: { audit: { kind: 'aliased', as: 'gamma-audit' } } } },
-    ]
-    const request = requestFor(contributions)
+    const facets: CollisionFacetContribution[] = [...TWO_WAY, skill('gamma', 'audit')]
+    const request = requestFor(facets, { gamma: { skills: { audit: { kind: 'aliased', as: 'gamma-audit' } } } })
     const draft = createDraft(request)
 
     expect(draft.overrides.gamma).toEqual({ skills: { audit: { kind: 'aliased', as: 'gamma-audit' } } })
@@ -84,7 +96,7 @@ describe('collision draft — resolving', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-review' })
     const model = evaluateDraft(request, draft)
 
     expect(model.confirmable).toBe(true)
@@ -98,7 +110,7 @@ describe('collision draft — resolving', () => {
     const request = requestFor(TWO_WAY)
     let draft = createDraft(request)
     for (const member of evaluateDraft(request, draft).groups[0]?.members ?? []) {
-      draft = reviseDraft(request, draft, member, { kind: 'omitted' })
+      draft = reviseDraft(request, draft, member.ref, { kind: 'omitted' })
     }
     const model = evaluateDraft(request, draft)
 
@@ -111,8 +123,8 @@ describe('collision draft — resolving', () => {
     const request = requestFor(TWO_WAY)
     let draft = createDraft(request)
     const model0 = evaluateDraft(request, draft)
-    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'a-review' })
-    draft = reviseDraft(request, draft, memberOf(model0, 'beta', 'review'), { kind: 'aliased', as: 'b-review' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review').ref, { kind: 'aliased', as: 'a-review' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'beta', 'review').ref, { kind: 'aliased', as: 'b-review' })
 
     expect(evaluateDraft(request, draft).confirmable).toBe(true)
   })
@@ -121,8 +133,8 @@ describe('collision draft — resolving', () => {
     const request = requestFor(TWO_WAY)
     let draft = createDraft(request)
     const model0 = evaluateDraft(request, draft)
-    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'shared' })
-    draft = reviseDraft(request, draft, memberOf(model0, 'beta', 'review'), { kind: 'aliased', as: 'shared' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review').ref, { kind: 'aliased', as: 'shared' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'beta', 'review').ref, { kind: 'aliased', as: 'shared' })
     const model = evaluateDraft(request, draft)
 
     expect(model.confirmable).toBe(false)
@@ -135,10 +147,10 @@ describe('collision draft — resolving', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-review' })
     expect(draft.overrides.alpha).toBeDefined()
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'authored' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'authored' })
     // The project schema rejects an explicit `authored` override, so the
     // only correct spelling of "use the authored name" is absence.
     expect(draft.overrides.alpha).toBeUndefined()
@@ -152,9 +164,9 @@ describe('collision draft — conflicts the user creates', () => {
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
 
     // `gamma/audit` was never colliding and is not in the initial report.
-    expect(request.groups.flatMap((g) => g.members).some((m) => m.facet === 'gamma')).toBe(false)
+    expect(request.groups.flatMap((g) => [...g.group.members]).some((member) => member.facet === 'gamma')).toBe(false)
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'audit' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'audit' })
     const model = evaluateDraft(request, draft)
 
     expect(model.confirmable).toBe(false)
@@ -171,11 +183,14 @@ describe('collision draft — conflicts the user creates', () => {
     let draft = createDraft(request)
     const model0 = evaluateDraft(request, draft)
 
-    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'alpha-review' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review').ref, {
+      kind: 'aliased',
+      as: 'alpha-review',
+    })
     const model1 = evaluateDraft(request, draft)
     expect(statusOf(model1, 'beta', 'review')).toBe('resolved')
 
-    draft = reviseDraft(request, draft, memberOf(model1, 'alpha', 'review'), { kind: 'aliased', as: 'review' })
+    draft = reviseDraft(request, draft, memberOf(model1, 'alpha', 'review').ref, { kind: 'aliased', as: 'review' })
     const model2 = evaluateDraft(request, draft)
     expect(statusOf(model2, 'alpha', 'review')).toBe('draft-conflict')
     expect(statusOf(model2, 'beta', 'review')).toBe('draft-conflict')
@@ -186,8 +201,8 @@ describe('collision draft — conflicts the user creates', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'audit' })
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'audit' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-review' })
     const model = evaluateDraft(request, draft)
 
     // If `gamma` vanished here, the list would reflow under the cursor
@@ -201,20 +216,20 @@ describe('collision draft — conflicts the user creates', () => {
     let draft = createDraft(request)
 
     // Point alpha's `one` at `two`. That drags alpha's own `two` in.
-    draft = reviseDraft(request, draft, memberOf(evaluateDraft(request, draft), 'alpha', 'one'), {
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', 'one'), {
       kind: 'aliased',
       as: 'two',
     })
     // Now send `two` the other way. Mid-swap the set is still colliding,
     // which is exactly the state the workspace has to tolerate.
-    draft = reviseDraft(request, draft, memberOf(evaluateDraft(request, draft), 'alpha', 'two'), {
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', 'two'), {
       kind: 'aliased',
       as: 'one',
     })
     expect(evaluateDraft(request, draft).confirmable).toBe(false)
 
     // Free the name beta was holding, and the swap lands.
-    draft = reviseDraft(request, draft, memberOf(evaluateDraft(request, draft), 'beta', 'one'), {
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'beta', 'one'), {
       kind: 'aliased',
       as: 'beta-one',
     })
@@ -243,8 +258,8 @@ describe('collision draft — grouping', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'audit' })
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-review' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'audit' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-review' })
     const model = evaluateDraft(request, draft)
 
     const singleton = model.groups.find((group) => group.members.some((member) => member.facet === 'gamma'))
@@ -260,7 +275,7 @@ describe('collision draft — grouping', () => {
     let draft = createDraft(request)
     const model0 = evaluateDraft(request, draft)
 
-    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review'), { kind: 'aliased', as: 'deploy' })
+    draft = reviseDraft(request, draft, memberOf(model0, 'alpha', 'review').ref, { kind: 'aliased', as: 'deploy' })
     const model = evaluateDraft(request, draft)
 
     // Three assets now want `deploy`. Splitting them across two screens
@@ -281,7 +296,7 @@ describe('collision draft — a draft holding an invalid alias', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', 'review')
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'Review' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'Review' })
     const model = evaluateDraft(request, draft)
 
     const member = memberOf(model, 'alpha', 'review')
@@ -313,7 +328,7 @@ describe('collision draft — names that collide with Object.prototype', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', PROTO)
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-proto' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-proto' })
     const model = evaluateDraft(request, draft)
 
     expect(model.confirmable).toBe(true)
@@ -329,8 +344,8 @@ describe('collision draft — names that collide with Object.prototype', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', PROTO)
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'first' })
-    draft = reviseDraft(request, draft, alpha, { kind: 'omitted' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'first' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'omitted' })
 
     const skills = draft.overrides.alpha?.skills ?? {}
     expect(Object.keys(skills)).toEqual([PROTO])
@@ -342,15 +357,18 @@ describe('collision draft — names that collide with Object.prototype', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', PROTO)
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-proto' })
-    draft = reviseDraft(request, draft, alpha, { kind: 'authored' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-proto' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'authored' })
 
     expect(draft.overrides.alpha).toBeUndefined()
   })
 
   test('a facet named __proto__ keeps its seeded overrides as an own key', () => {
     const overrides = JSON.parse('{"skills":{"audit":{"kind":"aliased","as":"vendor-audit"}}}')
-    const request = requestFor([...TWO_WAY, { ...skill(PROTO, 'audit'), overrides }])
+    const request = requestFor(
+      [...TWO_WAY, skill(PROTO, 'audit')],
+      JSON.parse(`{${JSON.stringify(PROTO)}:${JSON.stringify(overrides)}}`),
+    )
     const draft = createDraft(request)
 
     expect(Object.hasOwn(draft.overrides, PROTO)).toBe(true)
@@ -362,7 +380,7 @@ describe('collision draft — names that collide with Object.prototype', () => {
     const request = requestFor([skill('alpha', PROTO), skill(PROTO, PROTO)])
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', PROTO)
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-proto' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-proto' })
 
     expect(Object.getPrototypeOf(draft.overrides)).toBeNull()
     expect(Object.keys(Object.prototype)).toEqual([])
@@ -382,11 +400,10 @@ describe('collision draft — names that collide with Object.prototype', () => {
 
   test('a facet named constructor keeps an override it really has', () => {
     const overrides = JSON.parse('{"skills":{"review":{"kind":"aliased","as":"vendor-review"}}}')
-    const request = requestFor([
-      { ...skill(CTOR, 'review'), overrides },
-      skill('beta', 'review'),
-      skill('gamma', 'vendor-review'),
-    ])
+    const request = requestFor(
+      [skill(CTOR, 'review'), skill('beta', 'review'), skill('gamma', 'vendor-review')],
+      JSON.parse(`{${JSON.stringify(CTOR)}:${JSON.stringify(overrides)}}`),
+    )
     const model = evaluateDraft(request, createDraft(request))
 
     expect(memberOf(model, CTOR, 'review').effectiveName).toBe('vendor-review')
@@ -397,10 +414,10 @@ describe('collision draft — names that collide with Object.prototype', () => {
     let draft = createDraft(request)
     const alpha = memberOf(evaluateDraft(request, draft), 'alpha', CTOR)
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'aliased', as: 'alpha-ctor' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'aliased', as: 'alpha-ctor' })
     expect(evaluateDraft(request, draft).confirmable).toBe(true)
 
-    draft = reviseDraft(request, draft, alpha, { kind: 'authored' })
+    draft = reviseDraft(request, draft, alpha.ref, { kind: 'authored' })
     expect(draft.overrides.alpha).toBeUndefined()
   })
 })
@@ -424,15 +441,220 @@ describe('alias validation', () => {
     // engine would have produced for the same string. Asserting they are
     // equal is what stops the UI from growing its own friendlier — and
     // eventually divergent — description of the grammar.
-    const planned = planMaterialization([
-      {
-        facet: 'alpha',
-        assets: [{ scope: 'project', type: 'skill', name: 'review' }],
-        overrides: { skills: { review: { kind: 'aliased', as: 'Review' } } },
-      },
-    ])
+    const planned = planCollisionIntent(
+      [{ facet: 'alpha', assets: [{ scope: 'project', type: 'skill', name: 'review' }], servers: [] }],
+      { alpha: { skills: { review: { kind: 'aliased', as: 'Review' } } } },
+    )
     if (planned.ok || planned.reason !== 'invalid-alias') expect.unreachable()
 
     expect(validateAlias('Review')).toBe(planned.problems[0]?.reason ?? '')
+  })
+})
+
+describe('collision draft — MCP server claimants', () => {
+  const SERVERS = [server('alpha', 'filesystem'), server('beta', 'filesystem')]
+
+  test('two disagreeing declarations are one unresolved group', () => {
+    const request = requestFor(SERVERS)
+    const model = evaluateDraft(request, createDraft(request))
+
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.kind).toBe('mcp-server')
+    expect(model.confirmable).toBe(false)
+    expect(statusOf(model, 'alpha', 'filesystem')).toBe('unresolved')
+    expect(statusOf(model, 'beta', 'filesystem')).toBe('unresolved')
+  })
+
+  test('a server claimant carries its declaration, for a summary the user can tell apart', () => {
+    const request = requestFor(SERVERS)
+    const ref = refOf(evaluateDraft(request, createDraft(request)), 'alpha', 'filesystem')
+
+    if (ref.kind !== 'mcp-server') expect.unreachable()
+    expect(ref.declaration).toEqual({ type: 'stdio', command: 'alpha-filesystem' } as never)
+    expect(ref.fingerprint).toStartWith('sha256:')
+  })
+
+  test('aliasing one server resolves the group and writes the servers group', () => {
+    const request = requestFor(SERVERS)
+    let draft = createDraft(request)
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', 'filesystem'), {
+      kind: 'aliased',
+      as: 'alpha-fs',
+    })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(true)
+    expect(memberOf(model, 'alpha', 'filesystem').effectiveName).toBe('alpha-fs')
+    // The choice lands in `materialization.servers`, not in an asset group.
+    expect(draft.overrides.alpha).toEqual({ servers: { filesystem: { kind: 'aliased', as: 'alpha-fs' } } })
+  })
+
+  test('omitting every claimant is a resolution', () => {
+    const request = requestFor(SERVERS)
+    let draft = createDraft(request)
+    for (const facet of ['alpha', 'beta']) {
+      draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), facet, 'filesystem'), {
+        kind: 'omitted',
+      })
+    }
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(true)
+    expect(memberOf(model, 'alpha', 'filesystem').effectiveName).toBeNull()
+  })
+
+  test('a server alias onto another server surfaces the claimant it landed on', () => {
+    const request = requestFor([...SERVERS, server('gamma', 'search')])
+    let draft = createDraft(request)
+
+    expect(request.groups.flatMap((entry) => [...entry.group.members]).some((m) => m.facet === 'gamma')).toBe(false)
+
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', 'filesystem'), {
+      kind: 'aliased',
+      as: 'search',
+    })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(false)
+    // Reachable, and reachable from the same group: the user can fix the
+    // conflict they just created from either side.
+    expect(statusOf(model, 'gamma', 'search')).toBe('draft-conflict')
+  })
+
+  test('identical declarations compose instead of colliding', () => {
+    const shared: McpServerDeclaration = { type: 'stdio', command: 'shared' } as McpServerDeclaration
+    const facets: CollisionFacetContribution[] = [
+      { facet: 'alpha', assets: [], servers: [{ name: 'filesystem', declaration: shared }] },
+      { facet: 'beta', assets: [], servers: [{ name: 'filesystem', declaration: shared }] },
+    ]
+
+    // Not a collision at all, so the engine would never open a workspace.
+    const planned = planCollisionIntent(facets, {})
+    expect(planned.ok).toBe(true)
+  })
+
+  test('a draft holding an invalid server alias explains itself and blocks confirmation', () => {
+    // Same defensive branch the asset case covers: the workspace validates
+    // before committing, so this state is only reachable by writing one
+    // directly — which is exactly why it must still read as unresolved.
+    const request = requestFor(SERVERS)
+    let draft = createDraft(request)
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', 'filesystem'), {
+      kind: 'aliased',
+      as: 'NOPE',
+    })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(false)
+    const alpha = memberOf(model, 'alpha', 'filesystem')
+    expect(alpha.aliasError).toBe(validateAlias('NOPE'))
+    expect(alpha.status).toBe('unresolved')
+  })
+})
+
+describe('collision draft — separate identity spaces', () => {
+  test('a skill and a server sharing a name are separate groups, never merged', () => {
+    const facets = [
+      skill('alpha', 'review'),
+      skill('beta', 'review'),
+      server('gamma', 'review'),
+      server('delta', 'review'),
+    ]
+    const request = requestFor(facets)
+    const model = evaluateDraft(request, createDraft(request))
+
+    expect(model.groups).toHaveLength(2)
+    expect(model.groups.map((group) => group.kind).sort()).toEqual(['asset', 'mcp-server'])
+    for (const group of model.groups) {
+      expect(new Set(group.members.map((member) => member.ref.kind)).size).toBe(1)
+    }
+  })
+
+  test('resolving one domain leaves the other untouched and still blocking', () => {
+    const facets = [
+      skill('alpha', 'review'),
+      skill('beta', 'review'),
+      server('gamma', 'review'),
+      server('delta', 'review'),
+    ]
+    const request = requestFor(facets)
+    let draft = createDraft(request)
+
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', 'review'), {
+      kind: 'aliased',
+      as: 'alpha-review',
+    })
+    const model = evaluateDraft(request, draft)
+
+    expect(model.confirmable).toBe(false)
+    expect(statusOf(model, 'alpha', 'review')).toBe('resolved')
+    expect(statusOf(model, 'gamma', 'review')).toBe('unresolved')
+  })
+
+  test('an asset alias cannot resolve a server collision by taking its name', () => {
+    const facets = [skill('alpha', 'other'), server('gamma', 'review'), server('delta', 'review')]
+    const planned = planCollisionIntent(facets, { alpha: { skills: { other: { kind: 'aliased', as: 'review' } } } })
+
+    // The skill moved onto `review` and nothing happened to the servers:
+    // two spaces, no shared key to contend in.
+    if (planned.ok) expect.unreachable()
+    if (planned.reason !== 'collision') expect.unreachable()
+    expect(planned.groups).toHaveLength(1)
+    expect(planned.groups[0]?.kind).toBe('mcp-server')
+  })
+})
+
+describe('collision draft — server names that collide with Object.prototype', () => {
+  const PROTO = '__proto__'
+  const CTOR = 'constructor'
+
+  test('an alias for a server named __proto__ is recorded as an own key', () => {
+    const request = requestFor([server('alpha', PROTO), server('beta', PROTO)])
+    let draft = createDraft(request)
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', PROTO), {
+      kind: 'aliased',
+      as: 'alpha-proto',
+    })
+
+    const servers = draft.overrides.alpha?.servers ?? {}
+    expect(Object.hasOwn(servers, PROTO)).toBe(true)
+    expect(servers[PROTO]).toEqual({ kind: 'aliased', as: 'alpha-proto' })
+    expect(evaluateDraft(request, draft).confirmable).toBe(true)
+  })
+
+  test('Keep on a server named __proto__ collapses the group without deleting it', () => {
+    const request = requestFor([server('alpha', PROTO), server('beta', PROTO)])
+    let draft = createDraft(request)
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', PROTO), {
+      kind: 'aliased',
+      as: 'alpha-proto',
+    })
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', PROTO), { kind: 'authored' })
+
+    expect(draft.overrides.alpha).toBeUndefined()
+  })
+
+  test('a facet named constructor keeps a server override it really has', () => {
+    const overrides = JSON.parse('{"servers":{"filesystem":{"kind":"aliased","as":"vendor-fs"}}}')
+    const request = requestFor(
+      [server(CTOR, 'filesystem'), server('beta', 'filesystem'), server('gamma', 'vendor-fs')],
+      JSON.parse(`{${JSON.stringify(CTOR)}:${JSON.stringify(overrides)}}`),
+    )
+    const model = evaluateDraft(request, createDraft(request))
+
+    expect(memberOf(model, CTOR, 'filesystem').effectiveName).toBe('vendor-fs')
+  })
+
+  test('no server choice mutates Object.prototype', () => {
+    const request = requestFor([server('alpha', PROTO), server('beta', PROTO)])
+    let draft = createDraft(request)
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'alpha', PROTO), {
+      kind: 'aliased',
+      as: 'alpha-proto',
+    })
+    draft = reviseDraft(request, draft, refOf(evaluateDraft(request, draft), 'beta', PROTO), { kind: 'omitted' })
+
+    expect(Object.keys(Object.prototype)).toEqual([])
+    expect(({} as Record<string, unknown>).servers).toBeUndefined()
   })
 })

--- a/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
+++ b/packages/cli/src/tui/views/install/collision/__tests__/workspace.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import type { CollisionResolution, CollisionResolutionRequest } from '@agent-facets/engine'
-import type { FacetContribution } from '@agent-facets/protocol'
-import { planMaterialization } from '@agent-facets/protocol'
+import type { CollisionFacetContribution, CollisionResolution, CollisionResolutionRequest } from '@agent-facets/engine'
+import { planCollisionIntent } from '@agent-facets/engine'
+import type { McpServerDeclaration } from '@agent-facets/protocol'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
 import { stripTerminalControls, visibleTerminalText } from '../../../../../__tests__/helpers/terminal-output.ts'
@@ -21,29 +21,31 @@ function nextTick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 20))
 }
 
-function skill(facet: string, ...names: string[]): FacetContribution {
-  return { facet, assets: names.map((name) => ({ scope: 'project', type: 'skill', name })) }
+function skill(facet: string, ...names: string[]): CollisionFacetContribution {
+  return { facet, assets: names.map((name) => ({ scope: 'project', type: 'skill', name })), servers: [] }
 }
 
-function requestFor(contributions: FacetContribution[]): CollisionResolutionRequest {
-  const planned = planMaterialization(contributions)
-  if (planned.ok) expect.unreachable()
-  if (planned.reason !== 'collision') expect.unreachable()
+function server(facet: string, ...names: string[]): CollisionFacetContribution {
   return {
-    groups: planned.groups,
-    contributions,
-    staleOverrides: planned.staleOverrides.map((stale) => ({
-      facet: stale.facet,
-      contribution: { kind: 'asset' as const, assetType: stale.type },
-      authoredName: stale.authoredName,
-      disposition: stale.disposition,
+    facet,
+    assets: [],
+    servers: names.map((name) => ({
+      name,
+      declaration: { type: 'stdio', command: `${facet}-cmd` } as McpServerDeclaration,
     })),
   }
 }
 
-function mount(contributions: FacetContribution[]) {
+function requestFor(facets: CollisionFacetContribution[]): CollisionResolutionRequest {
+  const planned = planCollisionIntent(facets, {})
+  if (planned.ok) expect.unreachable()
+  if (planned.reason !== 'collision') expect.unreachable()
+  return { groups: planned.groups, facets, overrides: {}, staleOverrides: planned.staleOverrides }
+}
+
+function mount(facets: CollisionFacetContribution[]) {
   const resolutions: CollisionResolution[] = []
-  const request = requestFor(contributions)
+  const request = requestFor(facets)
   const app = render(
     createElement(CollisionWorkspace, {
       request,
@@ -292,6 +294,120 @@ describe('CollisionWorkspace — conflicts the user creates', () => {
     expect(frame).toContain('still contested with')
 
     await press(app, KEY.escape, KEY.down, KEY.enter)
+    expect(resolutions).toHaveLength(0)
+    app.unmount()
+  })
+})
+
+describe('CollisionWorkspace — MCP server claimants', () => {
+  const SERVERS = [server('alpha', 'filesystem'), server('beta', 'filesystem')]
+
+  test('names servers as servers, with a declaration summary to tell them apart', async () => {
+    const { app } = mount(SERVERS)
+    await nextTick()
+
+    const overview = visibleTerminalText(app.lastFrame() ?? '')
+    expect(overview).toContain('MCP servers')
+    expect(overview).not.toContain('assets')
+
+    await press(app, KEY.enter)
+    const group = visibleTerminalText(app.lastFrame() ?? '')
+    expect(group).toContain('server filesystem')
+    // The summary, not the declaration: enough to tell two rows apart.
+    expect(group).toContain('stdio, command "alpha-cmd"')
+    expect(group).toContain('stdio, command "beta-cmd"')
+    app.unmount()
+  })
+
+  test('a resolved server draft submits a servers override', async () => {
+    const { app, resolutions } = mount(SERVERS)
+    await nextTick()
+
+    // Open the group, alias the first claimant, confirm.
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+    await press(app, ...'\u007f'.repeat(12).split(''))
+    await press(app, ...'alpha-fs'.split(''))
+    await press(app, KEY.enter)
+    await press(app, KEY.escape, KEY.down, KEY.enter)
+
+    const resolution = resolutions[0]
+    if (resolution?.kind !== 'resolved') expect.unreachable()
+    expect(resolution.overrides.alpha).toEqual({ servers: { filesystem: { kind: 'aliased', as: 'alpha-fs' } } })
+    app.unmount()
+  })
+
+  test('omitting every server claimant resolves the group', async () => {
+    const { app, resolutions } = mount(SERVERS)
+    await nextTick()
+
+    await press(app, KEY.enter, KEY.right, KEY.right, KEY.enter, KEY.down, KEY.right, KEY.right, KEY.enter)
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('not configured')
+
+    await press(app, KEY.escape, KEY.down, KEY.enter)
+    const resolution = resolutions[0]
+    if (resolution?.kind !== 'resolved') expect.unreachable()
+    expect(resolution.overrides.alpha).toEqual({ servers: { filesystem: { kind: 'omitted' } } })
+    expect(resolution.overrides.beta).toEqual({ servers: { filesystem: { kind: 'omitted' } } })
+    app.unmount()
+  })
+
+  test('an interrupt mid-edit still cancels', async () => {
+    const { app, resolutions } = mount(SERVERS)
+    await nextTick()
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+    await press(app, KEY.ctrlC)
+
+    expect(resolutions).toEqual([{ kind: 'cancelled' }])
+    app.unmount()
+  })
+
+  test('status stays legible without color on a server row', async () => {
+    const { app } = mount(SERVERS)
+    await nextTick()
+    await press(app, KEY.enter)
+
+    // `stripTerminalControls`, so this is what a piped terminal shows.
+    const plain = stripTerminalControls(app.lastFrame() ?? '')
+    expect(plain).toContain('✕ unresolved')
+    app.unmount()
+  })
+})
+
+describe('CollisionWorkspace — mixed asset and server groups', () => {
+  const MIXED = [
+    skill('alpha', 'review'),
+    skill('beta', 'review'),
+    server('gamma', 'review'),
+    server('delta', 'review'),
+  ]
+
+  test('both groups appear in one overview, each named for its own domain', async () => {
+    const { app } = mount(MIXED)
+    await nextTick()
+
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('2 groups')
+    expect(frame).toContain('2 assets')
+    expect(frame).toContain('2 MCP servers')
+    app.unmount()
+  })
+
+  test('resolving the asset group alone does not enable confirm', async () => {
+    const { app, resolutions } = mount(MIXED)
+    await nextTick()
+
+    // First group is the asset one; alias its first claimant.
+    await press(app, KEY.enter, KEY.right, KEY.enter)
+    await press(app, ...'\u007f'.repeat(10).split(''))
+    await press(app, ...'alpha-review'.split(''))
+    await press(app, KEY.enter)
+    await press(app, KEY.escape)
+
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('resolve every group first')
+
+    // Pressing confirm anyway submits nothing.
+    await press(app, KEY.down, KEY.down, KEY.enter)
     expect(resolutions).toHaveLength(0)
     app.unmount()
   })

--- a/packages/cli/src/tui/views/install/collision/claimant-row.tsx
+++ b/packages/cli/src/tui/views/install/collision/claimant-row.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from 'ink'
+import { describeClaimantDeclaration } from '../../../../util/collision-report.ts'
 import { THEME } from '../../../theme.ts'
 import { COLLISION_STATUS, type CollisionStatus, describeStatus } from '../collision-status.ts'
 import { AliasInput } from './alias-input.tsx'
@@ -45,11 +46,41 @@ export function StatusTag({ status }: { status: CollisionStatus }) {
   return <Text color={COLLISION_STATUS[status].color}>{describeStatus(status)}</Text>
 }
 
-/** How this claimant's asset will land on disk, in one phrase. */
+/** How this claimant will land, in one phrase. */
 function outcomeOf(claimant: ClaimantModel): string {
-  if (claimant.effectiveName === null) return 'not materialized'
+  // An omitted asset is not written; an omitted server is not configured.
+  // Same decision, two different things that then do not happen.
+  if (claimant.effectiveName === null) {
+    return claimant.ref.kind === 'asset' ? 'not materialized' : 'not configured'
+  }
   if (claimant.effectiveName === claimant.authoredName) return claimant.authoredName
   return `${claimant.authoredName} → ${claimant.effectiveName}`
+}
+
+/**
+ * What a group of claimants is called, for a heading.
+ *
+ * A group never mixes domains, so one noun always fits — and "2 assets" above
+ * two MCP servers is the kind of wrong that makes a user doubt the rest of
+ * the screen.
+ */
+export function describeClaimantKind(kind: ClaimantModel['ref']['kind'], count: number): string {
+  if (kind === 'asset') return count === 1 ? 'asset' : 'assets'
+  return count === 1 ? 'MCP server' : 'MCP servers'
+}
+
+/**
+ * What this claimant IS, in the user's words.
+ *
+ * An asset is placed, so its scope and type are what distinguish it. A server
+ * is project-scoped and typeless, so what distinguishes it is the declaration
+ * — which is why the spec asks for a summary of one on every MCP row.
+ */
+export function describeClaimant(claimant: ClaimantModel): string {
+  const ref = claimant.ref
+  return ref.kind === 'asset'
+    ? `${ref.scope} ${ref.type} ${ref.authoredName}`
+    : `server ${ref.authoredName} · ${describeClaimantDeclaration(ref.declaration, ref.fingerprint)}`
 }
 
 export function ClaimantRow({
@@ -85,10 +116,7 @@ export function ClaimantRow({
       <Text>
         <Text color={focused ? THEME.focus : THEME.hint}>{focused ? '▸ ' : '  '}</Text>
         <Text bold>{claimant.facet}</Text>
-        <Text color={THEME.hint}>
-          {' '}
-          {claimant.scope} {claimant.type} {claimant.authoredName}
-        </Text>
+        <Text color={THEME.hint}> {describeClaimant(claimant)}</Text>
       </Text>
 
       <Box marginLeft={4} gap={1}>

--- a/packages/cli/src/tui/views/install/collision/draft.ts
+++ b/packages/cli/src/tui/views/install/collision/draft.ts
@@ -1,23 +1,25 @@
 import type { AssetType, Scope } from '@agent-facets/common'
-import type { CollisionResolutionRequest, StaleMaterializationOverride } from '@agent-facets/engine'
-import { ownEntry, ownRecord } from '@agent-facets/engine'
-import type { CollisionGroup, FacetMaterializationOverrides, MaterializationDisposition } from '@agent-facets/protocol'
-import {
-  compareCodeUnits,
-  isMaterialized,
-  materializedNameOf,
-  overrideFor,
-  overrideGroupKey,
-  planMaterialization,
-  validateAssetNameSegment,
+import type {
+  CollisionFacetContribution,
+  CollisionResolutionRequest,
+  MaterializationCollisionGroup,
+  StaleMaterializationOverride,
+} from '@agent-facets/engine'
+import { overrideGroupFor, ownEntry, ownRecord, planCollisionIntent } from '@agent-facets/engine'
+import type {
+  FacetMaterializationOverrides,
+  MaterializationDisposition,
+  McpServerDeclaration,
+  McpServerFingerprint,
 } from '@agent-facets/protocol'
+import { compareCodeUnits, isMaterialized, materializedNameOf, validateAssetNameSegment } from '@agent-facets/protocol'
 import type { CollisionStatus } from '../collision-status.ts'
 
 /**
  * The collision workspace's state, and the pure rule that turns it into
  * something renderable.
  *
- * Two properties drive the whole design:
+ * Three properties drive the whole design:
  *
  *  1. **There is exactly one draft, and it is the same shape the engine
  *     consumes.** The draft IS a `Record<facet, overrides>` — the same
@@ -25,35 +27,54 @@ import type { CollisionStatus } from '../collision-status.ts'
  *     There is no parallel "UI choice" model to keep in sync, so the
  *     thing shown and the thing submitted cannot disagree.
  *
- *  2. **Collision truth comes from the protocol planner, always.** This
+ *  2. **Collision truth comes from the shared planner, always.** This
  *     module never decides what collides. It arranges the planner's
- *     answer for display. That is what keeps the live preview and the
- *     engine's final validation from ever disagreeing — a disagreement
- *     would show a green confirm button that then fails the install.
+ *     answer for display, and it calls the SAME function the engine calls
+ *     to validate the submitted draft. That is what keeps the live preview
+ *     and the final validation from disagreeing — a disagreement would show
+ *     a green confirm button that then fails the install.
+ *
+ *  3. **Assets and MCP servers are separate identity spaces, and stay
+ *     separate here.** A skill named `review` and a server named `review`
+ *     never contend. The planner guarantees it; this module preserves it by
+ *     never merging a group from one domain with a group from the other.
  */
-
-/** One asset a facet contributes, addressed by its authored identity. */
-export interface ClaimantRef {
-  facet: string
-  scope: Scope
-  type: AssetType
-  authoredName: string
-}
 
 /**
- * Stable identity for a claimant. NUL-joined because it cannot occur in a
- * facet name, an asset name, or a scope, so no combination of legal
- * values can forge another claimant's key.
+ * One contributor to a contested name.
+ *
+ * Tagged, not a widened struct: a server has no scope and no asset type, and
+ * an asset has no declaration. A single shape with all of those optional
+ * would let a renderer read an asset type off a server row and print nothing
+ * where a kind belongs.
+ */
+export type ClaimantRef =
+  | { kind: 'asset'; facet: string; scope: Scope; type: AssetType; authoredName: string }
+  | {
+      kind: 'mcp-server'
+      facet: string
+      authoredName: string
+      declaration: McpServerDeclaration
+      fingerprint: McpServerFingerprint
+    }
+
+/**
+ * Stable identity for a claimant. NUL-joined and domain-prefixed, because
+ * neither separator nor prefix can occur in a facet name, an asset name, a
+ * scope, or a server name — so no combination of legal values can forge
+ * another claimant's key, in either domain.
  */
 export function claimantKey(ref: ClaimantRef): string {
-  return `${ref.facet}\u0000${ref.scope}\u0000${ref.type}\u0000${ref.authoredName}`
+  return ref.kind === 'asset'
+    ? `asset\u0000${ref.facet}\u0000${ref.scope}\u0000${ref.type}\u0000${ref.authoredName}`
+    : `mcp-server\u0000${ref.facet}\u0000${ref.authoredName}`
 }
 
 export interface CollisionDraft {
   /**
-   * Complete project intent. Handed to the engine verbatim, so facets and
-   * assets the workspace never displays keep the overrides they arrived
-   * with.
+   * Complete project intent. Handed to the engine verbatim, so facets,
+   * assets, and servers the workspace never displays keep the overrides they
+   * arrived with.
    */
   readonly overrides: Readonly<Record<string, FacetMaterializationOverrides>>
   /**
@@ -71,21 +92,26 @@ export interface CollisionDraft {
   readonly claimants: ReadonlyMap<string, ClaimantRef>
 }
 
-/** A claimant as displayed: its current choice, name, and standing. */
-export interface ClaimantModel extends ClaimantRef {
+/** What a claimant looks like once the planner has ruled on the draft. */
+export interface ClaimantModel {
+  ref: ClaimantRef
   key: string
+  facet: string
+  authoredName: string
   disposition: MaterializationDisposition
   /** Empty when omitted — there is no effective name to show. */
   effectiveName: string | null
   status: CollisionStatus
   /** Other claimants contesting this name right now, for navigation. */
   conflictsWith: readonly string[]
-  /** Why the current alias is not a legal asset name, if it isn't. */
+  /** Why the current alias is not a legal name, if it isn't. */
   aliasError: string | null
 }
 
 export interface DisplayGroup {
   key: string
+  /** Which identity space this group lives in. Groups never mix. */
+  kind: ClaimantRef['kind']
   /**
    * What to call this group on screen. Always non-empty.
    *
@@ -108,9 +134,9 @@ export interface DisplayGroup {
 export interface WorkspaceModel {
   groups: readonly DisplayGroup[]
   /**
-   * Whether the complete draft plans cleanly. This is the planner's
-   * verdict, not a count of green rows: the confirm gate and the engine's
-   * final check then answer the same question the same way.
+   * Whether the complete draft plans cleanly, in BOTH domains. This is the
+   * planner's verdict, not a count of green rows: the confirm gate and the
+   * engine's final check then answer the same question the same way.
    */
   confirmable: boolean
   staleOverrides: readonly StaleMaterializationOverride[]
@@ -121,10 +147,11 @@ export function createDraft(request: CollisionResolutionRequest): CollisionDraft
   // Null-prototype, because the keys are facet names straight out of
   // `facets.json`. A facet named `__proto__` assigned into a plain `{}`
   // creates no own key and replaces the map's prototype instead.
-  const overrides = ownRecord<FacetMaterializationOverrides>()
-  for (const contribution of request.contributions) {
-    if (contribution.overrides !== undefined) overrides[contribution.facet] = contribution.overrides
-  }
+  //
+  // Seeded from the project's COMPLETE intent, not just the colliding facets:
+  // the resolver's answer is a whole intent document, so an override this
+  // workspace never displays would be erased by omission.
+  const overrides = ownRecord<FacetMaterializationOverrides>(request.overrides)
   return {
     overrides,
     edited: new Set(),
@@ -150,11 +177,12 @@ export function reviseDraft(
   const edited = new Set(draft.edited)
   edited.add(claimantKey(ref))
 
-  // An alias can pull in an asset that was never colliding. Surface it
+  // An alias can pull in a contribution that was never colliding. Surface it
   // immediately: the user has to be able to reach the other side of a
-  // conflict they just created.
+  // conflict they just created. The complete set is re-planned, so an MCP
+  // alias surfaces the MCP claimant it landed on.
   const claimants = new Map(draft.claimants)
-  const planned = planMaterialization(contributionsWith(request, overrides))
+  const planned = planCollisionIntent(request.facets, overrides)
   if (!planned.ok && planned.reason === 'collision') {
     for (const [key, value] of claimantsOf(planned.groups)) {
       if (!claimants.has(key)) claimants.set(key, value)
@@ -166,38 +194,38 @@ export function reviseDraft(
 
 /** Arrange the planner's current verdict for display. */
 export function evaluateDraft(request: CollisionResolutionRequest, draft: CollisionDraft): WorkspaceModel {
-  const planned = planMaterialization(contributionsWith(request, draft.overrides))
+  const planned = planCollisionIntent(request.facets, draft.overrides)
 
   const currentGroups = !planned.ok && planned.reason === 'collision' ? planned.groups : []
 
-  // Defensive, not expected: the workspace commits an alias only after
-  // the same validator accepts it, and the engine rejects an unparseable
+  // Defensive, not expected: the workspace commits an alias only after the
+  // same validator accepts it, and the engine rejects an unparseable
   // persisted alias before ever opening a resolver. Kept so that a draft
-  // holding a bad alias explains itself instead of showing a green row
-  // beside a disabled confirm button.
+  // holding a bad alias explains itself instead of showing a green row beside
+  // a disabled confirm button.
+  //
+  // Keyed by what an OVERRIDE is keyed by — facet, group, authored name — and
+  // deliberately not by scope, which no override carries. An asset problem
+  // therefore attaches to every scope contributing that authored name, which
+  // is exactly the set of rows the one bad alias would affect.
   const aliasErrors = new Map<string, string>()
   if (!planned.ok && planned.reason === 'invalid-alias') {
     for (const problem of planned.problems) {
-      const scope = scopeOf(request, problem.facet, problem.type, problem.authoredName)
-      if (scope === null) continue
-      aliasErrors.set(
-        claimantKey({ facet: problem.facet, scope, type: problem.type, authoredName: problem.authoredName }),
-        problem.reason,
-      )
+      aliasErrors.set(aliasProblemKey(problem), problem.reason)
     }
   }
 
   // Which claimants are contesting a name right now, and with whom.
   const conflictsWith = new Map<string, string[]>()
   const contestedNameOf = new Map<string, string>()
-  for (const group of currentGroups) {
-    const keys = group.members.map((member) => claimantKey(member))
+  for (const entry of currentGroups) {
+    const keys = membersOf(entry).map((member) => claimantKey(member))
     for (const key of keys) {
       conflictsWith.set(
         key,
         keys.filter((other) => other !== key),
       )
-      contestedNameOf.set(key, group.effectiveName)
+      contestedNameOf.set(key, entry.group.effectiveName)
     }
   }
 
@@ -216,6 +244,7 @@ export function evaluateDraft(request: CollisionResolutionRequest, draft: Collis
     const origin = component.origin.join(', ')
     return {
       key: component.key,
+      kind: component.kind,
       title: titleFor(contested, origin, members),
       origin,
       contested,
@@ -227,14 +256,10 @@ export function evaluateDraft(request: CollisionResolutionRequest, draft: Collis
   return {
     groups,
     confirmable: planned.ok,
-    staleOverrides: planned.ok
-      ? planned.staleOverrides.map((stale) => ({
-          facet: stale.facet,
-          contribution: { kind: 'asset' as const, assetType: stale.type },
-          authoredName: stale.authoredName,
-          disposition: stale.disposition,
-        }))
-      : request.staleOverrides,
+    // Both domains, on every path. Reporting only the domain that happened to
+    // plan would make a server's leftover choice vanish the moment an asset
+    // collision was resolved.
+    staleOverrides: planned.ok || planned.reason === 'collision' ? planned.staleOverrides : request.staleOverrides,
   }
 }
 
@@ -251,6 +276,28 @@ export function choiceFor(draft: CollisionDraft, ref: ClaimantRef): Materializat
 // ---------------------------------------------------------------------------
 // internals
 // ---------------------------------------------------------------------------
+
+/** The claimant an invalid-alias problem belongs to, as a claimant key. */
+function aliasProblemKey(problem: {
+  kind: 'asset' | 'mcp-server'
+  facet: string
+  authoredName: string
+  assetType?: AssetType
+}): string {
+  // Assets: scope is absent from both the problem and the override that
+  // caused it, so the key is matched on the remaining segments. See
+  // `claimantMatchesAliasProblem`.
+  return problem.kind === 'asset'
+    ? `asset-alias\u0000${problem.facet}\u0000${problem.assetType}\u0000${problem.authoredName}`
+    : `mcp-server\u0000${problem.facet}\u0000${problem.authoredName}`
+}
+
+/** The alias-error key a claimant would be reported under. */
+function aliasKeyOf(ref: ClaimantRef): string {
+  return ref.kind === 'asset'
+    ? `asset-alias\u0000${ref.facet}\u0000${ref.type}\u0000${ref.authoredName}`
+    : `mcp-server\u0000${ref.facet}\u0000${ref.authoredName}`
+}
 
 /**
  * The heading for one group: what is contested now, else what brought these
@@ -275,14 +322,16 @@ function modelFor(
   const key = claimantKey(ref)
   const disposition = choiceFor(draft, ref)
   const conflicts = conflictsWith.get(key) ?? []
-  const aliasError = aliasErrors.get(key) ?? null
+  const aliasError = aliasErrors.get(aliasKeyOf(ref)) ?? null
 
   return {
-    ...ref,
+    ref,
     key,
+    facet: ref.facet,
+    authoredName: ref.authoredName,
     disposition,
     effectiveName: isMaterialized(disposition) ? materializedNameOf(ref.authoredName, disposition) : null,
-    status: statusFor({ key, conflicts, aliasError, draft, conflictsWith }),
+    status: statusFor({ conflicts, aliasError, edited: draft.edited, key }),
     conflictsWith: conflicts,
     aliasError,
   }
@@ -295,22 +344,21 @@ function modelFor(
  * and one their own edits produced: the first says "you must decide
  * something", the second says "your decision isn't finished". A group
  * counts as edited if ANY of its claimants was touched — otherwise the
- * asset someone else's alias landed on would stay red and read as an
+ * claimant someone else's alias landed on would stay red and read as an
  * unrelated pre-existing problem.
  */
 function statusFor(args: {
   key: string
   conflicts: readonly string[]
   aliasError: string | null
-  draft: CollisionDraft
-  conflictsWith: ReadonlyMap<string, readonly string[]>
+  edited: ReadonlySet<string>
 }): CollisionStatus {
-  const { key, conflicts, aliasError, draft } = args
+  const { key, conflicts, aliasError, edited } = args
   // An alias that isn't a legal name blocks confirmation, so it can never
   // read as settled — even though the planner reports no group for it.
   if (aliasError !== null) return 'unresolved'
   if (conflicts.length === 0) return 'resolved'
-  const touched = [key, ...conflicts].some((member) => draft.edited.has(member))
+  const touched = [key, ...conflicts].some((member) => edited.has(member))
   return touched ? 'draft-conflict' : 'unresolved'
 }
 
@@ -328,6 +376,26 @@ function worstStatus(statuses: readonly CollisionStatus[]): CollisionStatus {
   return worst
 }
 
+/** Every claimant of one tagged group, as refs. */
+function membersOf(entry: MaterializationCollisionGroup): ClaimantRef[] {
+  if (entry.kind === 'asset') {
+    return entry.group.members.map((member) => ({
+      kind: 'asset' as const,
+      facet: member.facet,
+      scope: member.scope,
+      type: member.type,
+      authoredName: member.authoredName,
+    }))
+  }
+  return entry.group.members.map((member) => ({
+    kind: 'mcp-server' as const,
+    facet: member.facet,
+    authoredName: member.authoredName,
+    declaration: member.declaration,
+    fingerprint: member.fingerprint,
+  }))
+}
+
 /**
  * Partition claimants into the groups the user works through.
  *
@@ -336,12 +404,17 @@ function worstStatus(statuses: readonly CollisionStatus[]): CollisionStatus {
  * contested name, because both relations move: aliasing one claimant onto
  * another group's name genuinely merges two problems into one decision,
  * and the user has to see them together to solve either.
+ *
+ * Only groups from the SAME identity space are ever unioned — which is free
+ * here, since a group's members all come from one domain and no group spans
+ * both. A skill and a server sharing a name are two rows the user resolves
+ * independently, because that is what the planner says they are.
  */
 function groupClaimants(
-  originalGroups: readonly CollisionGroup[],
-  currentGroups: readonly CollisionGroup[],
+  originalGroups: readonly MaterializationCollisionGroup[],
+  currentGroups: readonly MaterializationCollisionGroup[],
   claimants: ReadonlyMap<string, ClaimantRef>,
-): ReadonlyArray<{ key: string; origin: string[]; members: ClaimantRef[] }> {
+): ReadonlyArray<{ key: string; kind: ClaimantRef['kind']; origin: string[]; members: ClaimantRef[] }> {
   const parent = new Map<string, string>()
   const find = (key: string): string => {
     let root = key
@@ -357,8 +430,8 @@ function groupClaimants(
   for (const key of claimants.keys()) parent.set(key, key)
 
   const originNames = new Map<string, Set<string>>()
-  for (const group of [...originalGroups, ...currentGroups]) {
-    const keys = group.members.map((member) => claimantKey(member))
+  for (const entry of [...originalGroups, ...currentGroups]) {
+    const keys = membersOf(entry).map((member) => claimantKey(member))
     const first = keys[0]
     if (first === undefined) continue
     for (const key of keys) {
@@ -366,12 +439,12 @@ function groupClaimants(
       union(first, key)
     }
   }
-  for (const group of originalGroups) {
-    const first = group.members[0]
+  for (const entry of originalGroups) {
+    const first = membersOf(entry)[0]
     if (first === undefined) continue
     const root = find(claimantKey(first))
     const names = originNames.get(root) ?? new Set<string>()
-    names.add(group.effectiveName)
+    names.add(entry.group.effectiveName)
     originNames.set(root, names)
   }
 
@@ -396,84 +469,78 @@ function groupClaimants(
   return [...byRoot.entries()]
     .map(([root, members]) => ({
       key: root,
+      // Safe: every union above joins keys drawn from one group, and a group
+      // has members from exactly one domain, so a component is single-domain
+      // by construction.
+      kind: (members[0] as ClaimantRef).kind,
       origin: [...(foldedOrigins.get(root) ?? new Set<string>())].sort(compareCodeUnits),
       members,
     }))
     .sort((a, b) => compareCodeUnits(a.origin.join(', '), b.origin.join(', ')) || compareCodeUnits(a.key, b.key))
 }
 
-function claimantsOf(groups: readonly CollisionGroup[]): Map<string, ClaimantRef> {
+function claimantsOf(groups: readonly MaterializationCollisionGroup[]): Map<string, ClaimantRef> {
   const claimants = new Map<string, ClaimantRef>()
-  for (const group of groups) {
-    for (const member of group.members) {
-      const ref: ClaimantRef = {
-        facet: member.facet,
-        scope: member.scope,
-        type: member.type,
-        authoredName: member.authoredName,
-      }
+  for (const entry of groups) {
+    for (const ref of membersOf(entry)) {
       claimants.set(claimantKey(ref), ref)
     }
   }
   return claimants
 }
 
-function contributionsWith(
-  request: CollisionResolutionRequest,
-  overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
-) {
-  return request.contributions.map((contribution) => ({
-    ...contribution,
-    // Own-property read for the same reason `draftOverrideFor` uses one: a
-    // facet named `constructor` would otherwise hand the planner `Object`.
-    overrides: ownEntry(overrides, contribution.facet),
-  }))
-}
-
 /**
  * The draft's current choice for one claimant.
  *
- * Both lookups are own-property reads, via {@link ownEntry} and the published
- * {@link overrideFor}: facet names and asset names are ordinary strings, so an
- * indexed read for `constructor` or `__proto__` would return an inherited
- * value where the type promises a disposition or `undefined`.
+ * Both lookups are own-property reads: facet names, asset names, and server
+ * names are ordinary strings, so an indexed read for `constructor` or
+ * `__proto__` would return an inherited value where the type promises a
+ * disposition or `undefined`. Only the middle level — the override group — is
+ * a closed literal union and therefore safe to index directly.
  */
 function draftOverrideFor(
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
   ref: ClaimantRef,
 ): MaterializationDisposition | undefined {
-  return overrideFor(ownEntry(overrides, ref.facet), ref.type, ref.authoredName)
+  const facet = ownEntry(overrides, ref.facet)
+  if (facet === undefined) return undefined
+  const entries = facet[groupOf(ref)]
+  return entries === undefined ? undefined : ownEntry(entries, ref.authoredName)
+}
+
+/** The `facets.json` override group this claimant's choice is written to. */
+function groupOf(ref: ClaimantRef) {
+  return overrideGroupFor(ref.kind === 'asset' ? { kind: 'asset', assetType: ref.type } : { kind: 'mcp-server' })
 }
 
 /**
  * The draft with one claimant's choice recorded, as a fresh map.
  *
  * Every copy is null-prototyped and every lookup is an own read, because both
- * levels are keyed by names from `facets.json`: the facet map by facet name,
- * the asset map by authored asset name. Only the middle level — `skills` /
- * `agents` / `commands` — is a closed literal union and therefore safe to
- * index directly. Writing `assets[name] = disposition` into a plain object for
- * an asset named `__proto__` recorded nothing, and the empty-group check below
- * then deleted the group the user had just edited.
+ * outer levels are keyed by names from `facets.json`: the facet map by facet
+ * name, the inner map by authored asset or server name. Writing
+ * `entries[name] = disposition` into a plain object for a name spelled
+ * `__proto__` recorded nothing, and the empty-group check below then deleted
+ * the group the user had just edited.
  */
 function withOverride(
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
   ref: ClaimantRef,
   disposition: MaterializationDisposition,
 ): Record<string, FacetMaterializationOverrides> {
-  const group = overrideGroupKey(ref.type)
+  const group = groupOf(ref)
   const next = ownRecord(overrides)
   const facet: FacetMaterializationOverrides = { ...ownEntry(next, ref.facet) }
-  const assets = ownRecord(facet[group])
+  const entries = ownRecord(facet[group])
 
   if (disposition.kind === 'authored') {
-    delete assets[ref.authoredName]
+    delete entries[ref.authoredName]
   } else {
-    assets[ref.authoredName] = disposition
+    entries[ref.authoredName] = disposition
   }
 
-  if (Object.keys(assets).length === 0) delete facet[group]
-  else facet[group] = assets
+  if (Object.keys(entries).length === 0) delete facet[group]
+  else facet[group] = entries
 
   if (Object.keys(facet).length === 0) delete next[ref.facet]
   else next[ref.facet] = facet
@@ -482,32 +549,17 @@ function withOverride(
 }
 
 /**
- * Recover a claimant's scope from the authored contributions.
+ * Deterministic row order: assets before servers, then by facet and name.
  *
- * `InvalidAlias` carries no scope — it is a complaint about a string, not
- * about a placement — so the scope is looked up rather than assumed.
- * Returns null instead of defaulting: silently guessing `project` would
- * attach the error to a different claimant the day a second scope exists.
+ * The domain leads because a mixed group cannot occur — so within any group
+ * this is a constant — while the overview lists groups whose members must
+ * still sort predictably for a reader comparing two runs.
  */
-function scopeOf(
-  request: CollisionResolutionRequest,
-  facet: string,
-  type: AssetType,
-  authoredName: string,
-): Scope | null {
-  for (const contribution of request.contributions) {
-    if (contribution.facet !== facet) continue
-    for (const asset of contribution.assets) {
-      if (asset.type === type && asset.name === authoredName) return asset.scope
-    }
-  }
-  return null
-}
-
 function compareClaimants(a: ClaimantModel, b: ClaimantModel): number {
   return (
+    compareCodeUnits(a.ref.kind, b.ref.kind) ||
     compareCodeUnits(a.facet, b.facet) ||
-    compareCodeUnits(a.type, b.type) ||
+    compareCodeUnits(a.ref.kind === 'asset' ? a.ref.type : '', b.ref.kind === 'asset' ? b.ref.type : '') ||
     compareCodeUnits(a.authoredName, b.authoredName)
   )
 }
@@ -516,8 +568,17 @@ function unique(values: readonly string[]): string[] {
   return [...new Set(values)].sort(compareCodeUnits)
 }
 
-/** Validate an alias exactly as the planner will. */
+/**
+ * Validate an alias exactly as the planner will.
+ *
+ * One validator for both domains, because there is one grammar: the published
+ * server-name check delegates to this very function, so a divergence here
+ * would be a divergence from itself.
+ */
 export function validateAlias(value: string): string | null {
   const result = validateAssetNameSegment(value)
   return result.ok ? null : result.reason
 }
+
+/** Re-exported so the workspace can name the contribution kinds it renders. */
+export type { CollisionFacetContribution }

--- a/packages/cli/src/tui/views/install/collision/workspace.tsx
+++ b/packages/cli/src/tui/views/install/collision/workspace.tsx
@@ -4,7 +4,15 @@ import { Box, Text, useInput } from 'ink'
 import { useCallback, useMemo, useState } from 'react'
 import { contributionKey, describeContribution } from '../../../../util/contribution.ts'
 import { THEME } from '../../../theme.ts'
-import { CHOICES, type ChoiceKind, ClaimantRow, choiceOf, StatusTag } from './claimant-row.tsx'
+import {
+  CHOICES,
+  type ChoiceKind,
+  ClaimantRow,
+  choiceOf,
+  describeClaimant,
+  describeClaimantKind,
+  StatusTag,
+} from './claimant-row.tsx'
 import {
   type ClaimantModel,
   type CollisionDraft,
@@ -57,7 +65,7 @@ export function CollisionWorkspace({
 
   const revise = useCallback(
     (claimant: ClaimantModel, disposition: MaterializationDisposition) => {
-      setDraft((current) => reviseDraft(request, current, claimant, disposition))
+      setDraft((current) => reviseDraft(request, current, claimant.ref, disposition))
     },
     [request],
   )
@@ -225,13 +233,13 @@ function Overview({ model, index }: { model: ReturnType<typeof evaluateDraft>; i
               <Text bold> {group.title}</Text>
               <Text color={THEME.hint}>
                 {' '}
-                ({group.members.length} asset{group.members.length === 1 ? '' : 's'})
+                ({group.members.length} {describeClaimantKind(group.kind, group.members.length)})
               </Text>
             </Text>
             {group.members.map((member) => (
               <Text key={member.key} color={THEME.hint}>
                 {'      '}
-                {member.facet} {member.type} {member.authoredName}
+                {member.facet} {describeClaimant(member)}
                 {member.effectiveName === null ? ' — omitted' : ` → ${member.effectiveName}`}
               </Text>
             ))}
@@ -291,8 +299,8 @@ function GroupView({
         {group.title}
       </Text>
       <Text color={THEME.hint}>
-        {group.members.length} assets want this name. Give each one an outcome; they only have to differ from each
-        other.
+        {group.members.length} {describeClaimantKind(group.kind, group.members.length)} want this name. Give each one an
+        outcome; they only have to differ from each other.
       </Text>
 
       <Box flexDirection="column" marginTop={1}>

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -2,7 +2,12 @@ import type { LockfileDriftEntry, RollbackOutcome, RunInstallFailure, RunInstall
 import { Box, Text } from 'ink'
 import type React from 'react'
 import { describeCompatibilityFailure } from '../../../util/adapter-install-errors.ts'
-import { collisionClaimants, collisionGroupKey, describeCollisionGroup } from '../../../util/collision-report.ts'
+import {
+  aliasProblemLocation,
+  collisionClaimants,
+  collisionGroupKey,
+  describeCollisionGroup,
+} from '../../../util/collision-report.ts'
 import { contributionKey, describeContribution } from '../../../util/contribution.ts'
 import { diskStateSentence } from '../../../util/install-outcome.ts'
 import {
@@ -533,8 +538,16 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
                 <Box key={claimant.key} flexDirection="column">
                   <Text color={THEME.hint}>
                     {'   '}
-                    {claimant.facet} ({claimant.label})
+                    {claimant.facet} ({claimant.label}) → “{claimant.effectiveName}”
                   </Text>
+                  {/* A server's declaration summary, so two claimants sharing
+                      a name are still told apart. Empty for an asset. */}
+                  {claimant.detail.map((detail) => (
+                    <Text key={detail} color={THEME.hint}>
+                      {'     '}
+                      {detail}
+                    </Text>
+                  ))}
                   {/* The exact edit site, derived from the published
                       group mapping so it cannot drift from the schema. */}
                   <Text color={THEME.hint}>
@@ -555,9 +568,9 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
             ✕ invalid materialization alias
           </Text>
           {failure.problems.map((problem) => (
-            <Text key={`${problem.facet}:${problem.alias}`} color={THEME.hint}>
+            <Text key={aliasProblemLocation(problem)} color={THEME.hint}>
               {' '}
-              {problem.facet}: “{problem.alias}” {problem.reason}
+              “{problem.alias}” {problem.reason} — at {aliasProblemLocation(problem)}
             </Text>
           ))}
         </Box>
@@ -569,9 +582,9 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
             ✕ the chosen names still conflict
           </Text>
           {failure.problems.map((problem) => (
-            <Text key={`${problem.facet}:${problem.alias}`} color={THEME.hint}>
+            <Text key={aliasProblemLocation(problem)} color={THEME.hint}>
               {' '}
-              {problem.facet}: “{problem.alias}” {problem.reason}
+              “{problem.alias}” {problem.reason} — at {aliasProblemLocation(problem)}
             </Text>
           ))}
           {failure.groups.map((entry) => (

--- a/packages/cli/src/util/__tests__/collision-report.test.ts
+++ b/packages/cli/src/util/__tests__/collision-report.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from 'bun:test'
 import type { MaterializationCollisionGroup, StaleMaterializationOverride } from '@agent-facets/engine'
-import type { CollisionGroup } from '@agent-facets/protocol'
-import { formatCollisionReport, manifestLocation, PLACEHOLDER_ALIAS } from '../collision-report.ts'
+import type {
+  CollisionGroup,
+  McpServerDeclaration,
+  McpServerFingerprint,
+  ServerCollisionGroup,
+} from '@agent-facets/protocol'
+import { computeMcpServerFingerprint } from '@agent-facets/protocol'
+import {
+  formatCollisionReport,
+  manifestLocation,
+  PLACEHOLDER_ALIAS,
+  serverManifestLocation,
+} from '../collision-report.ts'
 
 /** Tag asset-domain fixtures for the cross-domain report. */
 function assetGroups(...groups: CollisionGroup[]): MaterializationCollisionGroup[] {
@@ -197,5 +208,124 @@ describe('formatCollisionReport', () => {
 
   test('omits the stale-override section entirely when there are none', () => {
     expect(formatCollisionReport(assetGroups(...TWO_WAY), [])).not.toContain('no longer contain')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MCP server claimants
+// ---------------------------------------------------------------------------
+
+function declaration(command: string): McpServerDeclaration {
+  return { type: 'stdio', command } as McpServerDeclaration
+}
+
+function serverMember(facet: string, command: string, effectiveName = 'filesystem') {
+  const decl = declaration(command)
+  return {
+    facet,
+    authoredName: 'filesystem',
+    effectiveName,
+    declaration: decl,
+    fingerprint: computeMcpServerFingerprint(decl) as McpServerFingerprint,
+    disposition: { kind: 'authored' } as const,
+  }
+}
+
+const SERVER_GROUP: ServerCollisionGroup = {
+  effectiveName: 'filesystem',
+  members: [serverMember('alpha', 'alpha-cmd'), serverMember('beta', 'beta-cmd')],
+}
+
+function serverGroups(...groups: ServerCollisionGroup[]): MaterializationCollisionGroup[] {
+  return groups.map((group) => ({ kind: 'mcp-server', group }))
+}
+
+describe('formatCollisionReport — MCP server claimants', () => {
+  const report = formatCollisionReport(serverGroups(SERVER_GROUP), [])
+
+  test('names the group as MCP servers and lists every claimant', () => {
+    expect(report).toContain('MCP servers — "filesystem" is claimed by:')
+    expect(report).toContain('alpha: server filesystem → "filesystem"')
+    expect(report).toContain('beta: server filesystem → "filesystem"')
+  })
+
+  test('summarizes each declaration without reproducing it', () => {
+    expect(report).toContain('stdio, command "alpha-cmd"')
+    expect(report).toContain('stdio, command "beta-cmd"')
+  })
+
+  test('the fingerprint prefix tells two claimants apart', () => {
+    const [first, second] = SERVER_GROUP.members
+    if (first === undefined || second === undefined) expect.unreachable()
+    for (const member of [first, second]) {
+      expect(report).toContain(member.fingerprint.slice('sha256:'.length, 'sha256:'.length + 8))
+    }
+  })
+
+  test('points at the exact materialization.servers location', () => {
+    expect(report).toContain(serverManifestLocation('alpha', 'filesystem'))
+    expect(report).toContain('facets["alpha"].materialization.servers["filesystem"]')
+  })
+
+  test('offers a valid alias and omission snippet for every claimant', () => {
+    const snippets = report.split('\n').filter((line) => line.includes('alias:') || line.includes('omit:'))
+    expect(snippets).toHaveLength(4)
+    for (const line of snippets) {
+      const body = line.slice(line.indexOf('"'))
+      expect(() => JSON.parse(`{${body}}`)).not.toThrow()
+    }
+  })
+
+  test('the shape example uses the servers group', () => {
+    expect(report).toContain('"servers": {')
+  })
+
+  test('prefers no claimant', () => {
+    // Each claimant gets the identical pair of snippets, so nothing in the
+    // report reads as a recommendation about which facet should yield.
+    const alpha = report.split('alpha:')[1]?.split('beta:')[0] ?? ''
+    const beta = report.split('beta:')[1] ?? ''
+    expect(alpha).toContain(PLACEHOLDER_ALIAS)
+    expect(beta).toContain(PLACEHOLDER_ALIAS)
+    expect(report).not.toContain('alpha-filesystem')
+  })
+
+  test('states that native configuration was not changed either', () => {
+    expect(report).toContain('MCP configuration were NOT changed')
+  })
+})
+
+describe('formatCollisionReport — mixed asset and server groups', () => {
+  const report = formatCollisionReport([...assetGroups(...TWO_WAY), ...serverGroups(SERVER_GROUP)], [])
+
+  test('reports both domains in one failure', () => {
+    expect(report).toContain('project skills and commands — "review" is claimed by:')
+    expect(report).toContain('MCP servers — "filesystem" is claimed by:')
+  })
+
+  test('every claimant from both domains gets a location', () => {
+    expect(report).toContain(manifestLocation('alpha', 'skill', 'review'))
+    expect(report).toContain(serverManifestLocation('alpha', 'filesystem'))
+  })
+
+  test('asset claimants carry their scope', () => {
+    expect(report).toContain('project skill review')
+  })
+})
+
+describe('formatCollisionReport — names that collide with Object.prototype', () => {
+  test('a server named __proto__ is quoted, not interpreted', () => {
+    const group: ServerCollisionGroup = {
+      effectiveName: '__proto__',
+      members: SERVER_GROUP.members.map((member) => ({
+        ...member,
+        authoredName: '__proto__',
+        effectiveName: '__proto__',
+      })),
+    }
+    const report = formatCollisionReport(serverGroups(group), [])
+
+    expect(report).toContain('facets["alpha"].materialization.servers["__proto__"]')
+    expect(Object.keys(Object.prototype)).toEqual([])
   })
 })

--- a/packages/cli/src/util/collision-report.ts
+++ b/packages/cli/src/util/collision-report.ts
@@ -1,10 +1,11 @@
 import type { AssetType, Scope } from '@agent-facets/common'
 import type {
+  MaterializationAliasProblem,
   MaterializationCollisionGroup,
   RunInstallFailure,
   StaleMaterializationOverride,
 } from '@agent-facets/engine'
-import type { MaterializationNamespace, McpServerDeclaration } from '@agent-facets/protocol'
+import type { MaterializationNamespace, McpServerDeclaration, McpServerFingerprint } from '@agent-facets/protocol'
 import { overrideGroupKey, SERVER_OVERRIDE_GROUP } from '@agent-facets/protocol'
 import { describeContribution } from './contribution.ts'
 
@@ -85,9 +86,20 @@ export function describeCollisionGroup(entry: MaterializationCollisionGroup): st
 export interface CollisionClaimant {
   key: string
   facet: string
-  /** What the claimant is, in the user's words. */
+  /** What the claimant is, in the user's words — including its scope, for an asset. */
   label: string
   authoredName: string
+  /** The name it is claiming. Always present: a collision is a claim on one. */
+  effectiveName: string
+  /**
+   * Extra lines about this claimant, rendered under it. Empty for an asset,
+   * one declaration summary for a server.
+   *
+   * A list rather than an optional string: "no extra detail" and "a detail
+   * that happens to be empty" are the same thing to a renderer, and a
+   * `string | undefined` invites a caller to print `undefined`.
+   */
+  detail: readonly string[]
   /** The exact `facets.json` path a choice is written to. */
   location: string
 }
@@ -102,10 +114,12 @@ export interface CollisionClaimant {
 export function collisionClaimants(entry: MaterializationCollisionGroup): CollisionClaimant[] {
   if (entry.kind === 'asset') {
     return entry.group.members.map((member) => ({
-      key: `${member.facet}:${member.type}:${member.authoredName}`,
+      key: `${member.facet}:${member.scope}:${member.type}:${member.authoredName}`,
       facet: member.facet,
-      label: `${member.type} ${member.authoredName}`,
+      label: `${member.scope} ${member.type} ${member.authoredName}`,
       authoredName: member.authoredName,
+      effectiveName: member.effectiveName,
+      detail: [],
       location: manifestLocation(member.facet, member.type, member.authoredName),
     }))
   }
@@ -114,6 +128,8 @@ export function collisionClaimants(entry: MaterializationCollisionGroup): Collis
     facet: member.facet,
     label: `server ${member.authoredName}`,
     authoredName: member.authoredName,
+    effectiveName: member.effectiveName,
+    detail: [describeClaimantDeclaration(member.declaration, member.fingerprint)],
     location: serverManifestLocation(member.facet, member.authoredName),
   }))
 }
@@ -132,28 +148,14 @@ export function formatCollisionReport(
   )
 
   for (const entry of groups) {
-    if (entry.kind === 'asset') {
-      const group = entry.group
-      lines.push(`  ${describeNamespace(group.namespace, group.scope)} — "${group.effectiveName}" is claimed by:`)
-      for (const member of group.members) {
-        const via = member.disposition.kind === 'aliased' ? ` (already aliased from "${member.authoredName}")` : ''
-        lines.push(`    • ${member.facet}: ${member.type} "${member.authoredName}" → "${member.effectiveName}"${via}`)
-        lines.push(`        edit ${manifestLocation(member.facet, member.type, member.authoredName)}`)
-        lines.push(`          alias:  ${aliasSnippet(member.authoredName)}`)
-        lines.push(`          omit:   ${omitSnippet(member.authoredName)}`)
-      }
-      lines.push(``)
-      continue
-    }
-    const group = entry.group
-    lines.push(`  MCP servers — "${group.effectiveName}" is claimed by:`)
-    for (const member of group.members) {
-      const via = member.disposition.kind === 'aliased' ? ` (already aliased from "${member.authoredName}")` : ''
-      lines.push(`    • ${member.facet}: server "${member.authoredName}" → "${member.effectiveName}"${via}`)
-      lines.push(`        ${describeDeclaration(member.declaration)}`)
-      lines.push(`        edit ${serverManifestLocation(member.facet, member.authoredName)}`)
-      lines.push(`          alias:  ${aliasSnippet(member.authoredName)}`)
-      lines.push(`          omit:   ${omitSnippet(member.authoredName)}`)
+    lines.push(`  ${describeCollisionGroup(entry)} — "${entry.group.effectiveName}" is claimed by:`)
+    for (const claimant of collisionClaimants(entry)) {
+      const via = aliasedFrom(entry, claimant.authoredName)
+      lines.push(`    • ${claimant.facet}: ${claimant.label} → "${claimant.effectiveName}"${via}`)
+      for (const detail of claimant.detail) lines.push(`        ${detail}`)
+      lines.push(`        edit ${claimant.location}`)
+      lines.push(`          alias:  ${aliasSnippet(claimant.authoredName)}`)
+      lines.push(`          omit:   ${omitSnippet(claimant.authoredName)}`)
     }
     lines.push(``)
   }
@@ -177,7 +179,10 @@ export function formatCollisionReport(
     lines.push(``)
   }
 
-  lines.push(`  facets.json, facets.lock, the install receipt, and your materialized assets were NOT changed.`)
+  lines.push(
+    `  facets.json, facets.lock, the install receipt, your materialized assets, and every tool's`,
+    `  MCP configuration were NOT changed.`,
+  )
 
   return lines.join('\n')
 }
@@ -186,20 +191,47 @@ export function formatCollisionReport(
  * A one-line summary of a declaration, enough to tell two colliding servers
  * apart without reproducing the declaration itself.
  *
- * Deliberately not the full command, arguments, environment, or URL. This
- * report goes to stderr, which is a log file in exactly the situations that
- * produce it, and the complete declaration belongs only on the interactive
- * approval screen. The fingerprint prefix is the tiebreaker when two
- * summaries coincide: it is derived from the whole declaration but reveals
- * none of it.
+ * Deliberately not the full command line, arguments, environment, or URL
+ * path. Both surfaces that call this — this stderr report and the collision
+ * workspace — are ordinary command output, and the complete declaration
+ * belongs on the approval screen, which is the one place whose purpose is
+ * showing a user what they are authorizing.
+ *
+ * The fingerprint prefix is the tiebreaker. Two colliding declarations can
+ * share a command and differ only in arguments or environment, and a user
+ * shown two identical lines learns nothing about which row is which. The
+ * prefix is derived from the whole declaration and reveals none of it.
  */
-function describeDeclaration(declaration: McpServerDeclaration): string {
-  switch (declaration.type) {
-    case 'stdio':
-      return `stdio, command "${declaration.command}"`
-    case 'http':
-      return `http, ${new URL(declaration.url).origin}`
-  }
+export function describeClaimantDeclaration(
+  declaration: McpServerDeclaration,
+  fingerprint: McpServerFingerprint,
+): string {
+  const summary =
+    declaration.type === 'stdio' ? `stdio, command "${declaration.command}"` : `http, ${originOf(declaration.url)}`
+  return `${summary} · ${shortFingerprint(fingerprint)}`
+}
+
+/**
+ * The origin of an absolute HTTP(S) URL, without parsing it.
+ *
+ * `new URL()` throws, and a formatter that throws turns a report about a
+ * collision into a crash. The schema already guarantees the shape; this reads
+ * the part it guarantees and falls back to the whole string rather than
+ * inventing a failure mode.
+ */
+function originOf(url: string): string {
+  return /^https?:\/\/[^/?#]+/i.exec(url)?.[0] ?? url
+}
+
+/** The first few hex digits of a fingerprint, enough to tell two rows apart. */
+function shortFingerprint(fingerprint: McpServerFingerprint): string {
+  return fingerprint.slice('sha256:'.length, 'sha256:'.length + 8)
+}
+
+/** How this claimant already reached the contested name, if by an alias. */
+function aliasedFrom(entry: MaterializationCollisionGroup, authoredName: string): string {
+  const member = entry.group.members.find((candidate) => candidate.authoredName === authoredName)
+  return member?.disposition.kind === 'aliased' ? ` (already aliased from "${authoredName}")` : ''
 }
 
 function aliasSnippet(authoredName: string): string {
@@ -234,6 +266,13 @@ function exampleOverrideBody(groups: readonly MaterializationCollisionGroup[]): 
   return `"${overrideGroupKey(member.type)}": { ${aliasSnippet(member.authoredName)} }`
 }
 
+/** Where in `facets.json` the alias that failed validation is written. */
+export function aliasProblemLocation(problem: MaterializationAliasProblem): string {
+  return problem.kind === 'asset'
+    ? manifestLocation(problem.facet, problem.assetType, problem.authoredName)
+    : serverManifestLocation(problem.facet, problem.authoredName)
+}
+
 /**
  * Write the long-form stderr detail for a materialization failure, if it
  * has one. Returns whether anything was written.
@@ -249,14 +288,14 @@ export function writeMaterializationDetail(failure: RunInstallFailure): boolean 
     case 'MATERIALIZATION_RESOLUTION_INVALID':
       process.stderr.write(
         `${formatCollisionReport(failure.groups, [])}\n${failure.problems
-          .map((problem) => `  • ${problem.facet}: alias "${problem.alias}" ${problem.reason}`)
+          .map((problem) => `  • alias "${problem.alias}" ${problem.reason}\n      at ${aliasProblemLocation(problem)}`)
           .join('\n')}\n`,
       )
       return true
     case 'MATERIALIZATION_ALIAS_INVALID':
       process.stderr.write(
-        `A materialization alias in facets.json is not a legal asset name. Nothing was changed.\n${failure.problems
-          .map((problem) => `  • ${problem.facet}: "${problem.alias}" ${problem.reason}`)
+        `A materialization alias in facets.json is not a legal name. Nothing was changed.\n${failure.problems
+          .map((problem) => `  • "${problem.alias}" ${problem.reason}\n      at ${aliasProblemLocation(problem)}`)
           .join('\n')}\n`,
       )
       return true

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -152,6 +152,15 @@ export type {
   AssetTakeoverRequest,
   AssetTakeoverResolver,
 } from './install/asset-takeover.ts'
+// The shared cross-domain naming rule. Exported because the CLI's collision
+// workspace must answer "does this draft plan cleanly?" with the SAME function
+// the engine uses to validate the answer it gets back.
+export type {
+  CollisionFacetContribution,
+  CollisionPlanResult,
+  MaterializationAliasProblem,
+} from './install/commit/collision-plan.ts'
+export { overrideGroupFor, planCollisionIntent } from './install/commit/collision-plan.ts'
 // install machinery
 // The collision-resolver contract. Exported because the interactive
 // workspace lives in the CLI (TTY detection and prompting are display

--- a/packages/engine/src/install/__tests__/compose.test.ts
+++ b/packages/engine/src/install/__tests__/compose.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Adapter } from '@agent-facets/adapter'
@@ -373,7 +373,7 @@ describe('compose — resolution', () => {
 
     // The resolver saw the complete authored set, not just the conflict.
     expect(seen?.groups).toHaveLength(1)
-    expect(seen?.contributions.map((c) => c.facet).sort()).toEqual(['alpha', 'beta'])
+    expect(seen?.facets.map((facet) => facet.facet).sort()).toEqual(['alpha', 'beta'])
 
     // Both assets materialized — nothing was silently dropped.
     expect(io.filter((c) => c.startsWith('install:')).length).toBe(2)
@@ -768,3 +768,149 @@ function existsSyncSafe(path: string): boolean {
     return false
   }
 }
+
+describe('compose — resolving server collisions', () => {
+  const OTHER = { type: 'stdio', command: 'other-server' }
+
+  test('a server collision reaches the resolver rather than reporting', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: serverFixture('beta', 'filesystem', OTHER),
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+
+    let seen: CollisionResolutionRequest | undefined
+    const result = await runInstall({
+      projectRoot,
+      adapters: [adapter],
+      mcpConsent: ACCEPT_MCP,
+      resolveCollisions: async (request): Promise<CollisionResolution> => {
+        seen = request
+        return {
+          kind: 'resolved',
+          overrides: { beta: { servers: { filesystem: { kind: 'aliased', as: 'beta-filesystem' } } } },
+        }
+      },
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(seen?.groups).toHaveLength(1)
+    expect(seen?.groups[0]?.kind).toBe('mcp-server')
+    // The complete authored set, so an alias can land on a server that was
+    // not colliding.
+    expect(seen?.facets.map((facet) => facet.facet).sort()).toEqual(['alpha', 'beta'])
+    expect(result.summary.mcp.configurations.added).toBe(2)
+  })
+
+  test('one report carries an asset group and a server group together', async () => {
+    writeManifest({
+      facets: {
+        alpha: fixture('alpha', 'review'),
+        beta: fixture('beta', 'review'),
+        gamma: serverFixture('gamma', 'filesystem', STDIO),
+        delta: serverFixture('delta', 'filesystem', OTHER),
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+
+    let seen: CollisionResolutionRequest | undefined
+    const result = await runInstall({
+      projectRoot,
+      adapters: [adapter],
+      mcpConsent: ACCEPT_MCP,
+      resolveCollisions: async (request): Promise<CollisionResolution> => {
+        seen = request
+        return { kind: 'cancelled' }
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MATERIALIZATION_CANCELLED')
+    expect(seen?.groups.map((entry) => entry.kind).sort()).toEqual(['asset', 'mcp-server'])
+  })
+
+  test('cancelling leaves the project and every native document unchanged', async () => {
+    const before = writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: serverFixture('beta', 'filesystem', OTHER),
+      },
+    })
+    const { adapter, io } = recordingAdapter('rec')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [adapter],
+      mcpConsent: ACCEPT_MCP,
+      resolveCollisions: async (): Promise<CollisionResolution> => ({ kind: 'cancelled' }),
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MATERIALIZATION_CANCELLED')
+    expect(result.rollback.kind).toBe('not-needed')
+    expect(readManifest()).toBe(before)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+    // Composition precedes MCP preparation, so no adapter was asked to plan
+    // a configuration, let alone write one.
+    expect(io).toEqual([])
+    expect(existsSync(join(projectRoot, '.rec', 'mcp.json'))).toBe(false)
+  })
+
+  test('a resolver that omits every server claimant resolves the group', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: serverFixture('beta', 'filesystem', OTHER),
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [adapter],
+      mcpConsent: ACCEPT_MCP,
+      resolveCollisions: async (): Promise<CollisionResolution> => ({
+        kind: 'resolved',
+        overrides: {
+          alpha: { servers: { filesystem: { kind: 'omitted' } } },
+          beta: { servers: { filesystem: { kind: 'omitted' } } },
+        },
+      }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.summary.mcp.declarations.omitted).toBe(2)
+    expect(result.summary.mcp.configurations.added).toBe(0)
+  })
+
+  test('a resolver answer that still collides fails without reopening it', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: serverFixture('beta', 'filesystem', OTHER),
+      },
+    })
+    const { adapter } = recordingAdapter('rec')
+
+    let calls = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [adapter],
+      mcpConsent: ACCEPT_MCP,
+      resolveCollisions: async (): Promise<CollisionResolution> => {
+        calls++
+        // Moves the problem rather than solving it.
+        return {
+          kind: 'resolved',
+          overrides: { alpha: { servers: { filesystem: { kind: 'aliased', as: 'filesystem' } } } },
+        }
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MATERIALIZATION_RESOLUTION_INVALID')
+    expect(calls).toBe(1)
+  })
+})

--- a/packages/engine/src/install/commit/collision-plan.ts
+++ b/packages/engine/src/install/commit/collision-plan.ts
@@ -1,0 +1,204 @@
+import type { AssetType } from '@agent-facets/common'
+import type {
+  AuthoredAsset,
+  AuthoredServer,
+  FacetMaterializationOverrides,
+  MaterializationOverrideGroup,
+  MaterializationPlan,
+  PlannedServer,
+  PlannedServerConfiguration,
+} from '@agent-facets/protocol'
+import {
+  overrideGroupKey,
+  planMaterialization,
+  planServerMaterialization,
+  SERVER_OVERRIDE_GROUP,
+} from '@agent-facets/protocol'
+import { ownEntry } from '../own-entry.ts'
+import type { ContributionKind, MaterializationCollisionGroup, StaleMaterializationOverride } from '../types.ts'
+
+/**
+ * The one cross-domain naming rule: given the complete desired set and one
+ * override document, what does the project materialize?
+ *
+ * Shared deliberately. The engine runs it to compose a plan and again to
+ * validate whatever an interactive resolver hands back; the CLI's collision
+ * workspace runs it after every edit to decide whether Confirm is legal. Two
+ * implementations of "does this draft plan cleanly?" is one implementation
+ * away from a green confirm button that fails the install a second later.
+ *
+ * Both domains are planned from the SAME override map, in separate identity
+ * spaces. That separation is what makes a skill named `review` and a server
+ * named `review` structurally incapable of contending — there is no shared
+ * key they could collide in — and it is a property of calling two planners,
+ * not of a check anyone has to remember to write.
+ */
+
+/**
+ * One facet's complete authored contribution.
+ *
+ * Assets and servers travel together, keyed by facet, because they are
+ * planned against one override document. Carrying that document per facet
+ * here as well would be a second place to say the same thing — and the one
+ * the planner ignores, since intent arrives as a separate map that a draft
+ * can replace wholesale.
+ */
+export interface CollisionFacetContribution {
+  facet: string
+  assets: readonly AuthoredAsset[]
+  servers: readonly AuthoredServer[]
+}
+
+/**
+ * An override whose alias is not a legal name.
+ *
+ * Tagged, and carrying exactly what the override document is keyed by:
+ * facet, group, authored name. Deliberately NO scope — an override lives at
+ * `materialization.skills["review"]`, which names no scope, so a scope here
+ * would be a field with nothing to fill it from and a renderer free to print
+ * a guess.
+ */
+export type MaterializationAliasProblem =
+  | { kind: 'asset'; facet: string; assetType: AssetType; authoredName: string; alias: string; reason: string }
+  | { kind: 'mcp-server'; facet: string; authoredName: string; alias: string; reason: string }
+
+/**
+ * What one override document plans to.
+ *
+ * The three arms mirror both planners': an invalid alias means the input
+ * cannot be interpreted at all, so no plan and no collision report exist for
+ * it, while a collision still carries the stale-override diagnostics that are
+ * orthogonal to it.
+ */
+export type CollisionPlanResult =
+  | {
+      ok: true
+      assets: MaterializationPlan
+      servers: { planned: readonly PlannedServer[]; configurations: readonly PlannedServerConfiguration[] }
+      staleOverrides: readonly StaleMaterializationOverride[]
+    }
+  | {
+      ok: false
+      reason: 'collision'
+      groups: readonly MaterializationCollisionGroup[]
+      staleOverrides: readonly StaleMaterializationOverride[]
+    }
+  | { ok: false; reason: 'invalid-alias'; problems: readonly MaterializationAliasProblem[] }
+
+/** Plan the complete desired set against one override document. */
+export function planCollisionIntent(
+  facets: readonly CollisionFacetContribution[],
+  overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
+): CollisionPlanResult {
+  // Own-property reads throughout: facet names come from `facets.json`, where
+  // `constructor` is a legal key that would otherwise resolve to `Object`.
+  const assets = planMaterialization(
+    facets.map((contribution) => ({
+      facet: contribution.facet,
+      assets: contribution.assets,
+      overrides: ownEntry(overrides, contribution.facet),
+    })),
+  )
+  const servers = planServerMaterialization(
+    facets.map((contribution) => ({
+      facet: contribution.facet,
+      servers: contribution.servers,
+      overrides: ownEntry(overrides, contribution.facet),
+    })),
+  )
+
+  // Invalid aliases first, and from both domains: an alias that does not
+  // satisfy the grammar is a problem with what the user wrote, and reporting a
+  // collision instead would send them looking for a conflict that is really a
+  // typo.
+  const problems: MaterializationAliasProblem[] = [
+    ...(!assets.ok && assets.reason === 'invalid-alias'
+      ? assets.problems.map(
+          (problem): MaterializationAliasProblem => ({
+            kind: 'asset',
+            facet: problem.facet,
+            assetType: problem.type,
+            authoredName: problem.authoredName,
+            alias: problem.alias,
+            reason: problem.reason,
+          }),
+        )
+      : []),
+    ...(!servers.ok && servers.reason === 'invalid-alias'
+      ? servers.problems.map(
+          (problem): MaterializationAliasProblem => ({
+            kind: 'mcp-server',
+            facet: problem.facet,
+            authoredName: problem.authoredName,
+            alias: problem.alias,
+            reason: problem.reason,
+          }),
+        )
+      : []),
+  ]
+  if (problems.length > 0) return { ok: false, reason: 'invalid-alias', problems }
+
+  // A stale override is reported from whichever domain still planned, so a
+  // collision in one does not suppress the other's diagnostics.
+  const staleOverrides: StaleMaterializationOverride[] = [
+    ...(assets.ok || assets.reason === 'collision'
+      ? assets.staleOverrides.map(
+          (stale): StaleMaterializationOverride => ({
+            facet: stale.facet,
+            contribution: { kind: 'asset', assetType: stale.type },
+            authoredName: stale.authoredName,
+            disposition: stale.disposition,
+          }),
+        )
+      : []),
+    ...(servers.ok || servers.reason === 'collision'
+      ? servers.staleOverrides.map(
+          (stale): StaleMaterializationOverride => ({
+            facet: stale.facet,
+            contribution: { kind: 'mcp-server' },
+            authoredName: stale.authoredName,
+            disposition: stale.disposition,
+          }),
+        )
+      : []),
+  ]
+
+  if (!assets.ok || !servers.ok) {
+    // Every group from both domains, in one report. A user shown asset
+    // collisions now and server collisions on the next attempt learns the
+    // shape of the problem one round trip at a time.
+    const groups: MaterializationCollisionGroup[] = [
+      ...(!assets.ok && assets.reason === 'collision'
+        ? assets.groups.map((group) => ({ kind: 'asset' as const, group }))
+        : []),
+      ...(!servers.ok && servers.reason === 'collision'
+        ? servers.groups.map((group) => ({ kind: 'mcp-server' as const, group }))
+        : []),
+    ]
+    return { ok: false, reason: 'collision', groups, staleOverrides }
+  }
+
+  return {
+    ok: true,
+    assets: assets.plan,
+    servers: { planned: servers.planned, configurations: servers.configurations },
+    staleOverrides,
+  }
+}
+
+/**
+ * The `facets.json` group one contribution kind's overrides live under.
+ *
+ * The single mapping, exported because four surfaces need it: the prune pass,
+ * the collision draft's read and write paths, and the failure renderer that
+ * tells a user where to type. `overrideGroupKey` alone cannot serve — its
+ * return type is the three asset directories, and cannot express `servers`.
+ */
+export function overrideGroupFor(contribution: ContributionKind): MaterializationOverrideGroup {
+  switch (contribution.kind) {
+    case 'asset':
+      return overrideGroupKey(contribution.assetType)
+    case 'mcp-server':
+      return SERVER_OVERRIDE_GROUP
+  }
+}

--- a/packages/engine/src/install/commit/compose.ts
+++ b/packages/engine/src/install/commit/compose.ts
@@ -1,47 +1,26 @@
 import type {
-  CollisionGroup,
   CurrentLockfileAssetEntry,
   CurrentLockfileFacet,
-  FacetContribution,
   FacetMaterializationOverrides,
   MaterializationDisposition,
   MaterializedAsset,
   PlannedServer,
   PlannedServerConfiguration,
-  ServerContribution,
-  StaleOverride,
-  StaleServerOverride,
 } from '@agent-facets/protocol'
-import { planMaterialization, planServerMaterialization } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
-import { ownEntry, ownRecord } from '../own-entry.ts'
+import { ownRecord } from '../own-entry.ts'
 import type {
   MaterializationCollisionGroup,
   RunInstallFailure,
   StageEvent,
   StaleMaterializationOverride,
 } from '../types.ts'
+import {
+  type CollisionFacetContribution,
+  type MaterializationAliasProblem,
+  planCollisionIntent,
+} from './collision-plan.ts'
 import type { ResolvedFacetRecord } from './resolve-all.ts'
-
-/** Tag an asset-planner stale override for the cross-domain report. */
-function taggedAssetStale(stale: StaleOverride): StaleMaterializationOverride {
-  return {
-    facet: stale.facet,
-    contribution: { kind: 'asset', assetType: stale.type },
-    authoredName: stale.authoredName,
-    disposition: stale.disposition,
-  }
-}
-
-/** Tag a server-planner stale override for the cross-domain report. */
-function taggedServerStale(stale: StaleServerOverride): StaleMaterializationOverride {
-  return {
-    facet: stale.facet,
-    contribution: { kind: 'mcp-server' },
-    authoredName: stale.authoredName,
-    disposition: stale.disposition,
-  }
-}
 
 /**
  * Compose: turn the complete set of verified authored contributions plus the
@@ -63,15 +42,24 @@ function taggedServerStale(stale: StaleServerOverride): StaleMaterializationOver
 
 /** What a collision resolver is shown, and what it may change. */
 export interface CollisionResolutionRequest {
-  /** Every unresolved group. Never truncated — one pass, not one at a time. */
-  groups: readonly CollisionGroup[]
+  /**
+   * Every unresolved group, from both identity spaces. Never truncated — one
+   * pass, not one at a time, and not one domain at a time either.
+   */
+  groups: readonly MaterializationCollisionGroup[]
   /**
    * Every authored contribution, so a workspace can offer a choice on any
-   * asset — including ones that are not currently colliding but could
-   * absorb a name.
+   * asset or server — including ones that are not currently colliding but
+   * could absorb a name.
    */
-  contributions: readonly FacetContribution[]
-  /** Overrides naming assets the resolved versions no longer contain. */
+  facets: readonly CollisionFacetContribution[]
+  /**
+   * The project's current intent, complete. A resolver returns a map of the
+   * same shape, so anything it does not mention is erased — which is why it
+   * starts from everything rather than from the colliding facets only.
+   */
+  overrides: Readonly<Record<string, FacetMaterializationOverrides>>
+  /** Overrides naming assets or servers the resolved versions no longer contain. */
   staleOverrides: readonly StaleMaterializationOverride[]
 }
 
@@ -155,8 +143,15 @@ export interface ComposeArgs {
   onStage: (event: StageEvent) => void
 }
 
-/** The contributions the planner reasons over, in resolve-all's order. */
-function contributionsOf(args: ComposeArgs): FacetContribution[] {
+/**
+ * The complete authored set the planner reasons over, in resolve-all's order.
+ *
+ * Every facet appears, including one that contributes nothing: the planner's
+ * stale sweep is driven by the override map, so a facet whose only override
+ * names a contribution it no longer publishes has to be visible here for that
+ * override to be reported at all.
+ */
+function facetContributionsOf(args: ComposeArgs): CollisionFacetContribution[] {
   return args.resolved.map((record) => ({
     facet: record.facet,
     assets: record.plan.assets.map((asset) => ({
@@ -164,23 +159,7 @@ function contributionsOf(args: ComposeArgs): FacetContribution[] {
       type: asset.type,
       name: asset.name,
     })),
-    overrides: ownEntry(args.desiredFacets, record.facet)?.overrides,
-  }))
-}
-
-/**
- * The server contributions, in the same order.
- *
- * Every facet appears, including one that declares nothing: the planner's
- * stale sweep is driven by the override map, so a facet whose only server
- * override names a declaration it no longer publishes has to be visible here
- * for that override to be reported at all.
- */
-function serverContributionsOf(args: ComposeArgs): ServerContribution[] {
-  return args.resolved.map((record) => ({
-    facet: record.facet,
     servers: record.servers,
-    overrides: ownEntry(args.desiredFacets, record.facet)?.overrides,
   }))
 }
 
@@ -225,14 +204,16 @@ function dispositionKey(facet: string, scope: string, type: string, authoredName
 }
 
 /**
- * Run the planner over one override set and project its result into the
- * pieces Compose needs. Shared by the initial pass and the post-resolver
- * defense-in-depth pass so the two cannot diverge.
+ * Run the shared cross-domain rule over one override set and project its
+ * result into the pieces Compose needs.
+ *
+ * The rule itself lives in `collision-plan.ts` because the interactive
+ * workspace runs the same one after every edit. This wrapper only adds what
+ * Compose alone needs: lockfile entries built from the resolved records.
  */
 function planWith(
   resolved: readonly ResolvedFacetRecord[],
-  contributions: readonly FacetContribution[],
-  serverContributions: readonly ServerContribution[],
+  facets: readonly CollisionFacetContribution[],
   overrides: Readonly<Record<string, FacetMaterializationOverrides>>,
 ):
   | { ok: true; plan: ComposedPlan }
@@ -242,75 +223,23 @@ function planWith(
       groups: readonly MaterializationCollisionGroup[]
       staleOverrides: readonly StaleMaterializationOverride[]
     }
-  | { ok: false; reason: 'invalid-alias'; problems: readonly { facet: string; alias: string; reason: string }[] } {
-  const withOverrides = contributions.map((contribution) => ({
-    ...contribution,
-    overrides: ownEntry(overrides, contribution.facet),
-  }))
-  const serversWithOverrides = serverContributions.map((contribution) => ({
-    ...contribution,
-    overrides: ownEntry(overrides, contribution.facet),
-  }))
-
-  // Both domains are planned from the SAME override map, in separate identity
-  // spaces. Planning them independently is what makes a skill and a server
-  // sharing a name structurally incapable of contending — there is no shared
-  // key they could collide in.
-  const assets = planMaterialization(withOverrides)
-  const servers = planServerMaterialization(serversWithOverrides)
-
-  // Invalid aliases first, and from both domains: an alias that does not
-  // satisfy the grammar is a problem with what the user wrote, and reporting
-  // a collision instead would send them looking for a conflict that is really
-  // a typo.
-  const aliasProblems = [
-    ...(!assets.ok && assets.reason === 'invalid-alias' ? assets.problems : []),
-    ...(!servers.ok && servers.reason === 'invalid-alias'
-      ? servers.problems.map((p) => ({ facet: p.facet, alias: p.alias, reason: p.reason }))
-      : []),
-  ]
-  if (aliasProblems.length > 0) {
-    return { ok: false, reason: 'invalid-alias', problems: aliasProblems }
-  }
-
-  // A stale override is reported from whichever domain still planned, so a
-  // collision in one does not suppress the other's diagnostics.
-  const staleOverrides: StaleMaterializationOverride[] = [
-    ...(assets.ok || assets.reason === 'collision' ? assets.staleOverrides.map(taggedAssetStale) : []),
-    ...(!servers.ok && servers.reason === 'invalid-alias' ? [] : servers.staleOverrides.map(taggedServerStale)),
-  ]
-
-  if (!assets.ok || !servers.ok) {
-    // Every group from both domains, in one report. A user shown asset
-    // collisions now and server collisions on the next attempt learns the
-    // shape of the problem one round trip at a time.
-    const groups: MaterializationCollisionGroup[] = [
-      ...(!assets.ok && assets.reason === 'collision'
-        ? assets.groups.map((group) => ({ kind: 'asset' as const, group }))
-        : []),
-      ...(!servers.ok && servers.reason === 'collision'
-        ? servers.groups.map((group) => ({ kind: 'mcp-server' as const, group }))
-        : []),
-    ]
-    return { ok: false, reason: 'collision', groups, staleOverrides }
-  }
+  | { ok: false; reason: 'invalid-alias'; problems: readonly MaterializationAliasProblem[] } {
+  const planned = planCollisionIntent(facets, overrides)
+  if (!planned.ok) return planned
 
   const dispositions = new Map<string, MaterializationDisposition>()
-  for (const planned of assets.plan.assets) {
-    dispositions.set(
-      dispositionKey(planned.facet, planned.scope, planned.type, planned.authoredName),
-      planned.disposition,
-    )
+  for (const asset of planned.assets.assets) {
+    dispositions.set(dispositionKey(asset.facet, asset.scope, asset.type, asset.authoredName), asset.disposition)
   }
 
   return {
     ok: true,
     plan: {
       facetEntries: lockfileEntriesFor(resolved, dispositions),
-      materialized: assets.plan.materialized,
-      mcpServers: { planned: servers.planned, configurations: servers.configurations },
+      materialized: planned.assets.materialized,
+      mcpServers: planned.servers,
       overrides,
-      staleOverrides,
+      staleOverrides: planned.staleOverrides,
     },
   }
 }
@@ -320,8 +249,7 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
 
   onStage({ kind: 'collision-check' })
 
-  const contributions = contributionsOf(args)
-  const serverContributions = serverContributionsOf(args)
+  const facets = facetContributionsOf(args)
   // Null-prototype: the keys are facet names from `facets.json`, and this is
   // where the map the resolver later edits and returns is born. A facet named
   // `__proto__` assigned into a plain `{}` would vanish here rather than in
@@ -331,7 +259,7 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
     if (entry.overrides !== undefined) loadedOverrides[facet] = entry.overrides
   }
 
-  const first = planWith(resolved, contributions, serverContributions, loadedOverrides)
+  const first = planWith(resolved, facets, loadedOverrides)
   if (first.ok) {
     return { ok: true, plan: first.plan }
   }
@@ -339,29 +267,25 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
     return { ok: false, failure: { code: 'MATERIALIZATION_ALIAS_INVALID', problems: first.problems } }
   }
 
-  const assetGroups = first.groups.flatMap((entry) => (entry.kind === 'asset' ? [entry.group] : []))
-  const collisionFailure: RunInstallFailure = {
-    code: 'MATERIALIZATION_COLLISION',
-    groups: first.groups,
-    staleOverrides: first.staleOverrides,
-  }
-
   // Collisions. Frozen mode reproduces recorded intent and never collects new
   // decisions, so it reports rather than resolves — the same report a
-  // non-interactive command gets.
-  //
-  // A server collision also reports rather than resolves, for now: the
-  // resolution workspace speaks only about assets, so handing it a set whose
-  // server half it cannot express would let a user confirm a draft that
-  // resolves nothing and fail on the re-plan. Reporting is the honest answer
-  // until the workspace can offer a choice for every claimant.
-  if (frozenLockfile || resolveCollisions === undefined || assetGroups.length !== first.groups.length) {
-    return { ok: false, failure: collisionFailure }
+  // non-interactive command gets. A caller with no resolver gets the same,
+  // because guessing a winner is the one thing this step must never do.
+  if (frozenLockfile || resolveCollisions === undefined) {
+    return {
+      ok: false,
+      failure: {
+        code: 'MATERIALIZATION_COLLISION',
+        groups: first.groups,
+        staleOverrides: first.staleOverrides,
+      },
+    }
   }
 
   const resolution = await resolveCollisions({
-    groups: assetGroups,
-    contributions,
+    groups: first.groups,
+    facets,
+    overrides: loadedOverrides,
     staleOverrides: first.staleOverrides,
   })
   if (resolution.kind === 'cancelled') {
@@ -372,7 +296,7 @@ export async function compose(args: ComposeArgs): Promise<ComposeResult> {
   // the same pure rule. The resolver is NOT reopened on failure — an
   // automatic retry loop would let a broken resolver spin indefinitely, and
   // the user has already been shown the groups once.
-  const second = planWith(resolved, contributions, serverContributions, resolution.overrides)
+  const second = planWith(resolved, facets, resolution.overrides)
   if (second.ok) {
     return { ok: true, plan: second.plan }
   }

--- a/packages/engine/src/install/frozen-gates.ts
+++ b/packages/engine/src/install/frozen-gates.ts
@@ -100,7 +100,14 @@ export function checkFrozenConsistency(args: FrozenGateArgs): RunInstallFailure 
     if (planned.reason === 'invalid-alias') {
       return {
         code: 'MATERIALIZATION_ALIAS_INVALID',
-        problems: planned.problems.map((p) => ({ facet: p.facet, alias: p.alias, reason: p.reason })),
+        problems: planned.problems.map((problem) => ({
+          kind: 'asset' as const,
+          facet: problem.facet,
+          assetType: problem.type,
+          authoredName: problem.authoredName,
+          alias: problem.alias,
+          reason: problem.reason,
+        })),
       }
     }
     // Unresolved collisions in recorded state. Frozen mode never prompts, so

--- a/packages/engine/src/install/types.ts
+++ b/packages/engine/src/install/types.ts
@@ -14,6 +14,7 @@ import type { UnsupportedManifestVersion } from '../manifest/project-files.ts'
 import type { RegistryError } from '../registry/index.ts'
 import type { ParseError, Source } from '../sources/facet/types.ts'
 import type { AssetTakeoverResolver } from './asset-takeover.ts'
+import type { MaterializationAliasProblem } from './commit/collision-plan.ts'
 import type { CollisionResolver } from './commit/compose.ts'
 import type { McpConsentPolicy, McpConsentRequest } from './mcp/consent.ts'
 import type { McpConfigurationOutcome, McpConsentRequestSummary, McpInstallOutcomes } from './mcp/outcomes.ts'
@@ -582,7 +583,7 @@ export type RunInstallFailure =
    * all, so no effective set — and therefore no collision report — can be
    * derived from it.
    */
-  | { code: 'MATERIALIZATION_ALIAS_INVALID'; problems: ReadonlyArray<{ facet: string; alias: string; reason: string }> }
+  | { code: 'MATERIALIZATION_ALIAS_INVALID'; problems: ReadonlyArray<MaterializationAliasProblem> }
   /**
    * Two or more assets claim one logical materialized identity and nothing
    * resolved it: frozen mode (which reproduces recorded intent and never
@@ -606,7 +607,7 @@ export type RunInstallFailure =
   | {
       code: 'MATERIALIZATION_RESOLUTION_INVALID'
       groups: ReadonlyArray<MaterializationCollisionGroup>
-      problems: ReadonlyArray<{ facet: string; alias: string; reason: string }>
+      problems: ReadonlyArray<MaterializationAliasProblem>
     }
   /** The user dismissed collision resolution. No state was mutated. */
   | { code: 'MATERIALIZATION_CANCELLED' }


### PR DESCRIPTION
### Why

The collision resolution workspace previously only handled asset claimants. MCP server declarations could collide but the workspace had no way to express a choice for them, so any install with a server collision would report and exit rather than opening the interactive resolver. This extends the full collision resolution flow — interactive workspace, draft model, non-interactive failure report, and the underlying planner — to cover MCP server claimants alongside assets.

### Details

The core change is a new shared `planCollisionIntent` function in `collision-plan.ts` that runs both the asset planner and the server planner against the same override document and merges their results into one tagged result type. This function is now the single source of truth for "does this draft plan cleanly?" — the engine calls it during compose and again to validate whatever the resolver returns, and the CLI's collision workspace calls it after every edit to decide whether Confirm is legal. Having two implementations of that question is what produces a green confirm button that then fails the install.

Assets and MCP servers are kept in separate identity spaces throughout. A skill named `review` and a server named `review` never contend because they are planned by two independent planners writing to two independent namespaces. The workspace, draft model, and grouping logic all preserve that separation: a `DisplayGroup` carries a `kind` tag, `ClaimantRef` is a discriminated union rather than a widened struct, and `groupClaimants` never unions a group from one domain with a group from the other.

The `CollisionResolutionRequest` now carries `facets` (the complete authored set, both assets and servers) and `overrides` (the full current intent document) instead of `contributions` (assets only, with overrides embedded per facet). The resolver returns a map of the same shape it received, so anything it does not mention is erased — which is why it starts from the complete intent rather than from the colliding facets only.

The non-interactive failure report and the `MATERIALIZATION_ALIAS_INVALID` failure type are updated to carry tagged problems (`kind: 'asset' | 'mcp-server'`) with the exact `facets.json` path, so a user reading stderr can find the field to edit without guessing which override group applies.

The guard that previously blocked the resolver when any server group was present is removed. The workspace can now express a choice for every claimant in every group.

### Verification

New tests cover: server-only collision groups reaching the resolver, mixed asset-and-server groups appearing in one report, cancellation leaving the project and every native document unchanged, omitting every server claimant as a valid resolution, a resolver answer that still collides failing without reopening, prototype-safety for server names like `__proto__` and `constructor`, and the interactive workspace rendering declaration summaries and submitting overrides to the correct `servers` group. CI covers the rest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install compose and materialization intent (draft confirm vs engine validation); mistakes could allow invalid resolutions or wrong override paths, though coverage is heavy on mixed groups, cancellation, and prototype-safe keys.
> 
> **Overview**
> MCP server name collisions can now go through the **same interactive collision flow as assets**, instead of blocking the resolver when any server group was present.
> 
> A new shared **`planCollisionIntent`** in the engine runs asset and server planners against one override document and is used by compose, post-resolver validation, and the CLI draft after every edit so Confirm matches what install will accept. **`CollisionResolutionRequest`** now carries full **`facets`** plus **`overrides`** rather than asset-only contributions with embedded overrides.
> 
> The collision **draft and UI** use a tagged **`ClaimantRef`** / group **`kind`**, declaration summaries on server rows, **`materialization.servers`** overrides, and domain-separated grouping so a skill and a server sharing a name never merge. **Non-interactive** collision and alias failures list every MCP claimant with exact **`facets.json`** paths, declaration summaries, and neutral alias/omit snippets; alias problems are tagged **`asset` | `mcp-server`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1be39963dea95078dbbfbd3c6de3ca0d8d9128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->