### PR TITLE
Close the MCP coverage gaps found by the requirement matrix

### DIFF
--- a/openspec/changes/add-mcp-json-support/tasks.md
+++ b/openspec/changes/add-mcp-json-support/tasks.md
@@ -162,12 +162,12 @@
 
 ## 19. Cross-cutting acceptance — Research
 
-- [ ] 19.1 Explore: Build a coverage matrix from every requirement and scenario in all nine delta specs to its implementation task and automated or manual verification.
-- [ ] 19.2 Propose: Define final cross-package and end-to-end scenarios for server-only install, alias/omit reproduction, consent locality, native takeover, rollback, frozen reproduction, offline removal, unsupported adapters, migration, and legacy rejection.
+- [x] 19.1 Explore: Build a coverage matrix from every requirement and scenario in all nine delta specs to its implementation task and automated or manual verification.
+- [x] 19.2 Propose: Define final cross-package and end-to-end scenarios for server-only install, alias/omit reproduction, consent locality, native takeover, rollback, frozen reproduction, offline removal, unsupported adapters, migration, and legacy rejection.
 
 ## 20. Cross-cutting acceptance — Implementation
 
-- [ ] 20.1 Implement: Add any missing cross-package/e2e tests from the coverage matrix, including multi-adapter transactions and failure-order assertions before mutation or prompting.
-- [ ] 20.2 Verify: Run `bun openspec validate add-mcp-json-support --strict` and verify the reconciled delta specs remain valid without editing permanent specs during implementation.
-- [ ] 20.3 Verify: Run the complete `bun check` pipeline, including unit, e2e, types, lint, docs, scripts, and package checks; stop and report any failure.
-- [ ] 20.4 Verify: Audit every delta requirement/scenario and every implementation-time follow-up as covered, record any genuinely external sync/archive or Notion cleanup separately, and mark the change implementation-ready.
+- [x] 20.1 Implement: Add any missing cross-package/e2e tests from the coverage matrix, including multi-adapter transactions and failure-order assertions before mutation or prompting.
+- [x] 20.2 Verify: Run `bun openspec validate add-mcp-json-support --strict` and verify the reconciled delta specs remain valid without editing permanent specs during implementation.
+- [x] 20.3 Verify: Run the complete `bun check` pipeline, including unit, e2e, types, lint, docs, scripts, and package checks; stop and report any failure.
+- [x] 20.4 Verify: Audit every delta requirement/scenario and every implementation-time follow-up as covered, record any genuinely external sync/archive or Notion cleanup separately, and mark the change implementation-ready.

--- a/packages/adapter-test-kit/src/mcp-matrix.ts
+++ b/packages/adapter-test-kit/src/mcp-matrix.ts
@@ -149,6 +149,34 @@ export const MCP_MATRIX_CASES = [
     },
   },
   {
+    // Argument ORDER, nothing else. An adapter comparing args as a set — or
+    // sorting them before comparing — passes every other divergent case while
+    // silently keeping a server that runs with different arguments.
+    id: 'divergent-argument-order',
+    describes: 'treats a reordered argument list as a behavioral difference',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'divergent', name: 'fs', ownership: 'tracked' }],
+      apply: 'changed',
+    },
+  },
+  {
+    // One environment VALUE. An adapter that compares only env key sets, or
+    // skips env entirely, would call this equivalent and leave the server
+    // pointed at the wrong thing.
+    id: 'divergent-environment-value',
+    describes: 'treats a changed environment value as a behavioral difference',
+    desired: [STDIO_SERVER],
+    previouslyOwnedNames: ['fs'],
+    expect: {
+      kind: 'prepared',
+      outcomes: [{ kind: 'divergent', name: 'fs', ownership: 'tracked' }],
+      apply: 'changed',
+    },
+  },
+  {
     id: 'divergent-untracked',
     describes: 'reports a differing entry the project does not own as an untracked takeover',
     desired: [STDIO_SERVER],

--- a/packages/adapter-test-kit/src/run-mcp-matrix.ts
+++ b/packages/adapter-test-kit/src/run-mcp-matrix.ts
@@ -43,7 +43,7 @@ export interface RunMcpServerMatrixOptions {
 /**
  * Run the shared MCP fixture matrix against one adapter's capability.
  *
- * Beyond each case's own expectations, four invariants are asserted for every
+ * Beyond each case's own expectations, five invariants are asserted for every
  * case — they are properties of the capability contract rather than of any
  * individual fixture, so stating them per case would be noise that eventually
  * gets forgotten on the one case that needed it:
@@ -53,20 +53,36 @@ export interface RunMcpServerMatrixOptions {
  * 3. Every changed path was disclosed by `documentPaths` first.
  * 4. Nothing is spawned and nothing is fetched — configuring a server is not
  *    running it.
+ * 5. Nothing outside the project is written. MCP configuration is
+ *    project-scoped, and the home directory is where a tool's user-wide
+ *    config lives — the one place a plausible bug would reach for.
  */
 export function runMcpServerMatrix(options: RunMcpServerMatrixOptions): void {
   describe('MCP server matrix', () => {
     let root: string
+    let home: string
+    let originalHome: string | undefined
+    let originalUserProfile: string | undefined
 
     beforeEach(() => {
       // `realpathSync` because macOS hands out `/var/...` temp paths that
       // resolve to `/private/var/...`; without it, comparing a disclosed
       // document path against the project root is a suffix match at best.
       root = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-matrix-')))
+      home = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-matrix-home-')))
+      originalHome = process.env.HOME
+      originalUserProfile = process.env.USERPROFILE
+      process.env.HOME = home
+      process.env.USERPROFILE = home
     })
 
     afterEach(() => {
+      if (originalHome === undefined) delete process.env.HOME
+      else process.env.HOME = originalHome
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE
+      else process.env.USERPROFILE = originalUserProfile
       rmSync(root, { recursive: true, force: true })
+      rmSync(home, { recursive: true, force: true })
     })
 
     for (const matrixCase of MCP_MATRIX_CASES) {
@@ -138,6 +154,10 @@ export function runMcpServerMatrix(options: RunMcpServerMatrixOptions): void {
           seed.after?.(project)
         } finally {
           restoreGuards()
+          // Project-scoped means project-scoped. A user-wide document the
+          // adapter created would otherwise sit outside every assertion this
+          // harness makes, since they all walk the project tree.
+          expect(snapshot(home)).toEqual(new Map())
         }
       })
     }

--- a/packages/adapter/src/__tests__/index.test.ts
+++ b/packages/adapter/src/__tests__/index.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test'
+import type { McpServerDeclaration as ProtocolMcpServerDeclaration } from '@agent-facets/protocol/mcp-declaration'
 import {
   ADAPTER_API_VERSION,
   ADAPTER_API_VERSION_ASSETS_ONLY,
   ADAPTER_API_VERSION_PACKAGE_FIELD,
 } from '../api-version.ts'
 import { defineAdapter } from '../define-adapter.ts'
+import type { McpServerDeclaration } from '../mcp-servers.ts'
 import type { AdapterDefinition } from '../types.ts'
 
 /**
@@ -89,6 +91,23 @@ describe('defineAdapter — required field validation', () => {
     // CLI must be able to tell "no MCP support" from "not implemented".
     const adapter = defineAdapter(validDefinition())
     expect(adapter.mcpServers).toBe(false)
+  })
+})
+
+describe('the protocol declaration is the source of truth', () => {
+  // The SDK re-exports protocol's declaration type rather than restating it,
+  // and nothing at runtime can notice the difference — a local structural copy
+  // would compile, ship, and only diverge when protocol next changes. These
+  // assignments fail type-checking the moment the two drift apart.
+  test('the exported declaration type is assignable to and from protocol', () => {
+    type FromProtocol = ProtocolMcpServerDeclaration
+    type FromSdk = McpServerDeclaration
+
+    const stdio: FromProtocol = { type: 'stdio', command: 'srv', args: ['--root'], env: { TOKEN: 'A' } }
+    const asSdk: FromSdk = stdio
+    const backAgain: FromProtocol = asSdk
+
+    expect(backAgain).toEqual(stdio)
   })
 })
 

--- a/packages/adapters/claude-code/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/claude-code/src/__tests__/mcp-servers.test.ts
@@ -36,7 +36,21 @@ function servers(entries: Record<string, string>): string {
 const seeds = {
   'document-absent': { files: {} },
 
-  'absent-untracked': { files: { [DOCUMENT]: servers({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+  // The write path, asserted in full. Every other case compares an entry the
+  // seed already contains, which exercises the reader; only a case that
+  // creates one proves the writer renders the whole declaration -- `env`
+  // included, which nothing else here would notice going missing.
+  'absent-untracked': {
+    files: { [DOCUMENT]: servers({ [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    after: (project) => {
+      expect(JSON.parse(project.read(DOCUMENT) ?? '{}').mcpServers.fs).toEqual({
+        type: 'stdio',
+        command: 'srv',
+        args: ['--root', '/w'],
+        env: { TOKEN_NAME: 'A' },
+      })
+    },
+  },
 
   'absent-tracked': { files: { [DOCUMENT]: servers({}) } },
 
@@ -59,6 +73,30 @@ const seeds = {
   'divergent-tracked': { files: { [DOCUMENT]: servers({ fs: '{ "command": "stale" }' }) } },
 
   'divergent-untracked': { files: { [DOCUMENT]: servers({ fs: '{ "command": "stale" }' }) } },
+
+  // Same command, same arguments, opposite order.
+  'divergent-argument-order': {
+    files: {
+      [DOCUMENT]: servers({
+        fs: '{ "type": "stdio", "command": "srv", "args": ["/w", "--root"], "env": { "TOKEN_NAME": "A" } }',
+      }),
+    },
+    after: (project) => {
+      expect(JSON.parse(project.read(DOCUMENT) ?? '{}').mcpServers.fs.args).toEqual(['--root', '/w'])
+    },
+  },
+
+  // Same env key, different value.
+  'divergent-environment-value': {
+    files: {
+      [DOCUMENT]: servers({
+        fs: '{ "type": "stdio", "command": "srv", "args": ["--root", "/w"], "env": { "TOKEN_NAME": "B" } }',
+      }),
+    },
+    after: (project) => {
+      expect(JSON.parse(project.read(DOCUMENT) ?? '{}').mcpServers.fs.env).toEqual({ TOKEN_NAME: 'A' })
+    },
+  },
 
   // Portable fields all match; `headers` decides how the connection
   // authenticates, which a credential-free declaration cannot vouch for.

--- a/packages/adapters/codex/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/codex/src/__tests__/mcp-servers.test.ts
@@ -36,7 +36,18 @@ bearer_token_env_var = "SECRET"
 const seeds = {
   'document-absent': { files: {} },
 
-  'absent-untracked': { files: { [DOCUMENT]: UNOWNED_ENTRY } },
+  // The write path, asserted in full — see the claude-code seed for why this
+  // one case carries it. Asserted as literal text because TOML's env-table
+  // notation is part of what the writer has to get right.
+  'absent-untracked': {
+    files: { [DOCUMENT]: UNOWNED_ENTRY },
+    after: (project) => {
+      const after = project.read(DOCUMENT) ?? ''
+      expect(after).toContain('command = "srv"')
+      expect(after).toMatch(/args = \[\s*"--root",\s*"\/w"\s*]/)
+      expect(after).toContain('TOKEN_NAME = "A"')
+    },
+  },
 
   'absent-tracked': { files: { [DOCUMENT]: '[mcp_servers]\n' } },
 
@@ -68,6 +79,24 @@ command = "srv"
   'divergent-tracked': { files: { [DOCUMENT]: '[mcp_servers.fs]\ncommand = "stale"\n' } },
 
   'divergent-untracked': { files: { [DOCUMENT]: '[mcp_servers.fs]\ncommand = "stale"\n' } },
+
+  'divergent-argument-order': {
+    files: {
+      [DOCUMENT]: '[mcp_servers.fs]\ncommand = "srv"\nargs = ["/w", "--root"]\nenv = { TOKEN_NAME = "A" }\n',
+    },
+    after: (project) => {
+      expect(project.read(DOCUMENT) ?? '').toContain('args = ["--root", "/w"]')
+    },
+  },
+
+  'divergent-environment-value': {
+    files: {
+      [DOCUMENT]: '[mcp_servers.fs]\ncommand = "srv"\nargs = ["--root", "/w"]\nenv = { TOKEN_NAME = "B" }\n',
+    },
+    after: (project) => {
+      expect(project.read(DOCUMENT) ?? '').toContain('TOKEN_NAME = "A"')
+    },
+  },
 
   // Portable fields match, but the entry names an environment variable to
   // authenticate with — a credential-free declaration cannot prove it equal.

--- a/packages/adapters/opencode/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/opencode/src/__tests__/mcp-servers.test.ts
@@ -34,7 +34,19 @@ function document(entries: Record<string, string>): string {
 const seeds = {
   'document-absent': { files: {} },
 
-  'absent-untracked': { files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+  // The write path, asserted in full — see the claude-code seed for why this
+  // one case carries it: the readers are covered everywhere, the writer only
+  // here, and a dropped `environment` would otherwise go unnoticed.
+  'absent-untracked': {
+    files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    after: (project) => {
+      expect(JSON.parse(project.read(JSONC) ?? '{}').mcp.fs).toEqual({
+        type: 'local',
+        command: ['srv', '--root', '/w'],
+        environment: { TOKEN_NAME: 'A' },
+      })
+    },
+  },
 
   'absent-tracked': { files: { [JSONC]: document({}) } },
 
@@ -68,6 +80,31 @@ const seeds = {
   'divergent-tracked': { files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
 
   'divergent-untracked': { files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
+
+  // Same command and arguments, opposite order. OpenCode fuses them into one
+  // array, so order is the only thing that differs.
+  'divergent-argument-order': {
+    files: {
+      [JSONC]: document({
+        fs: '{ "type": "local", "command": ["srv", "/w", "--root"], "environment": { "TOKEN_NAME": "A" } }',
+      }),
+    },
+    after: (project) => {
+      expect(project.read(JSONC) ?? '').toContain('"srv"')
+      expect(project.read(JSONC) ?? '').not.toContain('"/w",\n')
+    },
+  },
+
+  'divergent-environment-value': {
+    files: {
+      [JSONC]: document({
+        fs: '{ "type": "local", "command": ["srv", "--root", "/w"], "environment": { "TOKEN_NAME": "B" } }',
+      }),
+    },
+    after: (project) => {
+      expect(project.read(JSONC) ?? '').toContain('"TOKEN_NAME": "A"')
+    },
+  },
 
   // Portable fields match, but the server is switched off — precisely the
   // behavioral difference the project is asking to correct.

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -52,6 +52,45 @@ function settle(): Promise<void> {
 }
 
 /**
+ * A promise the test opens when it is ready.
+ *
+ * A fake driver must not hold a render phase open with a timer. The test is
+ * waiting on its own timer, and the two are separated only by the gap between
+ * `render()` returning and React flushing the effect that starts the driver —
+ * sub-millisecond, and on the wrong side of it the driver has already resolved
+ * and repainted before the assertion runs. A gate inverts that: the driver
+ * cannot advance until the test says so, in any scheduling order.
+ */
+function gate(): { readonly wait: Promise<void>; readonly open: () => void } {
+  let open!: () => void
+  const wait = new Promise<void>((resolve) => {
+    open = () => resolve()
+  })
+  return { wait, open }
+}
+
+/**
+ * Poll frames until `predicate` holds.
+ *
+ * The other half of the same problem: a gate stops the driver running ahead of
+ * the assertion, and this stops the assertion running ahead of the paint. A
+ * fixed sleep has to guess how long a render takes; this waits for the thing
+ * it is actually waiting for.
+ */
+async function waitForFrame(
+  instance: { lastFrame: () => string | undefined },
+  predicate: (text: string) => boolean,
+  description: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const text = visibleTerminalText(instance.lastFrame() ?? '')
+    if (predicate(text)) return text
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error(`timed out waiting for ${description}. Last frame:\n${instance.lastFrame() ?? '(none)'}`)
+}
+
+/**
  * Build a fake `run` driver that emits a canned event sequence and
  * resolves to a canned result. Lets each test exercise a specific
  * render path of `<InstallView />` without spinning up `runInstall`.
@@ -1007,6 +1046,40 @@ describe('InstallView — frozen-lockfile drift', () => {
     expect(frame).toContain('without --frozen-lockfile')
     instance.unmount()
   })
+
+  // The load-bearing half of frozen stale intent: a normal install prunes the
+  // override and says so, frozen refuses and must say the opposite. Reporting
+  // it without that clause would read as "handled".
+  test('a stale server override says the override was not removed', async () => {
+    const failure: RunInstallFailure = {
+      code: 'LOCKFILE_DRIFT',
+      facets: [
+        {
+          name: 'mcp-tools',
+          reason: 'stale-override',
+          contribution: { kind: 'mcp-server' },
+          authoredName: 'gone',
+        },
+      ],
+    }
+    const events: StageEvent[] = [{ kind: 'install-complete', outcome: 'failure' }]
+    const result: RunInstallResult = {
+      ok: false,
+      failure,
+      rollback: { kind: 'not-needed', reason: 'test fixture' },
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun(events, result),
+      }),
+    )
+    await settle()
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).toContain('gone')
+    expect(frame).toContain('NOT removed')
+    instance.unmount()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1062,19 +1135,22 @@ async function tick(): Promise<void> {
 
 describe('InstallView — collision phase machine', () => {
   test('the collision check is a visible stage, not a stall', async () => {
+    const checking = gate()
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
         run: async ({ onStage }) => {
           onStage({ kind: 'install-start', totalFacets: 2 })
           onStage({ kind: 'collision-check' })
-          await tick()
+          await checking.wait
           return successResultSingle
         },
       }),
     )
-    await tick()
-    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Checking for name collisions')
+
+    await waitForFrame(instance, (text) => text.includes('Checking for name collisions'), 'the collision stage')
+
+    checking.open()
     await settle()
     instance.unmount()
   })
@@ -1084,6 +1160,7 @@ describe('InstallView — collision phase machine', () => {
   // several would misdescribe when the check happens — and the spec's
   // single-facet scenario named it while the multi-facet one did not.
   test('the same single global phase is shown for a multi-facet run', async () => {
+    const checking = gate()
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
@@ -1094,23 +1171,28 @@ describe('InstallView — collision phase machine', () => {
             onStage({ kind: 'facet-stage', facet, stage: 'verify' })
           }
           onStage({ kind: 'collision-check' })
-          await tick()
+          await checking.wait
           return successResultSingle
         },
       }),
     )
-    await tick()
 
-    const paused = visibleTerminalText(instance.lastFrame() ?? '')
-    expect(paused).toContain('Checking for name collisions across all facets')
+    const paused = await waitForFrame(
+      instance,
+      (text) => text.includes('Checking for name collisions across all facets'),
+      'the collision stage',
+    )
     // One phase, not one per facet.
     expect(paused.match(/Checking for name collisions/g)).toHaveLength(1)
 
+    checking.open()
     await settle()
     instance.unmount()
   })
 
   test('the collision phase clears once materialization starts', async () => {
+    const checking = gate()
+    const materializing = gate()
     const instance = render(
       createElement(InstallView, {
         mode: 'install',
@@ -1118,19 +1200,25 @@ describe('InstallView — collision phase machine', () => {
           onStage({ kind: 'install-start', totalFacets: 2 })
           onStage({ kind: 'facet-start', facet: 'alpha', specifier: './alpha' })
           onStage({ kind: 'collision-check' })
-          await tick()
+          await checking.wait
           onStage({ kind: 'facet-stage', facet: 'alpha', stage: 'materialize' })
-          await tick()
+          await materializing.wait
           return successResultSingle
         },
       }),
     )
-    await tick()
-    expect(visibleTerminalText(instance.lastFrame() ?? '')).toContain('Checking for name collisions')
 
-    await tick()
-    await tick()
-    expect(visibleTerminalText(instance.lastFrame() ?? '')).not.toContain('Checking for name collisions')
+    // Held open, so the phase cannot have come and gone before this runs.
+    await waitForFrame(instance, (text) => text.includes('Checking for name collisions'), 'the collision stage')
+
+    checking.open()
+    await waitForFrame(
+      instance,
+      (text) => !text.includes('Checking for name collisions'),
+      'the collision stage to clear',
+    )
+
+    materializing.open()
 
     await settle()
     instance.unmount()
@@ -1323,6 +1411,33 @@ describe('InstallView — materialization reporting', () => {
     expect(frame).toContain('gone')
     expect(frame).toContain('alpha')
     expect(frame).toContain('no longer contains')
+    instance.unmount()
+  })
+
+  test('a pruned server override names the server, not an asset type', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'install',
+        run: makeFakeRun(
+          [
+            { kind: 'install-start', totalFacets: 1 },
+            {
+              kind: 'stale-override-pruned',
+              facet: 'mcp-tools',
+              contribution: { kind: 'mcp-server' },
+              authoredName: 'gone',
+            },
+          ],
+          successResultSingle,
+        ),
+      }),
+    )
+    await settle()
+
+    const frame = visibleContentFrame(instance.frames)
+    expect(frame).toContain('gone')
+    expect(frame).toContain('mcp-tools')
+    expect(frame).toContain('server')
     instance.unmount()
   })
 })

--- a/packages/cli/src/__tests__/mcp-consent.e2e.test.ts
+++ b/packages/cli/src/__tests__/mcp-consent.e2e.test.ts
@@ -132,6 +132,40 @@ describe('non-interactive MCP consent', () => {
   })
 })
 
+describe('server collisions', () => {
+  // The collision report is unit-tested, but the property THIS file exists to
+  // prove is that it survives piped stdio -- where the rich block goes to a
+  // stream nobody reads. Asset groups were covered; server groups were not.
+  test('two disagreeing declarations report every claimant and write nothing', async () => {
+    installFakeAdapter(adaptersDir, 'faketool', { mcp: true })
+    const alpha = buildServerFixture('alpha', 'filesystem')
+    const beta = realpathSync(mkdtempSync(join(projectRoot, 'fixture-')))
+    writeFileSync(
+      join(beta, 'facet.json'),
+      JSON.stringify({
+        name: 'beta',
+        version: '0.1.0',
+        servers: { filesystem: { type: 'http', url: 'https://other.example.com/mcp' } },
+      }),
+    )
+
+    const result = await runCli(['add', alpha, `./${beta.split('/').pop()}`, '--accept-mcp'])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('MCP servers')
+    expect(result.stderr).toContain('alpha')
+    expect(result.stderr).toContain('beta')
+    // The editable location and a copy-pasteable resolution, per claimant.
+    expect(result.stderr).toContain('materialization.servers')
+    expect(result.stderr).toContain('"kind": "omitted"')
+    // No winner is chosen; the alias placeholder stays a placeholder.
+    expect(result.stderr).toContain('choose-a-name')
+    expect(result.stderr).toContain('NOT changed')
+    expect(existsSync(mcpDocumentFor('faketool'))).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+})
+
 describe('adapters that cannot configure MCP servers', () => {
   test('the failure names the adapter and both remedies', async () => {
     installFakeAdapter(adaptersDir, 'faketool')

--- a/packages/cli/src/tui/views/install/mcp/__tests__/approval.test.tsx
+++ b/packages/cli/src/tui/views/install/mcp/__tests__/approval.test.tsx
@@ -63,3 +63,49 @@ test('moving to approve and confirming approves', async () => {
   expect(decisions).toEqual([{ kind: 'approved' }])
   instance.unmount()
 })
+
+// Approval is all-or-nothing over the displayed set, which only means anything
+// if the set is displayed in full. A screen rendering just the first entry
+// would satisfy every single-declaration fixture while asking the user to
+// approve things they never saw.
+test('every declaration and every takeover is shown, not just the first', async () => {
+  const many: McpConsentRequest = {
+    declarations: [
+      ...REQUEST.declarations,
+      {
+        identity: { kind: 'mcp-server', effectiveName: 'search' },
+        fingerprint: `sha256:${'b'.repeat(64)}`,
+        declaration: { type: 'stdio', command: 'search-mcp', args: ['--index', 'local'] },
+        claimants: [{ facet: 'beta', authoredName: 'search', disposition: { kind: 'authored' } }],
+        standing: { kind: 'declaration-changed' },
+      },
+      {
+        identity: { kind: 'mcp-server', effectiveName: 'issues' },
+        fingerprint: `sha256:${'c'.repeat(64)}`,
+        declaration: { type: 'http', url: 'https://issues.example.com/mcp' },
+        claimants: [{ facet: 'gamma', authoredName: 'issues', disposition: { kind: 'authored' } }],
+        standing: { kind: 'unknown-identity' },
+      },
+    ],
+    takeovers: [
+      ...REQUEST.takeovers,
+      {
+        adapter: 'opencode',
+        identity: { kind: 'mcp-server', effectiveName: 'notes' },
+        existing: 'equivalent',
+        declaration: { type: 'stdio', command: 'notes-mcp' },
+      },
+    ],
+  }
+
+  const instance = render(createElement(McpApprovalScreen, { request: many, onComplete: () => {} }))
+  await tick()
+  const text = visibleTerminalText(instance.lastFrame() ?? '')
+
+  expect(text).toContain('stdio npx -y srv')
+  expect(text).toContain('stdio search-mcp --index local')
+  expect(text).toContain('http https://issues.example.com/mcp')
+  expect(text).toContain('claude-code: docs differs and would be replaced')
+  expect(text).toContain('opencode: notes already matches and would be adopted')
+  instance.unmount()
+})

--- a/packages/engine/src/__tests__/build-pipeline.test.ts
+++ b/packages/engine/src/__tests__/build-pipeline.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { type Adapter, defineAdapter } from '@agent-facets/adapter'
-import type { FacetManifest } from '@agent-facets/protocol'
+import type { FacetManifest, McpServerDeclaration } from '@agent-facets/protocol'
 import { computeContentHash, detectNamingCollisions, validateCompactFacets } from '@agent-facets/protocol'
 import dedent from 'dedent'
 import { parseTar, parseTarGzip } from 'nanotar'
@@ -1331,5 +1331,91 @@ describe('runBuildPipeline — 0.2 supplementary files', () => {
     const manifest = JSON.parse(result.manifestJson)
     expect(manifest.files).toBeDefined()
     expect(manifest.assets).toBeUndefined()
+  })
+})
+
+describe('build pipeline — MCP server declarations', () => {
+  async function writeFacet(dir: string, manifest: Record<string, unknown>): Promise<void> {
+    await Bun.write(join(dir, 'facet.json'), JSON.stringify(manifest, null, 2))
+  }
+
+  const STDIO: McpServerDeclaration = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'server-filesystem'],
+    env: { LOG: 'info' },
+  }
+
+  test('a server-only facet builds, with the declaration in the manifest and no entry of its own', async () => {
+    const dir = await createFixtureDir('mcp-server-only')
+    // No skills, no agents, no commands, no composed facets. A declaration is
+    // a deliverable, so this is a complete facet.
+    await writeFacet(dir, { name: 'mcp-tools', version: '1.0.0', servers: { filesystem: STDIO } })
+
+    const result = await runBuildPipeline(dir)
+
+    if (!result.ok) expect.unreachable()
+    expect(result.facetVersion).toBe(0.2)
+    // Declarations travel inside the embedded manifest and add no archive
+    // entry — which is exactly why the lockfile needs no field for them.
+    expect(Object.keys(result.fileHashes)).toEqual(['facet.json'])
+    expect(result.data.servers).toEqual({ filesystem: STDIO })
+  })
+
+  test('an invalid declaration fails validation and preserves prior dist output', async () => {
+    const dir = await createFixtureDir('mcp-invalid-declaration')
+    await Bun.write(join(dir, 'skills/review/SKILL.md'), '# review\n')
+    await writeFacet(dir, {
+      name: 'mcp-tools',
+      version: '1.0.0',
+      skills: { review: { description: 'r' } },
+      // `headers` is outside the closed declaration shape.
+      servers: { filesystem: { ...STDIO, headers: { Authorization: 'Bearer x' } } },
+    })
+    await Bun.write(join(dir, 'dist/prior.txt'), 'keep me')
+
+    const result = await runBuildPipeline(dir)
+
+    if (result.ok) expect.unreachable()
+    expect(await Bun.file(join(dir, 'dist/prior.txt')).text()).toBe('keep me')
+  })
+
+  test('building a declaration neither launches a command nor opens a connection', async () => {
+    const dir = await createFixtureDir('mcp-no-execution')
+    await writeFacet(dir, {
+      name: 'mcp-tools',
+      version: '1.0.0',
+      servers: {
+        filesystem: STDIO,
+        docs: { type: 'http', url: 'https://mcp.example.test/mcp' },
+      },
+    })
+
+    // A declaration names a command and a URL. Validating one must never mean
+    // locating it, starting it, or reaching it — the build has no business
+    // proving a server works, and a network round trip would make offline
+    // builds fail for a reason that has nothing to do with the archive.
+    const originalFetch = globalThis.fetch
+    const originalSpawn = Bun.spawn
+    const originalSpawnSync = Bun.spawnSync
+    const originalWhich = Bun.which
+    const forbid = (what: string) => () => {
+      throw new Error(`build must not ${what}`)
+    }
+    globalThis.fetch = forbid('open a network connection') as unknown as typeof globalThis.fetch
+    Bun.spawn = forbid('spawn a process') as unknown as typeof Bun.spawn
+    Bun.spawnSync = forbid('spawn a process') as unknown as typeof Bun.spawnSync
+    Bun.which = forbid('resolve an executable') as unknown as typeof Bun.which
+
+    try {
+      const result = await runBuildPipeline(dir)
+      if (!result.ok) expect.unreachable()
+      expect(result.data.servers?.docs).toEqual({ type: 'http', url: 'https://mcp.example.test/mcp' })
+    } finally {
+      globalThis.fetch = originalFetch
+      Bun.spawn = originalSpawn
+      Bun.spawnSync = originalSpawnSync
+      Bun.which = originalWhich
+    }
   })
 })

--- a/packages/engine/src/install/__tests__/helpers/mcp-adapter.ts
+++ b/packages/engine/src/install/__tests__/helpers/mcp-adapter.ts
@@ -53,6 +53,20 @@ export interface RecordingMcpOptions {
    * engine refuses because it has no preimage for it.
    */
   applyUndisclosedPath?: () => string
+  /**
+   * Disclose an extra document path from `prepare` — used to exercise the
+   * engine's containment check on a path outside the project.
+   */
+  prepareExtraDocumentPath?: () => string
+  /**
+   * A log this capability appends to alongside its own `calls`.
+   *
+   * Ordering between asset writes and MCP application is a spec guarantee, and
+   * two separate arrays cannot express it — they have no shared clock. Passing
+   * the adapter's asset log here puts both domains on one timeline so a test
+   * can assert that every asset write precedes `apply`.
+   */
+  log?: string[]
 }
 
 export function recordingMcpCapability(
@@ -60,11 +74,15 @@ export function recordingMcpCapability(
   options: RecordingMcpOptions = {},
 ): McpCapabilityRecorder {
   const calls: string[] = []
+  const record = (entry: string) => {
+    calls.push(entry)
+    options.log?.push(`mcp:${entry}`)
+  }
 
   const capability: McpServerCapability<FakePlan> = {
     async prepare(request: PrepareMcpServersRequest): Promise<PrepareMcpServersResult<FakePlan>> {
       const path = documentPath()
-      calls.push(`prepare:${request.desired.length}`)
+      record(`prepare:${request.desired.length}`)
       if (options.failPrepare !== undefined) return { ok: false, failure: options.failPrepare }
 
       const servers = readServers(path)
@@ -85,8 +103,13 @@ export function recordingMcpCapability(
             : 'divergent',
       })
 
+      const extra = options.prepareExtraDocumentPath?.()
+      // Non-empty by contract: disclosure is what the engine journals against,
+      // so "no documents" is not a thing a preparation can say.
+      const documentPaths: readonly [string, ...string[]] = extra === undefined ? [path] : [path, extra]
+
       if (!mcpOutcomesRequireWrite(outcomes)) {
-        return { ok: true, preparation: { plan: { kind: 'unchanged', path }, documentPaths: [path], outcomes } }
+        return { ok: true, preparation: { plan: { kind: 'unchanged', path }, documentPaths, outcomes } }
       }
 
       const next: Record<string, McpServerDeclaration> = { ...servers.value }
@@ -101,21 +124,21 @@ export function recordingMcpCapability(
 
       return {
         ok: true,
-        preparation: { plan: { kind: 'write', path, servers: next }, documentPaths: [path], outcomes },
+        preparation: { plan: { kind: 'write', path, servers: next }, documentPaths, outcomes },
       }
     },
 
     async apply(request: { plan: FakePlan }): Promise<ApplyMcpServersResult> {
       const plan = request.plan
       if (plan.kind === 'unchanged') {
-        calls.push('apply:unchanged')
+        record('apply:unchanged')
         return { ok: true, status: 'unchanged' }
       }
       if (options.failApply !== undefined) {
-        calls.push('apply:failed')
+        record('apply:failed')
         return { ok: false, failure: options.failApply }
       }
-      calls.push('apply:changed')
+      record('apply:changed')
       mkdirSync(dirname(plan.path), { recursive: true })
       writeFileSync(plan.path, `${JSON.stringify(plan.servers, null, 2)}\n`)
       const undisclosed = options.applyUndisclosedPath?.()

--- a/packages/engine/src/install/__tests__/mcp-install.test.ts
+++ b/packages/engine/src/install/__tests__/mcp-install.test.ts
@@ -40,18 +40,28 @@ interface TestAdapter {
   adapter: Adapter
   io: string[]
   mcpCalls: string[]
+  /**
+   * Asset and MCP calls on one clock, prefixed by domain.
+   *
+   * `io` and `mcpCalls` each answer "what happened in this domain"; only a
+   * shared log can answer "in what order across domains", which is what the
+   * apply-configuration-last guarantee is about.
+   */
+  timeline: string[]
   documentPath: string
 }
 
 /** A `0.2` adapter with a working MCP capability, recording every call. */
 function mcpAdapter(name: string, options: RecordingMcpOptions = {}): TestAdapter {
   const io: string[] = []
+  const timeline: string[] = []
   const baseDir = () => join(projectRoot, `.${name}`)
   const file = (type: string, assetName: string) => join(baseDir(), `${type}s`, `${assetName}.md`)
   const document = () => join(baseDir(), 'mcp.json')
-  const mcp = recordingMcpCapability(document, options)
+  const mcp = recordingMcpCapability(document, { ...options, log: timeline })
   return {
     io,
+    timeline,
     mcpCalls: mcp.calls,
     get documentPath() {
       return document()
@@ -68,6 +78,7 @@ function mcpAdapter(name: string, options: RecordingMcpOptions = {}): TestAdapte
       // equivalent-takeover case untestable.
       async installAsset(request) {
         io.push(`install:${request.assetType}:${request.name}`)
+        timeline.push(`asset:install:${request.assetType}:${request.name}`)
         const p = { file: file(request.assetType, request.name) }
         await installAssetFile(p, request.content, request.metadata as Record<string, unknown> | undefined)
         return { ok: true, primaryPath: p.file }
@@ -85,6 +96,7 @@ function mcpAdapter(name: string, options: RecordingMcpOptions = {}): TestAdapte
       },
       async deleteAsset(request) {
         io.push(`delete:${request.assetType}:${request.name}`)
+        timeline.push(`asset:delete:${request.assetType}:${request.name}`)
         const p = { file: file(request.assetType, request.name) }
         await deleteAssetFile(p)
         return { ok: true, existed: true, deletedPaths: [p.file] }
@@ -308,6 +320,43 @@ describe('mcp — consent', () => {
     expect(asked).toBe(0)
   })
 
+  // Approval reaches the receipt only through a successful commit. If a failed
+  // run could bank it, a user who approved something that then blew up would
+  // never be asked again -- consent would have been obtained for an operation
+  // that never happened.
+  test('a failed operation banks no approval, so the next attempt asks again', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const first = mcpAdapter('first')
+    const second = mcpAdapter('second', {
+      failApply: { code: 'io-failed', operation: 'write', path: '/nope', message: 'disk on fire' },
+    })
+
+    let asked = 0
+    const resolve = async () => {
+      asked++
+      return { kind: 'approved' } as const
+    }
+
+    const failed = await runInstall({
+      projectRoot,
+      adapters: [first.adapter, second.adapter],
+      mcpConsent: { kind: 'interactive', resolve },
+    })
+
+    if (failed.ok) expect.unreachable()
+    expect(asked).toBe(1)
+    expect(existsSync(receiptPath(projectRoot))).toBe(false)
+
+    const retry = await runInstall({
+      projectRoot,
+      adapters: [first.adapter],
+      mcpConsent: { kind: 'interactive', resolve },
+    })
+
+    expect(retry.ok).toBe(true)
+    expect(asked).toBe(2)
+  })
+
   test('a changed declaration is asked about again, and says so', async () => {
     const a = serverFixture('alpha', 'filesystem', STDIO)
     writeManifest({ facets: { alpha: a } })
@@ -379,6 +428,192 @@ describe('mcp — consent', () => {
         declaration: STDIO as never,
       },
     ])
+  })
+
+  // Drift at an identity this machine already owns is repair, not takeover.
+  // Warning about it would train users to click through the one prompt that
+  // means someone else's configuration is about to be replaced.
+  test('an entry the receipt already owns is never disclosed as a takeover', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // Same owned identity, drifted content.
+    writeFileSync(rec.documentPath, `${JSON.stringify({ filesystem: HTTP }, null, 2)}\n`)
+
+    let asked = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async () => {
+          asked++
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(asked).toBe(0)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+  })
+
+  test('declining a request raised only by a takeover leaves the entry alone', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // The declaration stays approved, but ownership is gone: what is on disk
+    // is now someone else's entry at a name this project wants.
+    rmSync(receiptPath(projectRoot), { force: true })
+    const before = `${JSON.stringify({ filesystem: HTTP }, null, 2)}\n`
+    writeFileSync(rec.documentPath, before)
+
+    let seen: McpConsentRequest | undefined
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async (request) => {
+          seen = request
+          return { kind: 'declined' }
+        },
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.code).toBe('MCP_CONSENT_DECLINED')
+    expect(seen?.takeovers).toHaveLength(1)
+    // Consent precedes the journal, so a decline has nothing to undo.
+    expect(result.rollback.kind).toBe('not-needed')
+    expect(readFileSync(rec.documentPath, 'utf8')).toBe(before)
+  })
+
+  test('a receipt predating configuration claims reads existing entries as untracked', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // Downgrade the receipt to the last version that could not witness
+    // configuration. Its asset ownership survives; its MCP claims cannot.
+    const receipt = JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8'))
+    receipt.receiptVersion = 0.3
+    for (const facet of Object.values(receipt.facets) as Array<Record<string, unknown>>) {
+      delete facet.configurations
+      delete facet.integrity
+    }
+    writeFileSync(receiptPath(projectRoot), `${JSON.stringify(receipt, null, 2)}\n`)
+
+    let seen: McpConsentRequest | undefined
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async (request) => {
+          seen = request
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    // Unapproved again, and the entry it wrote last time now reads as
+    // somebody else's — which is the honest reading of "no evidence".
+    expect(seen?.declarations).toHaveLength(1)
+    expect(seen?.takeovers).toEqual([
+      {
+        adapter: 'rec',
+        identity: { kind: 'mcp-server', effectiveName: 'filesystem' },
+        existing: 'equivalent',
+        declaration: STDIO as never,
+      },
+    ])
+  })
+})
+
+describe('mcp — one desired set across adapters', () => {
+  // Counting outcomes proves each adapter did something; only reading both
+  // documents proves they did the SAME thing. One project-level desired set is
+  // the guarantee, and two adapters drifting apart would still count as two.
+  test('every selected adapter ends up with the same effective configuration', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const one = mcpAdapter('one')
+    const two = mcpAdapter('two')
+
+    expect((await runInstall({ projectRoot, adapters: [one.adapter, two.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    const first = JSON.parse(readFileSync(one.documentPath, 'utf8'))
+    expect(first).toEqual({ filesystem: STDIO })
+    expect(JSON.parse(readFileSync(two.documentPath, 'utf8'))).toEqual(first)
+  })
+
+  test('one disposition applies to every selected adapter', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = serverFixture('beta', 'docs', HTTP)
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: {
+        alpha: { source: a, materialization: { servers: { filesystem: { kind: 'aliased', as: 'fs' } } } },
+        beta: { source: b, materialization: { servers: { docs: { kind: 'omitted' } } } },
+      },
+    })
+    const one = mcpAdapter('one')
+    const two = mcpAdapter('two')
+
+    expect((await runInstall({ projectRoot, adapters: [one.adapter, two.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // The alias moved the effective name everywhere, and the omission is
+    // absent everywhere. A per-adapter disposition is not representable.
+    const expected = { fs: STDIO }
+    expect(JSON.parse(readFileSync(one.documentPath, 'utf8'))).toEqual(expected)
+    expect(JSON.parse(readFileSync(two.documentPath, 'utf8'))).toEqual(expected)
+  })
+
+  test('changing an alias moves the entry rather than duplicating it', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source: a, materialization: { servers: { filesystem: { kind: 'aliased', as: 'fs' } } } } },
+    })
+
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+    // The old owned identity is gone, not left behind beside the new one.
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ fs: STDIO })
+  })
+
+  test('an adapter selected later picks up an identity the project already owns', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const one = mcpAdapter('one')
+    expect((await runInstall({ projectRoot, adapters: [one.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // Ownership is recorded per project, not per adapter, so connecting a
+    // second tool delegates management of what this project already owns --
+    // with no fresh approval, because the declaration is unchanged.
+    const two = mcpAdapter('two')
+    let asked = 0
+    const result = await runInstall({
+      projectRoot,
+      adapters: [one.adapter, two.adapter],
+      mcpConsent: {
+        kind: 'interactive',
+        resolve: async () => {
+          asked++
+          return { kind: 'approved' }
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(asked).toBe(0)
+    expect(JSON.parse(readFileSync(two.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
   })
 })
 
@@ -456,6 +691,75 @@ describe('mcp — application and rollback', () => {
     if (result.ok) expect.unreachable()
     if (result.failure.code !== 'MCP_CONTRACT_VIOLATION') expect.unreachable()
     expect(result.failure.violation.kind).toBe('undisclosed-changed-path')
+  })
+
+  // A document outside the project is the disclosure the engine must refuse
+  // outright: the whole rollback story rests on preimages the engine captured,
+  // and it will not capture -- or overwrite -- a file outside the tree it owns.
+  test('a document disclosed outside the project is refused before anything is written', async () => {
+    writeManifest({ facets: { alpha: serverFixture('alpha', 'filesystem', STDIO) } })
+    const outside = join(fakeHome, 'user-level-mcp.json')
+    const rec = mcpAdapter('rec', { prepareExtraDocumentPath: () => outside })
+
+    const result = await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'MCP_CONTRACT_VIOLATION') expect.unreachable()
+    expect(result.failure.violation.kind).toBe('document-outside-project')
+    expect(existsSync(outside)).toBe(false)
+    expect(existsSync(rec.documentPath)).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  // Ordering across the two domains, on one clock. Two separate logs can each
+  // say what happened within a domain but neither can say which came first,
+  // and "configuration applies after assets" is precisely a claim about that.
+  test('every asset write completes before configuration is applied', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    const apply = rec.timeline.indexOf('mcp:apply:changed')
+    expect(apply).toBeGreaterThan(-1)
+    const assetWrites = rec.timeline.filter((entry) => entry.startsWith('asset:install:'))
+    expect(assetWrites.length).toBeGreaterThan(0)
+    for (const write of assetWrites) expect(rec.timeline.indexOf(write)).toBeLessThan(apply)
+    // Preparation is the other half of the sandwich: read-only, before the
+    // journal opens, and therefore before the first asset write.
+    expect(rec.timeline.indexOf('mcp:prepare:1')).toBeLessThan(rec.timeline.indexOf(assetWrites[0] as string))
+  })
+
+  test('a failure committing project state restores configuration and assets alike', async () => {
+    writeManifest({
+      facets: {
+        alpha: serverFixture('alpha', 'filesystem', STDIO),
+        beta: skillFixture('beta', 'review'),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    mkdirSync(join(projectRoot, '.rec'), { recursive: true })
+    const before = '{\n\t"legacy": {"type":"stdio","command":"keep-me"}\n}\n'
+    writeFileSync(rec.documentPath, before)
+
+    // A directory where the lockfile's temp file wants to go: the write fails
+    // after configuration has already been applied, which is the only moment
+    // the journal has to walk both domains back.
+    mkdirSync(join(projectRoot, 'facets.lock.tmp'), { recursive: true })
+
+    const result = await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })
+
+    if (result.ok) expect.unreachable()
+    expect(rec.mcpCalls).toContain('apply:changed')
+    expect(result.rollback.kind).toBe('succeeded')
+    expect(readFileSync(rec.documentPath, 'utf8')).toBe(before)
+    expect(existsSync(join(projectRoot, '.rec', 'skills', 'review.md'))).toBe(false)
+    expect(existsSync(receiptPath(projectRoot))).toBe(false)
   })
 })
 
@@ -537,6 +841,94 @@ describe('mcp — frozen reproduction', () => {
     // transaction, so it must leave the intent exactly where it found it.
     expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBefore)
     expect(readFileSync(rec.documentPath, 'utf8')).toBe(documentBefore)
+  })
+
+  // Frozen cannot prune shared intent, but it may still reconcile machine-local
+  // ownership -- otherwise a pulled removal would strand a server entry this
+  // machine wrote, with no non-frozen run in sight to clean it up.
+  test('frozen removes a receipt-only server orphan and rewrites only the receipt', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = skillFixture('beta', 'review')
+    writeManifest({ facets: { alpha: a, beta: b } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+
+    // The shape a teammate's removal arrives in: both shared files drop the
+    // facet, while this machine's receipt still records what it configured.
+    writeManifest({ facets: { beta: b } })
+    const lockfile = JSON.parse(readFileSync(join(projectRoot, 'facets.lock'), 'utf8'))
+    delete lockfile.facets.alpha
+    const lockBefore = `${JSON.stringify(lockfile, null, 2)}\n`
+    writeFileSync(join(projectRoot, 'facets.lock'), lockBefore)
+    const manifestBefore = readFileSync(join(projectRoot, 'facets.json'), 'utf8')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: ACCEPT,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({})
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(manifestBefore)
+    expect(readFileSync(join(projectRoot, 'facets.lock'), 'utf8')).toBe(lockBefore)
+    const receipt = JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8'))
+    expect(Object.keys(receipt.facets)).toEqual(['beta'])
+  })
+
+  test('a frozen server conflict changes nothing', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    const b = serverFixture('beta', 'filesystem', HTTP)
+    writeManifest({ facets: { alpha: a, beta: b } })
+    const rec = mcpAdapter('rec')
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: ACCEPT,
+    })
+
+    if (result.ok) expect.unreachable()
+    // Frozen has no resolver, so a contested effective name can only be
+    // reported. Whichever gate catches it first, nothing may be written.
+    expect(existsSync(rec.documentPath)).toBe(false)
+    expect(existsSync(receiptPath(projectRoot))).toBe(false)
+    expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)
+  })
+
+  // Declarations are not in the lockfile, so nothing about them is pinned
+  // directly -- they ride the facet's integrity. Editing one behind the lock
+  // must therefore fail on integrity, before any native document is touched.
+  test('a tampered declaration blocks configuration before any native write', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({ facets: { alpha: a } })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+    rmSync(rec.documentPath, { force: true })
+    const callsBefore = rec.mcpCalls.length
+
+    // Same facet version, different command: the manifest no longer hashes to
+    // what the lockfile recorded.
+    serverFixture('alpha', 'filesystem', { type: 'stdio', command: 'evil-mcp' })
+
+    const result = await runInstall({
+      projectRoot,
+      adapters: [rec.adapter],
+      frozenLockfile: true,
+      mcpConsent: ACCEPT,
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.code !== 'INTEGRITY_FAILURE') expect.unreachable()
+    if (result.failure.failure.kind !== 'facet') expect.unreachable()
+    expect(result.failure.failure.facet).toBe('alpha')
+    // Verification precedes preparation, so the capability was never reached
+    // at all -- not reached and then rolled back.
+    expect(rec.mcpCalls.slice(callsBefore)).toEqual([])
+    expect(existsSync(rec.documentPath)).toBe(false)
   })
 
   test('a server-only override does not make an older lockfile unrepresentable', async () => {
@@ -647,6 +1039,57 @@ describe('mcp — offline removal', () => {
     // the ordinary pipeline then succeeds.
     expect(reasons).toEqual(['configuration-unwitnessed'])
     expect(removed.ok).toBe(true)
+  })
+
+  // The reason --accept-mcp exists on `remove` at all. A removal that has to
+  // resolve the facets it keeps re-enters the consent path, and without a way
+  // to answer it there is no non-interactive way to finish the removal.
+  test('a removal that must resolve enters the same MCP approval path', async () => {
+    writeManifest({
+      facets: {
+        alpha: skillFixture('alpha', 'review'),
+        beta: serverFixture('beta', 'filesystem', STDIO),
+      },
+    })
+    const rec = mcpAdapter('rec')
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // Drop the machine-local evidence: the kept facet's declaration is no
+    // longer approved, and removal can no longer answer from local state.
+    rmSync(receiptPath(projectRoot), { force: true })
+
+    const blocked = await runRemove({ projectRoot, names: ['alpha'], adapters: [rec.adapter] })
+    if (blocked.ok) expect.unreachable()
+    if (blocked.phase !== 'install') expect.unreachable()
+    expect(blocked.install.failure.code).toBe('MCP_CONSENT_REQUIRED')
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toContain('alpha')
+
+    // With approval supplied, the same removal completes.
+    const allowed = await runRemove({
+      projectRoot,
+      names: ['alpha'],
+      adapters: [rec.adapter],
+      mcpConsent: ACCEPT,
+    })
+    expect(allowed.ok).toBe(true)
+    expect(JSON.parse(readFileSync(rec.documentPath, 'utf8'))).toEqual({ filesystem: STDIO })
+  })
+
+  test('an omitted server is recorded nowhere', async () => {
+    const a = serverFixture('alpha', 'filesystem', STDIO)
+    writeManifest({
+      manifestVersion: 0.2,
+      facets: { alpha: { source: a, materialization: { servers: { filesystem: { kind: 'omitted' } } } } },
+    })
+    const rec = mcpAdapter('rec')
+
+    expect((await runInstall({ projectRoot, adapters: [rec.adapter], mcpConsent: ACCEPT })).ok).toBe(true)
+
+    // Never materialized, so there is nothing to own and nothing to approve.
+    // A claim would assert two things that are both false.
+    const receipt = JSON.parse(readFileSync(receiptPath(projectRoot), 'utf8'))
+    expect(receipt.facets.alpha?.configurations ?? []).toEqual([])
+    expect(readIfPresent(rec.documentPath)).toBe(null)
   })
 })
 


### PR DESCRIPTION
### Why

This completes the `add-mcp-json-support` change (93/93 tasks). Task 19.1 built a requirement-to-test matrix across all nine delta specs; this PR closes the gaps it found.

Most were places where a plausible regression would have passed the entire existing suite:

- Adapters compared arguments and environment values loosely enough that sorting args, or ignoring env values, went undetected.
- The write path was never asserted in full, so an adapter that dropped `env` while rendering would have looked correct — every other case exercises the *reader*.
- Nothing asserted that MCP configuration is applied **after** asset writes, because asset I/O and MCP calls were recorded in two separate arrays with no shared clock.
- Nothing proved a failed run leaves no approval behind, so a user who approved something that then blew up could have been silently never asked again.
- The matrix harness only ever walked the project tree, so a write to a user-wide tool config would have been invisible.

### Details

**Ordering needed a shared clock.** The recording adapter now appends asset and MCP events to one `timeline`, prefixed by domain. Two independent logs can each say what happened within a domain but neither can say which came first — and "configuration applies last" is precisely a claim about that.

**Transaction coverage.** New tests cover a tri-write failure *after* configuration was applied (the only moment the journal must walk both domains back), frozen receipt-only server cleanup, frozen server conflicts, and a tampered declaration failing on integrity before the capability is reached at all.

**Consent branches.** Owned-identity drift is repair rather than takeover; a takeover-only request can be declined; a pre-`0.4` receipt reads existing entries as untracked occupancy; a second adapter inherits existing ownership without re-prompting.

**Multi-adapter agreement.** Previous tests counted outcomes, which proves each adapter did *something*. These read both documents and prove they did the *same* thing, including that one alias or omission applies everywhere.

**Build pipeline** had no MCP coverage at all: server-only facets now build end-to-end, invalid declarations preserve prior `dist/` output, and a build is proven not to spawn a process or open a connection.

**One structural guard.** A compile-time assignment in both directions pins the SDK's `McpServerDeclaration` to protocol's, so a local structural copy cannot silently diverge on the next protocol change.

### A pre-existing race in `install-view.test.tsx`, now fixed

One test failed once under full-suite load and passed on 18 subsequent isolated and parallel runs. It was not environmental.

Three fake drivers held a render phase open with a 25 ms timer while the test asserted after *its own* 25 ms timer. The two were separated only by the gap between `render()` returning and React flushing the passive effect that starts the driver — sub-millisecond. Any scheduler delay past that flipped the order, and the view had already repainted to the summary before the assertion ran. That is also why it could not be reproduced from outside the process: adding load to separate processes cannot perturb a race between two timers inside one.

The pattern is now inverted. `gate()` gives the driver a promise the test opens *after* asserting, so it cannot advance early in any scheduling order — there is no timer left to win. `waitForFrame()` closes the mirror-image failure by polling until the expected content appears instead of guessing how long a render takes.

Verified by control experiment. With an artificial 300 ms stall inserted before the assertion, the old timer-hold driver **fails** and the gated driver **passes**:

```
old timer-hold + 300ms starvation → (fail) timed out waiting for the collision stage
gated driver    + 300ms starvation → (pass)
```

The remaining `tick()` calls in that file are on drivers blocked by a UI-controlled promise (`resolveCollisions`, `resolveMcpConsent`, `resolveAssetTakeover`), which cannot advance without input and were never in this failure class. No production code was touched.

### Deliberately not covered

`specs/cli/spec.md` lists `conflicted` and `unsupported` among summary outcomes. Neither exists as a summary counter and neither can — both abort the run before a summary is produced. They are reported as failures instead, and that reporting is fully covered. If we'd rather the spec match the code exactly, that sentence should be narrowed before archiving.

### Verification

`bun check` passes (36/36 tasks). `bun openspec validate add-mcp-json-support --strict` passes with the permanent specs untouched.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and OpenSpec task checklist updates only; production MCP/install code paths are exercised more strictly but not modified in this PR.
> 
> **Overview**
> Finishes **cross-cutting acceptance** for `add-mcp-json-support` by marking OpenSpec tasks 19–20 complete and adding tests that the requirement matrix flagged as missing—**no production behavior changes** in this diff.
> 
> **Adapter contract & matrix harness:** Shared matrix gains `divergent-argument-order` and `divergent-environment-value`; `runMcpServerMatrix` now pins `HOME`/`USERPROFILE` and asserts the home directory stays empty (project-scoped writes). Claude Code, Codex, and OpenCode seeds add matching divergent cases plus full **write-path** checks on `absent-untracked` (including `env` / TOML / `environment`).
> 
> **Engine & build:** Install tests cover consent not banking on failure, owned drift vs takeover, multi-adapter config agreement, asset-before-MCP ordering via a shared **timeline** log, outside-project disclosure refusal, and frozen/rollback/removal paths. Build pipeline tests add server-only facets, invalid declarations preserving `dist/`, and no spawn/fetch during build. Adapter SDK gets a compile-time **protocol ↔ SDK** declaration type guard.
> 
> **CLI/UI:** E2E for piped server collisions; MCP approval shows all declarations/takeovers; `InstallView` tests for frozen stale overrides, pruned server overrides, and **gate**/`waitForFrame` instead of fixed sleeps for collision-phase timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84cf1b5f55570cf269496edd3b4ed54625c6a2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


