### PR TITLE
Reconcile OpenCode MCP servers across all four merged config documents

### DIFF
--- a/.changeset/opencode-mcp-config-precedence.md
+++ b/.changeset/opencode-mcp-config-precedence.md
@@ -1,0 +1,11 @@
+---
+"@agent-facets/adapter-opencode": patch
+---
+
+**MCP servers now land where OpenCode actually reads them.** The adapter considered only the project root's `opencode.jsonc` and `opencode.json`, so a project keeping its OpenCode configuration in `.opencode/` — the location that *outranks* the root — had servers written to a file the higher-precedence one shadows. The configuration you approved was not the configuration OpenCode loaded.
+
+All four documents OpenCode merges are now read, classified as one configuration, and disclosed. In decreasing precedence: `.opencode/opencode.jsonc`, `.opencode/opencode.json`, `opencode.jsonc`, `opencode.json`.
+
+Writes go to exactly one of them, chosen once per run: the highest-precedence document that already defines an `mcp` member (an empty `{}` counts), otherwise the highest-precedence document that exists, otherwise a newly created `.opencode/opencode.jsonc`. Following the existing `mcp` member rather than merely the file that sorts first is what keeps a project whose servers live in a root `opencode.json`, beside a `.opencode/opencode.jsonc` holding only agents, from having its servers split across two files that shadow each other.
+
+A definition of a desired server in a lower-precedence document is now left exactly as its author wrote it — the target's definition already wins, and deleting from a file this run is not otherwise writing is not the adapter's call. Previously a shadowed copy was deleted. An obsolete owned entry is still removed from **every** document that defines it, so a removal cannot promote a shadowed copy and leave the server configured. Entries the project neither desires nor owns remain untouched everywhere.

--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -177,9 +177,18 @@ Resolved facet content is stored at `$FACET_DIR/cache/<name>@<version>/` (defaul
 
 ## MCP servers
 
-A facet that declares [`servers`](/specification/manifest#mcp-server-declarations) contributes MCP server configuration to every selected adapter, written into each tool's own project file — `.mcp.json` for Claude Code, `opencode.jsonc` and `opencode.json` for OpenCode, `.codex/config.toml` for Codex. Only project-scoped files are ever touched; no user- or system-wide tool configuration is created or modified.
+A facet that declares [`servers`](/specification/manifest#mcp-server-declarations) contributes MCP server configuration to every selected adapter, written into each tool's own project file — `.mcp.json` for Claude Code, `.opencode/opencode.jsonc` for OpenCode, `.codex/config.toml` for Codex. Only project-scoped files are ever touched; no user- or system-wide tool configuration is created or modified.
 
-OpenCode merges its two configuration files, so both are read and both count as one configuration. A new entry goes to `opencode.jsonc` when that file exists, otherwise to an existing `opencode.json`, and otherwise into a newly created `opencode.jsonc`. An existing entry is updated in whichever file it currently wins in — and when your project owns an entry defined in both, the `opencode.jsonc` copy is updated and the shadowed `opencode.json` copy is removed in the same change. An entry your project owns is removed from every file that defines it. Entries you added yourself are never touched in either file.
+OpenCode merges four project files into one configuration, so all four are read. In decreasing precedence they are:
+
+1. `.opencode/opencode.jsonc`
+2. `.opencode/opencode.json`
+3. `opencode.jsonc`
+4. `opencode.json`
+
+Servers are written to a single one of them: the highest-precedence file that already has an `mcp` section — an empty one counts — otherwise the highest-precedence file that exists, otherwise a newly created `.opencode/opencode.jsonc`. So a project that keeps its servers in a root `opencode.json` keeps getting them there, even if a `.opencode/opencode.jsonc` exists for something else.
+
+A copy of the same server in a lower-precedence file is left alone: the one that was just written already wins. An entry your project owns and no longer wants is removed from *every* file that defines it, so a shadowed copy cannot come back. Entries you added yourself are never touched in any file.
 
 Installing a server **configures** it. Facets never downloads it, launches it, connects to it, checks its health, or authenticates to it. Whatever sign-in the server needs happens inside your coding tool afterwards.
 

--- a/docs/guides/custom-adapters.mdx
+++ b/docs/guides/custom-adapters.mdx
@@ -349,7 +349,9 @@ You are editing a file the user owns and may already be using:
 - For an owned entry, native fields outside the portable model (a timeout, say) survive where your format allows.
 - Use a syntax-aware edit and an atomic write. Semantic preservation is mandatory; comment and formatting preservation is best-effort and should be maximized.
 
-Write **project-scoped configuration only**. Never create or modify a user-wide or system-wide tool file. For reference, the first-party adapters use `.mcp.json` (Claude Code), both `opencode.jsonc` and `opencode.json` as one merged configuration (OpenCode), and `.codex/config.toml` (Codex).
+Write **project-scoped configuration only**. Never create or modify a user-wide or system-wide tool file. For reference, the first-party adapters use `.mcp.json` (Claude Code), the four documents OpenCode merges — `.opencode/opencode.jsonc`, `.opencode/opencode.json`, `opencode.jsonc`, `opencode.json` — as one configuration (OpenCode), and `.codex/config.toml` (Codex).
+
+If your tool merges several configuration layers, read them all and classify against the merged view, then write to one of them. Reading only the file you would write is how an obsolete entry in another layer survives a removal and keeps a server your user deleted.
 
 <Warning>
 Two selected adapters may not manage the same file. If your tool reads a configuration file another supported tool also reads, say so in your README: a user who selects both gets a failure telling them to deselect one, because there is no ordering in which both plans survive the other's write.

--- a/docs/guides/install-facets.mdx
+++ b/docs/guides/install-facets.mdx
@@ -194,7 +194,7 @@ If a facet declares MCP servers, those land somewhere else: each tool's own proj
 | Adapter | Native file |
 | --- | --- |
 | `claude-code` | `.mcp.json` |
-| `opencode` | `opencode.jsonc`, or an existing `opencode.json` |
+| `opencode` | `.opencode/opencode.jsonc`, or whichever merged config already holds your servers |
 | `codex` | `.codex/config.toml` |
 
 These are shared files you may already be using, so reconciliation is deliberately narrow: unrelated settings keep their values, server entries this project does not own are left alone, and comments and formatting are preserved wherever the format allows. Only project-scoped files are touched — no user- or system-wide tool configuration is ever created or modified.

--- a/openspec/specs/adapter__mcp-servers/spec.md
+++ b/openspec/specs/adapter__mcp-servers/spec.md
@@ -27,43 +27,50 @@ An adapter that supports MCP servers SHALL translate the complete desired projec
 
 The first-party adapters SHALL reconcile project-scoped MCP server maps at their tools' documented project locations. Claude Code SHALL use `.mcp.json`. Codex SHALL use trusted-project `.codex/config.toml` and its project MCP server tables.
 
-OpenCode merges `opencode.json` and `opencode.jsonc`, so the OpenCode adapter SHALL treat both as one configuration and SHALL inspect both, planning a change only for the layers it actually changes. It SHALL classify occupancy and equality against the merged per-key view in which a key defined in `opencode.jsonc` wins. It SHALL create a new entry in `opencode.jsonc` when that document exists, otherwise in an existing `opencode.json`, and SHALL create `opencode.jsonc` when neither exists. It SHALL update an existing entry in the layer where that key currently wins. When one owned key is defined in both layers, it SHALL update the `opencode.jsonc` definition and remove the shadowed `opencode.json` definition in the same change. It SHALL remove an obsolete owned key from every layer that defines it. It SHALL leave entries it neither desires nor owns untouched in both layers.
+OpenCode merges four project-scoped documents, in decreasing precedence: `.opencode/opencode.jsonc`, `.opencode/opencode.json`, `opencode.jsonc`, and `opencode.json`. The OpenCode adapter SHALL treat all four as one configuration and SHALL inspect all four, planning a change only for the documents it actually changes. It SHALL classify occupancy and equality against the merged per-key view in which the highest-precedence document defining a key wins.
+
+The OpenCode adapter SHALL choose one write target per run: the highest-precedence document that already defines an `mcp` member, otherwise the highest-precedence document that exists, otherwise `.opencode/opencode.jsonc`, which it SHALL create. A document defining an empty `mcp` member SHALL count as defining one. It SHALL write every desired server to that target. It SHALL leave a definition of a desired server in a lower-precedence document unchanged, since the target's definition already wins. It SHALL remove an obsolete owned key from every document that defines it, so that no shadowed definition is promoted by the removal. It SHALL leave entries it neither desires nor owns untouched in every document.
 
 #### Scenario: Claude Code uses its project server map
 
 - **WHEN** the Claude Code adapter reconciles project servers
 - **THEN** it SHALL update the `mcpServers` map in project `.mcp.json`
 
-#### Scenario: OpenCode prefers JSONC for a new entry
+#### Scenario: OpenCode writes where the project already keeps its servers
 
-- **WHEN** both `opencode.jsonc` and `opencode.json` exist and a desired server is absent from both
-- **THEN** the OpenCode adapter SHALL create the entry in the `mcp` map of `opencode.jsonc`
-- **AND** it SHALL NOT plan a change for the unchanged `opencode.json`
+- **WHEN** `.opencode/opencode.jsonc` exists without an `mcp` member and `opencode.json` defines one
+- **THEN** the OpenCode adapter SHALL write the desired server into the `mcp` map of `opencode.json`
+- **AND** it SHALL NOT plan a change for the unchanged `.opencode/opencode.jsonc`
 
-#### Scenario: OpenCode falls back to existing JSON
+#### Scenario: OpenCode prefers the highest-precedence server map
 
-- **WHEN** `opencode.json` exists and `opencode.jsonc` does not
-- **THEN** the OpenCode adapter SHALL reconcile the existing JSON document
+- **WHEN** more than one OpenCode document defines an `mcp` member
+- **THEN** the OpenCode adapter SHALL write the desired server into the highest-precedence one
 
-#### Scenario: OpenCode creates JSONC
+#### Scenario: OpenCode falls back to the highest-precedence existing document
 
-- **WHEN** neither OpenCode project document exists
-- **THEN** the OpenCode adapter SHALL create `opencode.jsonc`
+- **WHEN** no OpenCode document defines an `mcp` member and at least one exists
+- **THEN** the OpenCode adapter SHALL write the desired server into the highest-precedence existing document
 
-#### Scenario: OpenCode removes an obsolete entry from the lower layer
+#### Scenario: OpenCode creates its default document
 
-- **WHEN** an obsolete owned server is defined only in `opencode.json` while `opencode.jsonc` also exists
-- **THEN** the OpenCode adapter SHALL remove that entry from `opencode.json`
+- **WHEN** no OpenCode project document exists
+- **THEN** the OpenCode adapter SHALL create `.opencode/opencode.jsonc`
+- **AND** it SHALL NOT create any other OpenCode project document
 
-#### Scenario: OpenCode collapses a shadowed owned entry
+#### Scenario: OpenCode leaves a shadowed definition alone
 
-- **WHEN** one owned server is defined in both OpenCode documents and its declaration changed
-- **THEN** the adapter SHALL update the `opencode.jsonc` definition
-- **AND** it SHALL remove the shadowed `opencode.json` definition in the same change
+- **WHEN** a desired server is written to the target while a lower-precedence document also defines that key
+- **THEN** the OpenCode adapter SHALL leave the lower-precedence definition unchanged
 
-#### Scenario: OpenCode leaves unowned lower-layer entries alone
+#### Scenario: OpenCode removes an obsolete entry from every document
 
-- **WHEN** `opencode.json` defines a server the project neither desires nor owns
+- **WHEN** an obsolete owned server is defined in more than one OpenCode document
+- **THEN** the OpenCode adapter SHALL remove that entry from every document that defines it
+
+#### Scenario: OpenCode leaves unowned entries alone
+
+- **WHEN** an OpenCode document defines a server the project neither desires nor owns
 - **THEN** the adapter SHALL leave that entry unchanged
 
 #### Scenario: Codex uses trusted project configuration

--- a/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
+++ b/packages/adapters/opencode/src/__tests__/dist.e2e.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect, test } from 'bun:test'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -28,7 +28,7 @@ test('bundled JSONC parser survives bundling', async () => {
     // Comments and a trailing comma are readable only if jsonc-parser was
     // actually inlined; a bare specifier would have failed at import time and
     // a JSON parser would fail here.
-    await Bun.write(join(root, 'opencode.jsonc'), '{\n  // servers\n  "mcp": {},\n}\n')
+    await Bun.write(join(root, '.opencode/opencode.jsonc'), '{\n  // servers\n  "mcp": {},\n}\n')
     const planned = await capability.plan({
       projectRoot: root,
       desired: [STDIO_SERVER],
@@ -41,7 +41,29 @@ test('bundled JSONC parser survives bundling', async () => {
     // build parses fine but resolves its edit helpers lazily, so a mis-bundled
     // dependency only renders wrong text here.
     commitPlannedAction(planned.plan.action)
-    expect(readFileSync(join(root, 'opencode.jsonc'), 'utf8')).toContain('// servers')
+    expect(readFileSync(join(root, '.opencode/opencode.jsonc'), 'utf8')).toContain('// servers')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('the bundled capability creates its default document under .opencode', async () => {
+  const capability = await loadDistMcpCapability(bundlePath)
+  const root = mkdtempSync(join(tmpdir(), 'opencode-dist-'))
+  try {
+    // Creating a document inside a directory that does not exist yet is the
+    // path a fresh project takes, and it only works if the plan's mutation
+    // carries a boundary the caller can create directories under.
+    const planned = await capability.plan({
+      projectRoot: root,
+      desired: [STDIO_SERVER],
+      previouslyOwnedNames: [],
+    })
+    if (!planned.ok) expect.unreachable()
+    commitPlannedAction(planned.plan.action)
+
+    expect(readFileSync(join(root, '.opencode/opencode.jsonc'), 'utf8')).toContain('"fs"')
+    expect(existsSync(join(root, 'opencode.jsonc'))).toBe(false)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }

--- a/packages/adapters/opencode/src/__tests__/mcp-servers.test.ts
+++ b/packages/adapters/opencode/src/__tests__/mcp-servers.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import type { McpServerContribution, PlanMcpServersResult } from '@agent-facets/adapter'
 import { parseJsoncDocument, splitJsoncBom } from '@agent-facets/adapter-jsonc'
 import {
   commitPlannedAction,
@@ -16,8 +17,19 @@ import {
 import adapter from '../index.ts'
 import { openCodeMcpServers } from '../mcp-servers.ts'
 
-const JSONC = 'opencode.jsonc'
-const JSON_DOCUMENT = 'opencode.json'
+/**
+ * The four project documents OpenCode merges, highest precedence first.
+ *
+ * OpenCode loads the project root's pair and then the `.opencode` pair over
+ * it, and within a directory reads `.json` before `.jsonc`, so this is the
+ * order in which a key defined more than once takes its value.
+ */
+const DOT_JSONC = '.opencode/opencode.jsonc'
+const DOT_JSON = '.opencode/opencode.json'
+const ROOT_JSONC = 'opencode.jsonc'
+const ROOT_JSON = 'opencode.json'
+
+const CANDIDATES = [DOT_JSONC, DOT_JSON, ROOT_JSONC, ROOT_JSON] as const
 
 /** OpenCode fuses the executable and its arguments into one `command` array. */
 const NATIVE_STDIO = '{ "type": "local", "command": ["srv", "--root", "/w"], "environment": { "TOKEN_NAME": "A" } }'
@@ -61,7 +73,7 @@ function serverMap(text: string): Record<string, NativeEntry | undefined> {
 
 /** The written JSONC document's server map. */
 function parsedServers(project: McpMatrixProject): Record<string, NativeEntry | undefined> {
-  return serverMap(project.read(JSONC) ?? '{}')
+  return serverMap(project.read(DOT_JSONC) ?? '{}')
 }
 
 const seeds = {
@@ -71,7 +83,7 @@ const seeds = {
   // one case carries it: the readers are covered everywhere, the writer only
   // here, and a dropped `environment` would otherwise go unnoticed.
   'absent-untracked': {
-    files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    files: { [DOT_JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) },
     after: (project) => {
       expect(parsedServers(project).fs).toEqual({
         type: 'local',
@@ -81,19 +93,19 @@ const seeds = {
     },
   },
 
-  'absent-tracked': { files: { [JSONC]: document({}) } },
+  'absent-tracked': { files: { [DOT_JSONC]: document({}) } },
 
-  'equivalent-tracked': { files: { [JSONC]: document({ fs: NATIVE_STDIO }) } },
+  'equivalent-tracked': { files: { [DOT_JSONC]: document({ fs: NATIVE_STDIO }) } },
 
-  'equivalent-untracked': { files: { [JSONC]: document({ fs: NATIVE_STDIO }) } },
+  'equivalent-untracked': { files: { [DOT_JSONC]: document({ fs: NATIVE_STDIO }) } },
 
   'equivalent-normalized': {
-    files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["srv"], "environment": {} }' }) },
+    files: { [DOT_JSONC]: document({ fs: '{ "type": "local", "command": ["srv"], "environment": {} }' }) },
   },
 
   'equivalent-formatting-only': {
     files: {
-      [JSONC]: `{
+      [DOT_JSONC]: `{
   // hand-written
   "mcp": {
     "fs": {
@@ -106,19 +118,19 @@ const seeds = {
 `,
     },
     after: (project) => {
-      expect(project.read(JSONC)).toBe(project.seeded(JSONC))
+      expect(project.read(DOT_JSONC)).toBe(project.seeded(DOT_JSONC))
     },
   },
 
-  'divergent-tracked': { files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
+  'divergent-tracked': { files: { [DOT_JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
 
-  'divergent-untracked': { files: { [JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
+  'divergent-untracked': { files: { [DOT_JSONC]: document({ fs: '{ "type": "local", "command": ["stale"] }' }) } },
 
   // Same command and arguments, opposite order. OpenCode fuses them into one
   // array, so order is the only thing that differs.
   'divergent-argument-order': {
     files: {
-      [JSONC]: document({
+      [DOT_JSONC]: document({
         fs: '{ "type": "local", "command": ["srv", "/w", "--root"], "environment": { "TOKEN_NAME": "A" } }',
       }),
     },
@@ -133,7 +145,7 @@ const seeds = {
 
   'divergent-environment-value': {
     files: {
-      [JSONC]: document({
+      [DOT_JSONC]: document({
         fs: '{ "type": "local", "command": ["srv", "--root", "/w"], "environment": { "TOKEN_NAME": "B" } }',
       }),
     },
@@ -146,31 +158,34 @@ const seeds = {
   // behavioral difference the project is asking to correct.
   'divergent-unprovable': {
     files: {
-      [JSONC]: document({
+      [DOT_JSONC]: document({
         fs: '{ "type": "local", "command": ["srv", "--root", "/w"], "environment": { "TOKEN_NAME": "A" }, "enabled": false }',
       }),
     },
     after: (project) => {
-      expect(project.read(JSONC) ?? '').not.toContain('"enabled": false')
+      expect(project.read(DOT_JSONC) ?? '').not.toContain('"enabled": false')
     },
   },
 
   'safe-extension-preserved': {
     files: {
-      [JSONC]: document({ ext: '{ "type": "local", "command": ["ext-server", "--old"], "timeout": 45000 }' }),
+      [DOT_JSONC]: document({ ext: '{ "type": "local", "command": ["ext-server", "--old"], "timeout": 45000 }' }),
     },
     after: (project) => {
       expect(parsedServers(project).ext).toEqual({ type: 'local', command: ['ext-server', '--new'], timeout: 45000 })
     },
   },
 
-  'http-absent': { files: { [JSONC]: document({}) } },
+  'http-absent': { files: { [DOT_JSONC]: document({}) } },
 
-  'http-equivalent': { files: { [JSONC]: document({ api: NATIVE_HTTP }) } },
+  'http-equivalent': { files: { [DOT_JSONC]: document({ api: NATIVE_HTTP }) } },
 
   'obsolete-owned-present': {
     files: {
-      [JSONC]: document({ [OBSOLETE_NAME]: '{ "type": "local", "command": ["gone"] }', [UNOWNED_NAME]: UNOWNED_ENTRY }),
+      [DOT_JSONC]: document({
+        [OBSOLETE_NAME]: '{ "type": "local", "command": ["gone"] }',
+        [UNOWNED_NAME]: UNOWNED_ENTRY,
+      }),
     },
     after: (project) => {
       const servers = parsedServers(project)
@@ -179,18 +194,18 @@ const seeds = {
     },
   },
 
-  'obsolete-owned-absent': { files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+  'obsolete-owned-absent': { files: { [DOT_JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
 
   'unowned-entry-untouched': {
-    files: { [JSONC]: document({ fs: NATIVE_STDIO, [UNOWNED_NAME]: UNOWNED_ENTRY }) },
+    files: { [DOT_JSONC]: document({ fs: NATIVE_STDIO, [UNOWNED_NAME]: UNOWNED_ENTRY }) },
     after: (project) => {
-      expect(project.read(JSONC)).toBe(project.seeded(JSONC))
+      expect(project.read(DOT_JSONC)).toBe(project.seeded(DOT_JSONC))
     },
   },
 
   'complete-batch': {
     files: {
-      [JSONC]: document({
+      [DOT_JSONC]: document({
         fs: NATIVE_STDIO,
         api: '{ "type": "remote", "url": "https://elsewhere.example.com/mcp" }',
         [OBSOLETE_NAME]: '{ "type": "local", "command": ["gone"] }',
@@ -206,7 +221,7 @@ const seeds = {
 
   'unrelated-settings-preserved': {
     files: {
-      [JSONC]: `{
+      [DOT_JSONC]: `{
   // the model this project uses
   "$schema": "https://opencode.ai/config.json",
   "model": "anthropic/claude",
@@ -215,18 +230,18 @@ const seeds = {
 `,
     },
     after: (project) => {
-      const after = project.read(JSONC) ?? ''
+      const after = project.read(DOT_JSONC) ?? ''
       expect(after).toContain('// the model this project uses')
       expect(after).toContain('"model": "anthropic/claude"')
       expect(after).toContain('"$schema": "https://opencode.ai/config.json"')
     },
   },
 
-  'nothing-desired-nothing-owned': { files: { [JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
+  'nothing-desired-nothing-owned': { files: { [DOT_JSONC]: document({ [UNOWNED_NAME]: UNOWNED_ENTRY }) } },
 
-  'malformed-document': { files: { [JSONC]: '{ "mcp": { \n' } },
+  'malformed-document': { files: { [DOT_JSONC]: '{ "mcp": { \n' } },
 
-  'invalid-server-map': { files: { [JSONC]: '{ "mcp": [] }\n' } },
+  'invalid-server-map': { files: { [DOT_JSONC]: '{ "mcp": [] }\n' } },
 } satisfies Record<McpMatrixCaseId, McpMatrixSeed>
 
 runMcpServerMatrix({ capability: openCodeMcpServers, seeds })
@@ -235,150 +250,298 @@ describe('opencode configuration layers', () => {
   let root: string
 
   beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), 'opencode-mcp-'))
+    // `realpathSync` because macOS hands out `/var/...` temp paths that resolve
+    // to `/private/var/...`, and the disclosed document paths are compared
+    // against `join(root, …)` verbatim.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'opencode-mcp-')))
   })
 
   afterEach(() => {
     rmSync(root, { recursive: true, force: true })
   })
 
+  function seed(name: string, contents: string): void {
+    const file = join(root, name)
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, contents)
+  }
+
+  async function plan(
+    desired: readonly McpServerContribution[],
+    previouslyOwnedNames: readonly string[],
+  ): Promise<PlanMcpServersResult> {
+    return await openCodeMcpServers.plan({ projectRoot: root, desired, previouslyOwnedNames })
+  }
+
+  /** Reconcile one desired stdio server, returning the paths actually written. */
   async function reconcile(previouslyOwnedNames: readonly string[] = []): Promise<readonly string[]> {
-    const planned = await openCodeMcpServers.plan({
-      projectRoot: root,
-      desired: [STDIO_SERVER],
-      previouslyOwnedNames,
-    })
+    const planned = await plan([STDIO_SERVER], previouslyOwnedNames)
     if (!planned.ok) expect.unreachable()
     commitPlannedAction(planned.plan.action)
     return planned.plan.action.kind === 'mutate' ? planned.plan.action.mutations.map((m) => m.path) : []
   }
 
   async function removeAll(previouslyOwnedNames: readonly string[]): Promise<void> {
-    const planned = await openCodeMcpServers.plan({ projectRoot: root, desired: [], previouslyOwnedNames })
+    const planned = await plan([], previouslyOwnedNames)
     if (!planned.ok) expect.unreachable()
     commitPlannedAction(planned.plan.action)
   }
 
+  const exists = (name: string): boolean => existsSync(join(root, name))
   const read = (name: string): string => readFileSync(join(root, name), 'utf8')
   const servers = (name: string): Record<string, NativeEntry | undefined> => serverMap(read(name))
+  const candidatePaths = (): string[] => CANDIDATES.map((name) => join(root, name))
 
-  test('only the layer that actually changes is planned', async () => {
-    writeFileSync(join(root, JSONC), '{ "mcp": {} }\n')
+  describe('target selection', () => {
+    /**
+     * The three states a candidate document can be in, which is everything
+     * target selection distinguishes.
+     *
+     * `bare` and `configured` are separate on purpose: a document that exists
+     * without an `mcp` member is one this adapter would be introducing MCP
+     * configuration into, while `"mcp": {}` is already where this project
+     * keeps its servers.
+     */
+    const LAYER_STATES = ['absent', 'bare', 'configured'] as const
+    type LayerState = (typeof LAYER_STATES)[number]
 
-    const mutated = await reconcile()
+    const STATE_TEXT: Readonly<Record<Exclude<LayerState, 'absent'>, string>> = {
+      bare: '{ "model": "anthropic/claude" }\n',
+      configured: '{ "mcp": {} }\n',
+    }
 
-    // The layer nothing writes is not journaled: inspecting a document has
-    // never been a reason to own it, and a rollback that rewrote it could
-    // overwrite an edit this run never made.
-    expect(mutated).toEqual([join(root, JSONC)])
+    /**
+     * The rule, restated independently of the implementation: the
+     * highest-precedence document with an `mcp` member, else the
+     * highest-precedence one that exists, else the highest-precedence
+     * candidate.
+     */
+    function expectedTarget(states: readonly LayerState[]): string {
+      for (const preferred of ['configured', 'bare'] as const) {
+        for (const [index, candidate] of CANDIDATES.entries()) {
+          if (states[index] === preferred) return candidate
+        }
+      }
+      return CANDIDATES[0]
+    }
+
+    /** Every state each candidate can be in, crossed with every other. */
+    function everyCombination(): LayerState[][] {
+      let combinations: LayerState[][] = [[]]
+      for (const _candidate of CANDIDATES) {
+        combinations = combinations.flatMap((prefix) => LAYER_STATES.map((state) => [...prefix, state]))
+      }
+      return combinations
+    }
+
+    const cases = everyCombination().map(
+      (states) => [CANDIDATES.map((name, index) => `${name}=${states[index]}`).join(' '), states] as const,
+    )
+
+    test.each(cases)('%s', async (_label, states) => {
+      for (const [index, candidate] of CANDIDATES.entries()) {
+        const state = states[index]
+        if (state !== undefined && state !== 'absent') seed(candidate, STATE_TEXT[state])
+      }
+      const before = new Map(CANDIDATES.filter(exists).map((name) => [name, read(name)]))
+
+      const target = expectedTarget(states)
+      const written = await reconcile()
+
+      expect(written).toEqual([join(root, target)])
+      expect(servers(target).fs?.command).toEqual(['srv', '--root', '/w'])
+      // Every other candidate is left exactly as it was — including one that
+      // did not exist, which must not be conjured beside the target.
+      for (const candidate of CANDIDATES) {
+        if (candidate === target) continue
+        const previous = before.get(candidate)
+        expect(exists(candidate)).toBe(previous !== undefined)
+        if (previous !== undefined) expect(read(candidate)).toBe(previous)
+      }
+    })
   })
 
-  test('a new entry prefers the JSONC layer when both exist', async () => {
-    writeFileSync(join(root, JSONC), '{ "mcp": {} }\n')
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": {} }\n')
+  test('a document is created in .opencode when no candidate exists', async () => {
+    await reconcile()
+
+    expect(servers(DOT_JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
+    for (const candidate of [DOT_JSON, ROOT_JSONC, ROOT_JSON]) expect(exists(candidate)).toBe(false)
+  })
+
+  test('every candidate is disclosed, including ones that do not exist', async () => {
+    seed(ROOT_JSON, '{ "mcp": {} }\n')
+
+    const planned = await plan([STDIO_SERVER], [])
+    if (!planned.ok) expect.unreachable()
+
+    // Disclosure is how the caller establishes, before anything is approved,
+    // that no two selected adapters reconcile one file — so it must name every
+    // document the plan was computed from, in a fixed order.
+    expect([...planned.plan.documentPaths]).toEqual(candidatePaths())
+  })
+
+  test('a plan that changes nothing still discloses every candidate', async () => {
+    seed(DOT_JSONC, `{ "mcp": { "fs": ${NATIVE_STDIO} } }\n`)
+
+    const planned = await plan([STDIO_SERVER], ['fs'])
+    if (!planned.ok) expect.unreachable()
+
+    expect(planned.plan.action.kind).toBe('unchanged')
+    expect([...planned.plan.documentPaths]).toEqual(candidatePaths())
+  })
+
+  test('only the document that actually changes is planned', async () => {
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    seed(ROOT_JSONC, '{ "mcp": {} }\n')
+
+    const written = await reconcile()
+
+    // A document nothing writes is not journaled: inspecting a file has never
+    // been a reason to own it, and a rollback that rewrote it could overwrite
+    // an edit this run never made.
+    expect(written).toEqual([join(root, DOT_JSONC)])
+  })
+
+  test('a lower-precedence mcp member wins over a higher-precedence document without one', async () => {
+    seed(DOT_JSONC, '{ "model": "anthropic/claude" }\n')
+    seed(ROOT_JSON, '{ "mcp": {} }\n')
 
     await reconcile()
 
-    expect(servers(JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
-    expect(servers(JSON_DOCUMENT).fs).toBeUndefined()
+    // Where this project already keeps its servers, not merely the file that
+    // sorts first.
+    expect(servers(ROOT_JSON).fs?.command).toEqual(['srv', '--root', '/w'])
+    expect(read(DOT_JSONC)).toBe('{ "model": "anthropic/claude" }\n')
   })
 
-  test('an entry defined only in the JSON layer is updated there', async () => {
-    // That layer is where the key currently wins, so writing the JSONC file
-    // instead would leave the merged configuration unchanged.
-    writeFileSync(join(root, JSONC), '{ "mcp": {} }\n')
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": { "fs": { "type": "local", "command": ["other"] } } }\n')
+  test('.opencode outranks the project root when both define servers', async () => {
+    seed(DOT_JSON, '{ "mcp": {} }\n')
+    seed(ROOT_JSONC, '{ "mcp": {} }\n')
 
-    await reconcile(['fs'])
+    await reconcile()
 
-    expect(servers(JSON_DOCUMENT).fs?.command).toEqual(['srv', '--root', '/w'])
-    expect(servers(JSONC).fs).toBeUndefined()
+    expect(servers(DOT_JSON).fs?.command).toEqual(['srv', '--root', '/w'])
+    expect(servers(ROOT_JSONC).fs).toBeUndefined()
   })
 
-  test('an owned entry defined in both layers is collapsed into the JSONC one', async () => {
-    writeFileSync(join(root, JSONC), '{ "mcp": { "fs": { "type": "local", "command": ["stale"] } } }\n')
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": { "fs": { "type": "local", "command": ["shadowed"] } } }\n')
+  test('jsonc outranks json inside .opencode', async () => {
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    seed(DOT_JSON, '{ "mcp": {} }\n')
 
-    await reconcile(['fs'])
+    await reconcile()
 
-    expect(servers(JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
-    expect(servers(JSON_DOCUMENT).fs).toBeUndefined()
+    expect(servers(DOT_JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
+    expect(servers(DOT_JSON).fs).toBeUndefined()
   })
 
-  test('an obsolete owned entry is removed from the lower layer', async () => {
-    writeFileSync(join(root, JSONC), '{ "mcp": {} }\n')
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": { "fs": { "type": "local", "command": ["gone"] } } }\n')
+  test('the winning entry is classified from the merged view, not the target alone', async () => {
+    // The target defines nothing under this name; a lower document defines it
+    // equivalently. Classifying per-document would call this absent and write.
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    seed(ROOT_JSON, `{ "mcp": { "fs": ${NATIVE_STDIO} } }\n`)
+
+    const planned = await plan([STDIO_SERVER], ['fs'])
+    if (!planned.ok) expect.unreachable()
+
+    expect(planned.plan.outcomes).toEqual([{ kind: 'equivalent', name: 'fs', ownership: 'tracked' }])
+    expect(planned.plan.action.kind).toBe('unchanged')
+  })
+
+  test('a shadowed copy of a desired entry is left where its author put it', async () => {
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    const shadowed = '{ "mcp": { "fs": { "type": "local", "command": ["shadowed"] } } }\n'
+    seed(ROOT_JSON, shadowed)
+
+    const written = await reconcile(['fs'])
+
+    // The lower copy is inert once the target defines the same key, and this
+    // adapter did not put it there — so it is neither rewritten nor journaled.
+    expect(written).toEqual([join(root, DOT_JSONC)])
+    expect(servers(DOT_JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
+    expect(read(ROOT_JSON)).toBe(shadowed)
+  })
+
+  test('an obsolete owned entry is removed from every document that defines it', async () => {
+    // Removing only the winning copy would promote the shadowed one and leave
+    // the server configured.
+    seed(DOT_JSONC, '{ "mcp": { "fs": { "type": "local", "command": ["gone"] } } }\n')
+    seed(DOT_JSON, '{ "mcp": { "fs": { "type": "local", "command": ["also-gone"] } } }\n')
+    seed(ROOT_JSONC, '{ "mcp": { "fs": { "type": "local", "command": ["still-gone"] } } }\n')
+    seed(ROOT_JSON, '{ "mcp": { "fs": { "type": "local", "command": ["gone-too"] } } }\n')
 
     await removeAll(['fs'])
 
-    expect(servers(JSON_DOCUMENT).fs).toBeUndefined()
+    for (const candidate of CANDIDATES) expect(servers(candidate).fs).toBeUndefined()
   })
 
-  test('an unowned entry survives in either layer', async () => {
-    writeFileSync(join(root, JSONC), '{ "mcp": {} }\n')
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": { "manual": { "type": "local", "command": ["keep"] } } }\n')
+  test('an unowned entry survives in every document', async () => {
+    const unowned = '{ "mcp": { "manual": { "type": "local", "command": ["keep"] } } }\n'
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    seed(ROOT_JSONC, unowned)
+    seed(ROOT_JSON, unowned)
 
     await reconcile()
 
-    expect(servers(JSON_DOCUMENT).manual?.command).toEqual(['keep'])
+    expect(read(ROOT_JSONC)).toBe(unowned)
+    expect(read(ROOT_JSON)).toBe(unowned)
   })
 
-  test('an existing JSON layer is used rather than creating a JSONC one beside it', async () => {
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": {} }\n')
+  test('a malformed lower-precedence document fails the whole plan, read-only', async () => {
+    // It is part of the configuration a change would land in, so planning past
+    // it would be planning against a view OpenCode does not have.
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    seed(ROOT_JSON, '{ "mcp": { \n')
+
+    const planned = await plan([STDIO_SERVER], [])
+    if (planned.ok) expect.unreachable()
+    expect(planned.failure.code).toBe('parse-failed')
+    if (planned.failure.code !== 'parse-failed') expect.unreachable()
+    expect(planned.failure.path).toBe(join(root, ROOT_JSON))
+    expect(read(DOT_JSONC)).toBe('{ "mcp": {} }\n')
+  })
+
+  test('a non-object mcp member in a lower-precedence document is reported against that document', async () => {
+    seed(DOT_JSONC, '{ "mcp": {} }\n')
+    seed(ROOT_JSONC, '{ "mcp": [] }\n')
+
+    const planned = await plan([STDIO_SERVER], [])
+    if (planned.ok) expect.unreachable()
+    expect(planned.failure.code).toBe('validation-failed')
+    if (planned.failure.code !== 'validation-failed') expect.unreachable()
+    expect(planned.failure.path).toBe(join(root, ROOT_JSONC))
+  })
+
+  test('a byte-order mark on the target survives an edit', async () => {
+    seed(DOT_JSONC, '\uFEFF{\n  "mcp": {}\n}\n')
 
     await reconcile()
 
-    expect(servers(JSON_DOCUMENT).fs?.command).toEqual(['srv', '--root', '/w'])
-    expect(() => read(JSONC)).toThrow()
+    expect(read(DOT_JSONC).startsWith('\uFEFF')).toBe(true)
+    expect(servers(DOT_JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
   })
 
-  test('a JSONC document is created when neither layer exists', async () => {
-    await reconcile()
+  test('each document keeps its own byte-order mark through a multi-document change', async () => {
+    // Removal writes several documents at once, which is where one shared flag
+    // would put a mark on a file that never had one.
+    seed(DOT_JSONC, '\uFEFF{ "mcp": { "fs": { "type": "local", "command": ["gone"] } } }\n')
+    seed(ROOT_JSON, '{ "mcp": { "fs": { "type": "local", "command": ["shadowed"] } } }\n')
 
-    expect(servers(JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
-    expect(() => read(JSON_DOCUMENT)).toThrow()
-  })
+    await removeAll(['fs'])
 
-  test('a byte-order mark on the JSONC layer survives an edit', async () => {
-    writeFileSync(join(root, JSONC), '\uFEFF{\n  "mcp": {}\n}\n')
-
-    await reconcile()
-
-    expect(read(JSONC).startsWith('\uFEFF')).toBe(true)
-    expect(servers(JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
-  })
-
-  test('a byte-order mark on the JSON layer survives an edit', async () => {
-    writeFileSync(join(root, JSON_DOCUMENT), '\uFEFF{\n  "mcp": {}\n}\n')
-
-    await reconcile()
-
-    expect(read(JSON_DOCUMENT).startsWith('\uFEFF')).toBe(true)
-    expect(servers(JSON_DOCUMENT).fs?.command).toEqual(['srv', '--root', '/w'])
-  })
-
-  test('each layer keeps its own byte-order mark through a two-document change', async () => {
-    // The collapse path writes both layers at once, which is where one shared
-    // flag would put a mark on the file that never had one.
-    writeFileSync(join(root, JSONC), '\uFEFF{ "mcp": { "fs": { "type": "local", "command": ["stale"] } } }\n')
-    writeFileSync(join(root, JSON_DOCUMENT), '{ "mcp": { "fs": { "type": "local", "command": ["shadowed"] } } }\n')
-
-    await reconcile(['fs'])
-
-    expect(read(JSONC).startsWith('\uFEFF')).toBe(true)
-    expect(read(JSON_DOCUMENT).startsWith('\uFEFF')).toBe(false)
-    expect(servers(JSONC).fs?.command).toEqual(['srv', '--root', '/w'])
-    expect(servers(JSON_DOCUMENT).fs).toBeUndefined()
+    expect(read(DOT_JSONC).startsWith('\uFEFF')).toBe(true)
+    expect(read(ROOT_JSON).startsWith('\uFEFF')).toBe(false)
+    expect(servers(DOT_JSONC).fs).toBeUndefined()
+    expect(servers(ROOT_JSON).fs).toBeUndefined()
   })
 
   test('a nested first indented line does not re-indent the edited member', async () => {
-    writeFileSync(join(root, JSONC), '{\n  "tools": {\n        "deep": true\n  },\n  "mcp": {}\n}\n')
+    seed(DOT_JSONC, '{\n  "tools": {\n        "deep": true\n  },\n  "mcp": {}\n}\n')
 
     await reconcile()
 
     // The `mcp` member keeps the two-space step it was written with rather
     // than being laid out with the eight-space run further down.
-    expect(read(JSONC)).toContain('\n  "mcp": {')
+    expect(read(DOT_JSONC)).toContain('\n  "mcp": {')
   })
 })
 
@@ -399,8 +562,8 @@ describe('opencode MCP capability', () => {
       if (prepared.failure.code !== 'conflict') expect.unreachable()
       if (prepared.failure.reason !== 'interpolation') expect.unreachable()
       // No document is named: the guard runs before a write target is chosen,
-      // and this failure used to be attributed to the JSONC layer whether or
-      // not that file was the one a write would have touched.
+      // and this failure used to be attributed to one particular layer whether
+      // or not that file was the one a write would have touched.
       expect(prepared.failure).toEqual({
         code: 'conflict',
         reason: 'interpolation',

--- a/packages/adapters/opencode/src/mcp-servers.ts
+++ b/packages/adapters/opencode/src/mcp-servers.ts
@@ -26,44 +26,80 @@ import {
 /**
  * OpenCode MCP server reconciliation.
  *
- * ## Two documents, one configuration
+ * ## Four documents, one configuration
  *
- * OpenCode loads `opencode.json` and then `opencode.jsonc` from the same
- * directory and deep-merges them in that order, so a key defined in both is
- * the JSONC one. That merge is the configuration; neither file is it on its
- * own. So this adapter reads BOTH, classifies against the merged per-key view,
- * and discloses both paths.
+ * OpenCode merges four project-scoped configuration documents. It loads the
+ * project root's `opencode.json` and `opencode.jsonc` first, then
+ * `.opencode/opencode.json` and `.opencode/opencode.jsonc`, deep-merging each
+ * over the ones before it. A key defined in more than one of them takes its
+ * value from the last one loaded, so precedence runs:
  *
- * Reading only the JSONC file was a real defect, not a simplification: an
- * obsolete owned server living only in `opencode.json` looked absent, so
- * removal skipped it and OpenCode went on loading a server the project had
- * deleted.
+ *   1. `.opencode/opencode.jsonc`  (wins)
+ *   2. `.opencode/opencode.json`
+ *   3. `opencode.jsonc`
+ *   4. `opencode.json`
  *
- * Writes then target the layer that makes the change effective:
+ * That merge is the configuration; no one file is it on its own. So this
+ * adapter reads ALL four, classifies against the merged per-key view, and
+ * discloses all four paths.
  *
- *   - A new entry goes to `opencode.jsonc` when that file exists, otherwise to
- *     an existing `opencode.json`, otherwise into a newly created
- *     `opencode.jsonc`.
- *   - An existing entry is updated in the layer where it currently wins.
- *   - An owned entry defined in BOTH layers is updated in `opencode.jsonc` and
- *     its shadowed `opencode.json` copy is removed in the same change, so the
- *     merged view cannot silently disagree with either file.
- *   - An obsolete owned entry is deleted from every layer that defines it.
+ * Reading fewer of them was a real defect, not a simplification: an obsolete
+ * owned server living only in a document this adapter never opened looked
+ * absent, so removal skipped it and OpenCode went on loading a server the
+ * project had deleted.
  *
- * An entry the project neither desires nor owns is never touched, in either
- * layer.
+ * ## One write target
+ *
+ * Every write for a desired server goes to a single document, chosen once per
+ * run:
+ *
+ *   1. the highest-precedence document that already defines an `mcp` member —
+ *      an empty `{}` counts, since that is still where this project keeps its
+ *      servers;
+ *   2. otherwise the highest-precedence document that exists at all;
+ *   3. otherwise `.opencode/opencode.jsonc`, created.
+ *
+ * Following the user's own `mcp` member rather than merely the
+ * highest-precedence file that happens to exist is what keeps this adapter out
+ * of the way: a project whose `.opencode/opencode.jsonc` holds only agents,
+ * with its servers in a root `opencode.json`, gets its servers where its
+ * servers already are.
+ *
+ * A copy of a desired server in a lower-precedence document is left exactly as
+ * it is. It is shadowed and inert, this adapter did not put it there, and
+ * deleting from a document this run is not otherwise writing is not this
+ * adapter's call to make.
+ *
+ * An obsolete owned entry is the one exception: it is deleted from every
+ * document that defines it, because removing only the winning copy would
+ * promote a shadowed one and leave the server configured.
+ *
+ * An entry the project neither desires nor owns is never touched, in any
+ * document.
  *
  * ## Why JSONC, and why minimal edits
  *
- * OpenCode parses *both* filenames as JSONC, and its own `opencode mcp add`
- * edits configuration with a syntax-aware editor. This adapter does the same,
- * for the same reason: a targeted edit is a minimal text change rather than a
- * re-serialization, so comments, member order, indentation, and trailing
- * commas everywhere outside the one entry being changed survive.
+ * OpenCode parses *every* one of these filenames as JSONC, and its own
+ * `opencode mcp add` edits configuration with a syntax-aware editor. This
+ * adapter does the same, for the same reason: a targeted edit is a minimal
+ * text change rather than a re-serialization, so comments, member order,
+ * indentation, and trailing commas everywhere outside the one entry being
+ * changed survive.
  */
 
-/** Candidate documents, in the order OpenCode's own merge makes authoritative. */
-const DOCUMENT_NAMES = ['opencode.jsonc', 'opencode.json'] as const
+/**
+ * Candidate documents, highest precedence first.
+ *
+ * The single source of truth for the whole capability: reading, disclosure,
+ * the merged view, target selection, and edit order all derive from this one
+ * order, so none of them can disagree with another.
+ */
+const CANDIDATE_PATHS = [
+  '.opencode/opencode.jsonc',
+  '.opencode/opencode.json',
+  'opencode.jsonc',
+  'opencode.json',
+] as const satisfies readonly [string, ...string[]]
 
 /** The top-level member OpenCode reads servers from. */
 const SERVER_MAP_KEY = 'mcp'
@@ -85,6 +121,20 @@ const PORTABLE_KEYS: Readonly<Record<'local' | 'remote', ReadonlySet<string>>> =
 }
 
 /**
+ * Whether a document that exists defines the member OpenCode reads servers
+ * from, and what it held.
+ *
+ * A state rather than a possibly-empty record, because the two cases decide
+ * different things. A document carrying `"mcp": {}` is where this project
+ * keeps its servers even while it keeps none; a document with no `mcp` member
+ * is one this adapter would be introducing MCP configuration into. Collapsing
+ * them would make target selection unable to tell those apart.
+ */
+type ServerMapState =
+  | { readonly kind: 'unconfigured' }
+  | { readonly kind: 'configured'; readonly entries: Readonly<Record<string, unknown>> }
+
+/**
  * A layer's document as it was found on disk.
  *
  * The mark is split off rather than carried inline because every parser here
@@ -93,10 +143,24 @@ const PORTABLE_KEYS: Readonly<Record<'local' | 'remote', ReadonlySet<string>>> =
  * the split form is what makes "which text do I parse" and "which text do I
  * compare against" impossible to confuse — the exact original is derived from
  * these two fields, never stored beside them.
+ *
+ * The server map hangs off the `present` arm alone: a document that does not
+ * exist cannot define one, and hoisting the field would make that combination
+ * representable for no gain.
  */
 type LayerSource =
   | { readonly kind: 'absent' }
-  | { readonly kind: 'present'; readonly bom: boolean; readonly body: string }
+  | {
+      readonly kind: 'present'
+      readonly bom: boolean
+      readonly body: string
+      /**
+       * What this document defined when it was inspected. A snapshot on
+       * purpose: every target and removal decision is made against the view
+       * OpenCode itself loaded, not against a half-edited document.
+       */
+      readonly servers: ServerMapState
+    }
 
 /** One configuration layer, as inspected and as being edited. */
 interface Layer {
@@ -108,19 +172,22 @@ interface Layer {
    */
   readonly document: McpTextDocument
   readonly source: LayerSource
-  /**
-   * The server entries this layer defined when it was inspected. A snapshot on
-   * purpose: every write-target and shadowing decision is made against the view
-   * OpenCode itself loaded, not against a half-edited document.
-   */
-  readonly servers: Record<string, unknown>
   /** The working body, mark-free like {@link LayerSource}'s. */
   workingBody: string
 }
 
-/** The exact bytes this layer was read from, which a plan compares against. */
-function _inspectedText(layer: Layer): string | null {
-  return layer.source.kind === 'absent' ? null : restoreJsoncBom(layer.source.body, layer.source.bom)
+/** Shared empty view for a layer that defines no entries. */
+const NO_ENTRIES: Readonly<Record<string, unknown>> = Object.freeze({})
+
+/** The entries this layer defined when it was inspected. */
+function definedEntries(layer: Layer): Readonly<Record<string, unknown>> {
+  if (layer.source.kind !== 'present') return NO_ENTRIES
+  return layer.source.servers.kind === 'configured' ? layer.source.servers.entries : NO_ENTRIES
+}
+
+/** Whether this layer itself defines an entry under `name`. */
+function defines(layer: Layer, name: string): boolean {
+  return Object.hasOwn(definedEntries(layer), name)
 }
 
 /** The body a first edit starts from: the document's own, or a fresh object. */
@@ -146,21 +213,23 @@ export const openCodeMcpServers: McpServerCapability = {
   async plan(request: PlanMcpServersRequest): Promise<PlanMcpServersResult> {
     const read = readLayers(request.projectRoot)
     if (!read.ok) return { ok: false, failure: read.failure }
-    const [jsonc, json] = read.layers
+    const layers = read.layers
 
-    // The merged per-key view OpenCode itself sees: the lower layer first, then
-    // the winning one over it.
+    // The merged per-key view OpenCode itself sees: lowest precedence first,
+    // each layer written over the ones it outranks.
     const merged = new Map<string, unknown>()
-    for (const layer of [json, jsonc]) {
-      for (const [name, entry] of Object.entries(layer.servers)) merged.set(name, entry)
+    for (const layer of [...layers].reverse()) {
+      for (const [name, entry] of Object.entries(definedEntries(layer))) merged.set(name, entry)
     }
 
+    const target = selectTarget(layers)
     const tracked = new Set(request.previouslyOwnedNames)
     const desiredByName = new Map(request.desired.map((contribution) => [contribution.name, contribution]))
 
+    const [highest, ...lower] = layers
     return prepareMcpTextPlan({
       request,
-      documents: [jsonc.document, json.document],
+      documents: [highest.document, ...lower.map((layer) => layer.document)],
       interpolation: { pattern: INTERPOLATION_PATTERN },
       presentNames: new Set(merged.keys()),
       compare: (contribution) => compareEntry(merged.get(contribution.name), contribution.declaration),
@@ -176,27 +245,25 @@ export const openCodeMcpServers: McpServerCapability = {
                 outcome.kind === 'divergent' && tracked.has(outcome.name)
                   ? preservableExtensions(merged.get(outcome.name), contribution.declaration)
                   : {}
-              const target = writeTargetFor(outcome.name, jsonc, json)
+              // One target for the whole run. A shadowed copy in a
+              // lower-precedence document is inert and was not put there by
+              // this adapter, so it is left exactly as its author wrote it.
               setEntry(target, outcome.name, renderEntry(contribution.declaration, preserved))
-              // A copy in the losing layer would keep shadowing this one on
-              // every future read, so the two would drift apart silently.
-              if (target === jsonc && Object.hasOwn(json.servers, outcome.name)) {
-                setEntry(json, outcome.name, undefined)
-              }
               break
             }
             case 'obsolete-owned':
               // Deleted from every layer that defines it: the merged view is
-              // only free of the entry when no layer still carries it.
-              for (const layer of [jsonc, json]) {
-                if (Object.hasOwn(layer.servers, outcome.name)) setEntry(layer, outcome.name, undefined)
+              // only free of the entry when no layer still carries it, and
+              // removing just the winning copy would promote a shadowed one.
+              for (const layer of layers) {
+                if (defines(layer, outcome.name)) setEntry(layer, outcome.name, undefined)
               }
               break
           }
         }
 
         const edits: TextDocumentEdit[] = []
-        for (const layer of [jsonc, json]) {
+        for (const layer of layers) {
           const edit = pendingEdit(layer)
           if (edit !== null) edits.push(edit)
         }
@@ -207,47 +274,73 @@ export const openCodeMcpServers: McpServerCapability = {
 }
 
 type ReadLayersResult =
-  | { readonly ok: true; readonly layers: readonly [Layer, Layer] }
+  | { readonly ok: true; readonly layers: readonly [Layer, ...Layer[]] }
   | { readonly ok: false; readonly failure: McpServerCapabilityFailure }
 
 /**
- * Read and parse both layers.
+ * Read and parse every candidate document, highest precedence first.
  *
- * Both are always disclosed, including one that does not exist: "absent" is a
- * preimage the caller can restore to, and a run that creates the JSONC file
- * has to be able to put its absence back.
+ * All are disclosed, including ones that do not exist: "absent" is a preimage
+ * the caller can restore to, and a run that creates a document has to be able
+ * to put its absence back.
+ *
+ * The tuple is built from {@link CANDIDATE_PATHS}'s own head and tail rather
+ * than accumulated into an array, so "at least one layer" is carried by the
+ * type instead of asserted afterwards by a check that could never fire.
  */
 function readLayers(projectRoot: string): ReadLayersResult {
-  const layers: Layer[] = []
+  const [highestPath, ...lowerPaths] = CANDIDATE_PATHS
 
-  for (const name of DOCUMENT_NAMES) {
-    const path = join(projectRoot, name)
-    const read = readTextOrAbsent(path)
+  const highest = readLayer(projectRoot, highestPath)
+  if (!highest.ok) return { ok: false, failure: highest.failure }
+
+  const lower: Layer[] = []
+  for (const candidate of lowerPaths) {
+    const read = readLayer(projectRoot, candidate)
     if (!read.ok) return { ok: false, failure: read.failure }
-
-    const parsed = parseLayer(read.document, read.text)
-    if (!parsed.ok) return { ok: false, failure: parsed.failure }
-    layers.push(parsed.layer)
+    lower.push(read.layer)
   }
 
-  const [jsonc, json] = layers
-  // Unreachable: `DOCUMENT_NAMES` has exactly two entries and the loop pushes
-  // one layer per entry or returns.
-  if (jsonc === undefined || json === undefined) {
-    throw new Error('opencode: expected one layer per candidate document')
-  }
-  return { ok: true, layers: [jsonc, json] }
+  return { ok: true, layers: [highest.layer, ...lower] }
 }
 
-type ParseLayerResult =
+/**
+ * The one document every desired-server write goes to.
+ *
+ * The highest-precedence document that already defines an `mcp` member, else
+ * the highest-precedence one that exists, else the highest-precedence
+ * candidate — which this run then creates. Preferring an existing `mcp` member
+ * over mere existence is deliberate: it puts servers where this project's
+ * servers already live rather than splitting them across two files that
+ * shadow each other.
+ */
+function selectTarget(layers: readonly [Layer, ...Layer[]]): Layer {
+  const configured = layers.find(
+    (layer) => layer.source.kind === 'present' && layer.source.servers.kind === 'configured',
+  )
+  if (configured !== undefined) return configured
+
+  const existing = layers.find((layer) => layer.source.kind === 'present')
+  if (existing !== undefined) return existing
+
+  return layers[0]
+}
+
+type ReadLayerResult =
   | { readonly ok: true; readonly layer: Layer }
   | { readonly ok: false; readonly failure: McpServerCapabilityFailure }
 
-function parseLayer(document: McpTextDocument, text: string | null): ParseLayerResult {
+function readLayer(projectRoot: string, candidate: string): ReadLayerResult {
+  const read = readTextOrAbsent(join(projectRoot, candidate))
+  if (!read.ok) return { ok: false, failure: read.failure }
+  return parseLayer(read.document, read.text)
+}
+
+function parseLayer(document: McpTextDocument, text: string | null): ReadLayerResult {
   const path = document.path
   if (text === null) {
     const source = { kind: 'absent' } as const
-    return { ok: true, layer: { path, document, source, servers: {}, workingBody: startingBody(source) } }
+    return { ok: true, layer: { path, document, source, workingBody: startingBody(source) } }
   }
 
   const { bom, body } = splitJsoncBom(text)
@@ -271,24 +364,10 @@ function parseLayer(document: McpTextDocument, text: string | null): ParseLayerR
     }
   }
 
-  const source = { kind: 'present', bom, body } as const
-  return { ok: true, layer: { path, document, source, servers: rawServers ?? {}, workingBody: startingBody(source) } }
-}
-
-/**
- * The layer a write must target for this name to take effect.
- *
- * An existing key is updated where it currently wins; a new one goes to the
- * preferred existing document, or to a newly created JSONC file when neither
- * exists. Writing anywhere else would leave the merged view unchanged, which
- * from the user's point of view is a silent no-op.
- */
-function writeTargetFor(name: string, jsonc: Layer, json: Layer): Layer {
-  if (Object.hasOwn(jsonc.servers, name)) return jsonc
-  if (Object.hasOwn(json.servers, name)) return json
-  if (jsonc.source.kind === 'present') return jsonc
-  if (json.source.kind === 'present') return json
-  return jsonc
+  const servers: ServerMapState =
+    rawServers === undefined ? { kind: 'unconfigured' } : { kind: 'configured', entries: rawServers }
+  const source = { kind: 'present', bom, body, servers } as const
+  return { ok: true, layer: { path, document, source, workingBody: startingBody(source) } }
 }
 
 /**


### PR DESCRIPTION
### Why

The OpenCode adapter only ever looked at the project root's `opencode.jsonc` and `opencode.json`. OpenCode itself merges **four** project documents, and the two under `.opencode/` outrank both root files:

1. `.opencode/opencode.jsonc`
2. `.opencode/opencode.json`
3. `opencode.jsonc`
4. `opencode.json`

So a project keeping its OpenCode configuration in `.opencode/` — including this repo — got its servers written to a file the higher-precedence one shadows. The configuration the user approved was not the one OpenCode loaded, and nothing surfaced the difference. An obsolete owned server living only in an unread document survived removal for the same reason.

Confirmed against upstream `anomalyco/opencode@dev`: `config.ts` runs the root-file merge loop first and the `.opencode`-directory loop after it, and upstream's own test `"local .opencode config can override MCP from project config"` asserts exactly this ordering for `mcp`.

### Details

All four documents are now read, classified as one merged configuration, and disclosed in `documentPaths`. One candidate list in precedence order is the single source of truth for reading, disclosure, the merged view, target selection, and edit order, so those five cannot drift apart.

Writes go to exactly one document, chosen once per run:

1. the highest-precedence document that already defines an `mcp` member — an empty `{}` counts;
2. otherwise the highest-precedence document that exists;
3. otherwise `.opencode/opencode.jsonc`, created.

Rule 1 is the part worth reviewing. Following the user's existing `mcp` member rather than merely the file that sorts first is what stops a project whose servers live in a root `opencode.json`, beside a `.opencode/opencode.jsonc` holding only agents, from having its servers split across two files that shadow each other. `"mcp": {}` and "no `mcp` member" are therefore distinct states, modeled as a tagged `ServerMapState` hanging off the `present` arm of `LayerSource` — a document that does not exist cannot carry a server map, and now cannot represent one either.

Two behavioral changes beyond the path set:

- **A shadowed copy of a desired server is now left alone.** Previously the losing copy was deleted. The target's definition already wins, and deleting from a file this run is not otherwise writing is not the adapter's call to make.
- **An obsolete owned entry is still removed from every document that defines it.** This one cannot be narrowed: removing only the winning copy would promote a shadowed one and leave the server configured.

Generalizing the read from a fixed pair to a precedence list also retires the `throw new Error('unreachable')` that guarded the old two-element tuple. The non-empty tuple is built from the candidate list's own head and tail, so "at least one layer" is carried by the type instead of asserted by a check that could never fire.

No engine or adapter-SDK contract changed.

### Verification

`bun check`.

The adapter suite goes from 40 tests to 122. The core addition is table-driven over all 81 combinations of four candidates × {absent, exists without `mcp`, has `mcp`}, with the selection rule restated independently as the oracle rather than read back from the implementation. Mutation-checked: inverting the rule to prefer mere existence over an existing `mcp` member fails 26 of them. The remaining new cases cover four-path disclosure (including on an unchanged plan), classification from the merged view rather than the target alone, shadowed-copy preservation, all-layer obsolete removal, per-document parse and validation failures, and per-document BOM state through a multi-document write.

One upstream asymmetry found while confirming precedence, not acted on here: `ConfigPaths.directories` does not reverse its walk, so an *ancestor's* `.opencode/` config outranks a nearer one — the opposite of how OpenCode treats the root-level pair. This adapter only ever looks at `projectRoot`, so it is unaffected.
