### PR TITLE
Expand CONTRIBUTING.md and update README docs

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -21,4 +21,4 @@ Not every PR needs a changeset — changes to docs, CI, or other non-published f
 
 ## For maintainers
 
-See the [Release Pipeline](https://docs.agentfacets.io/contributing/release-pipeline) docs for the full end-to-end release flow.
+When changesets are merged to `main`, CI opens a version PR. Merging that PR creates version tags, which trigger per-package publishing to npm.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -21,4 +21,4 @@ Not every PR needs a changeset — changes to docs, CI, or other non-published f
 
 ## For maintainers
 
-When changesets are merged to `main`, CI opens a version PR. Merging that PR creates version tags, which trigger per-package publishing to npm.
+When changesets are merged to `main`, CI opens a version PR. Merging that PR creates version tags, which trigger guarded publishing for eligible public packages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ bun install    # installs workspace dependencies + sets up git hooks
 - Push your branch to your fork, then open a PR against `agent-facets/facets:main`.
 - Keep PRs focused on a single change.
 - Run `bun check` before submitting — CI runs the same command.
-- Add a changeset for any user-facing changes (see below).
+- Add a changeset for changes to published packages (see below).
 
 ## Changesets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,60 @@
 # Contributing
 
-Thanks for your interest in contributing to Facets!
+Thanks for your interest in contributing to Agent Facets!
 
-Full contributing documentation is available at [docs.agentfacets.io/contributing/getting-started](https://docs.agentfacets.io/contributing/getting-started).
+## Prerequisites
 
-## Quick start
+- [mise](https://mise.jdx.dev) — manages tooling (Bun, lefthook) via `mise.toml`
+
+## Setup
+
+Fork [agent-facets/facets](https://github.com/agent-facets/facets) on GitHub, then clone your fork:
 
 ```sh
-mise install && bun install
+git clone git@github.com:<your-username>/facets.git
+cd facets
+git remote add upstream git@github.com:agent-facets/facets.git
 ```
 
-Run `bun check` before submitting a PR. Add a changeset with `bun change` for user-facing changes.
+Adding the `upstream` remote lets you pull in changes from the main repo later with `git fetch upstream`.
+
+Then install tools and dependencies:
+
+```sh
+mise install   # installs Bun + lefthook as specified in mise.toml
+bun install    # installs workspace dependencies + sets up git hooks
+```
+
+## Scripts
+
+| Command                         | Description                                                                  |
+| ------------------------------- |------------------------------------------------------------------------------|
+| `bun dev`                       | Run `facet` from source (e.g. `bun dev build ./my-facet`)                    |
+| `bun check`                     | Turborepo lint + typecheck + build + tests — run this before submitting a PR |
+| `bun format`                    | Biome auto-fix and format                                                    |
+| `bun run types`                 | Typecheck only                                                               |
+
+## Pull requests
+
+- Push your branch to your fork, then open a PR against `agent-facets/facets:main`.
+- Keep PRs focused on a single change.
+- Run `bun check` before submitting — CI runs the same command.
+- Add a changeset for any user-facing changes (see below).
+
+## Changesets
+
+Before submitting a PR that changes published packages, run:
+
+```sh
+bun change
+```
+
+Follow the prompts to select a bump type (patch/minor/major) and write a summary. Commit the generated `.md` file with your PR.
+
+A good changeset describes:
+
+- **What** the change is
+- **Why** the change was made
+- **How** a consumer should update their code (if applicable)
+
+Not every PR needs a changeset — changes to docs, CI, or other non-published files can skip this step. The [changeset bot](https://github.com/apps/changeset-bot) comments on every PR to indicate whether one is present.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Facets
 
-`facet` is a CLI package manager and toolkit for facets — modular skills, agents, commands, and MCP server declarations that extend AI coding assistants. A facet can declare MCP servers that install configures in each connected tool's own config file (`.mcp.json`, `opencode.jsonc`, `.codex/config.toml`), after you approve them; a facet may even ship servers and nothing else. Facets can also ship non-asset files — a `README.md`, a `LICENSE`, or skill companion files — that travel inside the archive; only skill companions materialize on disk. See the [docs](https://docs.agentfacets.io) for details.
+`facet` is a CLI package manager and toolkit for facets — modular skills, agents, commands, and MCP server declarations that extend AI coding assistants. A facet can declare MCP servers that are installed and configured in each connected tool's own config file (`.mcp.json`, `opencode.jsonc`, `.codex/config.toml`), after you approve them; a facet may even ship servers and nothing else. Facets can also ship non-asset files — a `README.md`, a `LICENSE`, or skill companion files — that travel inside the archive; only skill companions materialize on disk. See the [docs](https://docs.agentfacets.io) for details.
 
 The official registry for Agent Facets is [agentfacets.io](https://agentfacets.io) where you can publish and share facets.
 
@@ -36,10 +36,6 @@ Please see https://docs.agentfacets.io/cli for a detailed reference for the `fac
 # pulling teammate changes:
 facet install
 
-# In CI, or any run without a terminal, approve MCP server configuration
-# up front — otherwise a facet that declares servers fails before writing.
-facet install --accept-mcp
-
 # Update the CLI later
 facet self-update
 ```
@@ -61,7 +57,7 @@ The monorepo also contains private internals that are never published: `@agent-f
 ## Development
 
 ```sh
-mise trust && mist install  # tooling (Bun, lefthook) via mise.toml
+mise trust && mise install  # tooling (Bun, lefthook) via mise.toml
 bun install                 # dependencies + git hooks
 bun dev --version           # run the CLI from source and verify it works
 bun check                   # lint, typecheck, build, and tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Facets
 
-`facet` is a CLI package manager and toolkit for facets — modular skills, agents, commands, and tools that extend AI coding assistants. Facets can also ship non-asset files — a `README.md`, a `LICENSE`, or skill companion files — that travel inside the archive; only skill companions materialize on disk. See the [docs](https://docs.agentfacets.io) for details.
+`facet` is a CLI package manager and toolkit for facets — modular skills, agents, commands, and MCP server declarations that extend AI coding assistants. A facet can declare MCP servers that install configures in each connected tool's own config file (`.mcp.json`, `opencode.jsonc`, `.codex/config.toml`), after you approve them; a facet may even ship servers and nothing else. Facets can also ship non-asset files — a `README.md`, a `LICENSE`, or skill companion files — that travel inside the archive; only skill companions materialize on disk. See the [docs](https://docs.agentfacets.io) for details.
 
 The official registry for Agent Facets is [agentfacets.io](https://agentfacets.io) where you can publish and share facets.
 
@@ -20,64 +20,54 @@ npm install -g agent-facets
 # Add a facet to any project — this resolves, fetches, verifies, and
 # installs in one step. If the project has no AI adapters connected
 # yet, the picker launches automatically.
-facet add github:agent-facets/viper-plans
+facet add viper-plans
+```
+
+The public registry is free – see [agentfacets.io](https://agentfacets.io). A bare name (`facet add cowsay`) resolves against it; you can also install from `github:owner/repo`, an `https://...git` URL, an SCP-style git URL, or a local path.
+
+Please see https://docs.agentfacets.io/cli for a detailed reference for the `facet` CLI tool.
+
+### Other Commands
+
+```shell
+
 
 # Reapply an existing project's facets after a fresh clone or after
 # pulling teammate changes:
 facet install
 
+# In CI, or any run without a terminal, approve MCP server configuration
+# up front — otherwise a facet that declares servers fails before writing.
+facet install --accept-mcp
+
 # Update the CLI later
 facet self-update
 ```
 
-The public registry is open-beta — see [docs.agentfacets.io/roadmap](https://docs.agentfacets.io/roadmap). A bare name (`facet add cowsay`) resolves against it; you can also install from `github:owner/repo`, an `https://...git` URL, an SCP-style git URL, or a local path.
-
-Please see https://docs.agentfacets.io for detailed guidance and documentation for the `facet` CLI tool.
-
 ## Packages
 
-| Package                                   | NPM                       | Description                                                          |
-|-------------------------------------------|---------------------------|----------------------------------------------------------------------|
-| [CLI](packages/cli/AGENTS.md)             | `agent-facets`            | CLI tool for managing facets                                         |
-| [Protocol](packages/protocol/AGENTS.md)   | `@agent-facets/protocol`  | TypeScript reference implementation of the facet artifact spec — Node-native, public, consumed by registries and other third-party tools |
-| [Brand](packages/brand)                   | `@agent-facets/brand`     | Agent Facets branding and styles                                     |
+| Package                                              | NPM                                 | Description                                                                                                                              |
+|------------------------------------------------------|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| [CLI](packages/cli/AGENTS.md)                        | `agent-facets`                      | CLI tool for managing facets                                                                                                             |
+| [Protocol](packages/protocol/AGENTS.md)              | `@agent-facets/protocol`            | TypeScript reference implementation of the facet artifact spec — Node-native, public, consumed by registries and other third-party tools |
+| [Adapter SDK](packages/adapter)                      | `@agent-facets/adapter`             | Contract for building adapters that target an AI coding tool — asset storage plus MCP server configuration                               |
+| [Claude Code adapter](packages/adapters/claude-code) | `@agent-facets/adapter-claude-code` | First-party adapter for Claude Code                                                                                                      |
+| [Codex adapter](packages/adapters/codex)             | `@agent-facets/adapter-codex`       | First-party adapter for Codex                                                                                                            |
+| [OpenCode adapter](packages/adapters/opencode)       | `@agent-facets/adapter-opencode`    | First-party adapter for OpenCode                                                                                                         |
+| [Brand](packages/brand)                              | `@agent-facets/brand`               | Agent Facets branding and styles                                                                                                         |
 
-> The legacy `@agent-facets/core` package was split into `@agent-facets/protocol` (the published spec implementation) and `@agent-facets/engine` (Bun-native CLI machinery, private to this monorepo). The `@agent-facets/core` package is no longer published; it is frozen at v0.9.1 on npm. New consumers MUST use `@agent-facets/protocol`. See [`AGENTS.md`](AGENTS.md) for the full layer description.
+The monorepo also contains private internals that are never published: `@agent-facets/engine` (Bun-native CLI machinery), `@agent-facets/common` (shared primitives), and `@agent-facets/adapter-test-kit`. See [`AGENTS.md`](AGENTS.md) for the full layer description.
 
 ## Development
 
-### Prerequisites
-
-- [mise](https://mise.jdx.dev) — manages tooling (Bun, lefthook) via `mise.toml`
-
-### Setup
-
 ```sh
-# Install Bun + lefthook
-mise install
-
-# Install dependencies + set up git hooks
-bun install
-
-# Run the CLI locally (runs source directly, no compilation needed)
-bun dev --version
-bun dev build ./my-facet
-
-# Run lint, typecheck, build, and tests
-bun check
+mise trust && mist install  # tooling (Bun, lefthook) via mise.toml
+bun install                 # dependencies + git hooks
+bun dev --version           # run the CLI from source and verify it works
+bun check                   # lint, typecheck, build, and tests
 ```
 
-### Publishing
-
-This project uses [changesets](https://github.com/changesets/changesets) for versioning and publishing. See the [changeset README](.changeset/README.md) for more details.
-
-```bash
-bun change          # create a changeset describing your changes
-```
-
-When changesets are merged to `main`, CI will automatically open a version PR. Merging that PR creates version tags, which trigger per-package publishing to npm.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Versioning and publishing use [changesets](https://github.com/changesets/changesets) — run `bun change` for user-facing changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 
 ### Code Review
 

--- a/facets.json
+++ b/facets.json
@@ -9,5 +9,5 @@
     "worktrunk": "0.1.0",
     "openspec": "0.1.0"
   },
-  "manifestVersion": 0.2
+  "manifestVersion": 0.1
 }

--- a/facets.json
+++ b/facets.json
@@ -9,5 +9,5 @@
     "worktrunk": "0.1.0",
     "openspec": "0.1.0"
   },
-  "manifestVersion": 0.1
+  "manifestVersion": 0.2
 }


### PR DESCRIPTION
### Why

The `CONTRIBUTING.md` and `README.md` were pointing to external docs that either don't exist yet or are incomplete, leaving contributors without enough information to get started locally. The docs also didn't reflect the current package structure, MCP server support, or release flow.

### Details

- `CONTRIBUTING.md` is rewritten in-place with full setup instructions (fork/clone, `mise install`, `bun install`), a script reference table, PR guidelines, and changeset guidance — removing the dependency on an external docs site.
- `README.md` updated to describe MCP server declaration as a first-class facet capability, including per-tool config file targets and the `--accept-mcp` flag for CI installs.
- The packages table in `README.md` now lists the Adapter SDK and the three first-party adapters (Claude Code, Codex, OpenCode), and replaces the legacy `@agent-facets/core` deprecation notice with a note about private internals.
- The development section in `README.md` is condensed to a minimal snippet and defers to `CONTRIBUTING.md` for the full guide.
- The changeset README replaces the broken external link with an inline description of the version PR and per-package publish flow.

### Verification

CI (`bun check`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or publishing behavior impact.
> 
> **Overview**
> **Contributor onboarding** no longer depends on incomplete external docs: `CONTRIBUTING.md` now covers fork/clone, `upstream`, `mise`/`bun` setup, a scripts table, PR expectations, and changeset guidance in-repo.
> 
> **README** is updated to position **MCP server declarations** as a first-class facet capability (per-tool config paths and user approval), simplify the quickstart (`facet add viper-plans`), point CLI details to `docs.agentfacets.io/cli`, expand the **packages** table with the Adapter SDK and first-party adapters, and replace the legacy `@agent-facets/core` note with private monorepo packages. The **Development** section is shortened and defers publishing/contributor detail to `CONTRIBUTING.md`.
> 
> **`.changeset/README.md`** replaces a broken release-pipeline doc link with a short inline description of the version PR → tags → publish flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58308395758b0d4e5fd5bc2a65f47d5ed489c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor guidance with setup requirements, development scripts, pull request expectations, and changeset instructions.
  * Updated the README with MCP server configuration, facet file details, installation guidance, package listings, and simplified development steps.
  * Clarified the release process, including automated version pull requests, tags, and package publishing.
* **Updates**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->