### PR TITLE
Plan exclusive `--adapter` targeting for installation commands

### DIFF
--- a/openspec/.gitignore
+++ b/openspec/.gitignore
@@ -1,0 +1,1 @@
+changes/archive/

--- a/openspec/changes/filter-installation-by-adapter/.openspec.yaml
+++ b/openspec/changes/filter-installation-by-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/filter-installation-by-adapter/design.md
+++ b/openspec/changes/filter-installation-by-adapter/design.md
@@ -1,0 +1,197 @@
+## Context
+
+`facet add`, `facet install`, and `facet remove` currently reconcile the complete desired project state into every installed materialization-capable adapter. The machine-local `0.4` receipt records adapter-agnostic project ownership: it identifies what the project may manage and delete, but does not record where each identity was written.
+
+Leaving non-target adapters untouched would require adapter-scoped receipt history so filtered updates and removals could preserve old deletion evidence. The simpler model is to make an explicit adapter list exclusive: every non-target adapter is purged during the same operation, while every target adapter receives the complete desired project state. Because no successful operation leaves intentionally stale project-owned state in a discoverable non-target adapter, the existing adapter-agnostic receipt remains sufficient.
+
+The manifest and lockfile remain project-wide desired state. The project lock, transaction journal, consent model, collision plan, and receipt format remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The three installation front doors MUST accept an optional, repeatable `--adapter <name>`.
+- Explicit adapter values MUST resolve to a non-empty exclusive target set before mutation.
+- Every successful filtered operation MUST remove all receipt-owned project materialization from every installed non-target materialization-capable adapter.
+- Every successful filtered operation MUST reconcile the complete desired project state into every target adapter.
+- Receipt schema `0.4` MUST remain the adapter-agnostic source of deletion authority.
+- Target writes, non-target purges, manifest changes, lockfile changes, and receipt changes MUST remain transactional.
+- Invocations without `--adapter` MUST retain existing behavior.
+
+**Non-Goals:**
+
+- This change SHALL NOT add project-level adapter configuration or a `facet configure` command. A future change MAY supply default targets from project configuration, with explicit CLI values taking precedence.
+- This change SHALL NOT add per-facet placement, per-adapter desired versions, or adapter-scoped receipt ownership.
+- This change SHALL NOT change the receipt version or add a receipt migration.
+- This change SHALL NOT apply adapter targeting to authoring, build, publish, adapter-management, or read-only commands.
+- This change SHALL NOT add comma-separated values, exclusion grammar, or an “all except” mode.
+- This change SHALL NOT alter adapter SDK placement or MCP translation contracts.
+- This change SHALL NOT guarantee removal from an adapter that is no longer installed or discoverable on the machine.
+
+## Decisions
+
+### 1. Parse repeatable adapter targets at the shared CLI boundary
+
+`INSTALL_PIPELINE_FLAGS` SHALL define one array-valued `adapter` flag so `add`, `install`, and `remove` receive an identical repeatable option. `FlagDef` SHALL gain a value-label field so help renders each occurrence as `--adapter <name>`.
+
+A pure parser SHALL produce:
+
+```ts
+type AdapterTargetRequest =
+  | { kind: "all" }
+  | { kind: "exclusive"; names: NonEmptyReadonlyArray<string> };
+```
+
+No flag SHALL produce `all`. One or more flags SHALL produce `exclusive`. Missing and empty values SHALL return typed usage failures, and duplicate names SHALL be deduplicated. These commands SHALL reject undeclared flags so a typo cannot silently widen the target set.
+
+The target resolver SHALL operate on this source-independent request rather than reading argv itself. Today, absence of CLI values resolves to `all`. A future project configuration MAY provide an `exclusive` default request, while explicit CLI values override it, without changing the engine contract.
+
+Semantic selection SHALL inspect the complete installed adapter set. A filtered invocation SHALL NOT launch the picker or implicitly install an adapter. Every requested target and every adapter that must be purged MUST load successfully and expose the capabilities required for its side of the transition. Any failure SHALL abort before the project lock or mutation and SHALL identify the affected adapter.
+
+The current command ordering SHALL remain: `add` parses sources before adapter discovery, and `remove` validates project state before adapter discovery.
+
+**Alternatives considered:** Comma-separated values were rejected because repeatable flags avoid another grammar. Persisted configuration was deferred to a separate change. Ignoring a broken non-target adapter was rejected because exclusive targeting cannot truthfully claim it was purged.
+
+### 2. Represent target and purge sets as one tagged engine value
+
+The engine SHALL receive one scope value:
+
+```ts
+type InstallationAdapterTargets =
+  | {
+      kind: "all";
+      targets: NonEmptyReadonlyArray<Adapter>;
+    }
+  | {
+      kind: "exclusive";
+      targets: NonEmptyReadonlyArray<Adapter>;
+      purge: readonly Adapter[];
+    };
+```
+
+The CLI selection boundary SHALL construct and validate this partition. In the `exclusive` arm, `targets` and `purge` SHALL be disjoint and together SHALL cover every installed materialization-capable adapter participating in the operation. Only concrete, successfully loaded adapters reach the engine because both sets may be touched.
+
+The engine SHALL derive target writes only from `targets` and full-project removal plans only from `purge`. The existing project-wide lock SHALL continue to serialize all operations because every invocation can modify the same manifest, lockfile, receipt, and adapter files.
+
+**Alternative considered:** Passing target names and resolving purge adapters inside the engine was rejected because installed-adapter discovery and diagnostics are CLI responsibilities. Passing only targets was rejected because the engine could not prove that every non-target adapter had been purged.
+
+### 3. Keep receipt ownership adapter-agnostic at schema `0.4`
+
+The install receipt SHALL remain:
+
+```ts
+type Receipt = {
+  version: 0.4;
+  path: string;
+  facets: Record<string, ReceiptFacetEntry>;
+};
+```
+
+The receipt SHALL continue to answer “which identities and paths may this project manage?” rather than “which adapter currently contains each identity?” A filtered operation does not require adapter history because it removes all prior project-owned state from non-target adapters before committing the new project-wide account.
+
+The committed receipt SHALL be derived from the complete desired project state successfully reconciled into the target set. Asking a purge adapter to remove a globally owned identity that is absent remains a safe no-op, matching existing adapter-agnostic semantics.
+
+No receipt migration, forward refinement, adapter list, version partition, or downgrade policy is introduced.
+
+**Alternatives considered:** Adapter-first snapshots, facet/version partitions, and per-asset adapter tags were rejected because exclusive target semantics prevent intentional stale ownership and make those dimensions unnecessary. Leaving non-target adapters untouched was rejected because it requires retaining per-adapter historical deletion evidence.
+
+### 4. Purge non-target adapters and reconcile targets in one transaction
+
+The engine SHALL complete all source resolution, desired-state composition, adapter compatibility checks, native-state planning, collision decisions, and consent before opening the mutation journal.
+
+For an exclusive operation, the mutation plan SHALL contain two physical phases:
+
+1. **Purge:** remove every receipt-owned asset and MCP configuration entry from every adapter in `purge`, regardless of whether the identity remains in project desired state.
+2. **Target reconciliation:** remove obsolete target-owned identities and materialize the complete desired project state into every adapter in `targets`.
+
+Both phases SHALL use the existing receipt as their only deletion authority. Purging MUST NOT scan for or delete untracked native files. Purge and target transitions SHALL participate in the same transaction, and any failure SHALL roll back both phases byte-exactly.
+
+`facet add` and `facet remove` SHALL commit project manifest, lockfile, and receipt changes through the existing tri-write after physical reconciliation succeeds. `facet install` SHALL retain current manifest/lockfile behavior.
+
+**Alternative considered:** Purging only facets changed by the command was rejected because it retains implicit per-facet placement and requires state-change detection. Purging the complete project account makes the target set exact and keeps the receipt model uniform.
+
+### 5. Reconcile the complete project state into every target
+
+Adapter targeting SHALL affect physical placement, not desired-state composition. Manifest mutation, lockfile generation, integrity, effective-name collision planning, aliases, omissions, and stale-override pruning SHALL remain project-wide.
+
+Every target adapter SHALL receive the complete materialized set after an `add`, `install`, or `remove` operation. The named facet is not the only item reconciled. Consequently:
+
+- `facet add cowsay --adapter opencode` purges the project account from non-target adapters and reconciles all desired facets, including `cowsay`, into OpenCode.
+- `facet remove cowsay --adapter opencode` purges the project account from non-target adapters, removes `cowsay` from project desired state, and reconciles every remaining facet into OpenCode.
+- A later unfiltered `facet install` reconciles the complete project state into every installed materialization-capable adapter again.
+
+Project-content collisions SHALL remain global. Native occupancy and takeover checks SHALL evaluate target adapters. Purge adapters SHALL use receipt authority and SHALL NOT require takeover decisions because they never adopt untracked files.
+
+### 6. Purge MCP ownership without narrowing consent
+
+Each purge adapter SHALL receive removal authority only for effective MCP server names claimed by the adapter-agnostic receipt. The purge phase SHALL remove those entries before target MCP application.
+
+Target adapters SHALL perform existing MCP support, native-document overlap, takeover, and consent checks. Declaration approval SHALL remain machine-wide identity-and-fingerprint evidence from the receipt. Filtering SHALL neither manufacture approval nor require approval again merely because the target set changed.
+
+When purge and target adapters address the same native document, their planned transitions SHALL compose in purge-then-target order inside the transaction. If the adapter plans cannot be composed safely, the operation MUST return a typed pre-commit failure rather than partially mutating the document.
+
+`--accept-mcp`, interactive consent, and frozen-mode consent behavior SHALL remain unchanged.
+
+### 7. Treat every successful filtered result as converged
+
+A successful filtered operation SHALL have one stable postcondition:
+
+- every target adapter reflects complete project desired state;
+- every discoverable purge adapter contains no receipt-owned project state.
+
+There is no deferred reconciliation state and no adapter-specific catch-up metadata. A later operation simply applies its own target/purge partition. An unfiltered operation targets every installed materialization-capable adapter and purges none.
+
+The existing adapter-agnostic removal-refinement path SHALL be disabled globally rather than expanded to prove role-aware target/purge transitions. Every removal SHALL resolve complete remaining target state before mutation, using cached content when available and source/network resolution on cache miss. This intentionally changes the execution strategy for unfiltered removal: a cold-cache invocation without source availability SHALL fail unchanged instead of completing through receipt-only refinement. Target selection, placement postconditions, and receipt-driven deletion authority remain unchanged.
+
+### 8. Report exclusive target and purge effects explicitly
+
+Install summaries SHALL carry a tagged scope summary containing every target adapter and, for exclusive operations, every purged adapter. Filtered headers and success summaries SHALL use exclusive language such as:
+
+```text
+Targets: opencode, claude-code
+Purged: codex
+```
+
+Help text and command documentation MUST state that non-target adapters lose all Facet-managed project assets and MCP entries. Failure remedies SHALL preserve every repeated `--adapter <name>` occurrence so suggested reruns do not widen scope.
+
+Facet outcomes remain project outcomes because manifest and lockfile state are project-wide. Physical counts SHALL include target writes and purge removals separately.
+
+No additional confirmation prompt is introduced: the explicit flag is usable in non-interactive and frozen workflows. The CLI MUST make the destructive scope visible before mutation when a rendered progress view is active and MUST repeat it in the final summary.
+
+### 9. Permit exclusive targeting in frozen lockfile mode
+
+`facet install --frozen-lockfile` SHALL permit one or more repeated `--adapter <name>` targets. Frozen mode constrains the project-wide locked set, while adapter targeting controls physical placement.
+
+Frozen consistency gates and all target/purge preflight SHALL complete before mutation. A successful run SHALL purge every non-target adapter, reconcile the locked set into every target adapter, leave manifest and lockfile bytes unchanged, and write the existing adapter-agnostic receipt through the current receipt-only frozen commit.
+
+Interactive decisions SHALL remain unavailable. The receipt-unpersisted outcome SHALL report the target and purge sets because failed receipt persistence leaves physical changes without refreshed ownership evidence.
+
+### 10. Update affected documentation with the implementation
+
+The CLI reference pages `docs/cli/add.mdx`, `docs/cli/install.mdx`, and `docs/cli/remove.mdx` MUST document repeatable exclusive targets, full non-target purge behavior, validation, and examples.
+
+The specification documentation `docs/specification/commit.mdx`, `install.mdx`, `materialization.mdx`, `terminology.mdx`, `manifest.mdx`, and `index.mdx` MUST define target and purge sets while retaining adapter-agnostic receipt ownership. `docs/specification/lockfile.mdx` and `project-manifest.mdx` MUST clarify that neither artifact stores adapter targets.
+
+The guides `docs/guides/install-facets.mdx`, `troubleshooting.mdx`, and `custom-adapters.mdx` MUST explain exclusive placement, rematerialization through later unfiltered installs, and failure when a purge adapter cannot be loaded. Root `README.md`, navigation, authoring docs, and adapter SDK reference were reviewed and do not require changes.
+
+## Risks / Trade-offs
+
+- **[Users interpret `--adapter` as “leave others untouched”]** → Help, progress, and summaries MUST call the list exclusive and explicitly name purge adapters. The absence of this flag retains current non-destructive behavior.
+- **[A non-target adapter is broken or unavailable]** → The operation MUST fail before mutation because it cannot guarantee the exclusive postcondition.
+- **[An adapter is no longer installed and therefore cannot be discovered]** → The operation cannot purge it. Adapter-agnostic receipt authority is retained so a later operation can manage identities if the adapter returns.
+- **[The purge touches many files for a small add or remove]** → This cost is accepted to preserve one simple placement invariant. Plans remain no-op aware, and all changes share one transaction.
+- **[Purge and target adapters share native configuration documents]** → Their transitions MUST compose in deterministic purge-then-target order or fail before commit.
+- **[The receipt claims identities in adapters where they are absent]** → This is the existing adapter-agnostic ownership model. Adapter removal plans tolerate absence, and later target reconciliation may rematerialize the identity.
+- **[Unknown-flag permissiveness causes an unfiltered run]** → The three installation commands SHALL reject undeclared flags before adapter selection.
+
+## Migration Plan
+
+1. Keep receipt schema `0.4` and existing loaders/writers unchanged.
+2. Add repeatable CLI target parsing and resolve `all` or `exclusive` target requests at the shared adapter-selection boundary.
+3. Add full-project purge planning for non-target assets and MCP entries, then compose purge and target transitions in the existing transaction.
+4. Update scope reporting, documentation, and tests in the same release. Tests MUST cover single and multiple targets, duplicate names, unavailable purge adapters, complete non-target asset and MCP removal, add/install/remove semantics, shared native documents, rollback, frozen mode, unfiltered rematerialization, and unchanged receipt bytes/schema.
+5. Rollback requires no artifact migration; removing the new CLI option and purge orchestration restores prior behavior.
+
+## Open Questions
+
+None. The design settles exclusive target semantics, receipt ownership, transaction ordering, MCP behavior, frozen mode, and the extension point for future project defaults.

--- a/openspec/changes/filter-installation-by-adapter/proposal.md
+++ b/openspec/changes/filter-installation-by-adapter/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Projects with multiple installed adapters currently materialize every facet into every compatible adapter. Users need a simple way to declare that Facet-managed project state belongs only in a chosen set of adapters for an invocation, without introducing per-adapter desired state or versioned materialization histories.
+
+## What Changes
+
+- The installation-manipulating CLI workflows (`facet add`, `facet install`, and `facet remove`) SHALL accept an optional, repeatable `--adapter <name>` option naming a non-empty exclusive target set.
+- When `--adapter` is present, the complete desired project state SHALL be reconciled into every target adapter, and every receipt-owned project asset and MCP entry SHALL be dematerialized from every other installed materialization-capable adapter.
+- Filter validation and all target/purge planning SHALL complete before mutation. If any requested or purge adapter is unavailable, incompatible, broken, or unable to perform the required operation, the complete operation MUST fail without changing project or adapter files.
+- `facet add` and `facet remove` SHALL continue to update the project manifest and lockfile as project-wide desired state. Adapter targets SHALL control physical placement only.
+- The install receipt SHALL remain adapter-agnostic project ownership using the existing receipt schema. It SHALL continue to describe what the project owns, not which adapters currently contain it.
+- Existing machine-local MCP approval SHALL continue to gate configuration. Filtering SHALL NOT bypass or narrow consent.
+- CLI feedback SHALL identify every target adapter and every adapter purged by the invocation.
+- Without `--adapter`, existing behavior SHALL remain unchanged: every installed materialization-capable adapter is a target and no adapter is purged.
+
+## Non-goals
+
+- This change SHALL NOT add project-level adapter configuration, a `facet configure` command, or persistent adapter targets. A future change MAY use project configuration as the default target set while allowing explicit `--adapter` flags to override it.
+- This change SHALL NOT add per-facet adapter placement, per-adapter versions, per-adapter aliases, or per-adapter receipt ownership.
+- This change SHALL NOT filter authoring, build, publish, adapter-management, or read-only commands.
+- This change SHALL NOT add comma-separated adapter syntax, exclusion grammar such as `--exclude-adapter`, or an “all except” mode.
+- This change SHALL NOT alter the adapter SDK's placement or MCP translation contracts.
+
+## Capabilities
+
+### New Capabilities
+
+- None. Exclusive adapter targeting extends existing product domains.
+
+### Modified Capabilities
+
+- `installation`: Define exclusive target/purge reconciliation while retaining adapter-agnostic receipt ownership and project-wide desired state.
+- `cli`: Define the optional, repeatable `--adapter <name>` option, atomic validation, and reporting of target and purged adapters.
+
+## Impact
+
+- **CLI:** Shared flags and validation for `facet add`, `facet install`, and `facet remove` will resolve a non-empty exclusive target set.
+- **Engine:** Installation orchestration will add a transactional purge pass for every non-target adapter before reconciling the complete desired project into target adapters.
+- **Receipt:** No schema or migration change is required. Existing adapter-agnostic ownership remains authoritative.
+- **Compatibility:** Invocations without `--adapter` retain existing behavior. Filtered invocations introduce intentionally destructive cleanup of non-target adapters and MUST report that scope clearly.
+- **Documentation:** This proposal is informed by `docs/cli/add.mdx`, `docs/cli/install.mdx`, and `docs/cli/remove.mdx`; by `docs/specification/commit.mdx`, `docs/specification/install.mdx`, `docs/specification/materialization.mdx`, and `docs/specification/terminology.mdx`; and by `docs/guides/install-facets.mdx`. Those pages SHALL describe exclusive target semantics and adapter-agnostic receipt ownership.

--- a/openspec/changes/filter-installation-by-adapter/specs/cli/spec.md
+++ b/openspec/changes/filter-installation-by-adapter/specs/cli/spec.md
@@ -1,0 +1,439 @@
+## ADDED Requirements
+
+### Requirement: Installation commands accept repeatable adapter targets
+
+The `add`, `install`, and `remove` commands SHALL each accept `--adapter <name>` as an optional repeatable flag with the same exclusive-target meaning. One or more occurrences SHALL name the complete target set. Duplicate names SHALL be treated as one target. Omitting the flag SHALL preserve existing all-adapter behavior.
+
+#### Scenario: Every installation command lists the target flag
+
+- **WHEN** a user requests help for `add`, `install`, or `remove`
+- **THEN** the help SHALL list `--adapter <name>` with the same meaning for each command
+- **AND** it SHALL state that the flag can be supplied more than once
+
+#### Scenario: Multiple targets are accepted
+
+- **WHEN** a user supplies `--adapter opencode --adapter claude-code`
+- **THEN** both OpenCode and Claude Code SHALL be targets
+- **AND** neither SHALL be reported as purged
+
+#### Scenario: Duplicate targets are deduplicated
+
+- **WHEN** a user names the same adapter more than once
+- **THEN** the adapter SHALL be targeted once
+- **AND** it SHALL appear once in command output
+
+#### Scenario: Omitting targets preserves existing behavior
+
+- **WHEN** a user supplies no `--adapter` flag
+- **THEN** every installed materialization-capable adapter SHALL be targeted
+- **AND** no adapter SHALL be purged because of placement scope
+
+#### Scenario: Frozen install accepts targets
+
+- **WHEN** a user runs `install --frozen-lockfile --adapter opencode`
+- **THEN** the command SHALL accept OpenCode as the exclusive target
+
+### Requirement: Explicit adapter targets are exclusive
+
+Command behavior SHALL make explicit adapter targets an exclusive placement set. A successful filtered command SHALL leave the complete desired project state in every named target and SHALL clear all receipt-owned project state from every discoverable non-target adapter.
+
+#### Scenario: Add targets the complete project
+
+- **WHEN** a user runs `add cowsay --adapter opencode`
+- **THEN** OpenCode SHALL receive every desired project facet including `cowsay`
+- **AND** every discoverable non-target adapter SHALL be purged of Facet-managed project state
+
+#### Scenario: Remove targets the complete remaining project
+
+- **WHEN** a user runs `remove cowsay --adapter opencode`
+- **THEN** `cowsay` SHALL be removed from project desired state
+- **AND** OpenCode SHALL receive every remaining desired facet
+- **AND** every discoverable non-target adapter SHALL be purged of Facet-managed project state
+
+#### Scenario: Unfiltered install restores all adapters
+
+- **WHEN** a filtered command previously purged non-target adapters
+- **AND** the user later runs `install` without explicit targets
+- **THEN** every installed materialization-capable adapter SHALL receive the complete desired project state
+
+### Requirement: Adapter targets are validated before any mutation
+
+The command SHALL validate the complete target and purge population before changing project or adapter files. A missing or empty value, an unknown target, or an installed target or purge adapter that is unavailable, incompatible, broken, or unable to perform its required transition SHALL produce a non-zero failure identifying the problem and SHALL leave all state unchanged.
+
+#### Scenario: Missing target value is a usage error
+
+- **WHEN** a user supplies `--adapter` without a value
+- **THEN** the command SHALL report a usage error
+- **AND** no project or adapter file SHALL change
+
+#### Scenario: Empty target value is a usage error
+
+- **WHEN** a user supplies an empty adapter value
+- **THEN** the command SHALL report a usage error
+- **AND** no project or adapter file SHALL change
+
+#### Scenario: Comma-separated names are not split
+
+- **WHEN** a user supplies `--adapter opencode,claude-code`
+- **THEN** the command SHALL treat `opencode,claude-code` as one adapter name
+- **AND** it SHALL fail if no installed adapter has that exact name
+
+#### Scenario: Unknown target fails safely
+
+- **WHEN** a user names an adapter that is not installed
+- **THEN** the command SHALL identify that adapter and exit non-zero
+- **AND** project, receipt, and adapter state SHALL remain unchanged
+
+#### Scenario: Unavailable purge adapter fails safely
+
+- **WHEN** an installed non-target adapter cannot be loaded for purge
+- **THEN** the command SHALL identify that adapter and exit non-zero
+- **AND** no target or purge mutation SHALL occur
+
+#### Scenario: Add source syntax precedes target discovery
+
+- **WHEN** an `add` request contains an invalid facet source and invalid adapter target
+- **THEN** the command SHALL report the source error before adapter discovery
+
+#### Scenario: Remove manifest validation precedes target discovery
+
+- **WHEN** a `remove` request runs in a project with an unreadable manifest and an invalid adapter target
+- **THEN** the command SHALL report the manifest problem before adapter discovery
+
+### Requirement: Installation commands reject unknown flags
+
+The `add`, `install`, and `remove` commands SHALL reject undeclared flags as usage errors. The command SHALL NOT continue with a wider placement scope when a user misspells an adapter target flag. Commands whose documented contract accepts dynamic undeclared flags SHALL retain that behavior.
+
+#### Scenario: Misspelled adapter flag does not run unfiltered
+
+- **WHEN** a user runs `add cowsay --adaptor opencode`
+- **THEN** the command SHALL report `--adaptor` as unknown and exit non-zero
+- **AND** no adapter SHALL be targeted or purged
+
+#### Scenario: Strict rejection applies to all installation commands
+
+- **WHEN** `add`, `install`, or `remove` receives an undeclared flag
+- **THEN** that command SHALL report a usage error rather than execute
+
+#### Scenario: Dynamic authoring flags remain supported
+
+- **WHEN** a command whose documented contract accepts dynamic adapter-prefixed flags receives one
+- **THEN** the command SHALL continue to receive and validate that dynamic flag
+
+### Requirement: Explicit adapter targets suppress adapter selection
+
+When a user supplies one or more explicit adapter targets, the command SHALL NOT launch interactive adapter selection and SHALL NOT install an adapter implicitly. A target that is not installed SHALL fail with guidance to install it explicitly.
+
+#### Scenario: Filtered add does not launch the picker
+
+- **WHEN** a user runs interactive `add` with an explicit target that is not installed
+- **THEN** the command SHALL NOT launch the adapter picker
+- **AND** it SHALL fail identifying the missing target
+
+#### Scenario: Filtered remove does not launch the picker
+
+- **WHEN** a user runs interactive `remove` with an explicit target that is not installed
+- **THEN** the command SHALL NOT launch the adapter picker
+- **AND** it SHALL fail identifying the missing target
+
+#### Scenario: Missing target is never installed implicitly
+
+- **WHEN** an explicit target is not installed
+- **THEN** the command SHALL NOT download or activate it
+- **AND** the error SHALL direct the user to the explicit adapter-add command
+
+### Requirement: Command output identifies target and purged adapters
+
+The `add`, `install`, and `remove` commands SHALL identify every target adapter and every purged adapter for an exclusive-target operation. When a rendered progress view is active, the destructive scope SHALL be visible before mutation and repeated in the final summary. The output SHALL distinguish target writes from purge removals and SHALL NOT describe a placement-changing operation as a no-op.
+
+#### Scenario: Filtered command names both placement sets
+
+- **WHEN** a filtered `add`, `install`, or `remove` succeeds
+- **THEN** the final summary SHALL name every target adapter
+- **AND** it SHALL name every purged adapter
+
+#### Scenario: Scope is shown before mutation
+
+- **WHEN** an exclusive-target command uses a rendered progress view
+- **THEN** the view SHALL identify the target and purge sets before any file changes
+
+#### Scenario: Purge and target counts are separate
+
+- **WHEN** an operation both writes target files and removes purge-adapter files
+- **THEN** the summary SHALL report target writes separately from purge removals
+
+#### Scenario: Placement-only work is not a no-op
+
+- **WHEN** project desired state is unchanged but a filtered command purges a non-target adapter
+- **THEN** the command SHALL report the purge rather than report that no changes were applied
+
+#### Scenario: Explicit targets require no confirmation prompt
+
+- **WHEN** a user runs a filtered command in an interactive terminal
+- **THEN** the command SHALL show the destructive scope
+- **AND** it SHALL NOT require an additional confirmation prompt
+
+#### Scenario: Empty purge adapter is still reported
+
+- **WHEN** an installed materialization-capable adapter is outside the explicit target set
+- **AND** that adapter contains no receipt-owned project state
+- **THEN** the command SHALL still identify it as within the purge scope
+- **AND** it SHALL report zero purge removals for that adapter
+
+### Requirement: Suggested reruns preserve explicit adapter targets
+
+When a failed filtered operation suggests a corrected or repeated command, the suggestion SHALL preserve every explicit adapter target. A suggested rerun SHALL NOT silently widen placement to an adapter the user did not name.
+
+#### Scenario: Generic rerun suggestion repeats every target
+
+- **WHEN** a command supplied with multiple adapter targets fails and suggests a rerun
+- **THEN** the suggested command SHALL include every supplied `--adapter <name>` target
+
+#### Scenario: Collision remedy preserves targets
+
+- **WHEN** a filtered operation fails because a collision requires durable intent
+- **THEN** any suggested rerun SHALL preserve every adapter target
+
+#### Scenario: MCP acceptance remedy preserves targets
+
+- **WHEN** a filtered non-interactive operation directs the user to add `--accept-mcp`
+- **THEN** the suggested command SHALL also preserve every adapter target
+
+## MODIFIED Requirements
+
+### Requirement: Commands declare per-command flags
+
+The system SHALL support per-command flag declarations on command definitions. The router SHALL parse per-command flags via the argument parser and pass the parsed values to command handlers alongside positional arguments. Flag declarations SHALL support boolean values, single string values, and repeatable string values. A command MAY require strict validation that rejects undeclared flags before its handler runs.
+
+#### Scenario: Command with declared boolean flag
+
+- **WHEN** a command declares a boolean flag (e.g., `--force`)
+- **AND** a user provides that flag on the command line
+- **THEN** the command handler SHALL receive the flag value as `true`
+
+#### Scenario: Command with declared string flag
+
+- **WHEN** a command declares a string flag (e.g., `--registry`)
+- **AND** a user provides that flag with a value on the command line
+- **THEN** the command handler SHALL receive the flag value as the provided string
+
+#### Scenario: Command with declared repeatable flag
+
+- **WHEN** a command declares a repeatable string flag
+- **AND** a user provides that flag multiple times
+- **THEN** the command handler SHALL receive every provided value in command-line order
+
+#### Scenario: Undeclared flags are omitted for permissive commands
+
+- **WHEN** a user provides a flag that is not declared by a command without strict validation
+- **THEN** the command handler SHALL NOT receive that flag
+
+#### Scenario: Undeclared flags fail for strict commands
+
+- **WHEN** a user provides a flag that is not declared by a command with strict validation
+- **THEN** the system SHALL report a usage error before the command handler runs
+
+### Requirement: Per-command help displays usage and flags
+
+The system SHALL render per-command help text from command metadata including usage syntax and flag descriptions. Authors SHALL NOT need to maintain help text manually. A flag that accepts a value SHALL render its value placeholder, and a repeatable flag's description SHALL state that it can be supplied more than once.
+
+#### Scenario: Per-command help shows usage line
+
+- **WHEN** a user runs `<command> --help` for a command that declares a `usage` field
+- **THEN** the help output SHALL display the usage syntax (e.g., `Usage: facet create [directory] [options]`)
+
+#### Scenario: Per-command help lists declared flags
+
+- **WHEN** a user runs `<command> --help` for a command that declares flags
+- **THEN** the help output SHALL list each declared flag with its description under an Options section
+- **AND** the `--help` flag SHALL also appear in the Options section
+
+#### Scenario: Value-carrying flag shows its placeholder
+
+- **WHEN** a declared flag accepts a value named `name`
+- **THEN** help SHALL render the value placeholder with the flag rather than render only the bare flag name
+
+### Requirement: Add and install render a unified progress view
+
+The `add` and `install` commands SHALL present progress through a single shared rendering. A user watching either command SHALL see the same shape of output: a per-facet section that names each facet, indicates its current stage, and shows whether it succeeded, failed, or is in progress, followed by a final summary that lists each affected facet on its own line. For an exclusive-target operation, the view SHALL additionally identify target and purge adapters before mutation and in the final summary.
+
+Collision checking SHALL be rendered as one global phase covering the complete desired set, entered after every facet is resolved and before any materialization, rather than as a per-facet stage. Every `add` or `install` operation SHALL make that phase visible whether it affects one facet or many, because it is evaluated once over all of them; a rendering that showed it for a single-facet run and omitted it for a multi-facet run would misdescribe when the check happens.
+
+When interactive materialization choices are required, the same command view SHALL transition from progress to the collision overview and focused resolution workspace, then return to progress after confirmation. It SHALL indicate that installation is awaiting collision resolution. A materialization-disposition change at an unchanged facet version SHALL be reported as an update; repair of disk-only drift SHALL remain reported as a repair. When materialization dispositions affect the result, the final summary SHALL show every aliased asset's authored name together with its effective materialized name and SHALL identify every omitted asset as omitted.
+
+#### Scenario: Single-facet operation shows per-facet detail
+
+- **WHEN** a user runs `add` or `install` with exactly one facet to install or update
+- **THEN** the rendered view SHALL show the facet's name and its current stage as it progresses through fetch, verification, build, and materialization
+- **AND** the view SHALL show the global collision-check phase between resolution and materialization
+- **AND** on completion the view SHALL show a one-line summary of the facet's resolved version
+
+#### Scenario: Multi-facet operation shows aggregate progress
+
+- **WHEN** a user runs `add` or `install` with multiple facets to install or update
+- **THEN** the rendered view SHALL show progress for each facet
+- **AND** the view SHALL show the same single global collision-check phase it shows for a single-facet operation
+- **AND** on completion the view SHALL show one summary line per affected facet identifying the action and resolved version
+
+#### Scenario: True no-op install renders an empty summary
+
+- **WHEN** a user runs `install`, desired state already matches every target, and no purge adapter contains receipt-owned project state
+- **THEN** the view SHALL render a summary indicating no changes were applied
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Filtered purge is not rendered as a no-op
+
+- **WHEN** desired project state is unchanged but an exclusive-target install purges receipt-owned state
+- **THEN** the view SHALL report the purge
+- **AND** it SHALL NOT state that no changes were applied
+
+#### Scenario: Progress pauses for collision choices
+
+- **WHEN** an interactive operation finishes resolving and verifying facets but requires collision choices
+- **THEN** the view SHALL indicate that installation is awaiting resolution
+- **AND** after confirmation it SHALL return to progress without starting a separate command output stream
+
+#### Scenario: Disposition-only change is shown as an update
+
+- **WHEN** an alias or omission changes while the facet version remains unchanged
+- **THEN** the final summary SHALL classify the facet as updated rather than repaired
+
+#### Scenario: Summary shows aliases and omissions
+
+- **WHEN** an install materializes skill `review` as `vendor-review` and omits command `deploy`
+- **THEN** the summary SHALL show `review` together with `vendor-review`
+- **AND** it SHALL identify `deploy` as omitted
+
+### Requirement: Add command auto-launches adapter selection when no adapter is selected
+
+When a user runs `add` without explicit adapter targets in a project that has no selected adapter, the system SHALL launch interactive adapter selection in a TTY and SHALL fail with a clear error in a non-TTY environment. Explicit adapter targets SHALL suppress interactive selection and implicit adapter installation.
+
+#### Scenario: Interactive add with no selected adapter or explicit target
+
+- **WHEN** a user runs `add` in an interactive terminal
+- **AND** the project has no selected adapter
+- **AND** the user supplies no explicit adapter target
+- **THEN** the system SHALL launch the adapter selection picker
+- **AND** if the user selects at least one adapter, the system SHALL proceed with the install
+- **AND** if the user cancels the picker, the system SHALL exit without modifying the project
+
+#### Scenario: Non-interactive add with no selected adapter or explicit target
+
+- **WHEN** a user runs `add` in a non-interactive environment
+- **AND** the project has no selected adapter
+- **AND** the user supplies no explicit adapter target
+- **THEN** the system SHALL exit with a non-zero code
+- **AND** the error SHALL direct the user to run interactive adapter selection
+
+#### Scenario: Explicit add target suppresses selection
+
+- **WHEN** a user runs `add` with one or more explicit adapter targets
+- **THEN** the system SHALL NOT launch the adapter picker
+- **AND** it SHALL NOT install an adapter implicitly
+
+### Requirement: Remove handles undeclared names gracefully
+
+When `remove` is given a name that is not declared in the project, the system SHALL silently ignore it. When every requested name is undeclared and no explicit adapter targets were supplied, the rendered view SHALL report that no changes were made and the process SHALL exit with code 0. When explicit targets were supplied, the rendered view SHALL report no facet changes but SHALL still report the ordinary target and purge placement effects.
+
+Whether a requested name is declared SHALL be decided by the commit, under the project lock. The CLI SHALL NOT skip any step of the ordinary removal flow on the strength of a pre-lock read, and SHALL therefore discover adapters for every removal request, including one whose names all appear undeclared. Adapter discovery for `remove` without explicit targets SHALL follow the same contract as the commands that add and install facets: a project with no installable adapter SHALL prompt for one in an interactive terminal and SHALL fail with a non-zero exit code in a non-interactive environment. Explicit targets SHALL suppress the picker. The CLI SHALL still validate that the project manifest can be read before discovering adapters, so an absent, malformed, or unsupported-version manifest is reported as such rather than as a missing adapter.
+
+#### Scenario: Removing only undeclared names without explicit targets shows no-op summary
+
+- **WHEN** a user runs `remove` with one or more names that are not declared in the project manifest
+- **AND** no requested name is declared
+- **AND** no explicit adapter target is supplied
+- **AND** the project has at least one installable adapter
+- **THEN** the rendered view SHALL show a summary indicating no changes
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Removing only undeclared names with explicit targets reports placement
+
+- **WHEN** every requested name is undeclared
+- **AND** the user supplies one or more explicit adapter targets
+- **THEN** the rendered view SHALL report no facet changes
+- **AND** it SHALL identify every target and purged adapter
+- **AND** the process SHALL exit with code 0 when placement succeeds
+
+#### Scenario: Removing only undeclared names still requires an adapter
+
+- **WHEN** a user runs `remove` in a non-interactive environment with names that are all undeclared
+- **AND** the project has no installable adapter
+- **AND** no explicit adapter target is supplied
+- **THEN** the system SHALL report that no adapters are installed
+- **AND** the process SHALL exit with a non-zero code
+- **AND** the project manifest, lockfile, receipt, and adapter state SHALL remain unchanged
+
+#### Scenario: An unreadable manifest is reported before adapter discovery
+
+- **WHEN** a user runs `remove` in a project whose manifest is absent, malformed, or declares an unsupported version
+- **THEN** the system SHALL report the manifest problem
+- **AND** the system SHALL NOT report a missing adapter in its place
+
+#### Scenario: Mix of declared and undeclared names removes the declared ones
+
+- **WHEN** a user runs `remove` with names where some are declared and some are not
+- **THEN** the system SHALL remove the declared facets
+- **AND** the system SHALL silently ignore the undeclared names
+- **AND** the process SHALL exit with code 0 if all declared facets were removed successfully
+
+### Requirement: Unsupported MCP adapters are reported completely
+
+When active MCP declarations exist and any target adapter declares no MCP support, the command SHALL fail before prompting or mutation. When the receipt owns an effective MCP identity requiring deletion from a purge adapter and that adapter cannot safely plan the removal, the command SHALL also fail before prompting or mutation. One error SHALL identify every affected adapter and SHALL give actionable remediation.
+
+#### Scenario: Every unsupported target is listed
+
+- **WHEN** two target adapters cannot configure active MCP declarations
+- **THEN** one failure SHALL name both adapters and give actionable remediation
+
+#### Scenario: Omitted declarations avoid target failure
+
+- **WHEN** every authored server is omitted and no active declaration remains
+- **THEN** a target adapter without MCP support SHALL NOT fail the operation for desired configuration
+
+#### Scenario: Pending purge cleanup still fails
+
+- **WHEN** the receipt owns an effective server identity requiring deletion from a purge adapter
+- **AND** that adapter cannot safely plan the native removal
+- **THEN** the operation SHALL fail before mutation naming that adapter
+
+#### Scenario: Purge adapter with no owned server does not fail
+
+- **WHEN** a purge adapter lacks MCP support
+- **AND** the receipt owns no effective server identity requiring removal from it
+- **THEN** that adapter SHALL NOT fail the operation for lacking MCP support
+
+### Requirement: Command output reports MCP configuration outcomes
+
+Command summaries SHALL report MCP servers separately from text assets and SHALL identify added, updated, unchanged, aliased, omitted, repaired, removed, purged, conflicted, unsupported, and takeover outcomes. An aliased server SHALL show authored and effective names. A server-only facet SHALL not be presented as a no-op. Declaration contents SHALL remain absent from summaries, which report outcomes rather than diagnose failures and therefore need no declaration value at all. A purged outcome SHALL identify removal from an adapter while the declaration may remain desired project-wide.
+
+#### Scenario: Server-only facet has a meaningful summary
+
+- **WHEN** a facet configures one server and zero text assets
+- **THEN** the summary SHALL report the server addition and zero assets
+
+#### Scenario: Alias and omission are visible
+
+- **WHEN** server `filesystem` is materialized as `project-filesystem` and server `docs` is omitted
+- **THEN** the summary SHALL show both authored and effective alias names and identify `docs` as omitted
+
+#### Scenario: Remove reports native server deletion
+
+- **WHEN** removal deletes an owned effective server entry from project desired state
+- **THEN** the summary SHALL identify the removed server and affected adapters
+
+#### Scenario: Purged server remains desired project-wide
+
+- **WHEN** exclusive targeting removes an owned effective server entry from a purge adapter
+- **AND** the same declaration remains configured in a target adapter
+- **THEN** the summary SHALL identify the purge adapter
+- **AND** it SHALL NOT present the server as removed from the project
+
+#### Scenario: Drift-only rewrite is repaired
+
+- **WHEN** an approved desired declaration rewrites only native drift
+- **THEN** the summary SHALL classify the configuration as repaired
+
+#### Scenario: Semantic match is unchanged
+
+- **WHEN** native configuration already matches semantically
+- **THEN** the summary SHALL classify it as unchanged

--- a/openspec/changes/filter-installation-by-adapter/specs/installation/spec.md
+++ b/openspec/changes/filter-installation-by-adapter/specs/installation/spec.md
@@ -1,0 +1,557 @@
+## ADDED Requirements
+
+### Requirement: Explicit adapter targets form an exclusive placement set
+
+The system SHALL treat one or more explicitly named adapters as the exclusive target set for that operation. Every installed adapter capable of holding Facet-managed project state that is not a target SHALL be a purge adapter. When no adapter is named explicitly, every installed materialization-capable adapter SHALL be a target and the purge set SHALL be empty. For an explicit-target operation, the named target set SHALL be the selected-adapter set wherever existing desired-materialization requirements refer to selected adapters; purge adapters SHALL participate only in purge, validation, transaction, and reporting requirements.
+
+#### Scenario: No explicit target preserves existing placement behavior
+
+- **WHEN** a user performs an installation operation without naming an adapter target
+- **THEN** every installed materialization-capable adapter SHALL be a target
+- **AND** no adapter SHALL be purged merely because of placement scope
+
+#### Scenario: Explicit targets are exclusive
+
+- **WHEN** a user performs an installation operation naming OpenCode and Claude Code as targets
+- **THEN** the complete desired project state SHALL be reconciled into OpenCode and Claude Code
+- **AND** every other installed adapter capable of holding Facet-managed project state SHALL be a purge adapter
+
+#### Scenario: Adapter targets control placement only
+
+- **WHEN** an operation names an exclusive target set
+- **THEN** the project manifest and lockfile SHALL continue to describe one project-wide desired state
+- **AND** neither file SHALL record the adapter targets
+
+#### Scenario: An adapter absent from the machine is outside the purge guarantee
+
+- **WHEN** an adapter that previously received project materialization is no longer installed or discoverable
+- **THEN** an exclusive-target operation SHALL NOT report that adapter as purged
+- **AND** adapter-agnostic receipt ownership SHALL remain available if that adapter later returns
+
+### Requirement: Non-target adapters are purged of project-owned state
+
+For every purge adapter, the system SHALL remove every asset and native MCP entry authorized by the project receipt, including identities that remain in desired project state. The receipt SHALL remain the sole deletion authority. Purging SHALL NOT scan for, adopt, modify, or delete untracked native state, and an authorized identity already absent from a purge adapter SHALL be a successful no-op.
+
+#### Scenario: Still-desired assets are removed from a purge adapter
+
+- **WHEN** the receipt records a desired facet's assets and an installed adapter is outside the explicit target set
+- **THEN** the system SHALL remove every recorded owned file for that facet from the purge adapter
+- **AND** it SHALL retain the facet in project desired state for reconciliation into the targets
+
+#### Scenario: Multi-file ownership is purged completely
+
+- **WHEN** a purge adapter contains a receipt-owned skill with a primary file and recorded companions
+- **THEN** the system SHALL remove every recorded owned file from that adapter
+- **AND** it SHALL leave files absent from receipt ownership unchanged
+
+#### Scenario: Desired MCP entry is removed from a purge adapter
+
+- **WHEN** the receipt owns an effective MCP entry that remains desired project-wide
+- **AND** an adapter containing that entry is outside the explicit target set
+- **THEN** the system SHALL remove the complete owned entry from the purge adapter
+- **AND** it SHALL reconcile the desired declaration into every target adapter
+
+#### Scenario: Untracked occupancy in a purge adapter is untouched
+
+- **WHEN** a purge adapter contains an asset or MCP entry that no receipt record covers
+- **THEN** the system SHALL leave that state unchanged
+- **AND** it SHALL NOT request takeover approval for that state
+
+#### Scenario: Authorized state already absent is a no-op
+
+- **WHEN** the receipt authorizes removal of an identity that is absent from a purge adapter
+- **THEN** the purge SHALL succeed for that identity without creating or deleting another file
+
+### Requirement: Target and purge adapters are validated before mutation
+
+Before changing project or adapter files, the system SHALL validate every target adapter and every purge adapter needed to establish the exclusive placement result. A target or purge adapter that is installed but unavailable, broken, API-incompatible, or unable to perform its required transition SHALL cause the complete operation to fail without mutation and SHALL be identified to the user.
+
+#### Scenario: Unavailable target fails safely
+
+- **WHEN** an explicitly named target adapter cannot be loaded
+- **THEN** the operation SHALL fail identifying that adapter
+- **AND** project, receipt, and adapter files SHALL remain unchanged
+
+#### Scenario: Unavailable purge adapter fails safely
+
+- **WHEN** an installed non-target adapter cannot be loaded for purge planning
+- **THEN** the operation SHALL fail identifying that adapter
+- **AND** no target or purge mutation SHALL occur
+
+#### Scenario: Target without required MCP support fails
+
+- **WHEN** active desired MCP declarations exist and a target adapter cannot configure them
+- **THEN** the operation SHALL fail before mutation identifying that target
+
+#### Scenario: Purge adapter without required MCP removal support fails
+
+- **WHEN** the receipt owns an effective MCP identity that a purge adapter may contain
+- **AND** that adapter cannot safely plan removal of the owned native entry
+- **THEN** the operation SHALL fail before mutation identifying that purge adapter
+
+#### Scenario: Purge adapter with no MCP work does not fail for that reason
+
+- **WHEN** a purge adapter cannot configure MCP servers
+- **AND** the receipt owns no effective MCP identity requiring removal from it
+- **THEN** the adapter SHALL NOT fail the operation solely for lacking MCP support
+
+### Requirement: Purge and target placement commit atomically
+
+The system SHALL plan the complete purge and target result before mutation. Purge removals SHALL be applied before target reconciliation, and both phases SHALL form one atomic operation with project manifest, lockfile, and receipt changes. A handled failure SHALL restore every changed file to its exact prior state. When purge and target plans address the same native document, their transitions SHALL compose in purge-then-target order or fail before mutation.
+
+#### Scenario: Target failure restores purge removals
+
+- **WHEN** a purge removes files and later target reconciliation fails
+- **THEN** every purged file SHALL be restored to its exact prior bytes
+- **AND** project and target state SHALL match their pre-operation state
+
+#### Scenario: Purge failure leaves targets untouched
+
+- **WHEN** a purge transition cannot be applied safely
+- **THEN** no target adapter SHALL be changed
+- **AND** every earlier purge change SHALL be restored
+
+#### Scenario: Shared native document composes purge before target
+
+- **WHEN** a purge adapter and a target adapter manage the same native configuration document
+- **AND** their planned transitions can be composed safely
+- **THEN** the committed document SHALL contain the target adapter's desired project entries
+- **AND** it SHALL contain none of the purged adapter's receipt-owned project entries
+
+#### Scenario: Uncomposable native document fails before mutation
+
+- **WHEN** purge and target transitions for one native document cannot be composed safely
+- **THEN** the operation SHALL fail naming the affected document
+- **AND** no project or adapter file SHALL change
+
+### Requirement: Successful exclusive targeting converges placement completely
+
+A successful exclusive-target operation SHALL leave every target adapter reconciled to the complete project desired state and every discoverable purge adapter free of receipt-owned project state. The system SHALL NOT retain deferred placement work or adapter-specific catch-up metadata. A later operation SHALL apply its own target and purge sets independently.
+
+#### Scenario: Add reconciles the complete project into targets
+
+- **WHEN** a user adds facet `cowsay` with OpenCode as the exclusive target
+- **THEN** OpenCode SHALL contain every desired project facet including `cowsay`
+- **AND** every discoverable purge adapter SHALL contain no receipt-owned project state
+
+#### Scenario: Remove reconciles every remaining facet into targets
+
+- **WHEN** a user removes facet `cowsay` with OpenCode as the exclusive target
+- **THEN** `cowsay` SHALL be absent from project desired state
+- **AND** OpenCode SHALL contain every remaining desired project facet
+- **AND** every discoverable purge adapter SHALL contain no receipt-owned project state
+
+#### Scenario: Later unfiltered install rematerializes every adapter
+
+- **WHEN** an exclusive-target operation previously purged non-target adapters
+- **AND** the user later installs without explicit adapter targets
+- **THEN** every installed materialization-capable adapter SHALL be reconciled to the complete desired project state
+
+#### Scenario: Opposite target sets converge independently
+
+- **WHEN** one successful operation exclusively targets OpenCode
+- **AND** a later successful operation exclusively targets Claude Code
+- **THEN** Claude Code SHALL contain the complete desired project state
+- **AND** OpenCode SHALL contain no receipt-owned project state
+
+### Requirement: Explicit-target removal resolves target completeness
+
+A remove operation with explicit adapter targets SHALL prove or resolve the complete desired state for every target before mutation. Adapter-agnostic receipt ownership alone SHALL NOT prove that a target currently contains every remaining desired facet after earlier exclusive operations. When local evidence is insufficient, the system SHALL perform ordinary content resolution; if resolution cannot complete, the operation SHALL fail without applying its otherwise-planned purge.
+
+#### Scenario: Filtered removal resolves missing target content
+
+- **WHEN** an explicit-target removal names an adapter that may not contain every remaining desired facet
+- **THEN** the system SHALL resolve the remaining desired content before mutation
+- **AND** success SHALL leave that target fully reconciled
+
+#### Scenario: Resolution failure preserves purge adapters
+
+- **WHEN** an explicit-target removal cannot resolve content required to complete target state
+- **THEN** the operation SHALL fail without purging a non-target adapter
+- **AND** project, receipt, and adapter files SHALL remain unchanged
+
+#### Scenario: Receipt-only deletion remains offline
+
+- **WHEN** receipt evidence is sufficient to plan deletion of project-owned state from a purge adapter
+- **THEN** that deletion plan SHALL require neither cache nor network content
+- **AND** whether the complete operation can proceed offline SHALL depend on proving the remaining target state
+
+### Requirement: Exclusive adapter targeting is permitted in frozen mode
+
+Frozen installation SHALL accept explicit adapter targets. Every frozen consistency, integrity, collision, and consent check SHALL pass before purge or target mutation. Success SHALL leave manifest and lockfile bytes unchanged, purge every discoverable non-target adapter, reconcile the exact locked state into every target adapter, and update only machine-local state.
+
+#### Scenario: Frozen install applies an exclusive target set
+
+- **WHEN** a user runs frozen installation with OpenCode as the exclusive target
+- **AND** every frozen consistency and approval check passes
+- **THEN** OpenCode SHALL contain the exact locked desired state
+- **AND** every discoverable purge adapter SHALL contain no receipt-owned project state
+- **AND** manifest and lockfile bytes SHALL remain unchanged
+
+#### Scenario: Frozen failure precedes purge
+
+- **WHEN** frozen consistency, integrity, collision, or consent validation fails
+- **THEN** no target or purge adapter SHALL be changed
+
+#### Scenario: Frozen targeting never prompts
+
+- **WHEN** a frozen exclusive-target operation requires an interactive decision
+- **THEN** it SHALL fail before mutation unless the decision was validly supplied in advance
+- **AND** it SHALL NOT open an interactive prompt
+
+### Requirement: Adapter targets are not persisted
+
+Adapter target and purge sets SHALL exist only for the current invocation. The project manifest, lockfile, and machine-local receipt SHALL NOT record those sets. The receipt SHALL remain schema `0.4` with adapter-agnostic project ownership, and filtered and unfiltered operations that commit the same desired project state SHALL commit the same ownership account.
+
+#### Scenario: Filtered operation retains receipt schema
+
+- **WHEN** an exclusive-target operation succeeds
+- **THEN** the receipt SHALL use schema `0.4`
+- **AND** it SHALL contain no adapter target, purge, or placement list
+
+#### Scenario: Desired state determines receipt content
+
+- **WHEN** filtered and unfiltered operations commit the same project desired state
+- **THEN** their receipts SHALL describe the same project-owned facets, assets, and configuration claims
+
+#### Scenario: Project files contain no target defaults
+
+- **WHEN** an operation uses explicit adapter targets
+- **THEN** the manifest and lockfile SHALL contain no adapter target or purge setting
+
+### Requirement: Adapter targeting does not bypass MCP consent
+
+Machine-local MCP approval SHALL continue to gate configuration during exclusive-target operations. Targeting SHALL NOT bypass, narrow, or substitute for consent: a declaration that would require consent in an unfiltered invocation SHALL require the same consent when only some adapters are targeted, and a previously approved effective declaration SHALL NOT require re-approval merely because the target set changed.
+
+#### Scenario: Unapproved declaration still requires consent with explicit targets
+
+- **WHEN** an exclusive-target operation would reconcile an MCP declaration this machine has not approved
+- **THEN** the system SHALL require consent before configuring any target adapter
+- **AND** targeting fewer adapters SHALL NOT reduce what is disclosed for approval
+
+#### Scenario: Approved declaration is not re-gated by targeting
+
+- **WHEN** an exclusive-target operation reconciles an effective declaration whose approval this machine already evidences
+- **THEN** the system SHALL NOT require new approval solely because the target set changed
+
+## MODIFIED Requirements
+
+### Requirement: Adding a facet installs it
+
+When a user adds a facet to a project, the system SHALL fetch its content, verify its integrity, reconcile the complete desired project state into every target adapter, and update the lockfile in a single operation. When the invocation names no explicit adapter targets, every selected adapter SHALL be targeted. When the invocation names an exclusive target set, exactly the named adapters SHALL be targeted and every discoverable non-target adapter SHALL be purged according to receipt ownership. A user SHALL NOT need to run a separate install step after adding. Registry-sourced facets SHALL support unscoped names and scoped names.
+
+#### Scenario: Adding a registry facet installs it
+
+- **WHEN** a user adds a registry facet to a project that has at least one target adapter
+- **THEN** the system SHALL update the project manifest to reference the facet
+- **AND** the system SHALL fetch the facet's content
+- **AND** the system SHALL verify the facet's integrity before any assets are written
+- **AND** the system SHALL reconcile the complete desired project state into every target adapter
+- **AND** the system SHALL update the lockfile to record the resolved version, integrity hash, and asset list
+- **AND** the operation SHALL complete in a single command invocation
+
+#### Scenario: Adding a scoped registry facet installs it
+
+- **WHEN** a user adds `@julian/cowsay` to a project that has at least one target adapter
+- **THEN** the system SHALL treat `@julian/cowsay` as a registry facet source
+- **AND** the system SHALL fetch, verify, materialize, and lock the scoped facet in a single command invocation
+
+#### Scenario: Adding a git facet installs it
+
+- **WHEN** a user adds a git-source facet to a project that has at least one target adapter
+- **THEN** the system SHALL resolve the symbolic ref to a commit
+- **AND** the system SHALL fetch the facet's content
+- **AND** the system SHALL build the facet locally
+- **AND** the system SHALL verify the facet's integrity before any assets are written
+- **AND** the system SHALL reconcile the complete desired project state into every target adapter
+- **AND** the system SHALL update the lockfile to record the resolved commit, integrity hash, and asset list
+
+#### Scenario: Adding a local facet installs it
+
+- **WHEN** a user adds a local-path facet to a project that has at least one target adapter
+- **THEN** the system SHALL build the facet from the local path
+- **AND** the system SHALL reconcile the complete desired project state into every target adapter
+- **AND** the system SHALL update the lockfile to record the version, integrity hash, and asset list
+
+#### Scenario: Explicit targets exclude every other adapter
+
+- **WHEN** a user adds a facet with one or more explicit adapter targets
+- **THEN** the system SHALL reconcile the complete desired project state into every named target
+- **AND** it SHALL purge every discoverable non-target adapter according to receipt ownership
+
+#### Scenario: Re-adding a facet at a different version
+
+- **WHEN** a user adds a facet that is already declared in the project manifest
+- **AND** the new specifier resolves to a different version than the current one
+- **THEN** the system SHALL update the manifest entry to the new specifier
+- **AND** the system SHALL replace the previous version in the lockfile and target materialization
+- **AND** the user-visible summary SHALL indicate that the facet was updated from the previous version to the new one
+
+#### Scenario: Re-adding the same facet at the same version
+
+- **WHEN** a user adds a facet that is already declared at the same resolved version
+- **THEN** the system SHALL leave the manifest unchanged
+- **AND** the system SHALL re-verify integrity and reconcile every target to repair any drift
+- **AND** the operation SHALL succeed without error
+
+### Requirement: Adding a facet without a selected adapter prompts the user
+
+When a user adds a facet without explicit adapter targets and no selected adapter exists, the system SHALL guide the user through selecting one before installing. In a non-interactive environment, the system SHALL fail with a clear error. Explicit adapter targets SHALL suppress interactive selection and implicit adapter installation.
+
+#### Scenario: Interactive terminal triggers adapter selection
+
+- **WHEN** a user adds a facet in an interactive terminal session
+- **AND** the project has no selected adapter
+- **AND** the user supplies no explicit adapter target
+- **THEN** the system SHALL prompt the user to select one or more adapters
+- **AND** if the user selects at least one adapter, the system SHALL proceed with installation
+- **AND** if the user cancels selection, the system SHALL leave the project manifest, lockfile, and on-disk adapter state unchanged
+
+#### Scenario: Non-interactive environment fails fast
+
+- **WHEN** a user adds a facet in a non-interactive environment
+- **AND** the project has no selected adapter
+- **AND** the user supplies no explicit adapter target
+- **THEN** the system SHALL exit with a non-zero status without modifying the project
+- **AND** the error SHALL direct the user to run interactive adapter selection
+
+#### Scenario: Explicit targets suppress adapter selection
+
+- **WHEN** a user adds a facet with one or more explicit adapter targets
+- **THEN** the system SHALL NOT prompt for adapter selection
+- **AND** it SHALL NOT install an adapter implicitly
+
+### Requirement: A machine-local record tracks what each project has materialized
+
+The system SHALL maintain a machine-local receipt describing the asset, file, and configuration ownership successfully materialized for each project. The receipt SHALL be separate from version-controlled state, identified by canonical project location, and sufficient to delete the assets and configuration entries it records without cache or network access. Each canonical project location SHALL have its own receipt; two projects SHALL never share one, and concurrent operations in different projects SHALL NOT contend on the same receipt. The receipt SHALL survive lockfile changes made outside the system. Current receipts SHALL use schema version `0.4` and record only assets actually materialized, with authored identity, authored owned-file paths, and the authored-or-aliased materialization disposition needed to address the effective adapter identity, without storing adapter-encoded hashes. Omitted assets SHALL NOT appear. Receipt `1`, `0.2`, and `0.3` assets SHALL refine losslessly to authored or recorded materialization. A legacy receipt that predates companion ownership MAY be refined to primary-only ownership because legacy installation could not materialize companions.
+
+A current receipt SHALL additionally record one configuration claim per active, successfully reconciled MCP server declaration, carrying the authored server name, its authored-or-aliased disposition, a content fingerprint of the declaration's canonical semantic form, and the facet integrity that witnessed the claim. Configuration claims SHALL be simultaneously keyed deletion authority and this machine's evidence of prior approval for that effective declaration; omitted declarations SHALL be unrepresentable as claims. Claims SHALL never store commands, arguments, URLs, environment names, or environment values. Receipts earlier than `0.4` SHALL retain their asset ownership but SHALL confer no configuration ownership and no approval evidence; the loader SHALL represent that distinction explicitly rather than synthesizing an empty witnessed configuration record.
+
+The receipt SHALL be the sole authority for materialized ownership. A receipt that cannot be loaded — absent, corrupt, or path-mismatched — SHALL confer no ownership, and the system SHALL NOT derive ownership from the lockfile in its place, because the lockfile is shared, version-controlled state that describes intended rather than local materialization. A corrupt or path-mismatched receipt SHALL be reported, because it silently withdraws deletion authority the project previously had; an absent receipt SHALL NOT be, being the ordinary first-operation state. An asset the receipt records SHALL be a **tracked materialization**; an asset on disk that no receipt record covers SHALL be an **untracked materialization**. Desired project state SHALL authorize writes and tracked ownership SHALL authorize deletion: the system SHALL reconcile every desired effective adapter identity in every target adapter, including one an untracked file already occupies, recording it as tracked thereafter, and SHALL leave untracked files at identities the desired state does not name untouched. Reconciling an identity SHALL mean establishing that its rendered content, metadata, and owned companion set match the desired state before ownership is recorded. Whether that state is established by writing or by determining that it already holds SHALL be an implementation concern, because reconciliation is defined by the state it leaves behind rather than by the operations used to reach it. The same rule SHALL govern MCP configuration identities: desired declarations authorize reconciliation, and recorded configuration claims alone authorize deletion.
+
+Receipt ownership SHALL be adapter-agnostic project ownership. A recorded identity SHALL be managed in every target adapter, and targeting an adapter SHALL delegate management of the identities the project's receipt records within that adapter's storage. During an exclusive-target operation, the same receipt authority SHALL permit removal of recorded identities from every purge adapter even when those identities remain desired project-wide. The system SHALL NOT record ownership per adapter and SHALL NOT require separate evidence per adapter before reconciling or deleting a recorded identity.
+
+The receipt, lockfile, project manifest, materialized assets, and native MCP configuration SHALL commit together: within one operation, handled failures SHALL roll back all of them, and an interruption that prevents rollback SHALL be recoverable by re-running installation, whose per-file integrity reconciliation converges disk, lockfile, and receipt without deleting unowned files. Receipt-driven deletion SHALL aggregate duplicate historical claims by effective adapter identity, delete each obsolete identity at most once, and pass each skill's validated authored companion ownership into the adapter deletion request so removal after a pulled lockfile drops an entry deletes exactly the recorded owned files without cache or network access. Deletion SHALL be limited to state the operation can restore. Every recorded owned file SHALL be removable on its own terms: each is inspected individually and its exact prior bytes recorded, so a recorded skill whose primary file is already gone SHALL still have its recorded companions removed, and a later failure SHALL restore them byte for byte. The receipt SHALL determine what is currently materialized when pulled version-control changes remove lockfile entries. In frozen-lockfile mode, receipt-driven cleanup SHALL begin only after the frozen consistency check passes. If that check rejects an orphaned lockfile entry, installation SHALL fail before cleanup changes any materialized state. Receipt data SHALL be treated as untrusted: project identity, record shape, and path containment within each target or purge adapter's storage SHALL be validated before deletion. Invalid or escaping records SHALL be reported and SHALL NOT cause deletion; files not recorded as owned SHALL never be deleted.
+
+#### Scenario: Pulled change cleans up a multi-file skill
+
+- **WHEN** pulled state removes a facet but the receipt records its effective skill and companions
+- **AND** that skill's primary is present on disk
+- **THEN** install SHALL supply the validated recorded companion paths in the adapter deletion request
+- **AND** it SHALL delete every recorded owned file from each participating target and purge adapter
+- **AND** no network or cache content SHALL be required
+
+#### Scenario: Pulled change cleans up an owned server entry
+
+- **WHEN** pulled state removes a facet whose receipt configuration claim covers an effective server identity no remaining claim uses
+- **THEN** the next operation SHALL remove that complete server entry from every participating target and purge adapter
+- **AND** no network or cache content SHALL be required for the deletion
+
+#### Scenario: A recorded bundle whose primary is gone still has its companions removed
+
+- **WHEN** an obsolete recorded skill's primary is absent and its recorded companions are present
+- **THEN** the system SHALL remove each present recorded companion
+- **AND** a later failure in the same operation SHALL restore each of them to its exact prior bytes
+
+#### Scenario: Interrupted install converges on re-run
+
+- **WHEN** installation is interrupted after some skill-bundle writes but before lockfile and receipt commit
+- **THEN** re-running SHALL compare locked per-file integrity against disk and complete or repair the bundle
+- **AND** the re-run SHALL NOT delete any file not recorded as owned
+
+#### Scenario: Deleting a tracked asset needs neither cache nor network
+
+- **WHEN** an unwanted facet is uncached and its registry unavailable
+- **AND** the receipt records its materialization
+- **THEN** the system SHALL delete the recorded files using the receipt alone
+- **AND** whether the surrounding operation completes offline SHALL depend on the remaining desired state, not on this deletion
+
+#### Scenario: Project without a receipt owns nothing yet
+
+- **WHEN** a project has a lockfile but no receipt
+- **THEN** the next operation SHALL treat every materialization as untracked
+- **AND** it SHALL NOT delete any file on the strength of a lockfile entry alone
+- **AND** it SHALL record ownership only for the identities it reconciles
+
+#### Scenario: Omitted contributions are excluded from receipt
+
+- **WHEN** a desired asset or server declaration is omitted
+- **THEN** the system SHALL NOT record it as materialized
+
+#### Scenario: Untracked desired identity is reconciled and tracked
+
+- **WHEN** an untracked asset or MCP entry already occupies an effective identity the desired state names
+- **AND** its applicable takeover gate permits continuation
+- **THEN** installation SHALL reconcile that identity to the desired state
+- **AND** the committed receipt SHALL record that identity as tracked
+
+#### Scenario: Targeting and purging delegate management of recorded identities
+
+- **WHEN** an adapter is targeted after a project already recorded ownership of an effective identity
+- **AND** that adapter's storage already contains state at the same identity
+- **THEN** reconciliation SHALL manage that identity in the target adapter
+- **AND** an exclusive-target operation SHALL remove the identity from every purge adapter according to the same project-wide ownership
+
+#### Scenario: Untracked identity outside desired state is left alone
+
+- **WHEN** an untracked asset or MCP entry occupies an effective identity no desired contribution names and no receipt record covers
+- **THEN** the system SHALL NOT address or delete it
+
+#### Scenario: Earlier receipts refine directly to current state
+
+- **WHEN** the system loads receipt version `1`, `0.2`, or `0.3`
+- **THEN** it SHALL refine each asset to its recorded materialization in the in-memory current `0.4` receipt shape
+- **AND** version `1` SHALL refine to primary-only ownership while `0.2` and `0.3` SHALL retain their complete owned-path sets
+- **AND** the refined receipt SHALL carry no configuration claims and confer no MCP approval evidence
+- **AND** the next successful receipt write SHALL emit `0.4`, never an intermediate writer format
+
+#### Scenario: Pre-current receipt confers no configuration authority
+
+- **WHEN** a project's receipt predates configuration claims
+- **AND** desired state declares MCP servers whose entries already exist in a tool's configuration
+- **THEN** those entries SHALL be treated as untracked occupancy subject to disclosure
+- **AND** every desired declaration SHALL require consent as unapproved
+
+#### Scenario: Escaping receipt path is not deleted
+
+- **WHEN** a receipt companion path resolves outside its target or purge adapter's storage through traversal, an absolute path, or a link
+- **THEN** the system SHALL NOT delete that path
+- **AND** it SHALL report the invalid record while continuing to process valid owned paths safely
+
+#### Scenario: Mismatched project receipt confers no ownership
+
+- **WHEN** receipt project identity differs from the active project
+- **THEN** the system SHALL NOT delete anything based on that receipt
+- **AND** it SHALL NOT recreate ownership from the lockfile in its place
+- **AND** it SHALL report that the receipt could not be used
+- **AND** it SHALL record ownership only for the identities it reconciles
+
+#### Scenario: Unreadable receipt confers no ownership
+
+- **WHEN** a receipt file exists but cannot be parsed or fails validation
+- **THEN** the system SHALL treat every materialization as untracked
+- **AND** it SHALL NOT delete any file
+- **AND** it SHALL report that the receipt could not be used
+
+#### Scenario: Unowned file survives cleanup
+
+- **WHEN** a skill directory contains a file absent from receipt ownership
+- **THEN** skill removal SHALL leave it unchanged
+
+#### Scenario: Configuration claim proves approval without revealing declaration
+
+- **WHEN** a successful operation records an MCP configuration claim
+- **THEN** a later operation SHALL be able to determine whether the same effective declaration was approved
+- **AND** the stored receipt SHALL NOT reveal the command, URL, environment names, or environment values
+
+### Requirement: Removing an undeclared facet is a silent no-op
+
+When a user removes a facet that is not declared in the project manifest, the system SHALL silently ignore the name. The project manifest, lockfile, and receipt SHALL remain unchanged for that name. When every requested name is undeclared under the project lock and no explicit adapter targets were supplied, the operation SHALL succeed, adapter state SHALL remain unchanged, and the system SHALL report that no changes were made. When explicit targets were supplied, the undeclared names SHALL still cause no project desired-state change, but the ordinary exclusive target and purge reconciliation SHALL proceed. That determination SHALL be made by the commit, under the lock — never by a pre-lock read — so a request whose names all appear undeclared SHALL still satisfy the operation's ordinary preconditions, including adapter availability.
+
+#### Scenario: Removing an undeclared facet without explicit targets
+
+- **WHEN** a user removes a facet whose name does not appear in the project manifest
+- **AND** the user supplies no explicit adapter target
+- **THEN** the system SHALL leave the project manifest, lockfile, receipt, and adapter state unchanged
+- **AND** the system SHALL NOT fail with an error
+
+#### Scenario: All requested names are undeclared without explicit targets
+
+- **WHEN** a user removes one or more facets and none are declared in the project manifest
+- **AND** no explicit adapter target is supplied
+- **THEN** the system SHALL exit successfully
+- **AND** the system SHALL report that no changes were made
+
+#### Scenario: Undeclared removal still applies explicit placement
+
+- **WHEN** every requested facet name is undeclared
+- **AND** the user supplies one or more explicit adapter targets
+- **THEN** the system SHALL make no project desired-state change for those names
+- **AND** it SHALL reconcile the complete desired project state into every target
+- **AND** it SHALL purge every discoverable non-target adapter
+
+### Requirement: Materialized ownership is reconciled against the complete effective set
+
+The system SHALL plan deletion and replacement from the complete tracked previous ownership and complete desired effective set. Previous ownership SHALL be read from the receipt alone. A materialized identity SHALL be deleted only when the receipt records it and either no desired asset still claims its adapter identity or the adapter is in the purge set for an exclusive-target operation. Cross-facet ownership transfer SHALL replace content without leaving a retained identity deleted in a target adapter; a purge adapter SHALL remove the identity regardless of whether desired state retains it. Duplicate historical claims SHALL be aggregated, each obsolete or purged identity SHALL be deleted at most once per adapter, and all recorded owned companions absent from the target's new owner SHALL be removed while unowned files remain untouched. An identity whose primary is already absent SHALL still have its recorded companions removed, because each is inspected and recorded individually and is therefore restorable on its own.
+
+Changing an alias SHALL delete the old effective identity and reconcile the new one transactionally in every target adapter. Changing to omitted SHALL delete prior target ownership; removing omission SHALL materialize the asset in every target. A disposition-only change SHALL be reported as updated, while disk-only drift SHALL remain repaired. Purge adapters SHALL retain neither the old nor new effective identity when receipt ownership authorizes their removal.
+
+#### Scenario: Ownership transfer retains the identity
+
+- **WHEN** one facet is removed while another desired asset takes its effective name
+- **THEN** the identity SHALL contain the new owner's content in every target adapter after success
+- **AND** it SHALL NOT be left deleted in a target adapter
+
+#### Scenario: Alias change moves owned files
+
+- **WHEN** an alias changes from `vendor-review` to `partner-review`
+- **THEN** the old owned files SHALL be deleted and the new effective identity SHALL be reconciled in every target adapter in one operation
+- **AND** neither effective identity SHALL remain in a purge adapter
+
+#### Scenario: An alias change removes a bundle whose primary is gone
+
+- **WHEN** an alias changes and the old effective identity's primary is already absent
+- **THEN** the old recorded companions SHALL still be removed
+- **AND** a later failure in the same operation SHALL restore each of them to its exact prior bytes
+- **AND** the new effective identity SHALL still be reconciled and recorded for the targets
+
+#### Scenario: Historical duplicate claims do not delete a retained target identity
+
+- **WHEN** a receipt has duplicate historical claims for one adapter identity and the desired set retains that identity
+- **THEN** the identity SHALL NOT be left deleted in a target adapter
+- **AND** companions absent from the retained ownership SHALL be removed
+
+#### Scenario: Both claimants aliased away vacate the authored identity
+
+- **WHEN** a tracked facet is materialized under an authored name, one other facet contributes the same authored name, and the accepted resolution assigns each of the two a distinct alias
+- **THEN** the vacated effective identity SHALL be deleted before either alias is written
+- **AND** each alias SHALL contain its own facet's authored content in every target adapter
+- **AND** the committed receipt SHALL record both aliased identities and SHALL NOT record the vacated one
+- **AND** the disposition-only change SHALL be reported as updated while the newly contributing facet is reported as installed
+
+#### Scenario: An authored identity no claimant retains is vacated only when tracked
+
+- **WHEN** every claimant of an authored name is aliased or omitted, so no desired asset retains that effective identity
+- **AND** the receipt records that identity
+- **THEN** it SHALL be deleted before any alias is written
+- **AND** WHEN no receipt record covers it, it SHALL be left in place as an untracked materialization
+
+#### Scenario: Desired identity is deleted from a purge adapter
+
+- **WHEN** the receipt records an effective identity that desired project state retains
+- **AND** an installed adapter is in the purge set
+- **THEN** the identity SHALL be removed from that adapter
+- **AND** it SHALL be reconciled into every target adapter
+
+#### Scenario: A lockfile-only claim authorizes no deletion
+
+- **WHEN** the lockfile records a materialized asset that no receipt record covers
+- **THEN** the system SHALL NOT delete anything from a target or purge adapter on the strength of that entry
+- **AND** the identity SHALL be reconciled, and only then recorded, if the desired state names it
+
+### Requirement: Removing facets reconciles MCP configuration ownership
+
+Removing a facet SHALL remove an effective MCP entry when machine-local configuration ownership covers it and either no remaining desired or safely carried-forward claim uses the identity or the adapter is in the purge set for an exclusive-target operation. An unowned native entry SHALL never be deleted merely because a facet, alias, lockfile entry, or adapter target changed. A removal that must resolve remaining facets SHALL enter the same MCP approval path as add or install.
+
+A removal-only operation MAY carry configuration claims forward without fetching only when existing local evidence proves each remaining claim is anchored to the same facet integrity and still matches desired project intent. An earlier receipt without configuration claims or any unavailable proof SHALL force ordinary resolution rather than invent ownership. An explicit-target removal SHALL additionally prove complete desired state for every target or perform ordinary resolution before mutation.
+
+#### Scenario: Last owned claimant removes the server
+
+- **WHEN** a removed facet is the last desired claimant of an owned effective server
+- **THEN** the system SHALL remove that server from every participating target and purge adapter
+
+#### Scenario: Remaining claimant preserves the server in targets
+
+- **WHEN** another desired facet retains the same effective configuration
+- **THEN** removal SHALL preserve or reconcile the native server entry in every target adapter
+- **AND** it SHALL remove the owned entry from every purge adapter
+
+#### Scenario: Purge removal requires receipt ownership
+
+- **WHEN** a purge adapter contains a native server entry that no receipt configuration claim covers
+- **THEN** the system SHALL leave that entry unchanged
+
+#### Scenario: Pre-0.4 receipt forces resolution
+
+- **WHEN** removal would carry a remaining server claim but the loaded receipt predates configuration ownership
+- **THEN** the system SHALL perform ordinary resolution rather than treating the lockfile as deletion authority

--- a/openspec/changes/filter-installation-by-adapter/tasks.md
+++ b/openspec/changes/filter-installation-by-adapter/tasks.md
@@ -1,0 +1,116 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+- **Pause** → PAUSE, NO TOOL. A model-switch pause. Emit this exact line of plain text and nothing else:
+  "Switch models if desired, then send any message to continue."
+  Then end the turn. Do NOT call the `question` tool, and do NOT tell the user to run a command.
+  An affirmative continuation resumes execution; a stop, revise-plan, or
+  question message is handled without advancing.
+
+## 1. CLI Targeting Foundation — Research
+
+- [ ] 1.1 Explore: Inspect argument-parser behavior for repeatable, missing, empty, comma-containing, digit-leading, negated, and undeclared flag values, and identify the safe normalization boundary.
+- [ ] 1.2 Explore: Inspect all flag declarations and help rendering to determine the type-safe value-label migration and the strict-versus-passthrough command policy.
+- [ ] 1.3 Explore: Inspect adapter discovery, picker fallback, capability declarations, and add/install/remove ordering to define the all-versus-exclusive request boundary and future project-config seam.
+- [ ] 1.4 Propose: Present the complete CLI targeting foundation, including result-shaped parse failures, target deduplication, strict unknown-flag behavior, capability-aware participation, and picker suppression.
+
+## 2. CLI Targeting Foundation — Implementation
+
+- [ ] 2.1 Pause: Switch model for implementation.
+- [ ] 2.2 Implement: Replace permissive flag metadata with a tagged definition that makes value labels valid only for value-carrying flags, add an explicit strict/passthrough command policy, and migrate existing declarations.
+- [ ] 2.3 Implement: Update command routing and help rendering to reject undeclared flags on add/install/remove before handler execution, preserve dynamic modify flags, reject missing or empty values, and render repeatable value placeholders.
+- [ ] 2.4 Implement: Add the shared repeatable `--adapter <name>` definition, with help text stating that explicit targets are exclusive and non-target adapters lose all Facet-managed project assets and MCP entries, and a pure `AdapterTargetRequest` parser that returns `all` or a deduplicated non-empty exclusive list without comma splitting.
+- [ ] 2.5 Implement: Add a source-independent target resolver that, before the project lock, validates and partitions every installed adapter exposing assets or MCP support into target and purge sets; return a named, role-aware failure for an unknown, unavailable, broken, incompatible, or incapable target or required purge adapter; suppress the picker for explicit targets and retain existing picker behavior for the all-adapters request.
+- [ ] 2.6 Implement: Add focused unit tests for strict flags, parser edge cases, help output including destructive exclusive-target wording, shared flag identity, target deduplication, capability-aware partitioning, pre-lock named target/purge validation, unknown-target guidance, and picker suppression.
+- [ ] 2.7 Verify: Run the focused CLI targeting tests and package type-checking before engine integration.
+
+## 3. Engine Scope and Asset Purge — Research
+
+- [ ] 3.1 Pause: Switch model for exploration.
+- [ ] 3.2 Explore: Trace every flat adapter-array consumer and test fixture through add, install, remove, source resolution, compatibility preflight, materialization, and public engine exports.
+- [ ] 3.3 Explore: Inspect receipt-derived asset ownership, deletion planning, transaction journaling, rollback, directory cleanup, and summary aggregation to identify the smallest reusable full-project purge plan.
+- [ ] 3.4 Explore: Inspect the removal-refinement fast path and cache/source resolution behavior, documenting how global removal resolution remains offline when cached and uses the network only on cache miss.
+- [ ] 3.5 Propose: Present the engine scope migration and purge orchestration, including target-only build validation, participating-adapter compatibility, capability-specific passes, global refinement removal, deterministic planning, and rollback boundaries.
+
+## 4. Engine Scope and Asset Purge — Implementation
+
+- [ ] 4.1 Pause: Switch model for implementation.
+- [ ] 4.2 Implement: Introduce and export the tagged `InstallationAdapterTargets` contract and role-specific helper accessors, then migrate runAdd, runInstall, runRemove, and existing tests through an all-target compatibility helper without changing unfiltered behavior.
+- [ ] 4.3 Implement: Wire the CLI target resolver into add/install/remove while preserving source-parse and manifest-validation ordering, pass the validated target/purge partition into the engine, and ensure removal of an undeclared facet is decided under the project lock as no desired-state change while explicit target reconciliation and purge placement still proceed.
+- [ ] 4.4 Implement: Run API compatibility over all participating adapters, validate local/git facet metadata against targets only, and route asset and MCP work only to adapters exposing the relevant capability.
+- [ ] 4.5 Implement: Disable the adapter-agnostic removal-refinement fast path globally, remove or retire unreachable refinement orchestration, and make every removal resolve complete remaining target state from cache or source before mutation. Record and test the accepted trade-off: an unfiltered removal with a cold cache now requires source/network availability, and resolution failure leaves all project and adapter state unchanged.
+- [ ] 4.6 Implement: Add a deterministic pre-mutation asset purge plan containing every receipt-owned identity regardless of desired state, while preserving absent-state no-ops, path validation, companion ownership, and untracked-file safety.
+- [ ] 4.7 Implement: Apply purge asset deletions before target deletion and materialization in the existing transaction, add abort checkpoints, and preserve byte-exact rollback and conservative directory restoration across both phases.
+- [ ] 4.8 Implement: Extend engine result and transaction-subject types with tagged target/purge scope and per-adapter purge counts, including zero-removal purge adapters, without changing receipt schema `0.4` or persisting placement.
+- [ ] 4.9 Implement: Add and update engine tests for single and multiple targets, complete still-desired asset purge, multi-file ownership, absent and untracked state, opposite target sets, add/remove semantics, global removal resolution including cold-cache failure before mutation, rollback, unchanged receipt bytes/schema, and filtered/unfiltered operations committing identical ownership accounts for identical desired state.
+- [ ] 4.10 Verify: Run focused asset-purge engine tests and package type-checking.
+
+## 5. MCP Purge, Consent, and Frozen Mode — Research
+
+- [ ] 5.1 Pause: Switch model for exploration.
+- [ ] 5.2 Explore: Inspect MCP support classification, receipt ownership, preparation, consent derivation, application, outcome classification, and receipt-claim generation for separate target and purge roles.
+- [ ] 5.3 Explore: Inspect shared native-document overlap and drift guards to design purge-then-target composition where target state wins, while retaining existing target/target overlap failure and external-drift protection.
+- [ ] 5.4 Explore: Inspect frozen consistency gates, receipt-only commit behavior, receipt-unpersisted reporting, and transaction ordering to place every purge after validation and before target application.
+- [ ] 5.5 Propose: Present the complete MCP and frozen implementation, including capability-partial adapters, role-aware failures, target-only consent, target-only receipt claims, target-wins shared-document composition, purged outcomes, and rollback.
+
+## 6. MCP Purge, Consent, and Frozen Mode — Implementation
+
+- [ ] 6.1 Pause: Switch model for implementation.
+- [ ] 6.2 Implement: Make MCP support validation role-aware so targets validate active declarations, purge adapters validate only receipt-owned removals, and adapters with no relevant MCP work do not fail.
+- [ ] 6.3 Implement: Prepare purge adapters with an empty desired set and all receipt-owned server identities, keep purge plans out of consent derivation and receipt-claim generation, and preserve machine-wide approval for target declarations.
+- [ ] 6.4 Implement: Split native-document overlap handling by role, retain target/target failure, allow purge/target composition, and update re-planning and drift checks so this operation's purge can be followed safely by target-wins application.
+- [ ] 6.5 Implement: Apply purge MCP changes before target MCP changes through the same transaction, preserve exact rollback, and add a distinct purged outcome for still-desired project declarations.
+- [ ] 6.6 Implement: Keep every frozen consistency, integrity, collision, and consent gate before purge, support exclusive targets with unchanged manifest/lockfile bytes, and include scope in receipt-unpersisted results.
+- [ ] 6.7 Implement: Add MCP and frozen tests for target-only consent, approval reuse, purge ownership, unsupported target and purge roles, no-work capability cases, shared-document target-wins composition, outcomes, rollback, and frozen failures preceding purge.
+- [ ] 6.8 Verify: Run focused MCP, consent, rollback, frozen, and CLI integration tests.
+
+## 7. CLI Scope Reporting and Remedies — Research
+
+- [ ] 7.1 Pause: Switch model for exploration.
+- [ ] 7.2 Explore: Inspect progress-view lifecycle, pre-mutation rendering, adapter counting, no-op classification, summary lines, removal-with-no-facet outcomes, and receipt-unpersisted presentation.
+- [ ] 7.3 Explore: Inspect every short and long failure remedy, collision/MCP report, and transaction-subject renderer that must preserve explicit targets or distinguish target from purge roles.
+- [ ] 7.4 Explore: Inspect the agent-facing `facet instructions` usage prompt and its tests for adapter command guidance that must distinguish tooling installation from exclusive placement targeting.
+- [ ] 7.5 Propose: Present the reporting and remedy approach, selecting one source of requested pre-mutation scope and one source of actual result scope, with deterministic empty-purge reporting.
+
+## 8. CLI Scope Reporting and Remedies — Implementation
+
+- [ ] 8.1 Pause: Switch model for implementation.
+- [ ] 8.2 Implement: Render target and purge sets from the resolved request before mutation and from the engine result after completion, including exclusive warnings, zero-removal purge adapters, and scope on receipt-unpersisted outcomes.
+- [ ] 8.3 Implement: Correct no-op and adapter-count derivation so placement-only purge work is visible, and report target writes separately from per-adapter asset and MCP purge removals.
+- [ ] 8.4 Implement: Render purged MCP entries distinctly from project-level removals and keep target declarations visible as still desired.
+- [ ] 8.5 Implement: Add a single shell-safe rerun-command renderer and thread it through every short and long failure path so generic, collision, frozen, and MCP-consent remedies preserve all explicit targets.
+- [ ] 8.6 Implement: Update target/purge role diagnostics for compatibility, MCP support, shared-document handling, and transaction failures without changing the canonical CLI error shape.
+- [ ] 8.7 Implement: Update the agent-facing usage prompt to document repeatable exclusive targets, destructive non-target purge, frozen compatibility, and the distinction from `facet adapter add`.
+- [ ] 8.8 Implement: Add view, outcome, help, prompt, failure-block, and remedy tests covering pre-mutation scope, final scope, empty purges, placement-only runs, undeclared removals, shell quoting, and filter-preserving reruns.
+- [ ] 8.9 Verify: Run focused CLI rendering, prompt, failure, and end-to-end tests.
+
+## 9. Integration, Documentation, and Release — Research
+
+- [ ] 9.1 Pause: Switch model for exploration.
+- [ ] 9.2 Explore: Inspect the fake-adapter and compiled-CLI harnesses and map the complete cross-command scenario matrix for target/purge placement, later unfiltered rematerialization, ordering failures, and frozen mode.
+- [ ] 9.3 Explore: Re-audit all CLI reference, specification, and guide pages named by the design, confirming exact conflicting statements and confirming README, navigation, authoring docs, and adapter SDK references remain unchanged.
+- [ ] 9.4 Explore: Inspect release metadata requirements for the user-facing CLI change and confirm the required changeset path without adding a manual documentation changelog entry.
+- [ ] 9.5 Propose: Present the final integration, documentation, release-metadata, and verification pass, including rollback-sensitive and cache-miss scenarios.
+
+## 10. Integration, Documentation, and Release — Implementation
+
+- [ ] 10.1 Pause: Switch model for implementation.
+- [ ] 10.2 Implement: Add compiled-CLI scenarios for single, multiple, duplicate, unknown, empty, comma-containing, and misspelled targets, complete non-target asset/MCP purge, opposite targets, empty purges, and later unfiltered rematerialization.
+- [ ] 10.3 Implement: Add cross-command scenarios for add/install/remove ordering, undeclared removal with placement work, cache-backed and cache-miss removal resolution, MCP consent and shared documents, rollback, and frozen exclusive targeting.
+- [ ] 10.4 Implement: Update `docs/cli/add.mdx`, `docs/cli/install.mdx`, and `docs/cli/remove.mdx` with the repeatable flag, exclusive semantics, picker suppression, validation, frozen interaction, examples, outcomes, and exit behavior.
+- [ ] 10.5 Implement: Update the affected specification pages with target/purge terminology, adapter-agnostic receipt authority, transactional ordering, consent, frozen behavior, and the absence of persisted targets in manifest and lockfile.
+- [ ] 10.6 Implement: Update the affected installation, troubleshooting, and custom-adapter guides with exclusive placement, purge failures, shared MCP visibility, and later unfiltered rematerialization; leave README, navigation, authoring docs, and SDK references unchanged after verification.
+- [ ] 10.7 Implement: Add the required release changeset or equivalent package-release metadata without editing `docs/changelog/index.mdx`.
+- [ ] 10.8 Verify: Run the complete `bun check` pipeline, fix formatting with `bun format` when required, and verify tests, types, lint, end-to-end behavior, documentation consistency, and unchanged receipt schema `0.4`.


### PR DESCRIPTION
### Why

Projects with multiple installed adapters currently materialize every facet into every compatible adapter. There is no way to say "this project's Facet-managed state belongs in OpenCode only" for a given invocation without hand-deleting files afterwards.

This PR is the plan for that feature, not the feature: it adds the OpenSpec change `filter-installation-by-adapter` (proposal, design, delta specs, task plan). No product code changes — `facet add`, `facet install`, and `facet remove` behave exactly as they do today.

### Details

The central decision is that explicit `--adapter` targets are **exclusive**, not additive. Every named adapter receives the complete desired project state, and every other installed materialization-capable adapter is purged of all receipt-owned assets and MCP entries in the same atomic operation.

That choice is what keeps the rest of the design small. Leaving non-target adapters untouched would require adapter-scoped receipt history so later filtered updates and removals could still prove what they were allowed to delete. Because no successful operation leaves project-owned state behind in a discoverable non-target adapter, the machine-local receipt stays adapter-agnostic at schema `0.4` — no adapter dimension, no version bump, no migration.

Constraints worth reviewing:

- The manifest and lockfile remain project-wide desired state. Targets control physical placement only, and nothing persists them.
- Purge authority comes from the receipt alone; untracked native files are never touched.
- Target and purge validation completes before the project lock. An unknown, unavailable, broken, or incapable adapter on either side aborts with no state changed.
- Purge and target transitions share one transaction with byte-exact rollback, purge first.
- MCP consent is unchanged. Targeting never manufactures approval or forces re-approval.

One deliberate behavioral regression outside the new flag: the adapter-agnostic removal-refinement fast path is retired globally rather than taught target/purge roles. Every removal will resolve complete remaining target state from cache or source before mutating, so a cold-cache `facet remove` with no source access will fail unchanged instead of completing receipt-only. Design decision 7 records the trade-off.

The task plan sequences this across ten phases: CLI parsing and flag strictness, engine scope migration and asset purge, MCP purge and frozen mode, scope reporting and failure remedies, then integration, documentation, and release metadata.

### Verification

Nothing to run — the diff is planning artifacts plus two `.gitignore` entries. All four artifacts are complete per `bun openspec status`, and each went through independent adversarial authoring, comparison review, and reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a proposal for repeatable `--adapter <name>` targeting across installation commands.
  * Defined exclusive adapter targeting, automatic cleanup from other adapters, atomic changes, validation, rollback, and clear command feedback.
  * Documented updated installation, CLI, testing, and release requirements.

* **Chores**
  * Updated repository ignore rules and added structured change metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->