### PR TITLE
Wire MCP consent and asset takeover screens into the install pipeline with `--accept-mcp`

### DIFF
--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -133,15 +133,15 @@ Your choices are written into `facets.json` as durable intent, so the next insta
 
 `Esc` or `Ctrl-C` cancels the whole install. Nothing was written, and re-running lets you make the choices again.
 
-**Without a terminal** — CI, piped output, or `--frozen-lockfile` — nothing is prompted. Every group and every claimant is printed to stderr with the exact `facets.json` location to edit and copy-pasteable alias and omit snippets. No winner is chosen and no alias is invented for you: the placeholder is literally `choose-a-name`. The report ends by stating that `facets.json`, `facets.lock`, the receipt, and your materialized assets were **not** changed.
+**Without a terminal** — CI, piped output, or `--frozen-lockfile` — nothing is prompted. Every group and every claimant is printed to stderr with the exact `facets.json` location to edit and copy-pasteable alias and omit snippets. No winner is chosen and no alias is invented for you: the placeholder is literally `choose-a-name`. The report ends by stating that `facets.json`, `facets.lock`, the receipt, your materialized assets, and every tool's MCP configuration were **not** changed.
 
 ## Cache
 
 Resolved facet content is stored at `$FACET_DIR/cache/<name>@<version>/` (default `~/.facet/cache/`) so subsequent installs of the same identity don't hit the network. Cache hits are re-verified on every use — see [cache self-audit](/specification/integrity). The cache root is part of the facet directory tree; set `FACET_DIR` to change it. See the [environment variables reference](/cli/env).
 
-## Servers
+## MCP servers
 
-A facet that declares `servers:` emits a warning during install  -- the server names are listed but not materialized. Server support is on the [roadmap](/roadmap).
+A facet that declares `servers:` contributes MCP server configuration to every selected adapter. New or changed declarations need your approval before anything is written: interactive runs show the exact command, arguments, and environment assignments -- or the exact URL -- on one approval screen, and non-interactive runs require `--accept-mcp`.
 
 ## See also
 

--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -128,20 +128,20 @@
 
 ## 15. Consent, takeover, flags, and command output — Research
 
-- [ ] 15.1 Explore: Inspect add/install/remove flag definitions, shared command plumbing, interactive phase/resolver lifecycle, abort settlement, and frozen prompt policy.
-- [ ] 15.2 Explore: Inspect success/failure rendering, verbose logging, help output, stale-intent notices, no-op detection, and all persistent surfaces that must not leak declarations.
-- [ ] 15.3 Propose: Define separate MCP-consent and asset-takeover phases plus result/failure rendering for complete non-interactive diagnostics and configuration outcomes.
+- [x] 15.1 Explore: Inspect add/install/remove flag definitions, shared command plumbing, interactive phase/resolver lifecycle, abort settlement, and frozen prompt policy.
+- [x] 15.2 Explore: Inspect success/failure rendering, verbose logging, help output, stale-intent notices, no-op detection, and all persistent surfaces that must not leak declarations.
+- [x] 15.3 Propose: Define separate MCP-consent and asset-takeover phases plus result/failure rendering for complete non-interactive diagnostics and configuration outcomes.
 
 ## 16. Consent, takeover, flags, and command output — Implementation
 
-- [ ] 16.1 Implement: Define `--accept-mcp` once and expose/thread it through add, install, and remove; honor it without prompting in frozen mode and keep it independent from asset collision/takeover decisions.
-- [ ] 16.2 Implement: Add an MCP-only approval screen showing all exact declarations and a distinct native-takeover section, with approve-all, decline, and abort settlement before any mutation.
-- [ ] 16.3 Implement: Add a separate just-in-time asset takeover screen with Continue selected by default and cancellation/restoration reporting.
-- [ ] 16.4 Implement: Render complete non-interactive MCP-consent and unsupported-adapter failures with every claimant/adapter, actionable upgrade or omission guidance, and explicit no-mutation state.
-- [ ] 16.5 Implement: Extend summaries and stale-intent output for added, updated, unchanged, aliased, omitted, repaired, removed, conflicted, unsupported, and takeover outcomes without treating server-only facets as no-ops.
-- [ ] 16.6 Implement: Remove the obsolete CLI server-warning state, rendering, fixtures, and help/documentation language.
-- [ ] 16.7 Implement: Add command/help, interactive phase, Ctrl-C, non-interactive, frozen, outcome, takeover, and declaration-secrecy tests proving commands/URLs/environment values appear only in approved disclosure surfaces.
-- [ ] 16.8 Verify: Run focused CLI unit and e2e tests plus type checks for add, install, and remove.
+- [x] 16.1 Implement: Define `--accept-mcp` once and expose/thread it through add, install, and remove; honor it without prompting in frozen mode and keep it independent from asset collision/takeover decisions.
+- [x] 16.2 Implement: Add an MCP-only approval screen showing all exact declarations and a distinct native-takeover section, with approve-all, decline, and abort settlement before any mutation.
+- [x] 16.3 Implement: Add a separate just-in-time asset takeover screen with Continue selected by default and cancellation/restoration reporting.
+- [x] 16.4 Implement: Render complete non-interactive MCP-consent and unsupported-adapter failures with every claimant/adapter, actionable upgrade or omission guidance, and explicit no-mutation state.
+- [x] 16.5 Implement: Extend summaries and stale-intent output for added, updated, unchanged, aliased, omitted, repaired, removed, conflicted, unsupported, and takeover outcomes without treating server-only facets as no-ops.
+- [x] 16.6 Implement: Remove the obsolete CLI server-warning state, rendering, fixtures, and help/documentation language.
+- [x] 16.7 Implement: Add command/help, interactive phase, Ctrl-C, non-interactive, frozen, outcome, takeover, and declaration-secrecy tests proving commands/URLs/environment values appear only in approved disclosure surfaces.
+- [x] 16.8 Verify: Run focused CLI unit and e2e tests plus type checks for add, install, and remove.
 
 ## 17. Documentation and release preparation — Research
 

--- a/packages/cli/src/__tests__/helpers/fake-adapter.ts
+++ b/packages/cli/src/__tests__/helpers/fake-adapter.ts
@@ -2,8 +2,17 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 
-/** Install an adapter bundle the compiled binary can load without workspace dependencies. */
-export function installFakeAdapter(adaptersDir: string, name: string): void {
+/**
+ * Install an adapter bundle the compiled binary can load without workspace
+ * dependencies.
+ *
+ * `mcp` opts the bundle into the MCP server capability, storing its native
+ * configuration in a JSON document of its own. The document format is
+ * deliberately trivial — this fixture exists to exercise the ENGINE's
+ * ordering, consent, and rollback behavior, not to re-test any real tool's
+ * schema, which the first-party adapters cover themselves.
+ */
+export function installFakeAdapter(adaptersDir: string, name: string, options: { mcp?: boolean } = {}): void {
   const dir = join(adaptersDir, name)
   mkdirSync(dir, { recursive: true })
   writeFileSync(
@@ -14,10 +23,62 @@ import { dirname, join } from 'node:path'
 
 function path(type, name) { return join(process.cwd(), '.${name}', type + 's', name + '.md') }
 
+const mcpDoc = (root) => join(root, '.${name}-mcp.json')
+function readMcp(root) {
+  const file = mcpDoc(root)
+  if (!existsSync(file)) return { servers: {} }
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+const mcpCapability = {
+  async prepare({ projectRoot, desired, previouslyOwnedNames }) {
+    const doc = readMcp(projectRoot)
+    const outcomes = []
+    for (const contribution of desired) {
+      const existing = doc.servers[contribution.name]
+      const ownership = previouslyOwnedNames.includes(contribution.name) ? 'tracked' : 'untracked'
+      if (existing === undefined) outcomes.push({ kind: 'absent', name: contribution.name, ownership })
+      else if (JSON.stringify(existing) === JSON.stringify(contribution.declaration))
+        outcomes.push({ kind: 'equivalent', name: contribution.name, ownership })
+      else outcomes.push({ kind: 'divergent', name: contribution.name, ownership })
+    }
+    const desiredNames = desired.map((c) => c.name)
+    for (const owned of previouslyOwnedNames) {
+      if (desiredNames.includes(owned)) continue
+      outcomes.push({
+        kind: 'obsolete-owned',
+        name: owned,
+        occupancy: doc.servers[owned] === undefined ? 'absent' : 'present',
+      })
+    }
+    return {
+      ok: true,
+      preparation: {
+        plan: { projectRoot, desired, previouslyOwnedNames },
+        documentPaths: [mcpDoc(projectRoot)],
+        outcomes,
+      },
+    }
+  },
+  async apply({ plan }) {
+    const doc = readMcp(plan.projectRoot)
+    const before = JSON.stringify(doc)
+    const desiredNames = plan.desired.map((c) => c.name)
+    for (const owned of plan.previouslyOwnedNames) {
+      if (!desiredNames.includes(owned)) delete doc.servers[owned]
+    }
+    for (const contribution of plan.desired) doc.servers[contribution.name] = contribution.declaration
+    const after = JSON.stringify(doc)
+    if (before === after) return { ok: true, status: 'unchanged' }
+    writeFileSync(mcpDoc(plan.projectRoot), after)
+    return { ok: true, status: 'changed', changedPaths: [mcpDoc(plan.projectRoot)] }
+  },
+}
+
 export default {
   name: '${name}',
   apiVersion: '${ADAPTER_API_VERSION}',
-  mcpServers: false,
+  mcpServers: ${options.mcp === true ? 'mcpCapability' : 'false'},
   supportsInstall: true,
   buildAssetMetadata(data) { return { ok: true, data: data || {} } },
   async installAsset(req) {

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -1,10 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import type {
+  AssetTakeoverDecision,
+  AssetTakeoverRequest,
   CollisionFacetContribution,
   CollisionResolution,
   CollisionResolutionRequest,
-  CollisionResolver,
   InstallSummary,
+  McpConsentDecision,
+  McpConsentRequest,
   McpInstallOutcomes,
   RollbackOutcome,
   RunInstallFailure,
@@ -16,7 +19,7 @@ import type { IntegrityFailure } from '@agent-facets/protocol'
 import { CURRENT_LOCKFILE_VERSION, LOCKFILE_VERSION_0_3 } from '@agent-facets/protocol'
 import { render } from 'ink-testing-library'
 import { createElement } from 'react'
-import { InstallView, type InstallViewResult } from '../tui/views/install/install-view.tsx'
+import { InstallView, type InstallViewHooks, type InstallViewResult } from '../tui/views/install/install-view.tsx'
 import { diskStateSentence } from '../util/install-outcome.ts'
 import {
   describeUnsupportedManifestVersion,
@@ -56,8 +59,8 @@ function settle(): Promise<void> {
 function makeFakeRun(
   events: ReadonlyArray<StageEvent>,
   result: RunInstallResult,
-): (onStage: (e: StageEvent) => void, onLog?: (build: () => string) => void) => Promise<RunInstallResult> {
-  return async (onStage, _onLog) => {
+): (hooks: InstallViewHooks) => Promise<RunInstallResult> {
+  return async ({ onStage }) => {
     for (const event of events) {
       onStage(event)
     }
@@ -1041,11 +1044,7 @@ function makeResolvingRun(
   onResolution: (resolution: CollisionResolution) => void,
   resolvedResult: RunInstallResult = successResultSingle,
 ) {
-  return async (
-    onStage: (e: StageEvent) => void,
-    _onLog: ((build: () => string) => void) | undefined,
-    resolveCollisions: CollisionResolver,
-  ): Promise<RunInstallResult> => {
+  return async ({ onStage, resolveCollisions }: InstallViewHooks): Promise<RunInstallResult> => {
     onStage({ kind: 'install-start', totalFacets: 2 })
     onStage({ kind: 'collision-check' })
     const resolution = await resolveCollisions(request)
@@ -1066,7 +1065,7 @@ describe('InstallView — collision phase machine', () => {
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
-        run: async (onStage) => {
+        run: async ({ onStage }) => {
           onStage({ kind: 'install-start', totalFacets: 2 })
           onStage({ kind: 'collision-check' })
           await tick()
@@ -1088,7 +1087,7 @@ describe('InstallView — collision phase machine', () => {
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
-        run: async (onStage) => {
+        run: async ({ onStage }) => {
           onStage({ kind: 'install-start', totalFacets: 2 })
           for (const facet of ['alpha', 'beta']) {
             onStage({ kind: 'facet-start', facet, specifier: `./${facet}` })
@@ -1115,7 +1114,7 @@ describe('InstallView — collision phase machine', () => {
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
-        run: async (onStage) => {
+        run: async ({ onStage }) => {
           onStage({ kind: 'install-start', totalFacets: 2 })
           onStage({ kind: 'facet-start', facet: 'alpha', specifier: './alpha' })
           onStage({ kind: 'collision-check' })
@@ -1356,6 +1355,491 @@ describe('InstallView — disposition-only change', () => {
     expect(frame).toContain('1 updated')
     expect(frame).not.toContain('repaired')
     expect(frame).not.toContain('1.0.0 → 1.0.0')
+    instance.unmount()
+  })
+})
+
+describe('InstallView — MCP configuration outcomes', () => {
+  // A server-only facet writes no file. Reporting "no changes" over a run
+  // that rewrote a tool's config is exactly what the separate counts exist
+  // to prevent.
+  test('a server-only facet is not a no-op', async () => {
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
+      summary: {
+        facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: {
+          configurations: { added: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+          declarations: { aliased: 0, omitted: 0 },
+          takeovers: { accepted: 0 },
+        },
+      },
+      perFacet: [{ kind: 'installed', name: 'alpha', version: '1.0.0' }],
+      mcp: {
+        consent: { kind: 'not-required' },
+        dispositions: [{ kind: 'authored', facet: 'alpha', authoredName: 'filesystem', change: 'introduced' }],
+        configurations: [
+          {
+            kind: 'active',
+            adapter: 'claude-code',
+            effectiveName: 'filesystem',
+            claimants: ['alpha'],
+            status: 'added',
+            takenOver: false,
+          },
+        ],
+        prunedIntent: [],
+      },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'add',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], result),
+      }),
+    )
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).not.toContain('no changes')
+    expect(frame).toContain('0 assets written')
+    expect(frame).toContain('1 server config added')
+    expect(frame).toContain('MCP server filesystem added in claude-code')
+    instance.unmount()
+  })
+
+  test('an alias shows both names and an omission is named', async () => {
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
+      summary: {
+        facets: { installed: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: {
+          configurations: { added: 1, updated: 0, repaired: 0, unchanged: 0, removed: 0 },
+          declarations: { aliased: 1, omitted: 1 },
+          takeovers: { accepted: 0 },
+        },
+      },
+      perFacet: [{ kind: 'installed', name: 'alpha', version: '1.0.0' }],
+      mcp: {
+        consent: { kind: 'not-required' },
+        dispositions: [
+          {
+            kind: 'aliased',
+            facet: 'alpha',
+            authoredName: 'filesystem',
+            effectiveName: 'project-filesystem',
+            change: 'introduced',
+          },
+          { kind: 'omitted', facet: 'alpha', authoredName: 'docs', change: 'introduced' },
+        ],
+        configurations: [
+          {
+            kind: 'active',
+            adapter: 'claude-code',
+            effectiveName: 'project-filesystem',
+            claimants: ['alpha'],
+            status: 'added',
+            takenOver: false,
+          },
+        ],
+        prunedIntent: [],
+      },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'add',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], result),
+      }),
+    )
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).toContain('alpha MCP server filesystem')
+    expect(frame).toContain('project-filesystem')
+    expect(frame).toContain('alpha MCP server docs')
+    expect(frame).toContain('omitted')
+    instance.unmount()
+  })
+
+  // Drift repair and a fresh write are different facts about the user's
+  // project, and one of them means someone else edited the config file.
+  test('a drift-only rewrite reads as repaired, not written', async () => {
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
+      summary: {
+        facets: { installed: 0, updated: 0, repaired: 1, unchanged: 0, removed: 0 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: {
+          configurations: { added: 0, updated: 0, repaired: 1, unchanged: 0, removed: 0 },
+          declarations: { aliased: 0, omitted: 0 },
+          takeovers: { accepted: 0 },
+        },
+      },
+      perFacet: [{ kind: 'repaired', name: 'alpha', version: '1.0.0' }],
+      mcp: {
+        consent: { kind: 'not-required' },
+        dispositions: [],
+        configurations: [
+          {
+            kind: 'active',
+            adapter: 'claude-code',
+            effectiveName: 'filesystem',
+            claimants: ['alpha'],
+            status: 'repaired',
+            takenOver: false,
+          },
+        ],
+        prunedIntent: [],
+      },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], result),
+      }),
+    )
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).toContain('1 server config repaired')
+    expect(frame).toContain('MCP server filesystem repaired in claude-code')
+    instance.unmount()
+  })
+
+  test('a removed server names the adapters it was removed from', async () => {
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
+      summary: {
+        facets: { installed: 0, updated: 0, repaired: 0, unchanged: 0, removed: 1 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: {
+          configurations: { added: 0, updated: 0, repaired: 0, unchanged: 0, removed: 1 },
+          declarations: { aliased: 0, omitted: 0 },
+          takeovers: { accepted: 0 },
+        },
+      },
+      perFacet: [{ kind: 'removed', name: 'alpha', oldVersion: '1.0.0' }],
+      mcp: {
+        consent: { kind: 'not-required' },
+        dispositions: [],
+        configurations: [
+          {
+            kind: 'obsolete',
+            adapter: 'claude-code',
+            effectiveName: 'filesystem',
+            previousClaimants: ['alpha'],
+            status: 'removed',
+          },
+          {
+            kind: 'obsolete',
+            adapter: 'opencode',
+            effectiveName: 'filesystem',
+            previousClaimants: ['alpha'],
+            status: 'removed',
+          },
+        ],
+        prunedIntent: [],
+      },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'remove',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], result),
+      }),
+    )
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).toContain('MCP server filesystem removed in claude-code, opencode')
+    instance.unmount()
+  })
+
+  // Adopting an untracked entry writes nothing and still changes who owns
+  // it — the one case where "unchanged" and "nothing happened" differ.
+  test('an adopted untracked entry is unchanged but not a no-op', async () => {
+    const result: RunInstallResult = {
+      ok: true,
+      lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
+      summary: {
+        facets: { installed: 0, updated: 0, repaired: 0, unchanged: 1, removed: 0 },
+        textAssets: { written: 0, removed: 0 },
+        mcp: {
+          configurations: { added: 0, updated: 0, repaired: 0, unchanged: 1, removed: 0 },
+          declarations: { aliased: 0, omitted: 0 },
+          takeovers: { accepted: 1 },
+        },
+      },
+      perFacet: [{ kind: 'unchanged', name: 'alpha', version: '1.0.0' }],
+      mcp: {
+        consent: { kind: 'not-required' },
+        dispositions: [],
+        configurations: [
+          {
+            kind: 'active',
+            adapter: 'claude-code',
+            effectiveName: 'filesystem',
+            claimants: ['alpha'],
+            status: 'unchanged',
+            takenOver: true,
+          },
+        ],
+        prunedIntent: [],
+      },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 1 }], result),
+      }),
+    )
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).not.toContain('no changes')
+    expect(frame).toContain('1 server config unchanged')
+    expect(frame).toContain('took over an existing entry')
+    instance.unmount()
+  })
+})
+
+// --- MCP consent and asset takeover phases ---
+
+const CONSENT_REQUEST: McpConsentRequest = {
+  declarations: [
+    {
+      identity: { kind: 'mcp-server', effectiveName: 'filesystem' },
+      fingerprint: `sha256:${'a'.repeat(64)}`,
+      declaration: { type: 'stdio', command: 'npx', args: ['-y', 'srv'], env: { TOKEN_NAME: 'hunter2' } },
+      claimants: [{ facet: 'alpha', authoredName: 'filesystem', disposition: { kind: 'authored' } }],
+      standing: { kind: 'unknown-identity' },
+    },
+  ],
+  takeovers: [],
+}
+
+/**
+ * A driver shaped like the engine's consent path: emit progress, block on
+ * the resolver, then continue or fail based on the answer.
+ */
+function makeConsentingRun(onDecision: (decision: McpConsentDecision) => void) {
+  return async ({ onStage, resolveMcpConsent }: InstallViewHooks): Promise<RunInstallResult> => {
+    onStage({ kind: 'install-start', totalFacets: 1 })
+    const decision = await resolveMcpConsent(CONSENT_REQUEST)
+    onDecision(decision)
+    if (decision.kind === 'declined') {
+      return {
+        ok: false,
+        failure: { code: 'MCP_CONSENT_DECLINED', request: { declarations: [], takeovers: [] } },
+        rollback: { kind: 'not-needed', reason: 'consent settles before the journal opens' },
+      }
+    }
+    onStage({ kind: 'facet-start', facet: 'alpha', specifier: './alpha' })
+    return successResultSingle
+  }
+}
+
+describe('InstallView — MCP consent phase', () => {
+  test('the approval screen replaces progress and returns to it once answered', async () => {
+    const decisions: McpConsentDecision[] = []
+    const instance = render(
+      createElement(InstallView, { mode: 'install', run: makeConsentingRun((d) => decisions.push(d)) }),
+    )
+    await tick()
+
+    const prompt = visibleTerminalText(instance.lastFrame() ?? '')
+    expect(prompt).toContain('MCP server configuration needs your approval')
+    expect(prompt).toContain('stdio npx -y srv')
+    // The progress bar must not repaint underneath a screen the user is
+    // reading; the prompt owns the mount while it is open.
+    expect(prompt).not.toContain('Installing facets:')
+
+    instance.stdin.write('\u001B[C')
+    await tick()
+    instance.stdin.write('\r')
+    await tick()
+
+    expect(decisions).toEqual([{ kind: 'approved' }])
+    await settle()
+    instance.unmount()
+  })
+
+  // Enter alone must not authorize execution: it is the key a user is
+  // already pressing their way through an install with.
+  test('confirming without navigating declines', async () => {
+    const decisions: McpConsentDecision[] = []
+    const instance = render(
+      createElement(InstallView, { mode: 'install', run: makeConsentingRun((d) => decisions.push(d)) }),
+    )
+    await tick()
+    instance.stdin.write('\r')
+    await tick()
+
+    expect(decisions).toEqual([{ kind: 'declined' }])
+    await settle()
+    expect(visibleContentFrame(instance.frames)).not.toContain('Install complete')
+    instance.unmount()
+  })
+
+  // An unsettled promise strands the engine holding the project lock, so an
+  // interrupt has to answer the prompt rather than kill the render.
+  test('an interrupt while the screen is open settles it', async () => {
+    const decisions: McpConsentDecision[] = []
+    const controller = new AbortController()
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        signal: controller.signal,
+        run: makeConsentingRun((d) => decisions.push(d)),
+      }),
+    )
+    await tick()
+    expect(decisions).toHaveLength(0)
+
+    controller.abort()
+    await tick()
+
+    expect(decisions).toEqual([{ kind: 'declined' }])
+    await settle()
+    instance.unmount()
+  })
+
+  test('ctrl-c while the screen is open settles it', async () => {
+    const decisions: McpConsentDecision[] = []
+    const instance = render(
+      createElement(InstallView, { mode: 'install', run: makeConsentingRun((d) => decisions.push(d)) }),
+    )
+    await tick()
+    instance.stdin.write('\u0003')
+    await tick()
+
+    expect(decisions).toEqual([{ kind: 'declined' }])
+    await settle()
+    instance.unmount()
+  })
+})
+
+describe('InstallView — asset takeover phase', () => {
+  const TAKEOVER_REQUEST: AssetTakeoverRequest = {
+    facet: 'alpha',
+    adapter: 'claude-code',
+    asset: assetIdentity('project', 'skill', 'review'),
+    authoredName: 'review',
+    occupancy: 'divergent',
+  }
+
+  function makeTakeoverRun(onDecision: (decision: AssetTakeoverDecision) => void) {
+    return async ({ onStage, resolveAssetTakeover }: InstallViewHooks): Promise<RunInstallResult> => {
+      onStage({ kind: 'install-start', totalFacets: 1 })
+      const decision = await resolveAssetTakeover(TAKEOVER_REQUEST)
+      onDecision(decision)
+      if (decision.kind === 'cancelled') {
+        return {
+          ok: false,
+          failure: {
+            code: 'ASSET_TAKEOVER_CANCELLED',
+            facet: 'alpha',
+            adapter: 'claude-code',
+            asset: assetIdentity('project', 'skill', 'review'),
+          },
+          rollback: { kind: 'succeeded', entriesUndone: 2 },
+        }
+      }
+      return successResultSingle
+    }
+  }
+
+  test('the screen names the destination and continues by default', async () => {
+    const decisions: AssetTakeoverDecision[] = []
+    const instance = render(
+      createElement(InstallView, { mode: 'install', run: makeTakeoverRun((d) => decisions.push(d)) }),
+    )
+    await tick()
+    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('project skill review')
+
+    instance.stdin.write('\r')
+    await tick()
+    expect(decisions).toEqual([{ kind: 'continue' }])
+    await settle()
+    instance.unmount()
+  })
+
+  // Cancelling here lands mid-journal, so the report has to say what the
+  // rollback did rather than claim nothing happened.
+  test('cancelling reports what was restored', async () => {
+    const decisions: AssetTakeoverDecision[] = []
+    const instance = render(
+      createElement(InstallView, { mode: 'install', run: makeTakeoverRun((d) => decisions.push(d)) }),
+    )
+    await tick()
+    instance.stdin.write('\u001B[C')
+    await tick()
+    instance.stdin.write('\r')
+    await tick()
+
+    expect(decisions).toEqual([{ kind: 'cancelled' }])
+    await settle()
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).toContain('restored')
+    expect(frame).not.toContain('nothing was written')
+    instance.unmount()
+  })
+
+  // An interrupt is a request to stop. Answering it with the default would
+  // let the operation write one more file on the way out.
+  test('an interrupt cancels rather than continuing', async () => {
+    const decisions: AssetTakeoverDecision[] = []
+    const controller = new AbortController()
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        signal: controller.signal,
+        run: makeTakeoverRun((d) => decisions.push(d)),
+      }),
+    )
+    await tick()
+    controller.abort()
+    await tick()
+
+    expect(decisions).toEqual([{ kind: 'cancelled' }])
+    await settle()
+    instance.unmount()
+  })
+})
+
+describe('InstallView — declaration secrecy', () => {
+  const SECRETS = ['npx', 'srv', 'hunter2', 'TOKEN_NAME']
+
+  // The approval screen is one of only two surfaces allowed to show a
+  // declaration. Everything the run prints afterwards is ordinary command
+  // output that can end up in a scrollback or a CI log.
+  test('a declaration does not survive into the success summary', async () => {
+    const instance = render(createElement(InstallView, { mode: 'install', run: makeConsentingRun(() => {}) }))
+    await tick()
+    instance.stdin.write('\u001B[C')
+    await tick()
+    instance.stdin.write('\r')
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    for (const secret of SECRETS) expect(frame).not.toContain(secret)
+    instance.unmount()
+  })
+
+  // Declining carries the SUMMARY, not the request: the user just read the
+  // declarations and said no, so reprinting them helps nobody.
+  test('declining does not reprint the declaration', async () => {
+    const instance = render(createElement(InstallView, { mode: 'install', run: makeConsentingRun(() => {}) }))
+    await tick()
+    instance.stdin.write('\r')
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    for (const secret of SECRETS) expect(frame).not.toContain(secret)
     instance.unmount()
   })
 })

--- a/packages/cli/src/__tests__/mcp-consent.e2e.test.ts
+++ b/packages/cli/src/__tests__/mcp-consent.e2e.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnCli } from './helpers/cli-process.ts'
+import { installFakeAdapter } from './helpers/fake-adapter.ts'
+
+/**
+ * End-to-end coverage for MCP configuration consent, driving the compiled
+ * binary with piped stdio.
+ *
+ * Piped stdio is the whole point: this is the path CI takes, and it is the
+ * one where the rich Ink block goes to a stream nobody reads. Everything a
+ * blocked user needs has to survive on stderr, and the regression mode for
+ * the interactive half is a hang rather than an error.
+ */
+
+let projectRoot: string
+let fakeHome: string
+let adaptersDir: string
+
+const runCli = (args: string[]) =>
+  spawnCli(args, { cwd: projectRoot, env: { HOME: fakeHome, FACET_DIR: join(fakeHome, '.facet') } })
+
+const COMMAND = 'npx'
+const ARGUMENT = 'server-filesystem'
+const ENV_NAME = 'TOKEN_NAME'
+const ENV_VALUE = 'hunter2'
+
+/** A facet whose only deliverable is one standard-input MCP server. */
+function buildServerFixture(name: string, server: string): string {
+  const repo = realpathSync(mkdtempSync(join(projectRoot, 'fixture-')))
+  writeFileSync(
+    join(repo, 'facet.json'),
+    JSON.stringify({
+      name,
+      version: '0.1.0',
+      servers: {
+        [server]: { type: 'stdio', command: COMMAND, args: ['-y', ARGUMENT], env: { [ENV_NAME]: ENV_VALUE } },
+      },
+    }),
+  )
+  return `./${repo.split('/').pop()}`
+}
+
+function mcpDocumentFor(adapter: string): string {
+  return join(projectRoot, `.${adapter}-mcp.json`)
+}
+
+beforeEach(() => {
+  projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mcp-e2e-')))
+  fakeHome = realpathSync(mkdtempSync(join(tmpdir(), 'facet-mcp-home-')))
+  adaptersDir = join(fakeHome, '.facet', 'adapters')
+  mkdirSync(adaptersDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+})
+
+describe('facet <command> --help', () => {
+  // One definition, three commands. `rm` is included because the alias is
+  // how many people invoke removal, and an alias that silently lacked the
+  // flag would leave them with no non-interactive way to finish.
+  test.each(['add', 'install', 'remove', 'rm'])('%s lists --accept-mcp', async (command) => {
+    const result = await runCli([command, '--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('--accept-mcp')
+  })
+})
+
+describe('non-interactive MCP consent', () => {
+  test('without the flag it fails before mutation and prints the whole declaration', async () => {
+    installFakeAdapter(adaptersDir, 'faketool', { mcp: true })
+    const source = buildServerFixture('alpha', 'filesystem')
+
+    const result = await runCli(['add', source])
+
+    expect(result.exitCode).toBe(1)
+    // The exact thing the flag would authorize. A user cannot approve
+    // execution from a failure code.
+    expect(result.stderr).toContain(`stdio ${COMMAND} -y ${ARGUMENT}`)
+    expect(result.stderr).toContain(`env ${ENV_NAME}=${ENV_VALUE}`)
+    expect(result.stderr).toContain('filesystem')
+    expect(result.stderr).toContain('from alpha')
+    // The alternative to approving, at the exact path it is written.
+    expect(result.stderr).toContain('facets["alpha"].materialization.servers["filesystem"]')
+    expect(result.stderr).toContain('"filesystem": { "kind": "omitted" }')
+    expect(result.stderr).toContain('--accept-mcp')
+    expect(result.stderr).toContain('NOT changed')
+
+    expect(existsSync(mcpDocumentFor('faketool'))).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  test('with the flag it configures the server', async () => {
+    installFakeAdapter(adaptersDir, 'faketool', { mcp: true })
+    const source = buildServerFixture('alpha', 'filesystem')
+
+    const result = await runCli(['add', source, '--accept-mcp'])
+
+    expect(result.exitCode).toBe(0)
+    const document = JSON.parse(readFileSync(mcpDocumentFor('faketool'), 'utf8'))
+    expect(document.servers.filesystem).toEqual({
+      type: 'stdio',
+      command: COMMAND,
+      args: ['-y', ARGUMENT],
+      env: { [ENV_NAME]: ENV_VALUE },
+    })
+  })
+
+  // Approval is recorded by the successful commit, so reproducing the same
+  // declaration must not ask again — including without the flag.
+  test('an already-approved declaration does not need the flag again', async () => {
+    installFakeAdapter(adaptersDir, 'faketool', { mcp: true })
+    const source = buildServerFixture('alpha', 'filesystem')
+    expect((await runCli(['add', source, '--accept-mcp'])).exitCode).toBe(0)
+
+    const result = await runCli(['install'])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test('a server-only facet reports configuration work rather than a no-op', async () => {
+    installFakeAdapter(adaptersDir, 'faketool', { mcp: true })
+    const source = buildServerFixture('alpha', 'filesystem')
+
+    const result = await runCli(['add', source, '--accept-mcp'])
+
+    expect(result.stdout).toContain('server config')
+    expect(result.stdout).not.toContain('no changes')
+  })
+})
+
+describe('adapters that cannot configure MCP servers', () => {
+  test('the failure names the adapter and both remedies', async () => {
+    installFakeAdapter(adaptersDir, 'faketool')
+    const source = buildServerFixture('alpha', 'filesystem')
+
+    const result = await runCli(['add', source, '--accept-mcp'])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('faketool')
+    expect(result.stderr).toContain('omit')
+    expect(result.stderr).toContain('filesystem')
+    expect(result.stderr).toContain('NOT changed')
+    // No declaration is needed to act on this, and this report reaches CI logs.
+    expect(result.stderr).not.toContain(ENV_VALUE)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  // An adapter without MCP support only blocks a run that has MCP work to do.
+  test('omitting every server lets an MCP-less adapter install', async () => {
+    installFakeAdapter(adaptersDir, 'faketool')
+    const source = buildServerFixture('alpha', 'filesystem')
+    writeFileSync(
+      join(projectRoot, 'facets.json'),
+      JSON.stringify({
+        manifestVersion: 0.2,
+        facets: {
+          alpha: { source, materialization: { servers: { filesystem: { kind: 'omitted' } } } },
+        },
+      }),
+    )
+
+    const result = await runCli(['install'])
+    expect(result.exitCode).toBe(0)
+  })
+})
+
+describe('declaration secrecy', () => {
+  // Verbose output is ordinary command output that lands in scrollback and
+  // CI logs. The consent surfaces are the only ones allowed to disclose.
+  test('verbose output does not leak the declaration', async () => {
+    installFakeAdapter(adaptersDir, 'faketool', { mcp: true })
+    const source = buildServerFixture('alpha', 'filesystem')
+
+    const result = await runCli(['add', source, '--accept-mcp', '--verbose'])
+
+    expect(result.exitCode).toBe(0)
+    const output = `${result.stdout}${result.stderr}`
+    expect(output).not.toContain(ENV_VALUE)
+    expect(output).not.toContain(ARGUMENT)
+    // The identity is not a secret, and a summary that omitted it would be
+    // useless — this is the line between naming a thing and disclosing it.
+    expect(result.stdout).toContain('filesystem')
+  })
+})

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -10,11 +10,12 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
-import { writeMaterializationDetail } from '../../util/collision-report.ts'
 import { type CliError, writeCliError } from '../../util/errors.ts'
+import { writeInstallFailureDetail } from '../../util/install-detail.ts'
 import { canPromptInteractively } from '../../util/interactive.ts'
 import { unsupportedManifestVersionError } from '../../util/unsupported-manifest-version.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS, mcpConsentPolicy } from '../shared/flags.ts'
 import { installFailureDetail, installFailureFix } from '../shared/install-failure.ts'
 
 /**
@@ -35,9 +36,7 @@ export const addCommand: Command = {
   description: 'Add a facet to facets.json and install it',
   usage: '<source> [more sources...]',
   implemented: true,
-  flags: {
-    verbose: { type: 'boolean', description: 'Show detailed step output on stderr' },
-  },
+  flags: INSTALL_PIPELINE_FLAGS,
   run: async (args, flags) => {
     if (args.length === 0) {
       writeCliError({
@@ -49,6 +48,7 @@ export const addCommand: Command = {
     }
 
     const verbose = flags.verbose === true
+    const acceptMcp = flags[ACCEPT_MCP_FLAG] === true
 
     // Parse every source up front. No I/O happens here; any parse error
     // aborts before mounting the view or touching disk.
@@ -88,14 +88,20 @@ export const addCommand: Command = {
       createElement(InstallView, {
         mode: 'add',
         signal: controller.signal,
-        run: async (onStage, onLog, resolveCollisions) => {
+        run: async ({ onStage, onLog, resolveCollisions, resolveMcpConsent, resolveAssetTakeover }) => {
           const result = await runAdd({
             projectRoot,
             sources,
             adapters,
             onStage,
-            ...(verbose && onLog ? { onLog } : {}),
-            ...(mayPrompt ? { resolveCollisions } : {}),
+            mcpConsent: mcpConsentPolicy({ acceptMcp, mayPrompt, resolve: resolveMcpConsent }),
+            ...(verbose ? { onLog } : {}),
+            // Withheld when this run cannot prompt, because absence is how
+            // "continue automatically" is expressed — the same behavior a
+            // non-interactive run had before the gate existed. Notably NOT
+            // gated on `--accept-mcp`: approving a command is not approving
+            // an overwrite.
+            ...(mayPrompt ? { resolveCollisions, resolveAssetTakeover } : {}),
             signal: controller.signal,
           })
           captured = result
@@ -145,7 +151,7 @@ export const addCommand: Command = {
     // Install-phase failure. The delta-based flow never writes the manifest
     // ahead of install, so there's nothing to restore — the journal rollback
     // handles asset cleanup.
-    writeMaterializationDetail(captured.install.failure)
+    writeInstallFailureDetail(captured.install.failure)
     writeCliError({
       what: 'add failed',
       detail: installFailureDetail(captured.install.failure),

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -3,10 +3,11 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
-import { writeMaterializationDetail } from '../../util/collision-report.ts'
 import { writeCliError } from '../../util/errors.ts'
+import { writeInstallFailureDetail } from '../../util/install-detail.ts'
 import { canPromptInteractively } from '../../util/interactive.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS, mcpConsentPolicy } from '../shared/flags.ts'
 import { installFailureDetail, installFailureFix } from '../shared/install-failure.ts'
 
 /**
@@ -23,7 +24,7 @@ export const installCommand: Command = {
   description: 'Install all facets from facets.json',
   implemented: true,
   flags: {
-    verbose: { type: 'boolean', description: 'Show detailed step output on stderr' },
+    ...INSTALL_PIPELINE_FLAGS,
     'frozen-lockfile': {
       type: 'boolean',
       description: 'Treat the lockfile as the source of truth; fail on any manifest/lockfile drift',
@@ -40,6 +41,7 @@ export const installCommand: Command = {
 
     const verbose = flags.verbose === true
     const frozenLockfile = flags['frozen-lockfile'] === true
+    const acceptMcp = flags[ACCEPT_MCP_FLAG] === true
 
     const projectRoot = process.cwd()
 
@@ -74,13 +76,16 @@ export const installCommand: Command = {
       createElement(InstallView, {
         mode: 'install',
         signal: controller.signal,
-        run: async (onStage, onLog, resolveCollisions) => {
+        run: async ({ onStage, onLog, resolveCollisions, resolveMcpConsent, resolveAssetTakeover }) => {
           const result = await runInstall({
             projectRoot,
             adapters,
             onStage,
-            ...(verbose && onLog ? { onLog } : {}),
-            ...(mayPrompt ? { resolveCollisions } : {}),
+            // `mayPrompt` already excludes frozen mode, so a frozen run can
+            // reach `preapproved` via the flag but never the prompting arm.
+            mcpConsent: mcpConsentPolicy({ acceptMcp, mayPrompt, resolve: resolveMcpConsent }),
+            ...(verbose ? { onLog } : {}),
+            ...(mayPrompt ? { resolveCollisions, resolveAssetTakeover } : {}),
             signal: controller.signal,
             frozenLockfile,
           })
@@ -130,7 +135,7 @@ export const installCommand: Command = {
       // contexts that produce one without a prompt are exactly the ones
       // where stdout is discarded — so the full report goes to stderr
       // first, leaving `fix:` as the last line.
-      writeMaterializationDetail(captured.failure)
+      writeInstallFailureDetail(captured.failure)
       writeCliError({
         what: 'install failed',
         detail: installFailureDetail(captured.failure),

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -3,11 +3,12 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import type { Command } from '../../commands.ts'
 import { InstallView } from '../../tui/views/install/install-view.tsx'
-import { writeMaterializationDetail } from '../../util/collision-report.ts'
 import { type CliError, writeCliError } from '../../util/errors.ts'
+import { writeInstallFailureDetail } from '../../util/install-detail.ts'
 import { canPromptInteractively } from '../../util/interactive.ts'
 import { unsupportedManifestVersionError } from '../../util/unsupported-manifest-version.ts'
 import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS, mcpConsentPolicy } from '../shared/flags.ts'
 import { installFailureDetail, installFailureFix } from '../shared/install-failure.ts'
 
 /**
@@ -28,9 +29,7 @@ export const removeCommand: Command = {
   usage: '<facet> [more facets...]',
   aliases: ['rm'],
   implemented: true,
-  flags: {
-    verbose: { type: 'boolean', description: 'Show detailed step output on stderr' },
-  },
+  flags: INSTALL_PIPELINE_FLAGS,
   run: async (args, flags) => {
     if (args.length === 0) {
       writeCliError({
@@ -42,6 +41,7 @@ export const removeCommand: Command = {
     }
 
     const verbose = flags.verbose === true
+    const acceptMcp = flags[ACCEPT_MCP_FLAG] === true
 
     const names = args
     const projectRoot = process.cwd()
@@ -87,15 +87,16 @@ export const removeCommand: Command = {
       createElement(InstallView, {
         mode: 'remove',
         signal: controller.signal,
-        run: async (onStage, onLog, resolveCollisions) => {
+        run: async ({ onStage, onLog, resolveCollisions, resolveMcpConsent, resolveAssetTakeover }) => {
           const result = await runRemove({
             projectRoot,
             names,
             adapters,
             prepared,
             onStage,
-            ...(verbose && onLog ? { onLog } : {}),
-            ...(mayPrompt ? { resolveCollisions } : {}),
+            mcpConsent: mcpConsentPolicy({ acceptMcp, mayPrompt, resolve: resolveMcpConsent }),
+            ...(verbose ? { onLog } : {}),
+            ...(mayPrompt ? { resolveCollisions, resolveAssetTakeover } : {}),
             signal: controller.signal,
           })
           captured = result
@@ -144,7 +145,7 @@ export const removeCommand: Command = {
 
     // Install-phase failure. The delta-based flow never writes the manifest
     // ahead of install — the journal rollback handles asset cleanup.
-    writeMaterializationDetail(captured.install.failure)
+    writeInstallFailureDetail(captured.install.failure)
     writeCliError({
       what: 'remove failed',
       detail: installFailureDetail(captured.install.failure),

--- a/packages/cli/src/commands/shared/__tests__/flags.test.ts
+++ b/packages/cli/src/commands/shared/__tests__/flags.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import type { McpConsentRequest } from '@agent-facets/engine'
+import { addCommand } from '../../add/index.ts'
+import { installCommand } from '../../install/index.ts'
+import { removeCommand } from '../../remove/index.ts'
+import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS, mcpConsentPolicy } from '../flags.ts'
+
+const PIPELINE_COMMANDS = [
+  ['add', addCommand],
+  ['install', installCommand],
+  ['remove', removeCommand],
+] as const
+
+describe('--accept-mcp is exposed by every install-pipeline command', () => {
+  test.each(PIPELINE_COMMANDS)('%s declares it', (_name, command) => {
+    expect(command.flags?.[ACCEPT_MCP_FLAG]).toBeDefined()
+  })
+
+  // Identity, not equality: three flag records that merely happen to contain
+  // the same words are three things to keep in sync. Help output is rendered
+  // straight from these, so a drifted description is a user-visible
+  // inconsistency about what the flag authorizes.
+  test.each(PIPELINE_COMMANDS)('%s uses the shared definition', (_name, command) => {
+    expect(command.flags?.[ACCEPT_MCP_FLAG]).toBe(INSTALL_PIPELINE_FLAGS[ACCEPT_MCP_FLAG])
+  })
+
+  // The one command where this is easy to forget: a removal that has to
+  // resolve the facets it keeps re-enters the same consent path as an
+  // install, so without the flag it has no non-interactive completion.
+  test('remove exposes it through its alias too', () => {
+    expect(removeCommand.aliases).toContain('rm')
+    expect(removeCommand.flags?.[ACCEPT_MCP_FLAG]).toBeDefined()
+  })
+
+  test('install keeps its own frozen flag alongside the shared ones', () => {
+    expect(installCommand.flags?.['frozen-lockfile']).toBeDefined()
+    expect(installCommand.flags?.verbose).toBe(INSTALL_PIPELINE_FLAGS.verbose)
+  })
+})
+
+describe('mcpConsentPolicy', () => {
+  const resolve = async (_request: McpConsentRequest) => ({ kind: 'approved' }) as const
+
+  test('no flag and no terminal cannot answer', () => {
+    expect(mcpConsentPolicy({ acceptMcp: false, mayPrompt: false, resolve })).toEqual({ kind: 'unavailable' })
+  })
+
+  test('a terminal prompts', () => {
+    expect(mcpConsentPolicy({ acceptMcp: false, mayPrompt: true, resolve })).toEqual({
+      kind: 'interactive',
+      resolve,
+    })
+  })
+
+  test('the flag pre-approves without a terminal', () => {
+    expect(mcpConsentPolicy({ acceptMcp: true, mayPrompt: false, resolve })).toEqual({ kind: 'preapproved' })
+  })
+
+  // The flag outranks the prompt. Otherwise passing it on a TTY would still
+  // open the screen, which makes the flag mean nothing exactly where a user
+  // is most likely to try it first.
+  test('the flag outranks an available prompt', () => {
+    expect(mcpConsentPolicy({ acceptMcp: true, mayPrompt: true, resolve })).toEqual({ kind: 'preapproved' })
+  })
+
+  // Frozen mode reaches here with `mayPrompt: false`, so the only arm it can
+  // produce is `preapproved` — it may USE an approval supplied up front and
+  // can never COLLECT one.
+  test('frozen with the flag is pre-approved, and without it cannot answer', () => {
+    expect(mcpConsentPolicy({ acceptMcp: true, mayPrompt: false, resolve })).toEqual({ kind: 'preapproved' })
+    expect(mcpConsentPolicy({ acceptMcp: false, mayPrompt: false, resolve })).toEqual({ kind: 'unavailable' })
+  })
+})

--- a/packages/cli/src/commands/shared/__tests__/install-failure.test.ts
+++ b/packages/cli/src/commands/shared/__tests__/install-failure.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import type { RollbackOutcome, RunInstallFailure } from '@agent-facets/engine'
+import { assetIdentity, type RollbackOutcome, type RunInstallFailure } from '@agent-facets/engine'
 import { describeDiskState } from '../../../util/install-outcome.ts'
+import { ACCEPT_MCP_FLAG } from '../flags.ts'
 import { installFailureDetail, installFailureFix } from '../install-failure.ts'
 
 /**
@@ -158,5 +159,85 @@ describe('installFailureFix — an unsupported manifest version', () => {
     )
     expect(fix).toContain('upgrade')
     expect(fix).not.toContain('fix the underlying issue')
+  })
+})
+
+describe('installFailureFix — MCP failures', () => {
+  const consentRequired: RunInstallFailure = {
+    code: 'MCP_CONSENT_REQUIRED',
+    request: { declarations: [], takeovers: [] },
+  }
+  const consentDeclined: RunInstallFailure = {
+    code: 'MCP_CONSENT_DECLINED',
+    request: { declarations: [], takeovers: [] },
+  }
+  const unsupported: RunInstallFailure = {
+    code: 'MCP_ADAPTERS_UNSUPPORTED',
+    adapters: [{ kind: 'capability-declined', adapter: 'plain-tool' }],
+    servers: ['docs'],
+  }
+
+  // The flag name is owned by the shared definition. A literal here and a
+  // literal there is how the guidance ends up naming a flag that no command
+  // declares — which is exactly the state this line was in before.
+  test.each(COMMANDS)('consent guidance names the %s command and the flag', (command) => {
+    const fix = installFailureFix(consentRequired, notNeeded, command)
+    expect(fix).toContain(`facet ${command} --${ACCEPT_MCP_FLAG}`)
+  })
+
+  // Two remedies, and only one of them is "upgrade". An adapter that
+  // declared no MCP support will not gain it in a newer release.
+  test('an unsupported adapter is offered both remedies', () => {
+    const fix = installFailureFix(unsupported, notNeeded, 'install')
+    expect(fix).toContain('upgrade')
+    expect(fix).toContain('omit')
+  })
+
+  test('declining derives its disk state from the rollback outcome', () => {
+    expect(installFailureFix(consentDeclined, notNeeded, 'install')).toContain(describeDiskState(notNeeded))
+  })
+
+  // This one lands mid-application, so what is on disk is the load-bearing
+  // half of the report and must never be hardcoded.
+  test.each([notNeeded, succeeded, partial])('a cancelled takeover reports $kind', (rollback) => {
+    const failure: RunInstallFailure = {
+      code: 'ASSET_TAKEOVER_CANCELLED',
+      facet: 'alpha',
+      adapter: 'claude-code',
+      asset: assetIdentity('project', 'skill', 'review'),
+    }
+    expect(installFailureFix(failure, rollback, 'install')).toContain(describeDiskState(rollback))
+  })
+})
+
+describe('installFailureFix — stale materialization intent under frozen mode', () => {
+  const staleServerDrift: RunInstallFailure = {
+    code: 'LOCKFILE_DRIFT',
+    facets: [
+      {
+        name: 'alpha',
+        reason: 'stale-override',
+        contribution: { kind: 'mcp-server' },
+        authoredName: 'filesystem',
+      },
+    ],
+  }
+
+  // The lockfile does not record server intent at all, so "run install to
+  // update the lockfile" sends the user to watch the same failure again.
+  // The choice lives in facets.json.
+  test('points at facets.json rather than at the lockfile', () => {
+    const fix = installFailureFix(staleServerDrift, notNeeded, 'install')
+    expect(fix).toContain('facets.json')
+    expect(fix).not.toContain('lockfile is out of date')
+  })
+
+  test('ordinary drift still points at the lockfile', () => {
+    const fix = installFailureFix(
+      { code: 'LOCKFILE_DRIFT', facets: [{ name: 'alpha', reason: 'missing-lockfile', manifestSpec: '1.*' }] },
+      notNeeded,
+      'install',
+    )
+    expect(fix).toContain('lockfile is out of date')
   })
 })

--- a/packages/cli/src/commands/shared/flags.ts
+++ b/packages/cli/src/commands/shared/flags.ts
@@ -1,0 +1,64 @@
+import type { McpConsentPolicy, McpConsentResolver } from '@agent-facets/engine'
+import type { FlagDef } from '../../commands.ts'
+
+/**
+ * The flag name a user types to pre-approve MCP server configuration.
+ *
+ * Declared once and referenced everywhere it appears — the flag table,
+ * the remediation line that tells a failed non-interactive run how to
+ * retry, and any test asserting help output. A literal repeated across
+ * those surfaces is a rename waiting to leave one of them stale, and the
+ * one most likely to be missed is the `fix:` line, which is exactly the
+ * text a blocked user is reading.
+ */
+export const ACCEPT_MCP_FLAG = 'accept-mcp'
+
+/**
+ * Flags shared by every command that can enter the install pipeline.
+ *
+ * `add`, `install`, and `remove` are three front doors to one
+ * orchestrator, so a flag that governs pipeline behavior belongs to all
+ * three or to none. `--accept-mcp` in particular must be on `remove`:
+ * a removal that has to resolve the facets it keeps re-enters the same
+ * consent path as an install, and a user who cannot pre-approve there
+ * has no non-interactive way to finish the operation.
+ */
+export const INSTALL_PIPELINE_FLAGS: Record<string, FlagDef> = {
+  verbose: { type: 'boolean', description: 'Show detailed step output on stderr' },
+  [ACCEPT_MCP_FLAG]: {
+    type: 'boolean',
+    description: 'Approve the MCP server configuration this operation would write, without prompting',
+  },
+}
+
+/**
+ * Choose the MCP consent policy for one run.
+ *
+ * Returns a total policy rather than an optional one. The engine already
+ * treats an absent option as `unavailable`, so returning `undefined` for
+ * "cannot answer" would encode the same fact twice — once by omission
+ * here and once by a default there — and let the two disagree.
+ *
+ * The flag outranks the prompt. Pre-approval is a stated intent, not a
+ * fallback for a missing terminal: a user who passes it on a TTY meant
+ * it, and prompting anyway would make the flag mean nothing there.
+ *
+ * `mayPrompt` is the caller's, because only it knows the mode. For
+ * `install` it must already exclude frozen: frozen may *use* an approval
+ * supplied up front but must never *collect* one. The engine independently
+ * downgrades an interactive policy under frozen, so the prompting arm is
+ * unreachable there even if a caller got this wrong.
+ *
+ * Approving a server's command says nothing about overwriting a file, so
+ * no asset collision or asset takeover decision is derived from this
+ * value. Those keep their own resolvers and their own screens.
+ */
+export function mcpConsentPolicy(options: {
+  acceptMcp: boolean
+  mayPrompt: boolean
+  resolve: McpConsentResolver
+}): McpConsentPolicy {
+  if (options.acceptMcp) return { kind: 'preapproved' }
+  if (options.mayPrompt) return { kind: 'interactive', resolve: options.resolve }
+  return { kind: 'unavailable' }
+}

--- a/packages/cli/src/commands/shared/install-failure.ts
+++ b/packages/cli/src/commands/shared/install-failure.ts
@@ -4,6 +4,7 @@ import {
   describeUnsupportedManifestVersion,
   UNSUPPORTED_MANIFEST_VERSION_FIX,
 } from '../../util/unsupported-manifest-version.ts'
+import { ACCEPT_MCP_FLAG } from './flags.ts'
 
 /**
  * The `detail:` line for a failed install-pipeline run.
@@ -64,7 +65,13 @@ export function installFailureFix(
       // manifest that is not wrong.
       return UNSUPPORTED_MANIFEST_VERSION_FIX
     case 'LOCKFILE_DRIFT':
-      return "lockfile is out of date; run 'facet install' (without --frozen-lockfile) or 'facet add' to update it"
+      // A stale override is the one drift the lockfile cannot fix, because it
+      // is not recorded there: the choice lives in facets.json and names a
+      // contribution the locked content no longer has. Sending the user to
+      // re-run install would have them watch the same failure again.
+      return failure.facets.some((entry) => entry.reason === 'stale-override')
+        ? `remove the materialization choices listed above from facets.json, or re-run 'facet ${command}' without --frozen-lockfile to drop them automatically`
+        : "lockfile is out of date; run 'facet install' (without --frozen-lockfile) or 'facet add' to update it"
     case 'MCP_ADAPTERS_UNSUPPORTED':
       // Two remedies, and which one applies is per adapter — the detail block
       // above names each. This line says only that both exist, so a user who
@@ -76,7 +83,7 @@ export function installFailureFix(
       // unhelpful without saying what state the tree is in.
       return `${describeDiskState(rollback)}. Re-run 'facet ${command}' and continue, or move the existing file aside first`
     case 'MCP_CONSENT_REQUIRED':
-      return `review the servers listed above, then re-run 'facet ${command} --accept-mcp' to approve them, or omit them in facets.json`
+      return `review the servers listed above, then re-run 'facet ${command} --${ACCEPT_MCP_FLAG}' to approve them, or omit them in facets.json`
     case 'MCP_CONSENT_DECLINED':
       return `${describeDiskState(rollback)}. Re-run 'facet ${command}' to review the servers again, or omit them in facets.json`
     case 'MCP_PREPARE_FAILED':

--- a/packages/cli/src/prompts/manifest.txt
+++ b/packages/cli/src/prompts/manifest.txt
@@ -31,7 +31,10 @@ Field notes
              but are NEVER written to disk at install (archive-only). A path
              must not resolve under skills/.
   facets     Optional. Compose other facets (advanced).
-  servers    Optional. Declare MCP servers (advanced).
+  servers    Optional. Declare MCP servers, keyed by server name. Each value
+             is either { "type": "stdio", "command", optional "args",
+             optional "env" } or { "type": "http", "url" }. Unlike the rest
+             of the manifest, these objects reject unrecognized members.
 
 Supplementary files (README, LICENSE, skill companions)
   - Top-level `files`: archive-only, never materialized on install.
@@ -39,11 +42,13 @@ Supplementary files (README, LICENSE, skill companions)
     materialize and are removed atomically with the skill and cannot list
     SKILL.md itself.
   - Supplementary files are NOT assets: they do not count toward the
-    "at least one asset" rule below, and they carry no description or adapters.
+    "at least one deliverable" rule below, and they carry no description or
+    adapters.
 
 Business rules the JSON Schema below cannot express
-  - A facet must declare at least one asset (skill, agent, command, or facet).
-    Supplementary `files` alone do not satisfy this.
+  - A facet must declare at least one deliverable: a skill, agent, command,
+    composed facet, or MCP server. Supplementary `files` alone do not
+    satisfy this.
   - Asset names must be a single segment (1-64 chars, lowercase
     letters/digits/hyphens, no leading/trailing/consecutive hyphens, no slash).
   - A skill and a command must not share a name (agents are separate).

--- a/packages/cli/src/tui/views/install/failure-block.tsx
+++ b/packages/cli/src/tui/views/install/failure-block.tsx
@@ -67,7 +67,10 @@ function describeDrift(entry: LockfileDriftEntry): string {
     case 'materialization-drift':
       return `${entry.assetType} "${entry.authoredName}": facets.json says ${describeDisposition(entry.manifest)}, lockfile says ${describeDisposition(entry.locked)}`
     case 'stale-override':
-      return `${describeContribution(entry.contribution)} "${entry.authoredName}" has a materialization override but is not in the locked content`
+      // Says explicitly that the override survived. Frozen mode reports
+      // stale intent instead of pruning it, and a line that only named the
+      // mismatch read as though it had already been cleaned up.
+      return `${describeContribution(entry.contribution)} "${entry.authoredName}" has a materialization override but is not in the locked content (the override was NOT removed)`
     case 'materialization-unrepresentable':
       return `lockfile v${entry.lockfileVersion} cannot record materialization overrides (needs v${entry.requiredVersion})`
   }
@@ -612,7 +615,7 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.warning} bold>
             ✕ {failure.adapters.length !== 1 ? 'selected adapters cannot' : 'a selected adapter cannot'} configure MCP
-            servers — nothing was changed
+            servers
           </Text>
           {failure.adapters.map((entry) => {
             const described = describeUnsupportedMcpAdapter(entry)
@@ -630,7 +633,7 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
       return (
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.warning} bold>
-            ✕ {failure.adapter} could not plan its MCP configuration — nothing was changed
+            ✕ {failure.adapter} could not plan its MCP configuration
           </Text>
           <Text> {describeMcpCapabilityFailure(failure.failure)}</Text>
         </Box>
@@ -639,8 +642,8 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
       return (
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.hint}>
-            Cancelled at {failure.adapter}: {failure.asset.type} “{failure.asset.name}” was already there and is not
-            tracked by this project.
+            Cancelled at {failure.adapter}: {failure.asset.scope} {failure.asset.type} “{failure.asset.name}” (wanted by{' '}
+            {failure.facet}) was already there and is not tracked by this project.
           </Text>
         </Box>
       )
@@ -667,7 +670,7 @@ function failureDetail(failure: RunInstallFailure): React.JSX.Element {
       return (
         <Box flexDirection="column" marginTop={1}>
           <Text color={THEME.warning} bold>
-            ✕ MCP server configuration needs your approval — nothing was changed
+            ✕ MCP server configuration needs your approval
           </Text>
           {failure.request.declarations.map((entry) => (
             <Box key={entry.identity.effectiveName} flexDirection="column">

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -1,11 +1,17 @@
 import type { AssetType } from '@agent-facets/common'
 import type {
   AddPrepareFailure,
+  AssetTakeoverDecision,
+  AssetTakeoverRequest,
+  AssetTakeoverResolver,
   CollisionResolution,
   CollisionResolutionRequest,
   CollisionResolver,
   InstallSummary,
   MaterializationOverrideRef,
+  McpConsentDecision,
+  McpConsentRequest,
+  McpConsentResolver,
   RemovePrepareFailure,
   RunInstallResult,
   StageEvent,
@@ -20,7 +26,9 @@ import { AddPrepareFailureBlock } from './add-prepare-failure-block.tsx'
 import { CollisionWorkspace } from './collision/workspace.tsx'
 import { type FacetState, STAGE_LABELS } from './facet-state.ts'
 import { FailureBlock } from './failure-block.tsx'
+import { McpApprovalScreen } from './mcp/approval.tsx'
 import { RemovePrepareFailureBlock } from './remove-prepare-failure-block.tsx'
+import { AssetTakeoverScreen } from './takeover/screen.tsx'
 
 /**
  * Driver result. The `install` flow returns a `RunInstallResult`. The
@@ -35,27 +43,42 @@ export type InstallViewResult =
   | { ok: false; prepareFailure: AddPrepareFailure }
   | { ok: false; removePrepareFailure: RemovePrepareFailure }
 
+/**
+ * Everything the view can lend a driver for one run.
+ *
+ * An object rather than a positional list because the list only grows —
+ * MCP consent and asset takeover are two more resolvers on the same
+ * mount — and a fourth and fifth positional callback of compatible type
+ * is a swap waiting to happen that the compiler would accept.
+ *
+ * Every resolver here is OFFERED, not imposed. The view can always drive
+ * a screen — it owns the mount — but only the command knows whether this
+ * invocation may prompt at all (an interactive terminal, not frozen
+ * mode, and for MCP not already pre-approved by flag). So the command
+ * decides which of these to forward to the engine; one that is never
+ * forwarded is simply never called.
+ */
+export interface InstallViewHooks {
+  onStage: (event: StageEvent) => void
+  /**
+   * Verbose log sink. Always supplied; the command decides whether to
+   * forward it, because whether `--verbose` was passed is its business
+   * and not the view's.
+   */
+  onLog: (build: () => string) => void
+  resolveCollisions: CollisionResolver
+  resolveMcpConsent: McpConsentResolver
+  resolveAssetTakeover: AssetTakeoverResolver
+}
+
 export interface InstallViewProps {
   /**
-   * Driver: caller supplies a `runInstall`-equivalent closure that takes
-   * an `onStage` callback, an optional `onLog` callback, and a collision
-   * resolver, and returns the result. The view runs it once on mount and
-   * surfaces its events / outcome. When verbose output is enabled, the
-   * caller should thread `onLog` into the engine call; the view routes it
-   * through Ink's stderr writer so it doesn't race the progress bar
-   * repaint.
-   *
-   * The resolver is OFFERED, not imposed. The view can always drive a
-   * workspace — it owns the mount — but only the command knows whether
-   * this invocation may prompt at all (an interactive terminal, and not
-   * frozen mode). So the command decides whether to forward it to the
-   * engine; a resolver that is never passed on is simply never called.
+   * Driver: caller supplies a `runInstall`-equivalent closure. The view
+   * runs it once on mount and surfaces its events / outcome. Verbose
+   * lines routed through {@link InstallViewHooks.onLog} reach Ink's
+   * stderr writer so they don't race the progress-bar repaint.
    */
-  run: (
-    onStage: (event: StageEvent) => void,
-    onLog: ((build: () => string) => void) | undefined,
-    resolveCollisions: CollisionResolver,
-  ) => Promise<InstallViewResult>
+  run: (hooks: InstallViewHooks) => Promise<InstallViewResult>
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
    * renders "Installing facets..."; `'remove'` renders "Removing
@@ -69,8 +92,8 @@ export interface InstallViewProps {
   onComplete?: (result: InstallViewResult) => void
   /**
    * The command's interrupt signal. Watched only to settle a pending
-   * collision prompt: an interrupt raised while the engine is blocked on
-   * the resolver would otherwise leave the promise unsettled forever,
+   * prompt: an interrupt raised while the engine is blocked on a
+   * resolver would otherwise leave the promise unsettled forever,
    * holding the project lock with nothing left to release it.
    */
   signal?: AbortSignal
@@ -131,14 +154,56 @@ type RetainedBundle = Extract<StageEvent, { kind: 'obsolete-bundle-retained' }>
 type ViewPhase =
   | { kind: 'progress' }
   | {
-      kind: 'resolution'
+      kind: 'collision'
       request: CollisionResolutionRequest
       /** Settles the engine's pending call. Idempotent. */
       settle: (resolution: CollisionResolution) => void
     }
+  | {
+      kind: 'mcp-consent'
+      request: McpConsentRequest
+      /** Settles the engine's pending call. Idempotent. */
+      settle: (decision: McpConsentDecision) => void
+    }
+  | {
+      kind: 'asset-takeover'
+      request: AssetTakeoverRequest
+      /** Settles the engine's pending call. Idempotent. */
+      settle: (decision: AssetTakeoverDecision) => void
+    }
   | { kind: 'result'; result: InstallViewResult }
   /** The driver threw rather than returning a structured failure. */
   | { kind: 'crashed'; error: Error }
+
+/**
+ * How an interrupt answers whatever prompt is open.
+ *
+ * Exhaustive rather than a `settle` field common to both prompt arms:
+ * the answers are not the same value and not even the same idea — a
+ * collision is *cancelled*, a consent request is *declined* — so a new
+ * prompt phase should have to state its own, and this refuses to compile
+ * until it does.
+ */
+function abortSettlerFor(phase: ViewPhase): (() => void) | null {
+  switch (phase.kind) {
+    case 'collision':
+      return () => phase.settle({ kind: 'cancelled' })
+    case 'mcp-consent':
+      // Declining is the answer that mutates nothing. The engine reads the
+      // signal before the decision anyway, so the run reports the abort
+      // rather than a refusal the user never gave.
+      return () => phase.settle({ kind: 'declined' })
+    case 'asset-takeover':
+      // Cancelling, not continuing: an interrupt is a request to stop, and
+      // continuing would let the operation write one more file on the way
+      // out. The engine rolls the journal back from here.
+      return () => phase.settle({ kind: 'cancelled' })
+    case 'progress':
+    case 'result':
+    case 'crashed':
+      return null
+  }
+}
 
 export function InstallView({ run, mode, onComplete, signal }: InstallViewProps) {
   const { exit } = useApp()
@@ -293,15 +358,21 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
       case 'mcp-consent-required':
       case 'mcp-consent-accepted':
       case 'mcp-consent-declined':
+        // The approval screen is driven by the resolver, not by these
+        // events: the resolver call carries the full request, while the
+        // event carries only a declaration-free summary. Rendering both
+        // would announce the prompt twice and, worse, invite the summary
+        // to grow into a second display of something already on screen.
+        return
       case 'asset-takeover-required':
       case 'asset-takeover-accepted':
       case 'asset-takeover-cancelled':
+        // Same reason as the consent events: the resolver call carries the
+        // request and drives the screen. The cancelled case is reported by
+        // the failure block, which also knows what the rollback did.
+        return
       case 'mcp-configured':
-        // Deliberately unrendered for now. This view cannot yet reach any of
-        // them: no command supplies a consent policy or a takeover resolver,
-        // so the engine settles both without asking. The approval and
-        // takeover screens, and the MCP half of the summary, arrive together
-        // with that plumbing rather than as a half-wired preview of it.
+        // Still unrendered: the MCP half of the summary is its own change.
         return
       default: {
         // Exhaustiveness guard. Without it a newly added stage event
@@ -346,7 +417,44 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
         setPhase({ kind: 'progress' })
         resolve(resolution)
       }
-      setPhase({ kind: 'resolution', request, settle })
+      setPhase({ kind: 'collision', request, settle })
+    })
+  }, [])
+
+  /**
+   * The same contract as {@link resolveCollisions}, for MCP consent: the
+   * engine is holding the project lock and awaiting this promise, so it
+   * must settle on every path — approve, decline, Esc, Ctrl-C, or an
+   * interrupt — and exactly once.
+   */
+  const resolveMcpConsent = useCallback<McpConsentResolver>((request) => {
+    return new Promise<McpConsentDecision>((resolve) => {
+      let settled = false
+      const settle = (decision: McpConsentDecision) => {
+        if (settled) return
+        settled = true
+        setPhase({ kind: 'progress' })
+        resolve(decision)
+      }
+      setPhase({ kind: 'mcp-consent', request, settle })
+    })
+  }, [])
+
+  /**
+   * The same contract again, for asset takeover. This one opens with the
+   * journal already open, so an unsettled promise strands a half-written
+   * operation rather than merely a lock.
+   */
+  const resolveAssetTakeover = useCallback<AssetTakeoverResolver>((request) => {
+    return new Promise<AssetTakeoverDecision>((resolve) => {
+      let settled = false
+      const settle = (decision: AssetTakeoverDecision) => {
+        if (settled) return
+        settled = true
+        setPhase({ kind: 'progress' })
+        resolve(decision)
+      }
+      setPhase({ kind: 'asset-takeover', request, settle })
     })
   }, [])
 
@@ -354,7 +462,7 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
     if (startedRef.current) return
     startedRef.current = true
     try {
-      const r = await run(onStage, onLog, resolveCollisions)
+      const r = await run({ onStage, onLog, resolveCollisions, resolveMcpConsent, resolveAssetTakeover })
       setElapsedMs(Date.now() - startTimeRef.current)
       onComplete?.(r)
       // Defer exit so React paints the result state before Ink unmounts.
@@ -362,7 +470,7 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
     } catch (error) {
       setPhase({ kind: 'crashed', error: error instanceof Error ? error : new Error(String(error)) })
     }
-  }, [run, onStage, onLog, onComplete, resolveCollisions])
+  }, [run, onStage, onLog, onComplete, resolveCollisions, resolveMcpConsent, resolveAssetTakeover])
 
   useEffect(() => {
     if (phase.kind === 'result') {
@@ -378,15 +486,15 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
   }, [phase, exit, start])
 
   /**
-   * An interrupt while the workspace is open cancels the prompt rather
-   * than killing the process. The engine then returns a structured
-   * cancellation, unwinds, and releases the lock through its own
-   * `finally` — which a hard exit here would have skipped.
+   * An interrupt while a prompt is open answers it rather than killing
+   * the process. The engine then returns a structured outcome, unwinds,
+   * and releases the lock through its own `finally` — which a hard exit
+   * here would have skipped.
    */
   useEffect(() => {
-    if (signal === undefined || phase.kind !== 'resolution') return
-    const { settle } = phase
-    const onAbort = () => settle({ kind: 'cancelled' })
+    if (signal === undefined) return
+    const onAbort = abortSettlerFor(phase)
+    if (onAbort === null) return
     if (signal.aborted) {
       onAbort()
       return
@@ -439,11 +547,17 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
   // Stage label for the progress bar line.
   const stageLabel = currentFacet ? (currentFacet.stage ? STAGE_LABELS[currentFacet.stage] : 'starting') : null
 
-  // The workspace owns the screen while it is open: mixing a live
-  // progress bar into a form the user is typing into repaints under the
+  // A prompt owns the screen while it is open: mixing a live progress bar
+  // into a form the user is reading or typing into repaints under the
   // cursor. Progress resumes, in this same mount, once it closes.
-  if (phase.kind === 'resolution') {
+  if (phase.kind === 'collision') {
     return <CollisionWorkspace request={phase.request} onComplete={phase.settle} />
+  }
+  if (phase.kind === 'mcp-consent') {
+    return <McpApprovalScreen request={phase.request} onComplete={phase.settle} />
+  }
+  if (phase.kind === 'asset-takeover') {
+    return <AssetTakeoverScreen request={phase.request} onComplete={phase.settle} />
   }
 
   return (
@@ -603,12 +717,17 @@ function SuccessSummary({
     summary.mcp.configurations.updated +
     summary.mcp.configurations.repaired +
     summary.mcp.configurations.removed
+  // Adopting an untracked entry writes nothing and still changes who owns
+  // it. Counting only writes would report "no changes" over a takeover the
+  // user was asked to approve moments earlier.
+  const takeoverWork = summary.mcp.takeovers.accepted
   const isNoOp =
     summary.facets.installed === 0 &&
     summary.facets.updated === 0 &&
     summary.facets.repaired === 0 &&
     summary.facets.removed === 0 &&
-    configurationWork === 0
+    configurationWork === 0 &&
+    takeoverWork === 0
   const elapsed = `${(elapsedMs / 1000).toFixed(2)}s`
 
   if (isNoOp) {
@@ -625,6 +744,7 @@ function SuccessSummary({
   const counts = countAssetsByType(result)
   const bundleVizNode = formatColoredBundleViz(counts)
   const notes = materializationNotes(result)
+  const configurations = configurationNotes(result)
 
   const removedNames = result.perFacet
     .filter((o) => o.kind === 'removed' || o.kind === 'removed-untracked')
@@ -669,8 +789,8 @@ function SuccessSummary({
             name they did not publish. Naming both sides makes the
             outcome checkable. */}
         {notes.map((note) => (
-          <Text key={`${note.facet}:${note.type}:${note.authoredName}`} color={THEME.hint}>
-            {note.facet} {note.type} {note.authoredName}
+          <Text key={note.key} color={THEME.hint}>
+            {note.facet} {note.label} {note.authoredName}
             {note.effectiveName === null ? (
               <Text color={THEME.caution}> — omitted</Text>
             ) : (
@@ -679,6 +799,16 @@ function SuccessSummary({
                 <Text color={THEME.success}>{note.effectiveName}</Text>
               </Text>
             )}
+          </Text>
+        ))}
+        {/* Per-identity, because the counts line cannot say WHICH server was
+            repaired or which adapters a removal reached — and those are the
+            two facts a user checks a native config file against. */}
+        {configurations.map((note) => (
+          <Text key={note.key} color={THEME.hint}>
+            MCP server <Text color={THEME.success}>{note.effectiveName}</Text> {note.status} in{' '}
+            {note.adapters.join(', ')}
+            {note.takenOver && <Text color={THEME.caution}> (took over an existing entry)</Text>}
           </Text>
         ))}
         {/* The remedy has to be one the user can still act on. By the time
@@ -708,27 +838,31 @@ interface AssetCounts {
 }
 
 /**
- * How one asset was materialized, for the summary.
+ * How one contribution was materialized, for the summary.
  *
- * `effectiveName: null` means omitted. Only a current lockfile records
- * dispositions at all; a legacy one is authored by definition, which is
- * why this is derived from the lockfile rather than carried separately.
+ * `effectiveName: null` means omitted. Carries its own `key` and `label`
+ * because assets and servers now share this list and come from different
+ * places: an asset's disposition is in the lockfile, while a server's is
+ * deliberately not — so keying by asset type alone let a server named like
+ * a skill collide with it in the rendered list.
  */
 interface MaterializationNote {
+  key: string
   facet: string
-  type: AssetType
+  label: string
   authoredName: string
   effectiveName: string | null
 }
 
-function materializationNotes(result: RunInstallResult & { ok: true }): MaterializationNote[] {
+/** Asset dispositions, which only a current lockfile can express. */
+function assetMaterializationNotes(result: RunInstallResult & { ok: true }): AssetNote[] {
   // Legacy lockfiles cannot express an alias or an omission, so there is
   // nothing to report — not "nothing happened", but "this format has no
   // opinion". Frozen mode returns the lockfile it read, so this branch is
   // reachable in normal use, not just during migration.
   if (result.lockfile.lockfileVersion !== LOCKFILE_VERSION_0_3) return []
 
-  const notes: MaterializationNote[] = []
+  const notes: AssetNote[] = []
   for (const [facet, entry] of Object.entries(result.lockfile.facets)) {
     for (const asset of entry.assets) {
       if (asset.materialization.kind === 'authored') continue
@@ -743,10 +877,88 @@ function materializationNotes(result: RunInstallResult & { ok: true }): Material
   return notes
 }
 
+/** An asset disposition before it is flattened for rendering. */
+interface AssetNote {
+  facet: string
+  type: AssetType
+  authoredName: string
+  effectiveName: string | null
+}
+
+/**
+ * Every alias and omission this run applied, assets and servers together.
+ *
+ * Servers cannot come from the lockfile — declarations and their
+ * dispositions are deliberately absent from it — so they come from the
+ * result's MCP outcomes instead. Rendering them in one list is the point:
+ * to a user, "this name is not what the facet published" is one fact,
+ * whatever kind of thing carries it.
+ */
+function materializationNotes(result: RunInstallResult & { ok: true }): MaterializationNote[] {
+  const notes: MaterializationNote[] = assetMaterializationNotes(result).map((note) => ({
+    key: `asset:${note.type}:${note.facet}:${note.authoredName}`,
+    facet: note.facet,
+    label: note.type,
+    authoredName: note.authoredName,
+    effectiveName: note.effectiveName,
+  }))
+
+  for (const disposition of result.mcp.dispositions) {
+    // `authored` is the absence of a choice; there is nothing to tell.
+    if (disposition.kind === 'authored') continue
+    notes.push({
+      key: `mcp-server:${disposition.facet}:${disposition.authoredName}`,
+      facet: disposition.facet,
+      label: describeContribution({ kind: 'mcp-server' }),
+      authoredName: disposition.authoredName,
+      effectiveName: disposition.kind === 'aliased' ? disposition.effectiveName : null,
+    })
+  }
+  return notes
+}
+
+/**
+ * What reconciling one effective server identity did, per identity rather
+ * than per adapter.
+ *
+ * Collapsed across adapters because the identity is the thing a user
+ * recognizes and the adapters are where it landed. One line per
+ * adapter-identity pair would report the same server three times for a
+ * project with three tools selected.
+ */
+interface ConfigurationNote {
+  key: string
+  effectiveName: string
+  status: string
+  adapters: string[]
+  takenOver: boolean
+}
+
+function configurationNotes(result: RunInstallResult & { ok: true }): ConfigurationNote[] {
+  const byKey = new Map<string, ConfigurationNote>()
+  for (const outcome of result.mcp.configurations) {
+    // `already-absent` is a claim dropped over an entry someone had already
+    // deleted by hand. Reporting it as a removal would credit this run with
+    // work it did not do.
+    if (outcome.kind === 'obsolete' && outcome.status === 'already-absent') continue
+    const status = outcome.kind === 'obsolete' ? 'removed' : outcome.status
+    const takenOver = outcome.kind === 'active' && outcome.takenOver
+    const key = `${outcome.effectiveName}\u0000${status}`
+    const existing = byKey.get(key)
+    if (existing === undefined) {
+      byKey.set(key, { key, effectiveName: outcome.effectiveName, status, adapters: [outcome.adapter], takenOver })
+      continue
+    }
+    existing.adapters.push(outcome.adapter)
+    existing.takenOver ||= takenOver
+  }
+  return [...byKey.values()]
+}
+
 function countAssetsByType(result: RunInstallResult & { ok: true }): AssetCounts {
   const counts: AssetCounts = { skill: 0, agent: 0, command: 0 }
   const omitted = new Set(
-    materializationNotes(result)
+    assetMaterializationNotes(result)
       .filter((note) => note.effectiveName === null)
       .map((note) => `${note.facet}\u0000${note.type}\u0000${note.authoredName}`),
   )
@@ -832,8 +1044,26 @@ function summaryLine(summary: InstallSummary): string {
 
   // Counted separately from assets, because they are: a server-only facet
   // writes no file and would otherwise summarize as having done nothing.
-  const configured = mcp.configurations.added + mcp.configurations.updated + mcp.configurations.repaired
-  if (configured > 0) parts.push(`${configured} server config${configured === 1 ? '' : 's'} written`)
-  if (mcp.configurations.removed > 0) parts.push(`${mcp.configurations.removed} server config removed`)
+  //
+  // Each status is its own count rather than one "written" total. Repaired
+  // in particular is a distinct fact — the declaration did not change, the
+  // native file had drifted — and folding it into "written" tells a user
+  // their project changed when what changed was someone's config file.
+  const servers = [
+    describeServerCount(mcp.configurations.added, 'added'),
+    describeServerCount(mcp.configurations.updated, 'updated'),
+    describeServerCount(mcp.configurations.repaired, 'repaired'),
+    describeServerCount(mcp.configurations.unchanged, 'unchanged'),
+    describeServerCount(mcp.configurations.removed, 'removed'),
+  ].filter((part) => part !== null)
+  parts.push(...servers)
+
+  if (mcp.declarations.aliased > 0) parts.push(`${mcp.declarations.aliased} server aliased`)
+  if (mcp.declarations.omitted > 0) parts.push(`${mcp.declarations.omitted} server omitted`)
   return parts.join(' · ')
+}
+
+function describeServerCount(count: number, status: string): string | null {
+  if (count === 0) return null
+  return `${count} server config${count === 1 ? '' : 's'} ${status}`
 }

--- a/packages/cli/src/tui/views/install/mcp/__tests__/approval.test.tsx
+++ b/packages/cli/src/tui/views/install/mcp/__tests__/approval.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from 'bun:test'
+import type { McpConsentDecision, McpConsentRequest } from '@agent-facets/engine'
+import { render } from 'ink-testing-library'
+import { createElement } from 'react'
+import { visibleTerminalText } from '../../../../../__tests__/helpers/terminal-output.ts'
+import { McpApprovalScreen } from '../approval.tsx'
+
+const REQUEST: McpConsentRequest = {
+  declarations: [
+    {
+      identity: { kind: 'mcp-server', effectiveName: 'filesystem' },
+      fingerprint: `sha256:${'a'.repeat(64)}`,
+      declaration: { type: 'stdio', command: 'npx', args: ['-y', 'srv'], env: { TOKEN_NAME: 'A' } },
+      claimants: [{ facet: 'alpha', authoredName: 'filesystem', disposition: { kind: 'authored' } }],
+      standing: { kind: 'unknown-identity' },
+    },
+  ],
+  takeovers: [
+    {
+      adapter: 'claude-code',
+      identity: { kind: 'mcp-server', effectiveName: 'docs' },
+      existing: 'divergent',
+      declaration: { type: 'http', url: 'https://mcp.example.com/mcp' },
+    },
+  ],
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 25))
+}
+
+test('shows both sections with full declarations', async () => {
+  const instance = render(createElement(McpApprovalScreen, { request: REQUEST, onComplete: () => {} }))
+  await tick()
+  const text = visibleTerminalText(instance.lastFrame() ?? '')
+  expect(text).toContain('stdio npx -y srv')
+  expect(text).toContain('env TOKEN_NAME=A')
+  expect(text).toContain('http https://mcp.example.com/mcp')
+  expect(text).toContain('claude-code: docs differs and would be replaced')
+  expect(text).toContain('Decline')
+  expect(text).toContain('Approve all')
+  instance.unmount()
+})
+
+test('enter with no navigation declines', async () => {
+  const decisions: McpConsentDecision[] = []
+  const instance = render(createElement(McpApprovalScreen, { request: REQUEST, onComplete: (d) => decisions.push(d) }))
+  await tick()
+  instance.stdin.write('\r')
+  await tick()
+  expect(decisions).toEqual([{ kind: 'declined' }])
+  instance.unmount()
+})
+
+test('moving to approve and confirming approves', async () => {
+  const decisions: McpConsentDecision[] = []
+  const instance = render(createElement(McpApprovalScreen, { request: REQUEST, onComplete: (d) => decisions.push(d) }))
+  await tick()
+  instance.stdin.write('\u001B[C')
+  await tick()
+  instance.stdin.write('\r')
+  await tick()
+  expect(decisions).toEqual([{ kind: 'approved' }])
+  instance.unmount()
+})

--- a/packages/cli/src/tui/views/install/mcp/approval.tsx
+++ b/packages/cli/src/tui/views/install/mcp/approval.tsx
@@ -1,0 +1,145 @@
+import type { McpConsentDecision, McpConsentRequest } from '@agent-facets/engine'
+import { Box, Text, useInput } from 'ink'
+import { useState } from 'react'
+import {
+  consentRequestCounts,
+  describeApprovalHeading,
+  describeDeclarationInFull,
+  describeTakeoverHeading,
+} from '../../../../util/mcp-report.ts'
+import { THEME } from '../../../theme.ts'
+
+/**
+ * The MCP configuration approval screen.
+ *
+ * What is being authorized is execution: every line under a declaration is
+ * a command this machine will hand to a tool to run, or an endpoint it will
+ * connect to. So the whole declaration is shown, unelided, and the answer
+ * defaults to declining. A default of Approve would let a stray Enter — the
+ * key a user is already pressing their way through an install with —
+ * authorize a command they never read.
+ *
+ * The set is answered as a whole. Per-server approval would imply the
+ * install can proceed with some servers approved and others not, which is
+ * not a state the pipeline has: the plan is composed before this screen
+ * opens and is not re-planned after it.
+ *
+ * Deliberately absent: asset collisions and asset takeovers. Approving a
+ * command says nothing about overwriting a file, and those keep their own
+ * screens.
+ */
+export function McpApprovalScreen({
+  request,
+  onComplete,
+}: {
+  request: McpConsentRequest
+  /** Settles the engine's pending resolver call. Called exactly once. */
+  onComplete: (decision: McpConsentDecision) => void
+}) {
+  const [choice, setChoice] = useState<ApprovalChoice>('decline')
+  const counts = consentRequestCounts(request)
+
+  useInput((input, key) => {
+    // The engine is holding the project lock on this promise, so an
+    // interrupt has to settle it rather than kill the render. Declining is
+    // the only safe reading of an interrupt: it is the answer that mutates
+    // nothing.
+    if (key.ctrl && input === 'c') {
+      onComplete({ kind: 'declined' })
+      return
+    }
+    if (key.escape) {
+      onComplete({ kind: 'declined' })
+      return
+    }
+    if (key.leftArrow || key.rightArrow || key.tab) {
+      setChoice((current) => (current === 'decline' ? 'approve' : 'decline'))
+      return
+    }
+    if (key.return) {
+      onComplete(choice === 'approve' ? { kind: 'approved' } : { kind: 'declined' })
+    }
+  })
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={THEME.brand}>
+        MCP server configuration needs your approval
+      </Text>
+      <Box flexDirection="column" marginLeft={2}>
+        <Text color={THEME.hint}>
+          Approving lets your coding tools launch these commands or connect to these URLs. Facets does not run or
+          authenticate to them.
+        </Text>
+      </Box>
+
+      {counts.declarations > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>
+            Servers to configure <Text color={THEME.hint}>({counts.declarations})</Text>
+          </Text>
+          <Box flexDirection="column" marginLeft={2}>
+            {request.declarations.map((entry) => (
+              <Box flexDirection="column" key={entry.identity.effectiveName}>
+                <Text color={THEME.caution}>{describeApprovalHeading(entry)}</Text>
+                <Box flexDirection="column" marginLeft={2}>
+                  {describeDeclarationInFull(entry.declaration).map((line) => (
+                    <Text key={line}>{line}</Text>
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {/* Its own section because it is a different question. The declarations
+          above are "may this run at all"; these are "may we take over an
+          entry you already had". A user can want one and not the other, and
+          collapsing them would hide the second inside the first. */}
+      {counts.takeovers > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>
+            Existing entries this would take over <Text color={THEME.hint}>({counts.takeovers})</Text>
+          </Text>
+          <Box flexDirection="column" marginLeft={2}>
+            {request.takeovers.map((entry) => (
+              <Box flexDirection="column" key={`${entry.adapter}\u0000${entry.identity.effectiveName}`}>
+                <Text color={THEME.caution}>{describeTakeoverHeading(entry)}</Text>
+                <Box flexDirection="column" marginLeft={2}>
+                  {describeDeclarationInFull(entry.declaration).map((line) => (
+                    <Text key={line}>{line}</Text>
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      <Box flexDirection="column" marginTop={1}>
+        <Box>
+          {CHOICES.map((option) => (
+            <Box key={option} marginRight={2}>
+              {/* The marker, not just the color, carries the selection: a
+                  status a user cannot see without color is a status some
+                  users cannot see. */}
+              <Text color={option === choice ? THEME.focus : THEME.hint} bold={option === choice}>
+                {option === choice ? '›' : ' '} {CHOICE_LABELS[option]}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+        <Text color={THEME.hint}>←/→ choose · enter confirm · esc decline</Text>
+      </Box>
+    </Box>
+  )
+}
+
+const CHOICES = ['decline', 'approve'] as const
+type ApprovalChoice = (typeof CHOICES)[number]
+
+const CHOICE_LABELS: Record<ApprovalChoice, string> = {
+  decline: 'Decline',
+  approve: 'Approve all',
+}

--- a/packages/cli/src/tui/views/install/takeover/__tests__/screen.test.tsx
+++ b/packages/cli/src/tui/views/install/takeover/__tests__/screen.test.tsx
@@ -1,0 +1,108 @@
+import { expect, test } from 'bun:test'
+import { type AssetTakeoverDecision, type AssetTakeoverRequest, assetIdentity } from '@agent-facets/engine'
+import { render } from 'ink-testing-library'
+import { createElement } from 'react'
+import { visibleTerminalText } from '../../../../../__tests__/helpers/terminal-output.ts'
+import { AssetTakeoverScreen } from '../screen.tsx'
+
+const KEY = { right: '\u001B[C', enter: '\r', escape: '\u001B', ctrlC: '\u0003' } as const
+
+function request(overrides: Partial<AssetTakeoverRequest> = {}): AssetTakeoverRequest {
+  return {
+    facet: 'alpha',
+    adapter: 'claude-code',
+    asset: assetIdentity('project', 'skill', 'review'),
+    authoredName: 'review',
+    occupancy: 'divergent',
+    ...overrides,
+  }
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 25))
+}
+
+test('names the destination and selects Continue by default', async () => {
+  const instance = render(createElement(AssetTakeoverScreen, { request: request(), onComplete: () => {} }))
+  await tick()
+  const text = visibleTerminalText(instance.lastFrame() ?? '')
+  expect(text).toContain('claude-code')
+  expect(text).toContain('project skill review')
+  expect(text).toContain('wanted by alpha')
+  // The marker, not the color, is what proves the default is Continue.
+  expect(text).toContain('› Continue')
+  instance.unmount()
+})
+
+test('an aliased asset names both the authored and effective name', async () => {
+  const instance = render(
+    createElement(AssetTakeoverScreen, {
+      request: request({ authoredName: 'review', asset: assetIdentity('project', 'skill', 'team-review') }),
+      onComplete: () => {},
+    }),
+  )
+  await tick()
+  expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('review → team-review')
+  instance.unmount()
+})
+
+test('an equivalent destination says it is adopted rather than replaced', async () => {
+  const instance = render(
+    createElement(AssetTakeoverScreen, { request: request({ occupancy: 'equivalent' }), onComplete: () => {} }),
+  )
+  await tick()
+  expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('adopts it without changing the file')
+  instance.unmount()
+})
+
+test('enter with no navigation continues', async () => {
+  const decisions: AssetTakeoverDecision[] = []
+  const instance = render(
+    createElement(AssetTakeoverScreen, { request: request(), onComplete: (d) => decisions.push(d) }),
+  )
+  await tick()
+  instance.stdin.write(KEY.enter)
+  await tick()
+  expect(decisions).toEqual([{ kind: 'continue' }])
+  instance.unmount()
+})
+
+test('moving to Cancel and confirming cancels', async () => {
+  const decisions: AssetTakeoverDecision[] = []
+  const instance = render(
+    createElement(AssetTakeoverScreen, { request: request(), onComplete: (d) => decisions.push(d) }),
+  )
+  await tick()
+  instance.stdin.write(KEY.right)
+  await tick()
+  instance.stdin.write(KEY.enter)
+  await tick()
+  expect(decisions).toEqual([{ kind: 'cancelled' }])
+  instance.unmount()
+})
+
+// An interrupt is a request to stop, so it must not be answered by the
+// default. Continuing here would write one more file on the way out.
+test('ctrl-c cancels', async () => {
+  const decisions: AssetTakeoverDecision[] = []
+  const instance = render(
+    createElement(AssetTakeoverScreen, { request: request(), onComplete: (d) => decisions.push(d) }),
+  )
+  await tick()
+  instance.stdin.write(KEY.ctrlC)
+  await tick()
+  expect(decisions).toEqual([{ kind: 'cancelled' }])
+  instance.unmount()
+})
+
+test('escape cancels', async () => {
+  const decisions: AssetTakeoverDecision[] = []
+  const instance = render(
+    createElement(AssetTakeoverScreen, { request: request(), onComplete: (d) => decisions.push(d) }),
+  )
+  await tick()
+  instance.stdin.write(KEY.escape)
+  await tick()
+  expect(decisions).toEqual([{ kind: 'cancelled' }])
+  instance.unmount()
+})

--- a/packages/cli/src/tui/views/install/takeover/screen.tsx
+++ b/packages/cli/src/tui/views/install/takeover/screen.tsx
@@ -1,0 +1,101 @@
+import type { AssetTakeoverDecision, AssetTakeoverRequest } from '@agent-facets/engine'
+import { Box, Text, useInput } from 'ink'
+import { useState } from 'react'
+import { THEME } from '../../../theme.ts'
+
+/**
+ * The just-in-time asset takeover screen.
+ *
+ * Opposite default to the MCP approval screen, for the opposite reason.
+ * There the question is whether a command may run at all; here the desired
+ * state already authorizes reconciling this identity, and the only news is
+ * that this machine did not put the current file there. Continuing is what
+ * the user asked for by running the command, so Continue is selected — and
+ * a non-interactive run, which never sees this screen, continues too. A
+ * default of Cancel would make the two disagree.
+ *
+ * Reached mid-write, unlike MCP consent: cancelling here rolls back
+ * everything the operation has already done, which is why the failure
+ * report — not this screen — is what tells the user what state the tree
+ * ended in.
+ */
+export function AssetTakeoverScreen({
+  request,
+  onComplete,
+}: {
+  request: AssetTakeoverRequest
+  /** Settles the engine's pending resolver call. Called exactly once. */
+  onComplete: (decision: AssetTakeoverDecision) => void
+}) {
+  const [choice, setChoice] = useState<TakeoverChoice>('continue')
+
+  useInput((input, key) => {
+    // The engine is mid-journal and awaiting this promise. An interrupt has
+    // to settle it — cancelling, which is the answer that triggers the
+    // rollback the user implicitly asked for by interrupting.
+    if (key.ctrl && input === 'c') {
+      onComplete({ kind: 'cancelled' })
+      return
+    }
+    if (key.escape) {
+      onComplete({ kind: 'cancelled' })
+      return
+    }
+    if (key.leftArrow || key.rightArrow || key.tab) {
+      setChoice((current) => (current === 'continue' ? 'cancel' : 'continue'))
+      return
+    }
+    if (key.return) {
+      onComplete(choice === 'continue' ? { kind: 'continue' } : { kind: 'cancelled' })
+    }
+  })
+
+  const { asset, authoredName, adapter, facet, occupancy } = request
+  // An alias is the case where the name on disk is not the name the facet
+  // published, so naming only one of them would leave the user unable to
+  // find either.
+  const naming = authoredName === asset.name ? asset.name : `${authoredName} → ${asset.name}`
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={THEME.brand}>
+        A file is already at this destination
+      </Text>
+      <Box flexDirection="column" marginLeft={2}>
+        <Text>
+          {adapter} <Text color={THEME.hint}>·</Text> {asset.scope} {asset.type} <Text bold>{naming}</Text>
+        </Text>
+        <Text color={THEME.hint}>wanted by {facet}, and not recorded as installed by this project on this machine</Text>
+        <Text color={occupancy === 'equivalent' ? THEME.hint : THEME.caution}>
+          {occupancy === 'equivalent'
+            ? 'It already matches what would be written, so continuing adopts it without changing the file.'
+            : 'It differs from what would be written, so continuing replaces its contents.'}
+        </Text>
+        <Text color={THEME.hint}>Cancelling undoes everything this command has done so far.</Text>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Box>
+          {CHOICES.map((option) => (
+            <Box key={option} marginRight={2}>
+              {/* Marker as well as color: a selection a user cannot see
+                  without color is a selection some users cannot see. */}
+              <Text color={option === choice ? THEME.focus : THEME.hint} bold={option === choice}>
+                {option === choice ? '›' : ' '} {CHOICE_LABELS[option]}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+        <Text color={THEME.hint}>←/→ choose · enter confirm · esc cancel</Text>
+      </Box>
+    </Box>
+  )
+}
+
+const CHOICES = ['continue', 'cancel'] as const
+type TakeoverChoice = (typeof CHOICES)[number]
+
+const CHOICE_LABELS: Record<TakeoverChoice, string> = {
+  continue: 'Continue',
+  cancel: 'Cancel',
+}

--- a/packages/cli/src/util/__tests__/mcp-report.test.ts
+++ b/packages/cli/src/util/__tests__/mcp-report.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import type { McpConsentRequest, McpUnsupportedAdapter } from '@agent-facets/engine'
+import { formatMcpConsentReport, formatUnsupportedMcpAdaptersReport } from '../mcp-report.ts'
+
+const REQUEST: McpConsentRequest = {
+  declarations: [
+    {
+      identity: { kind: 'mcp-server', effectiveName: 'filesystem' },
+      fingerprint: `sha256:${'a'.repeat(64)}`,
+      declaration: { type: 'stdio', command: 'npx', args: ['-y', 'srv'], env: { TOKEN_NAME: 'A' } },
+      claimants: [
+        { facet: 'alpha', authoredName: 'filesystem', disposition: { kind: 'authored' } },
+        { facet: 'beta', authoredName: 'fs', disposition: { kind: 'aliased', as: 'filesystem' } },
+      ],
+      standing: { kind: 'unknown-identity' },
+    },
+  ],
+  takeovers: [
+    {
+      adapter: 'claude-code',
+      identity: { kind: 'mcp-server', effectiveName: 'docs' },
+      existing: 'divergent',
+      declaration: { type: 'http', url: 'https://mcp.example.com/mcp' },
+    },
+  ],
+}
+
+describe('formatMcpConsentReport', () => {
+  const report = formatMcpConsentReport(REQUEST, 'accept-mcp')
+
+  // The whole reason this report exists: the Ink block goes to stdout, which
+  // in CI is the discarded stream, so a caller deciding whether to pass the
+  // flag would otherwise be approving something they were never shown.
+  test('discloses each declaration in full', () => {
+    expect(report).toContain('stdio npx -y srv')
+    expect(report).toContain('env TOKEN_NAME=A')
+    expect(report).toContain('http https://mcp.example.com/mcp')
+  })
+
+  test('names every claimant of a shared identity', () => {
+    expect(report).toContain('from alpha, beta')
+  })
+
+  // An effective identity claimed by two facets is omitted by editing BOTH,
+  // and each edit is keyed by that facet's own authored name — `beta` reaches
+  // `filesystem` through an alias from `fs`.
+  test('gives one editable omission location per claimant', () => {
+    expect(report).toContain('facets["alpha"].materialization.servers["filesystem"]')
+    expect(report).toContain('"filesystem": { "kind": "omitted" }')
+    expect(report).toContain('facets["beta"].materialization.servers["fs"]')
+    expect(report).toContain('"fs": { "kind": "omitted" }')
+  })
+
+  test('names the takeover section separately from the declarations', () => {
+    expect(report).toContain('Existing entries this would take over:')
+    expect(report).toContain('claude-code: docs differs and would be replaced')
+  })
+
+  test('names the flag from the shared definition', () => {
+    expect(report).toContain('Re-run with --accept-mcp')
+  })
+
+  test('states that nothing was changed', () => {
+    expect(report).toContain('MCP configuration were NOT changed.')
+  })
+})
+
+describe('formatUnsupportedMcpAdaptersReport', () => {
+  const adapters: McpUnsupportedAdapter[] = [
+    { kind: 'asset-only-api', adapter: 'legacy-tool', apiVersion: '0.1' },
+    { kind: 'capability-declined', adapter: 'plain-tool' },
+  ]
+  const report = formatUnsupportedMcpAdaptersReport(adapters, ['docs', 'filesystem'])
+
+  test('names every unsupported adapter', () => {
+    expect(report).toContain('legacy-tool')
+    expect(report).toContain('plain-tool')
+  })
+
+  // "Upgrade it" is wrong advice for an adapter that answered the question
+  // and said no, so the two remedies must not be collapsed into one line.
+  test('gives the remedy that actually applies to each adapter', () => {
+    expect(report).toContain('upgrade it:')
+    expect(report).toContain('omit the server declarations in facets.json, or deselect this adapter')
+  })
+
+  test('names the servers that forced the requirement', () => {
+    expect(report).toContain('docs, filesystem')
+  })
+
+  test('states that nothing was changed', () => {
+    expect(report).toContain('MCP configuration were NOT changed.')
+  })
+
+  // A declaration is not needed to act on this failure, and this report can
+  // reach a CI log, so it must not carry one.
+  test('discloses no declaration', () => {
+    expect(report).not.toContain('npx')
+    expect(report).not.toContain('https://')
+  })
+})

--- a/packages/cli/src/util/collision-report.ts
+++ b/packages/cli/src/util/collision-report.ts
@@ -179,13 +179,22 @@ export function formatCollisionReport(
     lines.push(``)
   }
 
-  lines.push(
-    `  facets.json, facets.lock, the install receipt, your materialized assets, and every tool's`,
-    `  MCP configuration were NOT changed.`,
-  )
+  lines.push(...UNCHANGED_FOOTER)
 
   return lines.join('\n')
 }
+
+/**
+ * The "nothing happened" footer, shared by every pre-mutation report.
+ *
+ * One copy because it is a claim about the same five things every time. Two
+ * copies drift, and the failure mode is a report that quietly stops
+ * mentioning one of them after a later report is edited.
+ */
+export const UNCHANGED_FOOTER: readonly string[] = [
+  `  facets.json, facets.lock, the install receipt, your materialized assets, and every tool's`,
+  `  MCP configuration were NOT changed.`,
+]
 
 /**
  * A one-line summary of a declaration, enough to tell two colliding servers
@@ -238,7 +247,8 @@ function aliasSnippet(authoredName: string): string {
   return `${JSON.stringify(authoredName)}: { "kind": "aliased", "as": ${JSON.stringify(PLACEHOLDER_ALIAS)} }`
 }
 
-function omitSnippet(authoredName: string): string {
+/** The exact JSON member that removes one contribution from the active set. */
+export function omitSnippet(authoredName: string): string {
   return `${JSON.stringify(authoredName)}: { "kind": "omitted" }`
 }
 

--- a/packages/cli/src/util/install-detail.ts
+++ b/packages/cli/src/util/install-detail.ts
@@ -1,0 +1,31 @@
+import type { RunInstallFailure } from '@agent-facets/engine'
+import { ACCEPT_MCP_FLAG } from '../commands/shared/flags.ts'
+import { writeMaterializationDetail } from './collision-report.ts'
+import { formatMcpConsentReport, formatUnsupportedMcpAdaptersReport } from './mcp-report.ts'
+
+/**
+ * Write the long-form stderr detail for a failed install-pipeline run, if
+ * the failure has one. Returns whether anything was written.
+ *
+ * One dispatcher over every code, rather than each report owning its own
+ * entry point, because the question a command asks is "does this failure
+ * need more than three lines?" and that question has one answer per code.
+ * Routing MCP failures through a function named for materialization was how
+ * they ended up with no stderr detail at all: the collision switch had no
+ * arm for them and fell through to `false`.
+ *
+ * Called before the canonical three-line block so the `fix:` line stays the
+ * last thing on the stream, where people look for it.
+ */
+export function writeInstallFailureDetail(failure: RunInstallFailure): boolean {
+  switch (failure.code) {
+    case 'MCP_CONSENT_REQUIRED':
+      process.stderr.write(`${formatMcpConsentReport(failure.request, ACCEPT_MCP_FLAG)}\n`)
+      return true
+    case 'MCP_ADAPTERS_UNSUPPORTED':
+      process.stderr.write(`${formatUnsupportedMcpAdaptersReport(failure.adapters, failure.servers)}\n`)
+      return true
+    default:
+      return writeMaterializationDetail(failure)
+  }
+}

--- a/packages/cli/src/util/mcp-report.ts
+++ b/packages/cli/src/util/mcp-report.ts
@@ -7,6 +7,7 @@ import type {
   McpUnsupportedAdapter,
 } from '@agent-facets/engine'
 import { adapterInstallCommand } from './adapter-install-errors.ts'
+import { omitSnippet, serverManifestLocation, UNCHANGED_FOOTER } from './collision-report.ts'
 
 /**
  * Shared renderings for MCP configuration failures.
@@ -16,9 +17,10 @@ import { adapterInstallCommand } from './adapter-install-errors.ts'
  * non-interactive stderr report — and a user comparing them should not find
  * three different descriptions of one condition.
  *
- * Nothing here renders a declaration. Commands, arguments, environment
- * assignments, and URLs belong only on the approval surface a user is
- * actively reading; every path through this module can end up in a CI log.
+ * With one deliberate exception — {@link describeDeclarationInFull} and the
+ * consent report built on it — nothing here renders a declaration. Commands,
+ * arguments, environment assignments, and URLs belong only on a surface whose
+ * purpose is showing a user what they would be authorizing.
  */
 
 /** What an unsupported adapter means, and what to do about it. */
@@ -92,6 +94,98 @@ export function describeTakeoverHeading(entry: McpNativeTakeover): string {
 /** Whether a request has anything to say in each of its two sections. */
 export function consentRequestCounts(request: McpConsentRequest): { declarations: number; takeovers: number } {
   return { declarations: request.declarations.length, takeovers: request.takeovers.length }
+}
+
+/**
+ * The full stderr report for a run that needs MCP approval and cannot ask.
+ *
+ * This is the second of the two surfaces allowed to print a declaration, and
+ * it exists for the same reason the collision report does: the rich Ink block
+ * goes to stdout, and the situations that produce this failure — CI, a piped
+ * command, `--frozen-lockfile` — are exactly the ones where stdout is a log
+ * nobody reads. A user deciding whether to pass the approval flag has to be
+ * able to see what it would authorize, and `code=MCP_CONSENT_REQUIRED` alone
+ * asks them to approve a command they were never shown.
+ *
+ * Every claimant gets its own omission location, and none is recommended:
+ * the alternative to approving is omitting, and which server to omit is not
+ * a question this tool has an opinion about.
+ */
+export function formatMcpConsentReport(request: McpConsentRequest, flag: string): string {
+  const lines: string[] = [
+    `MCP server configuration needs approval, and this run has no way to ask for it.`,
+    `Approving lets your coding tools launch these commands or connect to these URLs.`,
+    ``,
+  ]
+
+  if (request.declarations.length > 0) {
+    lines.push(`  Servers to configure:`)
+    for (const entry of request.declarations) {
+      lines.push(`    • ${describeApprovalHeading(entry)}`)
+      for (const line of describeDeclarationInFull(entry.declaration)) lines.push(`        ${line}`)
+      // One location per claimant: an effective identity can be claimed by
+      // several facets, and omitting it means editing every one of them.
+      for (const claimant of entry.claimants) {
+        lines.push(`        omit in ${serverManifestLocation(claimant.facet, claimant.authoredName)}`)
+        lines.push(`          ${omitSnippet(claimant.authoredName)}`)
+      }
+    }
+    lines.push(``)
+  }
+
+  if (request.takeovers.length > 0) {
+    lines.push(`  Existing entries this would take over:`)
+    for (const entry of request.takeovers) {
+      lines.push(`    • ${describeTakeoverHeading(entry)}`)
+      for (const line of describeDeclarationInFull(entry.declaration)) lines.push(`        ${line}`)
+    }
+    lines.push(``)
+  }
+
+  lines.push(
+    `  Re-run with --${flag} to approve everything above, or record an omission in facets.json.`,
+    ``,
+    ...UNCHANGED_FOOTER,
+  )
+  return lines.join('\n')
+}
+
+/**
+ * The full stderr report for selected adapters that cannot configure MCP.
+ *
+ * Carries no declaration, and needs none: neither remedy — upgrade the
+ * adapter, or stop asking for the servers — depends on what a server would
+ * run. The per-adapter split matters, though, because "upgrade it" is wrong
+ * advice for an adapter that answered the question and said no.
+ */
+export function formatUnsupportedMcpAdaptersReport(
+  adapters: readonly McpUnsupportedAdapter[],
+  servers: readonly string[],
+): string {
+  const lines: string[] = [
+    `Some selected adapters cannot configure MCP servers, so installation stopped before`,
+    `writing anything.`,
+    ``,
+  ]
+
+  for (const entry of adapters) {
+    const described = describeUnsupportedMcpAdapter(entry)
+    lines.push(`    • ${described.what}`)
+    lines.push(`        fix: ${described.fix}`)
+  }
+  lines.push(``)
+
+  if (servers.length > 0) {
+    lines.push(`  Servers that need configuring: ${servers.join(', ')}`)
+    lines.push(
+      `  Omitting every one of them in facets.json also resolves this, because an adapter`,
+      `  without MCP support only blocks a run that has MCP work to do.`,
+      ``,
+    )
+  }
+
+  lines.push(...UNCHANGED_FOOTER)
+  return lines.join('\n')
 }
 
 /** One line naming an adapter's breach of the MCP capability contract. */


### PR DESCRIPTION
### Why

MCP server configuration previously emitted a warning during install and was never materialized. This completes the consent and configuration pipeline: facets that declare `servers:` now contribute MCP server configuration to every selected adapter, with explicit user approval required before anything is written.

### Details

**Consent gate (`--accept-mcp`)** — A single flag definition in `commands/shared/flags.ts` is shared across `add`, `install`, and `remove`. The flag is required on `remove` too because a removal that re-resolves the facets it keeps re-enters the same consent path as an install. The `mcpConsentPolicy` helper maps `(acceptMcp, mayPrompt)` to one of three engine policies: `preapproved` (flag set), `interactive` (terminal available), or `unavailable` (neither). The flag outranks the prompt — passing it on a TTY skips the screen rather than opening it and immediately approving.

**Interactive screens** — Two new Ink screens replace the progress bar while a prompt is open:
- `McpApprovalScreen` shows every declaration in full (command, args, env, or URL) and defaults to *Decline*. Defaulting to Approve would let a stray Enter — the key a user is already pressing through an install — authorize a command they never read.
- `AssetTakeoverScreen` defaults to *Continue*, the opposite, because the desired state already authorizes reconciling this identity and the only news is that this machine did not put the current file there.

Both screens settle their promise on Ctrl-C, Esc, and abort signal, because the engine holds the project lock on that promise and an unsettled one would strand it.

**`InstallViewHooks`** — The `run` prop's positional callback list is replaced with a named object. The list was growing (stage, log, collision resolver, consent resolver, takeover resolver) and positional callbacks of compatible types are a swap the compiler accepts silently.

**Non-interactive stderr report** — `writeInstallFailureDetail` dispatches over every failure code. MCP failures previously fell through a collision-only switch and produced no stderr detail, leaving a non-interactive user with a failure code and no actionable information. The consent report is one of two surfaces allowed to print a full declaration (the other is the approval screen); the unsupported-adapter report carries none, because neither remedy depends on what a server would run.

**Summary line** — Server configuration counts are broken out by status (`added`, `updated`, `repaired`, `unchanged`, `removed`) rather than collapsed into one "written" total. A server-only facet no longer reports as a no-op. Takeover acceptances are counted separately so adopting an untracked entry is not invisible.

**Declaration secrecy** — Commands, arguments, environment values, and URLs appear only on the two approved surfaces. The success summary, verbose output, and CI logs name server identities but do not reproduce declarations.

**Stale-override drift** — `LOCKFILE_DRIFT` with `reason: 'stale-override'` now points at `facets.json` rather than the lockfile, because the override is not recorded in the lockfile and re-running install would reproduce the same failure.

### Verification

New unit tests cover `mcpConsentPolicy` combinations, the approval and takeover screens (keyboard navigation, default selection, interrupt handling), declaration secrecy across the success summary and decline path, and the non-interactive stderr reports. New e2e tests drive the compiled binary with piped stdio to cover `--accept-mcp` on `add`/`install`/`remove`/`rm`, the no-flag failure path and its stderr content, already-approved declarations not requiring the flag again, unsupported-adapter failures, omit-all bypass, and verbose output not leaking declarations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/add/remove consent, mid-install prompts, and what sensitive MCP details appear in logs versus approval UI; mistakes could block CI installs or leak declarations outside approved surfaces.
> 
> **Overview**
> Completes the **CLI layer** for MCP server materialization: facets with `servers:` now go through explicit consent and configuration instead of a warn-and-skip path.
> 
> **`--accept-mcp`** is defined once in `commands/shared/flags.ts` and shared by `add`, `install`, and `remove` (including `rm`). `mcpConsentPolicy` maps the flag and whether prompting is allowed to engine policies (`preapproved` / `interactive` / `unavailable`); the flag wins over an interactive terminal so CI-style pre-approval works on a TTY too. MCP consent stays separate from asset collision and takeover resolvers.
> 
> **`InstallView`** now drives two prompt phases—**MCP approval** (full declaration, default Decline) and **asset takeover** (default Continue)—via a new **`InstallViewHooks`** object instead of growing positional callbacks. Prompts settle on Esc, Ctrl-C, and abort so the engine is not left holding the lock.
> 
> **Failures and summaries:** `writeInstallFailureDetail` routes MCP consent and unsupported-adapter failures to full **stderr** reports (with declarations only where approval is required); collision reports share an **unchanged** footer that also mentions MCP config. Success output breaks out server config by status, treats server-only facets and takeovers as real work (not “no changes”), and keeps commands/URLs/env off post-approval surfaces. **`LOCKFILE_DRIFT`** for stale server overrides now points at **`facets.json`**, not the lockfile.
> 
> Docs (`install.mdx`) and openspec task **16** are marked done; test fake adapters can opt into MCP. Broad engine/adapter work is assumed landed elsewhere—this PR is the consent/takeover/command UX slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6338594e6cfef39028ed1a86e0041ad39bf5f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->