### PR TITLE
Bump viper-plans to 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ mise.local.toml
 .codex/
 .opencode/
 .pr-reviews/
+.mcp.json
 
 .env
 

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "1.2.1",
+    "viper-plans": "1.3.0",
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.2",

--- a/facets.lock
+++ b/facets.lock
@@ -668,8 +668,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.2.1",
-      "integrity": "sha256:cb6f0be50bf57cdaaa664eb24fd69e486490b2ff1228a96b00fbc9addc1990a0",
+      "version": "1.3.0",
+      "integrity": "sha256:be85be9bc09b87be4ffca314ec83cd317589a3da573ec73abc28e0cdda0e2ab2",
       "assets": [
         {
           "scope": "project",
@@ -709,7 +709,7 @@
           "files": [
             {
               "path": "commands/viper-continue.md",
-              "integrity": "sha256:c18e84a503bf98f8f153e9af33c1007ad01de46a9ff9b289a2b5f7072c9a51bf"
+              "integrity": "sha256:80f8444039799ae1f06286994a2d420be97f1fe95c600f96b9cbc80516d29b79"
             }
           ]
         },
@@ -723,7 +723,7 @@
           "files": [
             {
               "path": "commands/viper-plan.md",
-              "integrity": "sha256:594a642ae65fa75d0881e6ace749a65706ef55aecbe72aba17c0f9fca7c7bc56"
+              "integrity": "sha256:1faa52ff624a8fc997a4ce1a25857d9ce6d205c9e4d26015722dcd355272ed2d"
             }
           ]
         },
@@ -737,7 +737,7 @@
           "files": [
             {
               "path": "commands/viper-run.md",
-              "integrity": "sha256:bfff09006b1e319e441ccc46c0b10d5079ee2c9e35231cf64e9931b606cde983"
+              "integrity": "sha256:ab4e2036931dc344424b52d0019e96853cf8e235e755a452e942953504000eee"
             }
           ]
         }

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -53,7 +53,7 @@ const steps: Step[] = [
   },
   {
     label: 'facets',
-    run: () => $`bun dev install`.quiet().then(() => undefined),
+    run: () => $`bun dev install --accept-mcp`.quiet().then(() => undefined),
   },
 ]
 


### PR DESCRIPTION
### Why

Bumps `viper-plans` from version `1.2.1` to `1.3.0`.

### Verification

CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `viper-plans` facet to version 1.3.0.
  * Improved installation setup to automatically accept MCP configuration.
  * Excluded local MCP configuration files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->