### PR TITLE
Rename `facet adapter install` to `add`, keep `install` as a deprecated alias

### DIFF
--- a/.changeset/agent-facets-cli.md
+++ b/.changeset/agent-facets-cli.md
@@ -2,20 +2,6 @@
 "agent-facets": minor
 ---
 
-<!--
-DEFERRED CHANGESET — not in `.changeset/`, and deliberately so.
-
-Move this file to `.changeset/` only after `@agent-facets/adapter-claude-code`,
-`@agent-facets/adapter-opencode`, and `@agent-facets/adapter-codex` all report
-`facetAdapterApiVersion: 0.3` on npm. See "Adapter API compatibility rollout"
-in `scripts/release/README.md`.
-
-Leaving it in `.changeset/` would put the CLI and the adapters in one Version
-PR, whose tags publish in parallel — the exact race the adapter-first order
-exists to prevent. A note asking a human not to merge it is not a mechanism;
-its absence from `.changeset/` is.
--->
-
 **Every file an operation changes is now restorable to its exact prior state.** Assets, native MCP documents, and the project's own `facets.json`, `facets.lock`, and receipt all commit through one filesystem transaction that records each change as the exact state before and the exact state after. Adapters no longer write anything: they return exact per-file transitions, and the CLI commits them.
 
 **A file the run only inspected is never journaled**, so a concurrent edit to it survives a rollback untouched. **A file this run wrote and something else then changed is preserved and reported by path** rather than overwritten, and rollback continues past it so one contested file cannot strand the rest. **Restoration is byte-exact**, including permission bits, so YAML front matter and TOML formatting come back as authored instead of being re-rendered from parsed data. **A file already holding the bytes a plan would write contributes no change**, so a re-install touches no modification time.

--- a/.changeset/ready-dancers-poke.md
+++ b/.changeset/ready-dancers-poke.md
@@ -1,0 +1,7 @@
+---
+"agent-facets": minor
+---
+
+**`facet adapter install` is now `facet adapter add`.** The verb matches the split it mirrors at the top level: `add` takes a specifier and installs what you name, `install` takes none. Every reinstall command the CLI prints — next to a failing entry in `facet adapter list`, and in the compatibility diagnostics that stop `facet build`, `facet add`, `facet remove`, and `facet install` — now names `facet adapter add`.
+
+The old spelling keeps working as a deprecated alias. It runs the same code, produces the same stdout, and exits with the same code; the only difference is one deprecation notice on stderr naming the new command. No existing script breaks, and nothing parsing stdout sees a change.

--- a/docs/cli/adapters/add.mdx
+++ b/docs/cli/adapters/add.mdx
@@ -1,17 +1,21 @@
 ---
-title: facet adapter install
+title: facet adapter add
 description: Installs an adapter
 ---
 
 ## Usage
 
 ```sh
-facet adapter install [specifier]
+facet adapter add [specifier]
 ```
 
 Installs an adapter from the given specifier. An adapter is a way for the `facet` system to talk to external tools, most often AI coding harnesses (OpenCode, Claude Code, Codex, etc.). Adapters define where assets and configuration live on disk.
 
 Run with no specifier to choose from an interactive picker of the first-party adapters (TTY only) — in a non-interactive shell the no-argument form fails with a structured error and exit `1`.
+
+<Note>
+`facet adapter install` is a deprecated alias of `add`. It still installs exactly the same way and exits with the same code; it just prints a deprecation notice on stderr first. Prefer `add`, which mirrors the top-level split: [`facet add`](/cli/add) takes a specifier, [`facet install`](/cli/install) takes none.
+</Note>
 
 ## Built-in adapters
 
@@ -34,7 +38,7 @@ A per-install `--target-dir` flag is intentionally not supported: later invocati
 
 ## What it does
 
-The install flow stages and verifies a candidate before it ever touches the existing installation:
+The flow stages and verifies a candidate before it ever touches the existing installation:
 
 1. Download (or clone/copy) the source and bundle it into a self-contained `adapter.js` in temporary storage.
 2. Verify the bundle: it must export a valid adapter that declares a supported adapter API. For npm sources the runtime declaration must also match the package metadata used for selection.
@@ -49,31 +53,31 @@ Any failure **before** activation leaves the existing installation untouched —
 <CodeGroup>
 
 ```sh Built-in name
-facet adapter install opencode
+facet adapter add opencode
 # resolves to the first-party npm package
 ```
 
 ```sh npm package
-facet adapter install @acme/adapter-custom          # highest compatible release
-facet adapter install @acme/adapter-custom@1.2.3    # exact version — fails if incompatible
-facet adapter install @acme/adapter-custom@1.*      # highest compatible in the range
-facet adapter install opencode@latest               # explicit latest = highest compatible
+facet adapter add @acme/adapter-custom          # highest compatible release
+facet adapter add @acme/adapter-custom@1.2.3    # exact version — fails if incompatible
+facet adapter add @acme/adapter-custom@1.*      # highest compatible in the range
+facet adapter add opencode@latest               # explicit latest = highest compatible
 ```
 
 ```sh Git URL
-facet adapter install git+https://github.com/user/repo.git#v1.0.0
+facet adapter add git+https://github.com/user/repo.git#v1.0.0
 # clones the repository; optional #ref pins a tag, branch, or commit
 ```
 
 ```sh Local path
-facet adapter install ./path/to/adapter
+facet adapter add ./path/to/adapter
 # uses a local directory
 ```
 
 </CodeGroup>
 
 <Note>
-Adapter specifiers accept `git+` URLs even though facet sources for [`facet add`](/cli/add) reject them — adapter installs and facet installs follow different source rules.
+Adapter specifiers accept `git+` URLs even though facet sources for [`facet add`](/cli/add) reject them — adapters and facets follow different source rules.
 </Note>
 
 Version selectors use the Facet grammar: exact `1.2.3`, major wildcard `1.*`, minor wildcard `1.2.*`, `*`, or `latest`. npm range syntax (`^1.2.3`, `~1.2.3`, comparators, hyphen/OR/x-ranges, prerelease tags) is rejected with an error listing the supported forms.

--- a/docs/cli/adapters/list.mdx
+++ b/docs/cli/adapters/list.mdx
@@ -14,10 +14,10 @@ Lists all installed adapters by inspecting the adapter base directory, `$FACET_D
 ```text
 Installed adapters:
   claude-code  api 0.3      supported
-  legacy-tool  api 0.2      unsupported — reinstall: facet adapter install legacy-tool
-  codex        api 0.0      unsupported — reinstall: facet adapter install codex
-  opencode     api missing  unsupported — reinstall: facet adapter install opencode
-  my-tool      api unknown  broken (bundle failed to load) — reinstall: facet adapter install my-tool
+  legacy-tool  api 0.2      unsupported — reinstall: facet adapter add legacy-tool
+  codex        api 0.0      unsupported — reinstall: facet adapter add codex
+  opencode     api missing  unsupported — reinstall: facet adapter add opencode
+  my-tool      api unknown  broken (bundle failed to load) — reinstall: facet adapter add my-tool
 ```
 
 ## Output columns
@@ -29,7 +29,7 @@ Installed adapters:
 `supported` means the adapter **loads**. It does not mean the adapter can configure MCP servers: a supported adapter may still decline MCP support. If an install fails because an adapter [cannot configure MCP servers](/cli/install#adapters-that-cannot-configure-mcp-servers), that failure names the adapter and the right fix — this listing will show it as `supported`.
 </Note>
 
-Listing stays available when entries are incompatible or broken — run it to find the best available `facet adapter install <specifier>` command next to each failing entry.
+Listing stays available when entries are incompatible or broken — run it to find the best available `facet adapter add <specifier>` command next to each failing entry.
 
 <Note>
 If an adapter was originally installed with an **exact** npm version, such as `my-adapter@1.2.3`, its printed command preserves that exact pin. Re-running it fails again when that release is incompatible rather than silently upgrading. Drop or change the exact selector — use the bare package name, `@latest`, or a wider selector such as `1.*` — so the CLI can select the highest compatible release. Git and local commands rebuild the same supplied source, so that source must itself be updated when incompatible.
@@ -43,5 +43,5 @@ If an adapter was originally installed with an **exact** npm version, such as `m
 
 ## See also
 
-- [`facet adapter install`](/cli/adapters/install) -- install an adapter.
+- [`facet adapter add`](/cli/adapters/add) -- install an adapter.
 - [`facet adapter remove`](/cli/adapters/remove) -- remove an installed adapter.

--- a/docs/cli/adapters/remove.mdx
+++ b/docs/cli/adapters/remove.mdx
@@ -20,5 +20,5 @@ Removes an installed adapter by deleting its directory from the adapter base dir
 
 ## See also
 
-- [`facet adapter install`](/cli/adapters/install) -- install an adapter.
+- [`facet adapter add`](/cli/adapters/add) -- install an adapter.
 - [`facet adapter list`](/cli/adapters/list) -- list installed adapters.

--- a/docs/cli/add.mdx
+++ b/docs/cli/add.mdx
@@ -11,7 +11,7 @@ facet add <source> [more sources...]
 
 Adds the named facet(s) to `facets.json` and immediately installs them into every connected adapter. There is no separate "install after add" step  -- `facet add` is the single command for bringing a new facet into a project.
 
-Every source specifier is validated first. If the project then has no adapters installed, `facet add` launches the adapter picker — but only when the terminal can prompt. Otherwise it exits with an error pointing at `facet adapter install`.
+Every source specifier is validated first. If the project then has no adapters installed, `facet add` launches the adapter picker — but only when the terminal can prompt. Otherwise it exits with an error pointing at `facet adapter add`.
 
 ## Examples
 
@@ -162,4 +162,4 @@ What gets written per specifier shape is defined by the [manifest-write policy](
 ## See also
 
 - [`facet install`](/cli/install)  -- re-runs the install pipeline against the current `facets.json` and lockfile, useful after a fresh `git clone` or to reapply assets after manual edits.
-- [`facet adapter install`](/cli/adapters/install)  -- install adapters into your machine.
+- [`facet adapter add`](/cli/adapters/add)  -- install adapters into your machine.

--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -28,7 +28,7 @@ no separate per-subsystem env vars.
 
 ```sh
 export FACET_DIR=/opt/facet
-facet adapter install opencode
+facet adapter add opencode
 # adapter lands in /opt/facet/adapters/opencode/generations/<id>/adapter.js
 # with its receipt at /opt/facet/adapters/opencode/installation.json
 # cache lands in /opt/facet/cache/<name>@<version>/
@@ -36,7 +36,7 @@ facet adapter install opencode
 # adapter replacement locks land in /opt/facet/locks/adapter-<name>-<hash>.lock
 ```
 
-Each adapter directory is a **managed installation**: the `installation.json` receipt records the active generation, the verified adapter API, and the source provenance used to install it (specifier, resolved npm package/version, integrity). Replacements stage a new generation and switch the receipt atomically — see [`facet adapter install`](/cli/adapters/install#what-it-does).
+Each adapter directory is a **managed installation**: the `installation.json` receipt records the active generation, the verified adapter API, and the source provenance used to install it (specifier, resolved npm package/version, integrity). Replacements stage a new generation and switch the receipt atomically — see [`facet adapter add`](/cli/adapters/add#what-it-does).
 
 Whitespace-only values (`FACET_DIR=`, `FACET_DIR=" "`) are treated as
 unset so a misconfigured shell rc doesn't accidentally point everything

--- a/docs/cli/help.mdx
+++ b/docs/cli/help.mdx
@@ -32,7 +32,7 @@ Lists every registered command with a short description. Aliases (e.g., `self-up
 ```sh
 facet add --help
 facet build --help
-facet adapter install --help
+facet adapter add --help
 ```
 
 Shows the command's usage line, description, available flags with defaults, and a `--help` flag reference.

--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -56,7 +56,7 @@ Reads `facets.json`, fetches and materializes every facet declared there, and wr
 
 <Steps>
   <Step title="Validate the project">
-    `facets.json` must exist, and at least one **install-capable** adapter must be installed. If none are, the picker launches when the terminal can prompt; otherwise the command exits pointing at [`facet adapter install`](/cli/adapters/install). Installed-but-incompatible adapters fail here rather than falling through to the picker.
+    `facets.json` must exist, and at least one **install-capable** adapter must be installed. If none are, the picker launches when the terminal can prompt; otherwise the command exits pointing at [`facet adapter add`](/cli/adapters/add). Installed-but-incompatible adapters fail here rather than falling through to the picker.
   </Step>
   <Step title="Run the install pipeline">
     Runs the [install pipeline](/specification/install) with an empty delta: acquire the install lock, resolve and [verify](/specification/commit#verify) *every* declared facet ([honoring satisfying lockfile pins](/specification/commit#resolve)), [compose one global plan](/specification/commit#compose) checking for name collisions, check that every selected adapter can configure any active MCP servers, ask each adapter to [prepare](/specification/commit#reconciliation) its native MCP change read-only, obtain [MCP approval](#mcp-servers), then [remove drift](/specification/commit#drift-removal) and materialize assets into every adapter, apply the prepared MCP changes, and finally [write manifest + lockfile + receipt atomically](/specification/commit#transactional-tri-write).
@@ -251,5 +251,5 @@ The non-interactive report also lists every existing entry the run would take ov
 ## See also
 
 - [`facet add`](/cli/add)  -- adds a new facet to `facets.json` and installs it in one step.
-- [`facet adapter install`](/cli/adapters/install)  -- install adapters that `facet install` materializes facets into.
+- [`facet adapter add`](/cli/adapters/add)  -- install adapters that `facet install` materializes facets into.
 - [Installation specification](/specification/install)  -- the two-phase pipeline this command runs.

--- a/docs/cli/instructions.mdx
+++ b/docs/cli/instructions.mdx
@@ -61,5 +61,5 @@ The instructions point agents at the non-interactive, machine-readable surfaces:
 - [`facet modify`](/cli/authoring/modify) — make scriptable edits to a facet.
 - [`facet build`](/cli/authoring/build) — build, or `--verify` to validate without output.
 - [`facet add`](/cli/add) — add facets to a project (registry-first).
-- [`facet adapter`](/cli/adapters/install) — install and manage adapter tooling.
+- [`facet adapter`](/cli/adapters/add) — install and manage adapter tooling.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,13 @@
     "dark": "#4C1D95"
   },
   "favicon": "/assets/favicon.ico",
+  "redirects": [
+    {
+      "source": "/cli/adapters/install",
+      "destination": "/cli/adapters/add",
+      "permanent": true
+    }
+  ],
   "navigation": {
     "tabs": [
       {
@@ -89,7 +96,7 @@
           {
             "group": "Adapters",
             "icon": "wrench",
-            "pages": ["cli/adapters/install", "cli/adapters/list", "cli/adapters/remove"]
+            "pages": ["cli/adapters/add", "cli/adapters/list", "cli/adapters/remove"]
           },
           {
             "group": "Authentication",

--- a/docs/guides/custom-adapters.mdx
+++ b/docs/guides/custom-adapters.mdx
@@ -3,7 +3,7 @@ title: Build a Custom Adapter
 description: Write custom adapters for AI coding tools
 ---
 
-An <Tooltip headline="Adapter" tip={<span>The bridge between facets and an AI coding tool. It tells <code>facet</code> where and how to write a facet's assets on disk so the tool can find them.</span>} cta="Adapter reference" href="/cli/adapters/install">adapter</Tooltip> teaches the `facet` CLI how to install assets into a specific AI coding tool. The first-party adapters cover Claude Code, OpenCode, and Codex; this guide shows how to build your own using the [`@agent-facets/adapter`](https://github.com/agent-facets/facets/tree/main/packages/adapter) SDK.
+An <Tooltip headline="Adapter" tip={<span>The bridge between facets and an AI coding tool. It tells <code>facet</code> where and how to write a facet's assets on disk so the tool can find them.</span>} cta="Adapter reference" href="/cli/adapters/add">adapter</Tooltip> teaches the `facet` CLI how to install assets into a specific AI coding tool. The first-party adapters cover Claude Code, OpenCode, and Codex; this guide shows how to build your own using the [`@agent-facets/adapter`](https://github.com/agent-facets/facets/tree/main/packages/adapter) SDK.
 
 An adapter is a small TypeScript library. You write one file, build it, and install it locally  -- from a directory, from GitHub, or (once published) by name.
 
@@ -75,9 +75,9 @@ An adapter is a small TypeScript library. You write one file, build it, and inst
 > Build with `tsdown`/`tsc`, then install:
 >
 > ```sh
-> facet adapter install ./my-adapter                        # local directory
-> facet adapter install git+https://github.com/you/repo.git # from GitHub
-> facet adapter install my-adapter                           # by npm name, once published
+> facet adapter add ./my-adapter                        # local directory
+> facet adapter add git+https://github.com/you/repo.git # from GitHub
+> facet adapter add my-adapter                          # by npm name, once published
 > ```
 
 </Visibility>
@@ -369,7 +369,7 @@ Configuring a server is not running one. Never launch the command, connect to th
 
 ## Bundle it
 
-`facet adapter install` re-bundles your adapter into a self-contained `adapter.js`, but it needs a clean single-module entry to start from. Compile your package first  -- for example with `tsdown` (what the first-party adapters use) or `tsc`:
+`facet adapter add` re-bundles your adapter into a self-contained `adapter.js`, but it needs a clean single-module entry to start from. Compile your package first  -- for example with `tsdown` (what the first-party adapters use) or `tsc`:
 
 ```sh
 bunx tsdown src/index.ts
@@ -379,32 +379,32 @@ Point your `package.json` `exports`/`main` at the compiled entry so the CLI can 
 
 ## Install your adapter
 
-`facet adapter install` accepts your adapter three ways:
+`facet adapter add` accepts your adapter three ways:
 
 <CodeGroup>
 
 ```sh Local directory
 # Fastest while developing — installs from a local build.
-facet adapter install ./my-adapter
+facet adapter add ./my-adapter
 ```
 
 ```sh Git repository
 # Note the git+ prefix; add #ref to pin a tag or branch.
-facet adapter install git+https://github.com/you/my-adapter.git
-facet adapter install git+https://github.com/you/my-adapter.git#v1.0.0
+facet adapter add git+https://github.com/you/my-adapter.git
+facet adapter add git+https://github.com/you/my-adapter.git#v1.0.0
 ```
 
 ```sh npm package
 # By package name, once you've published it.
-facet adapter install my-adapter
+facet adapter add my-adapter
 ```
 
 </CodeGroup>
 
-The CLI downloads the source, bundles it into `adapter.js`, verifies it exports a valid adapter, and places it in `$FACET_DIR/adapters/<name>/` (default `~/.facet`). See [`facet adapter install`](/cli/adapters/install) for every specifier format.
+The CLI downloads the source, bundles it into `adapter.js`, verifies it exports a valid adapter, and places it in `$FACET_DIR/adapters/<name>/` (default `~/.facet`). See [`facet adapter add`](/cli/adapters/add) for every specifier format.
 
 <Tip>
-  During development, `facet adapter install ./my-adapter` picks up your latest local build immediately. Reinstall after each rebuild to test changes end-to-end.
+  During development, `facet adapter add ./my-adapter` picks up your latest local build immediately. Reinstall after each rebuild to test changes end-to-end.
 </Tip>
 
 ## Verify it works
@@ -424,7 +424,7 @@ Note that `supported` answers whether the adapter **loads**, not whether it can 
 
 ## Publish to npm
 
-Installing by bare name (`facet adapter install my-adapter`) resolves through npm, and the CLI selects a release **before downloading it** by reading one required field from your published `package.json`:
+Installing by bare name (`facet adapter add my-adapter`) resolves through npm, and the CLI selects a release **before downloading it** by reading one required field from your published `package.json`:
 
 ```json package.json
 {
@@ -436,7 +436,7 @@ Declare the adapter API version your SDK release stamps at runtime (currently `0
 
 Selection is by **package version** among compatible releases; the supported API tokens are an unordered set, so numeric ordering confers nothing — the highest satisfying release that declares a supported token wins. The npm `latest` dist-tag is never consulted, so you never need to move, pin, or withhold it for compatibility.
 
-That is what makes publishing safe for consumers on older CLIs: a CLI supporting only `{0.2}` keeps selecting your highest `0.2` release and ignores the `0.3` one. The exception is an **exact** request (`facet adapter install my-adapter@1.4.0`), which is never substituted — it fails if that specific release is incompatible with the CLI asking.
+That is what makes publishing safe for consumers on older CLIs: a CLI supporting only `{0.2}` keeps selecting your highest `0.2` release and ignores the `0.3` one. The exception is an **exact** request (`facet adapter add my-adapter@1.4.0`), which is never substituted — it fails if that specific release is incompatible with the CLI asking.
 
 The canonical values are exported from `@agent-facets/adapter/api-version` (`ADAPTER_API_VERSION` and `ADAPTER_API_VERSION_PACKAGE_FIELD`), so release tooling can inject the field instead of hardcoding it. That entry and `@agent-facets/adapter/terminal` are both dependency-free, so importing either one costs you nothing at runtime.
 
@@ -444,6 +444,6 @@ The canonical values are exported from `@agent-facets/adapter/api-version` (`ADA
 
 Built an adapter for a major AI coding assistant? Contributions are welcome. If your adapter targets a widely used tool, open a pull request on the [facets repository](https://github.com/agent-facets/facets) to share it upstream as a first-party adapter.
 
-A first-party adapter is installable by name (`facet adapter install <name>`) via the CLI, so everyone using that tool benefits.
+A first-party adapter is installable by name (`facet adapter add <name>`) via the CLI, so everyone using that tool benefits.
 
 </Visibility>

--- a/docs/guides/install-facets.mdx
+++ b/docs/guides/install-facets.mdx
@@ -16,7 +16,7 @@ Bring facets into a project in two moves: connect an adapter for your AI tool, t
 > The short version:
 >
 > ```sh
-> facet adapter install claude-code   # connect your AI tool (once per machine)
+> facet adapter add claude-code       # connect your AI tool (once per machine)
 > facet add viper-plans               # registry-first: a bare name is a registry facet
 > facet add viper-plans@1.2.3         # or pin a version
 > facet install                       # after a git clone: materialize from the lockfile
@@ -42,7 +42,7 @@ Bring facets into a project in two moves: connect an adapter for your AI tool, t
 > Approval is per machine, so a teammate's approval never covers yours.
 >
 > See [`facet add`](/cli/add), [`facet install`](/cli/install),
-> [`facet remove`](/cli/remove), and [`facet adapter install`](/cli/adapters/install).
+> [`facet remove`](/cli/remove), and [`facet adapter add`](/cli/adapters/add).
 
 </Visibility>
 
@@ -53,10 +53,10 @@ Bring facets into a project in two moves: connect an adapter for your AI tool, t
 An adapter is the bridge between facets and your AI coding tool  -- it tells the CLI where to place assets on disk, and how to write MCP server configuration into that tool's own config file, so your tool can find both. You need at least one before adding facets.
 
 ```sh
-facet adapter install claude-code
+facet adapter add claude-code
 ```
 
-The first-party adapters are `claude-code`, `opencode`, and `codex`. Run [`facet adapter install`](/cli/adapters/install) with no name for an interactive picker, or pass a name to install it directly. Third-party adapters install the same way from an npm package, git URL, or local path.
+The first-party adapters are `claude-code`, `opencode`, and `codex`. Run [`facet adapter add`](/cli/adapters/add) with no name for an interactive picker, or pass a name to install it directly. Third-party adapters install the same way from an npm package, git URL, or local path.
 
 All three first-party adapters support MCP server configuration. A third-party adapter that declares no MCP support still works fine for a project with no MCP servers, but [blocks one that has them](/cli/install#adapters-that-cannot-configure-mcp-servers).
 
@@ -341,6 +341,6 @@ facet adapter list                # what's connected
 facet adapter remove opencode     # disconnect one
 ```
 
-See the [adapter reference](/cli/adapters/install) for details. Connecting an adapter later hands it everything this project already owns: the next install materializes those assets and MCP servers into the new tool too, because ownership is recorded per project rather than per adapter.
+See the [adapter reference](/cli/adapters/add) for details. Connecting an adapter later hands it everything this project already owns: the next install materializes those assets and MCP servers into the new tool too, because ownership is recorded per project rather than per adapter.
 
 </Visibility>

--- a/docs/guides/setup.mdx
+++ b/docs/guides/setup.mdx
@@ -42,10 +42,10 @@ What you need before adding, authoring, or publishing facets. If you just want t
   </Step>
 
   <Step title="Connect an adapter (required before adding facets)">
-    A facet is only useful once it's materialized into an AI tool, which the <Tooltip tip="An adapter is the bridge between facet and a specific AI coding tool.">adapter</Tooltip> handles. Install one per machine with [`facet adapter install`](/cli/adapters/install):
+    A facet is only useful once it's materialized into an AI tool, which the <Tooltip tip="An adapter is the bridge between facet and a specific AI coding tool.">adapter</Tooltip> handles. Install one per machine with [`facet adapter add`](/cli/adapters/add):
 
     ```sh
-    facet adapter install claude-code   # or: opencode, codex
+    facet adapter add claude-code   # or: opencode, codex
     facet adapter list
     ```
 

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -26,10 +26,10 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
   <Accordion title='"no adapters installed" when running facet add (non-interactive)'>
     **Cause:** a facet has to be materialized into at least one adapter, but none is connected. In a real terminal `facet add` shows a picker; in a non-interactive shell (CI, piped stdin) it exits with an error instead.
 
-    **Fix:** install an adapter first with [`facet adapter install`](/cli/adapters/install):
+    **Fix:** install an adapter first with [`facet adapter add`](/cli/adapters/add):
 
     ```sh
-    facet adapter install claude-code
+    facet adapter add claude-code
     facet adapter list
     ```
   </Accordion>
@@ -49,11 +49,11 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
 
     ```sh
     facet adapter list
-    # my-adapter  api missing  unsupported — reinstall: facet adapter install my-adapter
-    facet adapter install my-adapter
+    # my-adapter  api missing  unsupported — reinstall: facet adapter add my-adapter
+    facet adapter add my-adapter
     ```
 
-    Reinstalling selects the newest release compatible with this CLI. See [compatible resolution](/cli/adapters/install#compatible-resolution) for how selection works, and note that [`facet adapter remove`](/cli/adapters/remove) always works regardless of compatibility.
+    Reinstalling selects the newest release compatible with this CLI. See [compatible resolution](/cli/adapters/add#compatible-resolution) for how selection works, and note that [`facet adapter remove`](/cli/adapters/remove) always works regardless of compatibility.
   </Accordion>
 
   <Accordion title='"unsupported archive format" on install'>

--- a/docs/roadmap/alpha.mdx
+++ b/docs/roadmap/alpha.mdx
@@ -30,7 +30,7 @@ The alpha is the **current phase**. The core loop  -- author, publish, discover,
 
 **Platform**
 
-- [`facet adapter`](/cli/adapters/install)  -- install/list/remove adapters; first-party adapters for Claude Code, OpenCode, and Codex; a public [adapter SDK](/guides/custom-adapters) for building your own
+- [`facet adapter`](/cli/adapters/add)  -- add/list/remove adapters; first-party adapters for Claude Code, OpenCode, and Codex; a public [adapter SDK](/guides/custom-adapters) for building your own
 - [`facet instructions`](/cli/instructions)  -- built-in usage guidance for AI agents
 - [`facet self-update`](/cli/self-update)  -- update the CLI in place
 

--- a/docs/specification/terminology.mdx
+++ b/docs/specification/terminology.mdx
@@ -20,7 +20,7 @@ Canonical terms used throughout the specification. Implementations SHOULD use th
   <Card title="Facet archive" icon="package" href="/specification/archive">
     The self-contained two-layer `.facet` artifact the author's CLI builds and the registry stores. The transport form between publish and install.
   </Card>
-  <Card title="Adapter" icon="plug" href="/cli/adapters/install">
+  <Card title="Adapter" icon="plug" href="/cli/adapters/add">
     An AI coding tool abstraction (OpenCode, Claude Code, Codex). The layer between a facet's contributions and the tool's own conventions — both asset storage and native MCP project configuration.
   </Card>
   <Card title="Registry" icon="database" href="/specification/publish#what-the-registry-does">

--- a/openspec/specs/adapter__management/spec.md
+++ b/openspec/specs/adapter__management/spec.md
@@ -4,7 +4,7 @@ Users install, list, and remove adapters (AI coding tool integrations) through t
 ## Requirements
 ### Requirement: Users can install adapters from multiple sources
 
-The system SHALL provide a command to install adapters. The command SHALL accept specifiers in multiple formats: built-in names for first-party adapters, npm package names, Git URLs using standard Git protocols, and local filesystem paths.
+The system SHALL provide a command to install adapters, named `facet adapter add`. The command SHALL accept specifiers in multiple formats: built-in names for first-party adapters, npm package names, Git URLs using standard Git protocols, and local filesystem paths.
 
 #### Scenario: Install a first-party adapter by name
 
@@ -264,7 +264,7 @@ A managed installation SHALL retain its original source specifier, verified adap
 
 - **WHEN** a managed npm adapter is later found incompatible or broken
 - **THEN** its retained provenance SHALL include the original install specifier, resolved package name and version, verified adapter API, and registry integrity
-- **AND** the CLI SHALL be able to present `facet adapter install <specifier>` as the repair command
+- **AND** the CLI SHALL be able to present `facet adapter add <specifier>` as the repair command
 
 #### Scenario: Git or local installation retains source-specific provenance
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -305,6 +305,45 @@ The system SHALL register an `install` command that brings the project on disk i
 - **THEN** the system SHALL print a usage error directing the user to `add` for adding new facets
 - **AND** the process SHALL exit with code 1
 
+### Requirement: Adapter command is registered
+
+The system SHALL register an `adapter` command that manages the adapter tooling installed on the machine, exposing the subcommands `add`, `list`, and `remove`. `add` SHALL be the canonical name for installing an adapter and SHALL accept an optional source specifier, matching the top-level split where the command that takes a specifier is named `add` and the command that takes none is named `install`.
+
+The system SHALL also accept `install` as a deprecated alias of `add`, so users with muscle memory for the former name succeed; both names SHALL invoke identical behavior. An operational invocation of the alias SHALL additionally emit a deprecation notice naming the canonical name. That notice SHALL be written to stderr, so it cannot corrupt output a caller consumes from stdout, and it SHALL NOT change the command's exit code.
+
+Advertised usage, per-command help, and recovery guidance SHALL name only the canonical subcommands, and every repair or recovery command the CLI renders for an adapter SHALL name `add` rather than the deprecated alias.
+
+#### Scenario: Adapter command is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the help output SHALL list the `adapter` command with its description
+
+#### Scenario: Adapter add installs the named adapter
+
+- **WHEN** a user runs `adapter add` with a source specifier
+- **THEN** the system SHALL install the adapter identified by that specifier
+- **AND** the system SHALL NOT emit a deprecation notice
+
+#### Scenario: Deprecated install alias produces identical behavior
+
+- **WHEN** a user runs `adapter install` with the same arguments as a corresponding `adapter add` invocation
+- **THEN** the system SHALL produce the same stdout output, the same side effects, and the same exit code as `adapter add`
+- **AND** the system SHALL write a deprecation notice to stderr naming `adapter add` as the command to use instead
+
+#### Scenario: Usage lists only the canonical subcommands
+
+- **WHEN** a user runs `adapter` with no subcommand
+- **THEN** the system SHALL print a usage error listing `add`, `list`, and `remove`
+- **AND** the usage error SHALL NOT advertise the deprecated alias
+- **AND** the process SHALL exit with code 1
+
+#### Scenario: Unknown adapter subcommand names the canonical set
+
+- **WHEN** a user runs `adapter` with a subcommand that is neither registered nor the deprecated alias
+- **THEN** the system SHALL print an error identifying the unknown subcommand
+- **AND** the error SHALL name `add`, `list`, and `remove` as the available subcommands
+- **AND** the process SHALL exit with code 1
+
 ### Requirement: Add and install render a unified progress view
 
 The `add` and `install` commands SHALL present progress through a single shared rendering. A user watching either command SHALL see the same shape of output: a per-facet section that names each facet, indicates its current stage, and shows whether it succeeded, failed, or is in progress, followed by a final summary that lists each affected facet on its own line.

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -1189,7 +1189,7 @@ When the operation has MCP work to do, the system SHALL additionally require eve
 
 - **WHEN** a facet operation detects an incompatible selected adapter or missing MCP support
 - **THEN** the system SHALL NOT download or activate a replacement adapter automatically
-- **AND** the failure SHALL direct the user to an explicit adapter install command
+- **AND** the failure SHALL direct the user to an explicit `facet adapter add` command
 
 ### Requirement: Removing a facet uninstalls it
 

--- a/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/adapter-install-cli.e2e.test.ts
@@ -7,7 +7,7 @@ import { CLI_PATH, spawnCli } from './helpers/cli-process.ts'
 
 /**
  * End-to-end integration tests that spawn the compiled `./dist/facet` binary
- * as a subprocess and verify adapter install / list / remove behavior.
+ * as a subprocess and verify adapter add / list / remove behavior.
  *
  * These tests exercise the full real code path:
  *   - argv parsing and exit codes
@@ -15,7 +15,7 @@ import { CLI_PATH, spawnCli } from './helpers/cli-process.ts'
  *   - `bundleAdapter` (fast path + slow-path fallback in `locateAndVerifyAdapter`)
  *   - `verifyAdapter` (dynamic import of the bundle)
  *   - `placeAdapter` / `listInstalledAdapters` / `removeAdapter`
- *   - temp-dir cleanup in the `handleInstall` finally block
+ *   - temp-dir cleanup in the `handleAdd` finally block
  *
  * Isolation: each test sets `FACET_DIR` to a unique `mkdtemp` dir
  * so the user's real `~/.facet/adapters/` is never touched.
@@ -243,12 +243,12 @@ beforeAll(async () => {
   }
 })
 
-describe('facet adapter install — fast path from extracted npm tarball', () => {
+describe('facet adapter add — fast path from extracted npm tarball', () => {
   test('installs from a packed tarball using the prebuilt dist/index.mjs', async () => {
     const extractedDir = await packOpencode()
     const facetDir = await makeFacetDir()
     try {
-      const result = await runCli(['adapter', 'install', extractedDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', extractedDir], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(0)
       expect(result.stdout).toContain('using prebuilt bundle for')
@@ -270,7 +270,7 @@ describe('facet adapter install — fast path from extracted npm tarball', () =>
   })
 })
 
-describe('facet adapter install — slow path from unbuilt local source', () => {
+describe('facet adapter add — slow path from unbuilt local source', () => {
   test('bundles from src/index.ts when no prebuilt dist exists', async () => {
     const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
     const adapterDir = join(workDir, 'my-adapter')
@@ -278,7 +278,7 @@ describe('facet adapter install — slow path from unbuilt local source', () => 
     try {
       await makeMinimalAdapter(adapterDir, { kind: 'unbuilt', name: 'my-unbuilt-adapter' })
 
-      const result = await runCli(['adapter', 'install', adapterDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', adapterDir], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(0)
       // Fast path is NOT used (exports pointed at .ts, classified as 'source')
@@ -302,7 +302,7 @@ describe('facet adapter install — slow path from unbuilt local source', () => 
     try {
       await makeMinimalAdapter(adapterDir, { kind: 'unbuilt', name: 'my-clean-adapter' })
 
-      const result = await runCli(['adapter', 'install', adapterDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', adapterDir], { FACET_DIR: facetDir })
       expect(result.exitCode).toBe(0)
 
       // The slow path must NOT write `.facet-build/` (or any other scratch
@@ -324,7 +324,7 @@ describe('facet adapter install — slow path from unbuilt local source', () => 
   })
 })
 
-describe('facet adapter install — slow-path fallback after broken prebuilt', () => {
+describe('facet adapter add — slow-path fallback after broken prebuilt', () => {
   test('falls back to rebundling from source when the prebuilt bundle fails to load', async () => {
     const workDir = await mkdtemp(join(tmpdir(), 'facets-install-cli-fixture-'))
     const adapterDir = join(workDir, 'my-adapter')
@@ -332,7 +332,7 @@ describe('facet adapter install — slow-path fallback after broken prebuilt', (
     try {
       await makeMinimalAdapter(adapterDir, { kind: 'broken-prebuilt', name: 'my-fallback-adapter' })
 
-      const result = await runCli(['adapter', 'install', adapterDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', adapterDir], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(0)
       // Fast path is attempted then rejected — both logs should appear
@@ -360,7 +360,7 @@ describe('facet adapter install — slow-path fallback after broken prebuilt', (
   })
 })
 
-describe('facet adapter install — externalized prebuilt (PR #142 P1 regression)', () => {
+describe('facet adapter add — externalized prebuilt (PR #142 P1 regression)', () => {
   test('rejects an in-place-verifiable prebuilt that depends on the source tree node_modules', async () => {
     // This guards against the Codex P1 from PR #142: a prebuilt bundle
     // that imports externals which happen to be present in the source
@@ -375,7 +375,7 @@ describe('facet adapter install — externalized prebuilt (PR #142 P1 regression
     try {
       await makeMinimalAdapter(adapterDir, { kind: 'externalized-prebuilt', name: 'my-externalized-adapter' })
 
-      const result = await runCli(['adapter', 'install', adapterDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', adapterDir], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(0)
       // The fast path is tried (the bundle looks OK from package.json's
@@ -401,13 +401,13 @@ describe('facet adapter install — externalized prebuilt (PR #142 P1 regression
   })
 })
 
-describe('facet adapter install — temp dir cleanup (PR #142 follow-up)', () => {
+describe('facet adapter add — temp dir cleanup (PR #142 follow-up)', () => {
   test('does not leak facet-adapter-build-* dirs in tmpdir after a slow-path install', async () => {
     // Regression test for the Copilot-suppressed comment on PR #142:
     // `rebundleAdapter` creates `mkdtemp(tmpdir(), 'facet-adapter-build-')`
     // for its build output. Without an explicit cleanup, these would
     // accumulate in the OS temp directory across installs. Our fix
-    // returns a `cleanup()` from rebundleAdapter and `handleInstall`
+    // returns a `cleanup()` from rebundleAdapter and `handleAdd`
     // calls it in the finally block.
     //
     // We can't easily isolate this from other tests running in parallel
@@ -422,7 +422,7 @@ describe('facet adapter install — temp dir cleanup (PR #142 follow-up)', () =>
       await makeMinimalAdapter(adapterDir, { kind: 'unbuilt', name: 'cleanup-check-adapter' })
 
       const before = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
-      const result = await runCli(['adapter', 'install', adapterDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', adapterDir], { FACET_DIR: facetDir })
       const after = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
 
       expect(result.exitCode).toBe(0)
@@ -446,7 +446,7 @@ describe('facet adapter install — temp dir cleanup (PR #142 follow-up)', () =>
       await makeMinimalAdapter(adapterDir, { kind: 'broken-prebuilt', name: 'cleanup-fallback-adapter' })
 
       const before = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
-      const result = await runCli(['adapter', 'install', adapterDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', adapterDir], { FACET_DIR: facetDir })
       const after = (await readdir(tmpdir())).filter((n) => n.startsWith('facet-adapter-build-'))
 
       expect(result.exitCode).toBe(0)
@@ -459,14 +459,14 @@ describe('facet adapter install — temp dir cleanup (PR #142 follow-up)', () =>
   })
 })
 
-describe('facet adapter install + list + remove — round trip', () => {
+describe('facet adapter add + list + remove — round trip', () => {
   test('all three subcommands share the same FACET_DIR', async () => {
     const extractedDir = await packOpencode()
     const facetDir = await makeFacetDir()
     const env = { FACET_DIR: facetDir }
     try {
       // Install
-      const installResult = await runCli(['adapter', 'install', extractedDir], env)
+      const installResult = await runCli(['adapter', 'add', extractedDir], env)
       expect(installResult.exitCode).toBe(0)
 
       // List — should show the adapter
@@ -495,17 +495,17 @@ describe('facet adapter install + list + remove — round trip', () => {
   })
 })
 
-describe('facet adapter install — managed replacement', () => {
+describe('facet adapter add — managed replacement', () => {
   test('reinstalling keeps exactly one active generation and updates the receipt', async () => {
     const extractedDir = await packOpencode()
     const facetDir = await makeFacetDir()
     const env = { FACET_DIR: facetDir }
     try {
-      const first = await runCli(['adapter', 'install', extractedDir], env)
+      const first = await runCli(['adapter', 'add', extractedDir], env)
       expect(first.exitCode).toBe(0)
       const firstBundle = await activeManagedBundle(facetDir, 'opencode')
 
-      const second = await runCli(['adapter', 'install', extractedDir], env)
+      const second = await runCli(['adapter', 'add', extractedDir], env)
       expect(second.exitCode).toBe(0)
       const secondBundle = await activeManagedBundle(facetDir, 'opencode')
 
@@ -525,7 +525,7 @@ describe('facet adapter list — inspection-backed output', () => {
     const extractedDir = await packOpencode()
     const facetDir = await makeFacetDir()
     try {
-      const installResult = await runCli(['adapter', 'install', extractedDir], { FACET_DIR: facetDir })
+      const installResult = await runCli(['adapter', 'add', extractedDir], { FACET_DIR: facetDir })
       expect(installResult.exitCode).toBe(0)
 
       const listResult = await runCli(['adapter', 'list'], { FACET_DIR: facetDir })
@@ -560,7 +560,7 @@ describe('facet adapter list — inspection-backed output', () => {
       expect(listResult.stdout).toContain('legacy-tool')
       expect(listResult.stdout).toContain('api missing')
       expect(listResult.stdout).toContain('unsupported')
-      expect(listResult.stdout).toContain('facet adapter install legacy-tool')
+      expect(listResult.stdout).toContain('facet adapter add legacy-tool')
     } finally {
       await rm(facetDir, { recursive: true, force: true })
     }
@@ -579,7 +579,7 @@ describe('facet adapter list — inspection-backed output', () => {
       expect(listResult.stdout).toContain('broken-tool')
       expect(listResult.stdout).toContain('api unknown')
       expect(listResult.stdout).toContain('broken (invalid installation record)')
-      expect(listResult.stdout).toContain('facet adapter install broken-tool')
+      expect(listResult.stdout).toContain('facet adapter add broken-tool')
     } finally {
       await rm(facetDir, { recursive: true, force: true })
     }
@@ -587,7 +587,7 @@ describe('facet adapter list — inspection-backed output', () => {
 })
 
 describe('FACET_DIR redirect', () => {
-  test('install writes to the env-var dir, leaving ~/.facet/adapters untouched', async () => {
+  test('add writes to the env-var dir, leaving ~/.facet/adapters untouched', async () => {
     const extractedDir = await packOpencode()
     const facetDir = await makeFacetDir()
     try {
@@ -596,7 +596,7 @@ describe('FACET_DIR redirect', () => {
       // adapter DEFINITELY lands in the temp dir. Combined with the fact that
       // every other test also uses the env var, this guards against anyone
       // accidentally changing `resolveAdapterBaseDir()` to ignore it.
-      const result = await runCli(['adapter', 'install', extractedDir], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', extractedDir], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(0)
 
@@ -609,12 +609,77 @@ describe('FACET_DIR redirect', () => {
   })
 })
 
-describe('facet adapter install — error handling', () => {
-  test('install from a nonexistent local path exits 1 with a clear error', async () => {
+describe('facet adapter install — deprecated alias of add', () => {
+  test('the alias installs exactly like add, and says so on stderr', async () => {
+    const extractedDir = await packOpencode()
+    const facetDir = await makeFacetDir()
+    try {
+      const result = await runCli(['adapter', 'install', extractedDir], { FACET_DIR: facetDir })
+
+      // Identical behavior: same exit code, same stdout, same installation.
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Adapter "opencode" installed successfully.')
+      const stats = await stat(await activeManagedBundle(facetDir, 'opencode'))
+      expect(stats.isFile()).toBe(true)
+
+      // The notice is the ONLY difference, and it stays out of stdout so a
+      // script piping the command's output is unaffected by it.
+      expect(result.stderr).toContain(
+        "warning: 'facet adapter install' is deprecated; use 'facet adapter add' instead.",
+      )
+      expect(result.stdout).not.toContain('deprecated')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+
+  test('the canonical spelling warns about nothing', async () => {
+    const extractedDir = await packOpencode()
+    const facetDir = await makeFacetDir()
+    try {
+      const result = await runCli(['adapter', 'add', extractedDir], { FACET_DIR: facetDir })
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).not.toContain('deprecated')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter — subcommand surface', () => {
+  test('an unknown subcommand names the canonical set', async () => {
+    const facetDir = await makeFacetDir()
+    try {
+      const result = await runCli(['adapter', 'instal'], { FACET_DIR: facetDir })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('Unknown adapter subcommand "instal"')
+      expect(result.stderr).toContain('Use add, list, or remove.')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a bare invocation prints usage without advertising the deprecated alias', async () => {
+    const facetDir = await makeFacetDir()
+    try {
+      const result = await runCli(['adapter'], { FACET_DIR: facetDir })
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('Usage: facet adapter <add|list|remove> [args]')
+    } finally {
+      await rm(facetDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('facet adapter add — error handling', () => {
+  test('add from a nonexistent local path exits 1 with a clear error', async () => {
     const facetDir = await makeFacetDir()
     const missingPath = join(facetDir, 'does-not-exist')
     try {
-      const result = await runCli(['adapter', 'install', missingPath], { FACET_DIR: facetDir })
+      const result = await runCli(['adapter', 'add', missingPath], { FACET_DIR: facetDir })
 
       expect(result.exitCode).toBe(1)
       // Error should mention the path or "does not exist" / "not an adapter"

--- a/packages/cli/src/commands/__tests__/build-gate.test.ts
+++ b/packages/cli/src/commands/__tests__/build-gate.test.ts
@@ -87,7 +87,7 @@ describe('facet build — incompatible installed adapter gate', () => {
     expect(stderr).toContain('future-adapter')
     expect(stderr).toContain('9.9')
     expect(stderr).toContain(ADAPTER_API_VERSION)
-    expect(stderr).toContain('facet adapter install future-adapter')
+    expect(stderr).toContain('facet adapter add future-adapter')
 
     // Secondary check: no dist/ output. Under --verify writeBuildOutput is
     // skipped regardless, so this alone can't prove ordering — the throwing

--- a/packages/cli/src/commands/adapter/index.ts
+++ b/packages/cli/src/commands/adapter/index.ts
@@ -6,6 +6,14 @@ import {
 } from '@agent-facets/engine'
 import type { Command } from '../../commands.ts'
 import {
+  ADAPTER_ADD_SUBCOMMAND,
+  ADAPTER_INSTALL_DEPRECATION_WARNING,
+  ADAPTER_INSTALL_SUBCOMMAND,
+  ADAPTER_SUBCOMMAND_LIST,
+  ADAPTER_SUBCOMMAND_USAGE,
+  adapterAddCommandFor,
+} from '../../util/adapter-command.ts'
+import {
   describeAdapterInstallFailure,
   formatPlacementWarning,
   repairCommand,
@@ -17,31 +25,41 @@ import { pickAndInstallAdapters } from './pick-and-install.ts'
  * `facet adapter` command — manages adapter installations.
  *
  * Subcommands:
- * - `facet adapter install <specifier>` — Install an adapter
+ * - `facet adapter add <specifier>` — Install an adapter
  * - `facet adapter list` — List installed adapters
  * - `facet adapter remove <name>` — Remove an installed adapter
+ *
+ * `facet adapter install` remains accepted as a deprecated alias of
+ * `add`. Subcommand aliases cannot go through `Command.aliases`, which
+ * the router resolves for top-level names only, so the alias is a case
+ * in this switch — which is also what lets it warn before delegating.
  */
 export const adapterCommand: Command = {
   name: 'adapter',
   description: 'Manage adapter installations',
-  usage: '<install|list|remove> [args]',
+  usage: `${ADAPTER_SUBCOMMAND_USAGE} [args]`,
   implemented: true,
 
   async run(args, _flags) {
     const subcommand = args[0]
 
     switch (subcommand) {
-      case 'install':
-        return handleInstall(args.slice(1))
+      case ADAPTER_ADD_SUBCOMMAND:
+        return handleAdd(args.slice(1))
+      case ADAPTER_INSTALL_SUBCOMMAND:
+        // Deprecated alias. The notice is the only difference: stdout,
+        // side effects, and the exit code come from the canonical path.
+        console.error(ADAPTER_INSTALL_DEPRECATION_WARNING)
+        return handleAdd(args.slice(1))
       case 'list':
         return handleList()
       case 'remove':
         return handleRemove(args.slice(1))
       default: {
         if (subcommand) {
-          console.error(`Unknown adapter subcommand "${subcommand}". Use install, list, or remove.`)
+          console.error(`Unknown adapter subcommand "${subcommand}". Use ${ADAPTER_SUBCOMMAND_LIST}.`)
         } else {
-          console.error('Usage: facet adapter <install|list|remove> [args]')
+          console.error(`Usage: facet adapter ${ADAPTER_SUBCOMMAND_USAGE} [args]`)
         }
         return 1
       }
@@ -54,11 +72,11 @@ export const adapterCommand: Command = {
  * `installAdapter()` service (Adjustment Q) that maps progress stages to
  * console.log lines.
  */
-async function handleInstall(args: string[]): Promise<number> {
+async function handleAdd(args: string[]): Promise<number> {
   const specifier = args[0]
   if (!specifier) {
     // No-arg path: launch the shared zero-adapter picker (Adjustment A).
-    return handleInstallPicker()
+    return handleAddPicker()
   }
 
   const result = await installAdapter(specifier, {
@@ -93,14 +111,14 @@ async function handleInstall(args: string[]): Promise<number> {
   return 0
 }
 
-async function handleInstallPicker(): Promise<number> {
+async function handleAddPicker(): Promise<number> {
   const result = await pickAndInstallAdapters()
   if (result.ok) return 0
   if (result.reason === 'non-tty') {
     writeCliError({
       what: 'no adapters installed',
       detail: 'this is a non-interactive environment; the picker cannot run here',
-      fix: "run 'facet adapter install <name>' with an explicit adapter (e.g. claude-code, opencode)",
+      fix: `run '${adapterAddCommandFor('<name>')}' with an explicit adapter (e.g. claude-code, opencode)`,
     })
     return 1
   }
@@ -159,7 +177,7 @@ async function handleList(): Promise<number> {
   if (inspections.length === 0) {
     console.log('No adapters installed.')
     console.log('')
-    console.log('Install one with: facet adapter install <specifier>')
+    console.log(`Add one with: ${adapterAddCommandFor('<specifier>')}`)
     return 0
   }
 

--- a/packages/cli/src/commands/adapter/install-picker.tsx
+++ b/packages/cli/src/commands/adapter/install-picker.tsx
@@ -8,7 +8,7 @@ import { THEME } from '../../tui/theme.ts'
  *
  * Rendered in both entry paths where the user needs to pick which AI tool
  * adapter to install:
- *   - `facet adapter install` invoked with no argument.
+ *   - `facet adapter add` invoked with no argument.
  *   - `facet install` run in a project with no adapters installed.
  *
  * Header text is identical in both paths ("No AI tools are connected yet.")

--- a/packages/cli/src/commands/adapter/pick-and-install.ts
+++ b/packages/cli/src/commands/adapter/pick-and-install.ts
@@ -36,7 +36,7 @@ export type PickAndInstallResult =
  * Mount the adapter picker, install whatever the user selects, and
  * return the freshly-loaded set of installed adapters. Used by:
  *
- *   - `facet adapter install` (no-arg path) — the original caller.
+ *   - `facet adapter add` (no-arg path) — the original caller.
  *   - `facet add` when the project has zero installed adapters and
  *     stdout is a TTY.
  *

--- a/packages/cli/src/commands/add/__tests__/add.test.ts
+++ b/packages/cli/src/commands/add/__tests__/add.test.ts
@@ -266,7 +266,7 @@ describe('facet add — incompatible installed adapter gate', () => {
     const { result: code, stderr } = await withTTY(true, () => captureStderr(() => addCommand.run([relPath], {})))
     expect(code).toBe(1)
     expect(stderr).toContain('future-adapter')
-    expect(stderr).toContain('facet adapter install future-adapter')
+    expect(stderr).toContain('facet adapter add future-adapter')
     expect(stderr).not.toContain('No AI tools are connected yet')
     // No project files were created.
     expect(existsSync(join(projectRoot, 'facets.json'))).toBe(false)

--- a/packages/cli/src/commands/install/__tests__/install-cli.test.ts
+++ b/packages/cli/src/commands/install/__tests__/install-cli.test.ts
@@ -142,7 +142,7 @@ describe('facet install — CLI error paths', () => {
     expect(code).toBe(1)
     expect(stderr).toContain('no adapters installed')
     expect(stderr).toContain('non-interactive environment')
-    expect(stderr).toContain('facet adapter install <name>')
+    expect(stderr).toContain('facet adapter add <name>')
   })
 
   test('exits 1 with usage error on positional argument', async () => {
@@ -185,7 +185,7 @@ describe('facet install — incompatible installed adapter gate', () => {
     expect(code).toBe(1)
     expect(stderr).toContain('future-adapter')
     expect(stderr).toContain('9.9')
-    expect(stderr).toContain('facet adapter install future-adapter')
+    expect(stderr).toContain('facet adapter add future-adapter')
     expect(stderr).not.toContain('No AI tools are connected yet')
     // Nothing was installed or written.
     expect(existsSync(join(projectRoot, 'facets.lock'))).toBe(false)

--- a/packages/cli/src/commands/shared/ensure-adapters.ts
+++ b/packages/cli/src/commands/shared/ensure-adapters.ts
@@ -1,5 +1,6 @@
 import type { Adapter } from '@agent-facets/adapter'
 import { loadInstalledAdapters } from '@agent-facets/engine'
+import { adapterAddCommandFor } from '../../util/adapter-command.ts'
 import { describeInstalledAdapterFailure } from '../../util/adapter-install-errors.ts'
 import { writeCliError } from '../../util/errors.ts'
 import { pickAndInstallAdapters } from '../adapter/pick-and-install.ts'
@@ -36,7 +37,7 @@ export async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
       what: `installed adapters do not support install yet: ${stale}`,
       detail:
         'these adapters declare no asset capability, so they can validate manifest config but materialize nothing',
-      fix: "update each with 'facet adapter install <name>' to pull a version that materializes assets",
+      fix: `update each with '${adapterAddCommandFor('<name>')}' to pull a version that materializes assets`,
     })
     return null
   }
@@ -60,7 +61,7 @@ export async function ensureAdapters(): Promise<ReadonlyArray<Adapter> | null> {
     writeCliError({
       what: 'no adapters installed',
       detail: 'this is a non-interactive environment; the picker cannot run here',
-      fix: "run 'facet adapter install <name>' first (e.g. claude-code, opencode)",
+      fix: `run '${adapterAddCommandFor('<name>')}' first (e.g. claude-code, opencode)`,
     })
   } else if (result.reason === 'aborted') {
     process.stderr.write('Aborted: no adapters installed.\n')

--- a/packages/cli/src/prompts/overview.txt
+++ b/packages/cli/src/prompts/overview.txt
@@ -43,7 +43,7 @@ Command index
   facet remove         Remove a facet from the project (alias: facet rm).
   facet list           List declared facets and their resolved versions.
   facet search         Search the registry.
-  facet adapter        Install / list / remove adapter tooling.
+  facet adapter        Add / list / remove adapter tooling.
   facet publish        Publish a built facet to the registry.
   facet login          Authenticate with the registry (also: logout, whoami).
   facet self-update    Update the CLI itself.

--- a/packages/cli/src/prompts/usage.txt
+++ b/packages/cli/src/prompts/usage.txt
@@ -141,9 +141,12 @@ MCP servers — when a facet configures a server
 Adapter tooling — `facet adapter`
   Adapters teach facets how to target a specific AI coding tool. Installing an
   adapter is project setup, not authoring.
-    facet adapter install <specifier>     Install an adapter.
+    facet adapter add <specifier>         Install an adapter.
     facet adapter list                    List installed adapters.
     facet adapter remove <name>           Remove an installed adapter.
+
+  `facet adapter install` still works as a deprecated alias of `add`; it
+  behaves identically and prints a deprecation notice on stderr.
 
   This CLI supports adapter API {{ADAPTER_API_SUPPORT_SET}}. An adapter that declares an older or
   unsupported API fails closed before any project files change. Note that
@@ -154,7 +157,7 @@ Adapter tooling — `facet adapter`
   incompatible adapter:
     1. Run `facet adapter list` to see each adapter's API and status. Failing
        entries print the exact reinstall command to run.
-    2. Reinstall an unsupported first-party adapter: facet adapter install <name>
+    2. Reinstall an unsupported first-party adapter: facet adapter add <name>
     3. For a CUSTOM adapter, rebuild it against the current
        @agent-facets/adapter SDK first, then reinstall from that source.
 

--- a/packages/cli/src/util/__tests__/adapter-install-errors.test.ts
+++ b/packages/cli/src/util/__tests__/adapter-install-errors.test.ts
@@ -141,19 +141,17 @@ describe('describeNoCompatibleRelease — fix branches on newestConsidered', () 
 
 describe('repairCommand — shell-safe specifiers', () => {
   test('renders an ordinary managed specifier unquoted', () => {
-    expect(repairCommand({ kind: 'managed', specifier: 'my-adapter@1.2.3' })).toBe(
-      'facet adapter install my-adapter@1.2.3',
-    )
+    expect(repairCommand({ kind: 'managed', specifier: 'my-adapter@1.2.3' })).toBe('facet adapter add my-adapter@1.2.3')
   })
 
   test('quotes a managed local-path specifier containing whitespace', () => {
     expect(repairCommand({ kind: 'managed', specifier: './My Adapters/tool' })).toBe(
-      "facet adapter install './My Adapters/tool'",
+      "facet adapter add './My Adapters/tool'",
     )
   })
 
   test('quotes an unmanaged name containing whitespace', () => {
-    expect(repairCommand({ kind: 'unmanaged-name', name: 'weird name' })).toBe("facet adapter install 'weird name'")
+    expect(repairCommand({ kind: 'unmanaged-name', name: 'weird name' })).toBe("facet adapter add 'weird name'")
   })
 })
 
@@ -165,7 +163,7 @@ describe('describeCompatibilityFailure — install target', () => {
       found: '9.9',
       supported: SUPPORTED_ADAPTER_APIS,
     })
-    expect(described.fix).toContain('facet adapter install future-adapter')
+    expect(described.fix).toContain('facet adapter add future-adapter')
   })
 
   test('prefers an explicit install target over the adapter identity', () => {
@@ -177,7 +175,7 @@ describe('describeCompatibilityFailure — install target', () => {
       },
       'my-adapter',
     )
-    expect(described.fix).toContain('facet adapter install my-adapter')
+    expect(described.fix).toContain('facet adapter add my-adapter')
     expect(described.fix).not.toContain('/tmp/')
   })
 })
@@ -200,7 +198,7 @@ describe('describeAdapterInstallFailure — nameless bundle verify failure', () 
     // Diagnostic identity still names the bundle the failure came from.
     expect(described.what).toContain(bundlePath)
     // The actionable command uses the user's original specifier.
-    expect(described.fix).toContain('facet adapter install my-adapter')
+    expect(described.fix).toContain('facet adapter add my-adapter')
     expect(described.fix).not.toContain(bundlePath)
   })
 })

--- a/packages/cli/src/util/adapter-command.ts
+++ b/packages/cli/src/util/adapter-command.ts
@@ -1,0 +1,68 @@
+import { quoteShellArg } from './shell-quote.ts'
+
+/**
+ * The `facet adapter` command surface, in one place.
+ *
+ * `add` is the canonical verb for installing an adapter; `install` is a
+ * deprecated alias that still dispatches so muscle memory keeps working.
+ * Every string the CLI renders back to a user — usage lines, unknown-
+ * subcommand recovery, repair commands, the deprecation notice — derives
+ * from the constants here, so the canonical spelling cannot drift between
+ * surfaces or fall out of step with what the router actually accepts.
+ *
+ * Only the *command word* lives here. The operation it performs is still
+ * an installation everywhere else (`installAdapter`, installation
+ * receipts, "Installing adapter…" progress), and that vocabulary is
+ * deliberately left alone.
+ */
+
+/** Canonical subcommand that installs an adapter. */
+export const ADAPTER_ADD_SUBCOMMAND = 'add'
+
+/** Deprecated spelling of {@link ADAPTER_ADD_SUBCOMMAND}. Still dispatches. */
+export const ADAPTER_INSTALL_SUBCOMMAND = 'install'
+
+/** Advertised subcommands, in help order. The deprecated alias is not advertised. */
+export const ADAPTER_SUBCOMMANDS = [ADAPTER_ADD_SUBCOMMAND, 'list', 'remove'] as const
+
+const [FIRST_SUBCOMMAND, SECOND_SUBCOMMAND, THIRD_SUBCOMMAND] = ADAPTER_SUBCOMMANDS
+
+/** `<add|list|remove>` — the usage fragment for `facet adapter`. */
+export const ADAPTER_SUBCOMMAND_USAGE = `<${ADAPTER_SUBCOMMANDS.join('|')}>`
+
+/** `add, list, or remove` — the prose list for recovery messages. */
+export const ADAPTER_SUBCOMMAND_LIST = `${FIRST_SUBCOMMAND}, ${SECOND_SUBCOMMAND}, or ${THIRD_SUBCOMMAND}`
+
+/** `facet adapter add` — the canonical command, with no argument. */
+export const ADAPTER_ADD_COMMAND = `facet adapter ${ADAPTER_ADD_SUBCOMMAND}`
+
+/** `facet adapter install` — the deprecated alias, with no argument. */
+export const ADAPTER_INSTALL_COMMAND = `facet adapter ${ADAPTER_INSTALL_SUBCOMMAND}`
+
+/**
+ * The one-line notice written to stderr when the deprecated alias runs.
+ * It is the only observable difference between the two spellings: stdout,
+ * side effects, and the exit code are identical.
+ */
+export const ADAPTER_INSTALL_DEPRECATION_WARNING = `warning: '${ADAPTER_INSTALL_COMMAND}' is deprecated; use '${ADAPTER_ADD_COMMAND}' instead.`
+
+/**
+ * Render the canonical command with a concrete target. Targets are
+ * user/source-derived (receipt specifiers, local paths, package names)
+ * and must paste back into a shell safely.
+ */
+export function adapterAddCommand(target: string): string {
+  return `${ADAPTER_ADD_COMMAND} ${quoteShellArg(target)}`
+}
+
+/** The placeholders guidance uses when it has no concrete target to name. */
+export type AdapterAddPlaceholder = '<name>' | '<specifier>'
+
+/**
+ * Render the canonical command with a literal placeholder. Placeholders
+ * are prose, not arguments, so they are never shell-quoted — which is
+ * exactly why they cannot go through {@link adapterAddCommand}.
+ */
+export function adapterAddCommandFor(placeholder: AdapterAddPlaceholder): string {
+  return `${ADAPTER_ADD_COMMAND} ${placeholder}`
+}

--- a/packages/cli/src/util/adapter-install-errors.ts
+++ b/packages/cli/src/util/adapter-install-errors.ts
@@ -11,16 +11,7 @@ import type {
   RepairSource,
   VerifyAdapterFailure,
 } from '@agent-facets/engine'
-import { quoteShellArg } from './shell-quote.ts'
-
-/**
- * Single rendering seam for `facet adapter install <target>` commands in
- * fix lines. Targets are user/source-derived (receipt specifiers, local
- * paths, package names) and must paste back into a shell safely.
- */
-export function adapterInstallCommand(target: string): string {
-  return `facet adapter install ${quoteShellArg(target)}`
-}
+import { adapterAddCommand } from './adapter-command.ts'
 
 /**
  * Map an `AdapterInstallFailure` to the `{ what, detail, fix }` triple
@@ -81,11 +72,11 @@ export function formatPlacementWarning(warning: PlacementWarning): string {
 export function repairCommand(repair: RepairSource): string {
   switch (repair.kind) {
     case 'managed':
-      return adapterInstallCommand(repair.specifier)
+      return adapterAddCommand(repair.specifier)
     case 'first-party-alias':
-      return adapterInstallCommand(repair.alias)
+      return adapterAddCommand(repair.alias)
     case 'unmanaged-name':
-      return adapterInstallCommand(repair.name)
+      return adapterAddCommand(repair.name)
   }
 }
 
@@ -300,19 +291,19 @@ export function describeCompatibilityFailure(
       return {
         what: `adapter "${failure.adapter}" does not declare an adapter API version`,
         detail: `this CLI supports adapter API ${supported}; undeclared adapters are incompatible`,
-        fix: `install a release built with a current @agent-facets/adapter SDK: ${adapterInstallCommand(installTarget)}`,
+        fix: `install a release built with a current @agent-facets/adapter SDK: ${adapterAddCommand(installTarget)}`,
       }
     case 'api-malformed':
       return {
         what: `adapter "${failure.adapter}" declares a malformed adapter API version`,
         detail: `found "${failure.found}"; this CLI supports adapter API ${supported}`,
-        fix: `install a release with a valid API declaration: ${adapterInstallCommand(installTarget)}`,
+        fix: `install a release with a valid API declaration: ${adapterAddCommand(installTarget)}`,
       }
     case 'api-unsupported':
       return {
         what: `adapter "${failure.adapter}" declares unsupported adapter API ${failure.found}`,
         detail: `this CLI supports adapter API ${supported}`,
-        fix: `install a compatible release: ${adapterInstallCommand(installTarget)}`,
+        fix: `install a compatible release: ${adapterAddCommand(installTarget)}`,
       }
     case 'api-metadata-mismatch':
       return {
@@ -462,7 +453,7 @@ function describeNoCompatibleRelease(failure: {
  * would contradict the detail line.
  */
 function noCompatibleReleaseFix(request: NpmVersionRequest, packageName: string, considered: boolean): string {
-  const bareInstall = adapterInstallCommand(packageName)
+  const bareInstall = adapterAddCommand(packageName)
   if (considered) {
     return request.kind === 'exact'
       ? `that exact version is incompatible; try \`${bareInstall}\` for the highest compatible release`

--- a/packages/engine/src/adapters/__tests__/bundler.test.ts
+++ b/packages/engine/src/adapters/__tests__/bundler.test.ts
@@ -249,7 +249,7 @@ describe('resolveEntryPoint', () => {
  * tree whose dependencies are already satisfied (an installed workspace,
  * a zero-dep adapter) must bundle without spawning a package manager —
  * an unconditional install would re-enter the enclosing workspace's
- * lifecycle scripts (the repo's own postinstall → adapter install →
+ * lifecycle scripts (the repo's own postinstall → adapter add →
  * bun install recursion). The fallback install must still fire for a
  * standalone source dir with uninstalled dependencies.
  *

--- a/packages/engine/src/adapters/bundler.ts
+++ b/packages/engine/src/adapters/bundler.ts
@@ -86,7 +86,7 @@ export async function bundleAdapter(sourceDir: string): Promise<BundleResult> {
  * succeeds without spawning a package manager. This ordering is
  * load-bearing: an unconditional `bun install` here resolves the
  * enclosing workspace root and re-runs its lifecycle scripts, so the
- * repo's own `postinstall → facet adapter install ./packages/adapters/…
+ * repo's own `postinstall → facet adapter add ./packages/adapters/…
  * → bun install → postinstall` chain would recurse indefinitely.
  *
  * Only when that first build fails (typically a standalone source dir

--- a/packages/engine/src/adapters/first-party.ts
+++ b/packages/engine/src/adapters/first-party.ts
@@ -1,6 +1,6 @@
 /**
  * First-party adapters known to the CLI. Drives the zero-adapter install
- * picker (both `facet adapter install` no-arg and `facet install` zero-
+ * picker (both `facet adapter add` no-arg and `facet install` zero-
  * adapter paths) so partners see a curated list of the tools we officially
  * support in closed alpha.
  *

--- a/packages/engine/src/adapters/installation.ts
+++ b/packages/engine/src/adapters/installation.ts
@@ -25,7 +25,7 @@ export const INSTALLATION_SCHEMA_VERSION = 1
  * Tagged source provenance. Source-specific fields live only on their
  * variant so impossible npm/git/local combinations cannot be
  * constructed. `specifier` is always the original user input — the
- * repair command renders `facet adapter install <specifier>`.
+ * repair command renders `facet adapter add <specifier>`.
  */
 export type InstallationSource =
   | {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -3,7 +3,7 @@
  *
  * Runs three steps in sequence:
  *   1. lefthook install        — git hooks
- *   2. facet adapter install   — install the opencode adapter
+ *   2. facet adapter add       — install the opencode adapter
  *   3. facet install           — install repo facets
  *
  * Each step's stdout/stderr is captured and only printed if the step
@@ -49,7 +49,7 @@ const steps: Step[] = [
     // deadlock the release CI that publishes the first compatible
     // release). The local path bundles and verifies the same adapter
     // source this checkout was built against.
-    run: () => $`bun dev adapter install ./packages/adapters/opencode`.quiet().then(() => undefined),
+    run: () => $`bun dev adapter add ./packages/adapters/opencode`.quiet().then(() => undefined),
   },
   {
     label: 'facets',

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -64,12 +64,12 @@ The compatibility-aware CLI selects npm adapter releases by their `facetAdapterA
 
 Both directions of getting it wrong are bad, in different ways:
 
-- When the set **replaces** a token (`{0.1, 0.2}` → `{0.3}`), a CLI-first release leaves `facet adapter install <alias>` with no compatible candidate at all — including for the three first-party adapters. Every user upgrading the CLI is stranded, and the reinstall command the CLI's own diagnostic prints cannot succeed.
+- When the set **replaces** a token (`{0.1, 0.2}` → `{0.3}`), a CLI-first release leaves `facet adapter add <alias>` with no compatible candidate at all — including for the three first-party adapters. Every user upgrading the CLI is stranded, and the reinstall command the CLI's own diagnostic prints cannot succeed.
 - When the set **widens** (`{0.1}` → `{0.1, 0.2}`), a CLI-first release is worse in one respect: nothing looks broken until a user adds a facet that needs the new capability, and the remedy the failure prints **cannot succeed** either. A dead-end diagnostic is harder to act on than an honest hard stop.
 
 Adapter-first avoids both. For a **widening** it is safe because an older CLI simply keeps selecting the highest release declaring a token it does support. For a **replacement** it is the only order that works at all: the new adapter releases must exist on npm before any CLI that requires them ships, or the first thing the new CLI does is refuse every adapter on the machine.
 
-> **A replacement is a hard cutover for users, by design.** Every already-installed adapter — first-party included — becomes `unsupported` the moment the new CLI runs, and each needs one `facet adapter install <name>`. That is the intended behavior when the contract change is one no caller can paper over; make sure `docs/guides/troubleshooting.mdx` and the changelog say so plainly before the CLI ships.
+> **A replacement is a hard cutover for users, by design.** Every already-installed adapter — first-party included — becomes `unsupported` the moment the new CLI runs, and each needs one `facet adapter add <name>`. That is the intended behavior when the contract change is one no caller can paper over; make sure `docs/guides/troubleshooting.mdx` and the changelog say so plainly before the CLI ships.
 
 Checklist (protocol → SDK + first-party adapters → CLI):
 
@@ -89,7 +89,7 @@ Checklist (protocol → SDK + first-party adapters → CLI):
    ```
 
 5. Only after all three respond with the expected API version, move the parked changeset from `scripts/release/deferred/` into `.changeset/` and merge the second Version Packages PR. Its tag triggers the `release-cli` pipeline, which ships the compatibility-aware CLI.
-6. No action is needed for already-published CLIs. Users of the new CLI with previously installed, undeclared bundles get fail-closed diagnostics and a `facet adapter install <specifier>` reinstall command.
+6. No action is needed for already-published CLIs. Users of the new CLI with previously installed, undeclared bundles get fail-closed diagnostics and a `facet adapter add <specifier>` reinstall command.
 
 Why separate Version-PR cycles: a single Version PR creates **all** tags at once, and the library and CLI pipelines then run in parallel — racing the CLI release against the adapter publishes. Splitting the changesets across cycles is the only serialization primitive available; there is no linked group in `.changeset/config.json` (`linked` and `fixed` are both empty, so every package versions independently).
 


### PR DESCRIPTION
### Why

`facet adapter install` used the verb `install` while the top-level command that takes a specifier is `add` and the one that takes none is `install`. The mismatch made the surface inconsistent. The canonical subcommand is now `add`, matching the pattern: `facet add <specifier>` / `facet adapter add <specifier>`, `facet install` / `facet adapter install` (no-arg).

### Details

`facet adapter install` is retained as a deprecated alias that dispatches identically — same stdout, same side effects, same exit code — but writes a deprecation notice to stderr so existing scripts and muscle memory continue to work without silently breaking. The notice is stderr-only so piped output is unaffected.

A new `packages/cli/src/util/adapter-command.ts` module centralises every string the CLI renders for this surface: the canonical subcommand name, the deprecated alias, the usage fragment, the prose recovery list, the deprecation notice, and the two rendering helpers (`adapterAddCommand` for shell-safe specifiers, `adapterAddCommandFor` for prose placeholders). All repair commands, usage lines, and recovery guidance derive from these constants so the canonical spelling cannot drift between surfaces.

The `docs/cli/adapters/install.mdx` page is renamed to `docs/cli/adapters/add.mdx` with a permanent redirect from the old path, and a note on the renamed page documents the deprecated alias and explains the naming rationale.

### Verification

New e2e tests cover the deprecated alias (identical behavior, deprecation notice on stderr only, no notice on the canonical spelling), unknown subcommand recovery (names only the canonical set), and bare invocation usage output. Existing tests are updated to assert `facet adapter add` in all rendered repair commands and error messages. CI covers the rest.