### PR TITLE
Add `facet update` command with two-phase discovery, transactional application, and `upgrade` alias

### DIFF
--- a/openspec/changes/.gitignore
+++ b/openspec/changes/.gitignore
@@ -1,1 +1,2 @@
 archive/
+/*/adversarial/

--- a/openspec/changes/add-facet-update-command/.openspec.yaml
+++ b/openspec/changes/add-facet-update-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/add-facet-update-command/design.md
+++ b/openspec/changes/add-facet-update-command/design.md
@@ -1,0 +1,184 @@
+## Context
+
+`facet install` intentionally reproduces a satisfying `facets.lock` entry, while an explicit non-exact `facet add` request re-resolves that one facet. There is no project-wide operation that resolves every registry-backed manifest entry against both its authored version intent and the registry’s latest release, lets the user choose targets, and then applies those targets through the verified install transaction.
+
+The required behavior crosses the CLI router and Ink UI, the engine registry client, manifest and lockfile loading, and the install transaction. The existing protocol version-spec grammar, manifest schema, lockfile schema, cache, materialization planner, MCP reconciliation, and file transaction remain authoritative. No persisted format or registry deployment changes are required.
+
+Relevant constraints are:
+
+- `facets.json` values preserve user-authored version intent and comment metadata; updates MUST use the existing normalized mutation and transactional write path rather than rebuilding JSON.
+- A satisfying lockfile entry anchors reproduction, so an update MUST carry an explicit target into resolution rather than relying on ordinary install behavior.
+- Discovery, dry-run, and interactive selection MUST NOT download facet content, populate the cache, install adapters, or mutate project or machine-local configuration.
+- Registry discovery MUST be complete or fail closed. The existing metadata resolver accepts caller-relative version specifiers but has no server-side batch transport yet.
+- Selected updates MUST retain the existing integrity, collision, MCP-consent, ownership, receipt, rollback, and concurrent-write guarantees.
+- Engine failures MUST remain structured values; the CLI owns rendering and exit codes.
+
+Stakeholders are project users updating facets, automation previewing updates, registry users with caller-relative private-version visibility, and maintainers of the install transaction and CLI documentation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide one engine-owned discovery model containing each checkable registry facet's manifest specifier, Current version, range-respecting Target, and registry Latest version.
+- Support range-respecting application, explicit latest application, Bun-style interactive selection, and write-free dry-run from the same discovered plan.
+- Preserve manifest specifier style and materialization overrides while forcing each selected exact target through registry confirmation and the existing install transaction.
+- Detect a plan that became stale between discovery and application before any mutation.
+- Make `facet upgrade` a true alias of `facet update` and keep facet-package updates distinct from CLI-binary self-update.
+- Align user, agent, roadmap, and specification documentation with the shipped behavior.
+
+**Non-Goals:**
+
+- Updating git or local facet sources.
+- Adding positional, wildcard-name, or dependency-group selectors.
+- Adding another check-only mode, JSON output, changelog retrieval, package diffs, or asset-level previews.
+- Adding a registry batch endpoint or changing the registry OpenAPI contract.
+- Changing version-spec grammar, project-manifest schema, lockfile schema, receipt schema, cache layout, or archive formats.
+- Making `facet upgrade` an independent implementation.
+- Changing `facet list` into a network-backed outdated check.
+
+## Decisions
+
+### D1. Separate read-only preparation from guarded application
+
+The engine SHALL expose a two-phase update workflow:
+
+1. `prepareFacetUpdate` SHALL load and validate `facets.json` and `facets.lock`, capture their exact `FileState` values, perform registry version discovery, re-read both files, and return either a structured preparation failure or a `PreparedFacetUpdate` containing the display plan and its snapshot.
+2. `runPreparedFacetUpdate` SHALL accept that prepared value, selected target choices, adapters, and the normal install callbacks. It SHALL validate the selection, select the exact metadata already carried by the prepared plan for every chosen target, and invoke the install transaction with an update operation bound to the captured snapshot.
+
+Preparation SHALL remain lock-free and read-only. This avoids holding the project install lock while a user reviews an interactive screen and ensures dry-run or cancellation leaves no persistent lock-directory, cache, adapter, receipt, manifest, lockfile, materialization, or native-configuration change. The post-network re-read SHALL reject a plan if either file changed during discovery.
+
+Application SHALL acquire the existing install lock before reading project state. Under that lock it SHALL compare the newly loaded manifest and lockfile states with the preparation snapshot using exact file-state equality. A mismatch SHALL return a structured `UPDATE_PLAN_STALE` failure before resolution, content download, cache writes, or transaction creation and SHALL direct the user to rerun the command. Exact selected targets are immutable registry identities, so a version published after discovery SHALL not silently change an already-confirmed plan.
+
+The CLI SHALL perform interactive selection before calling adapter selection. Therefore cancelling the update picker SHALL not install an adapter as a side effect. Default application MAY obtain adapters immediately after preparation because the user requested application without a selection gate.
+
+**Alternatives considered:** Holding the install lock through network discovery and the interactive picker would eliminate the snapshot handoff but could block every other facet operation indefinitely and would make a preview acquire persistent machine-local lock infrastructure. Discovering before application without a snapshot precondition would allow a confirmed plan to overwrite or merge against state the user never saw. Both alternatives are rejected.
+
+### D2. Build one validated, tagged discovery plan through existing metadata resolution
+
+Discovery SHALL construct exactly two `RegistrySpec` inputs for each registry-backed manifest entry: one using the authored `VersionSpec` to resolve Target and one using `latest` to resolve Latest. It SHALL flatten those pairs in manifest order, divide them into groups of at most 100 specifiers, and invoke `resolveRegistryMetadataBatch` for every group concurrently. A full group therefore covers 50 facets. `resolveRegistryMetadataBatch` SHALL accept at most 100 specifiers per invocation and SHALL run its current per-specifier requests concurrently.
+
+After every group settles, discovery SHALL inspect group results in original input order and return the first input-ordered failure rather than a partial plan. Successful metadata SHALL be paired back to facets in manifest order. The client SHALL validate that each response matches the requested facet name, contains usable integrity fields, and resolves to an exact supported `MAJOR.MINOR.PATCH`; Target SHALL additionally satisfy the authored specifier. The registry is authoritative for resolving the authored specifier and `latest`.
+
+**TODO:** Replace the internal per-specifier requests in `resolveRegistryMetadataBatch` with the registry’s planned batch endpoint when it becomes available.
+
+Discovery SHALL parse and classify every manifest entry before presenting a plan:
+
+- A registry entry is checkable only when it has a matching, usable registry lockfile entry whose exact Current version satisfies the manifest specifier.
+- Update SHALL not re-resolve Current or use registry availability of the locked version as a discovery precondition. Repairing an unavailable installed version remains the responsibility of `facet install`.
+- A registry entry with missing, mismatched, invalid, or drifted local resolution state SHALL make preparation fail with all affected facet names and a remedy to run `facet install`. It SHALL never be reported as current and update SHALL not become a second drift-repair command.
+- Git and local entries SHALL appear as tagged `unsupported-source` rows for dry-run output but SHALL not block updates to checkable registry facets.
+- A checkable registry row SHALL carry the exact Target and Latest metadata returned by discovery and SHALL be tagged as `candidate` when either resolved version is newer than Current, otherwise as `current`. Exact pins therefore remain unchanged by default but still appear as candidates when a newer Latest can be selected interactively or with `--latest`.
+
+Target SHALL be the exact version returned for the authored specifier. Latest SHALL be the exact version returned for `latest`. Only a choice newer than Current SHALL be selectable, so update SHALL never downgrade an installed facet. A registry lookup failure SHALL fail the whole preparation before any actionable plan is rendered.
+
+The plan types SHALL use tagged unions rather than optional fields to distinguish `candidate`, `current`, and `unsupported-source` rows. CLI rendering and application SHALL consume this one engine result; the CLI SHALL NOT reimplement version matching, ordering, or specifier rewriting.
+
+**Alternatives considered:** Creating a dedicated version-list discovery client would duplicate an existing registry boundary and fetch information update does not use. Resolving selected targets again during application would repeat discovery without adding trust because exact published versions are immutable. Treating absent lock state as current would produce false clean reports. Proceeding with checkable facets while merely listing registry facets with unusable local state would make one invocation look complete while silently omitting facets that require install or repair. Returning partial registry lookup successes would likewise let users apply a plan known to omit failures. These alternatives are rejected.
+
+### D3. Represent update as a distinct install operation and resolve selected versions exactly
+
+Adding optional update fields to the existing `InstallDelta` would permit illegal combinations such as additions, removals, and snapshot-bound updates in one value. The install input SHALL instead become a tagged operation with mutually exclusive `reproduce`, `add`, `remove`, and `update` arms. Frozen-lockfile mode SHALL be representable only with `reproduce`; `update` SHALL always be non-frozen. Existing add and remove front doors SHALL construct their corresponding arms, preserving current behavior while removing the existing add/remove conflict state.
+
+An update operation SHALL carry:
+
+- the exact prepared manifest and lockfile states;
+- a non-empty set of selected facets;
+- for each facet, its exact selected metadata and its final manifest source string.
+
+`runPreparedFacetUpdate` SHALL validate each selected choice against the prepared rows and attach the corresponding Target or Latest `RegistryMetadata` already returned by discovery. It SHALL NOT perform a second registry metadata request. Exact published versions are immutable, so the selected metadata remains the authoritative registry confirmation supplied to content resolution.
+
+For each selected facet, the install merge SHALL preserve existing overrides, write only the chosen manifest source in memory, and provide the selected exact version as a resolution override. Resolution SHALL ignore the old lock anchor for that facet and SHALL use the prefetched metadata as registry confirmation. Non-selected facets SHALL follow normal reproduction semantics. The prior lock entry SHALL remain available to ownership diffing and outcome classification, so existing `updated` summaries retain the old and new versions.
+
+The final manifest source SHALL be derived by one pure engine helper shared by all modes:
+
+- Range Target keeps the authored source unchanged.
+- Latest chosen from an exact pin writes the selected exact version.
+- Latest chosen from a major wildcard writes the selected major plus `.*`.
+- Latest chosen from a minor wildcard writes the selected major and minor plus `.*`.
+- Latest chosen from `*` or `latest` leaves that token unchanged.
+
+The existing comment-preserving `applyDesiredFacets` path SHALL apply this in-memory intent only during the manifest/lockfile/receipt tri-write. Selected content SHALL continue through cache audit or download, registry integrity confirmation, verified plan construction, complete-set collision detection, MCP consent and takeover handling, materialization, native configuration, and one `FileTransaction`. All selected updates SHALL therefore commit or roll back together.
+
+**Alternatives considered:** Encoding a selected target as an ordinary exact addition would collapse two independent values: the exact version to install and the source string to persist in `facets.json`. For example, installing exact Target `1.5.0` for an authored `1.*` entry must resolve and verify `1.5.0` while preserving `1.*` in the manifest. An exact addition would overwrite the range; a range addition would resolve again during application, could select a version published after discovery, and would discard the metadata already reviewed. Adding optional update-only fields to `Addition` would permit mismatched source, metadata, and snapshot combinations, while adding another tagged variant inside additions would bury operation-wide snapshot and non-empty-selection requirements inside a nested union. The top-level `update` arm keeps those requirements together while still reusing the existing install transaction. Patching the manifest after resolution would create two sources of truth for desired intent. Building a separate updater transaction would duplicate integrity, ownership, rollback, and concurrent-write guarantees. These alternatives are rejected.
+
+### D4. Keep target choice and preview semantics explicit
+
+The engine SHALL accept selected choices as facet name plus `range` or `latest`; it SHALL reject duplicates, unknown names, unsupported rows, and choices that do not advance Current as structured selection failures. Selection validation and manifest rewriting SHALL occur in engine so dry-run display and application cannot disagree.
+
+The CLI SHALL derive mode defaults from the prepared candidates:
+
+- Plain `facet update` SHALL select every candidate whose range Target is newer than Current.
+- `facet update --latest` SHALL select every candidate whose Latest is newer than Current.
+- `--interactive` SHALL show every candidate for which either choice is newer. Range SHALL be the initial choice unless `--latest` is present; `l` SHALL toggle the focused row between Range Target and Latest.
+- A row whose displayed choice equals Current SHALL not be selectable until the user toggles to an advancing choice. Interactive row state SHALL be a tagged selected/unselected union so a selected no-op choice is not representable.
+- Confirm SHALL require at least one selected advancing target. Escape or Ctrl-C SHALL cancel before application.
+- `--dry-run` without `--interactive` SHALL render the complete prepared plan using the mode's default choices. With `--interactive`, it SHALL render the user's confirmed selection and then stop before adapter selection or application.
+
+Dry-run is a successful preview, not a drift-check contract. It SHALL exit `0` both when updates are available and when no update is selected, matching `self-update --dry-run`; real preparation failures SHALL exit non-zero. A future check mode MAY define a distinct updates-available exit contract, but is outside this change.
+
+Interactive cancellation SHALL exit `1`, not `0`, because the user abandoned the requested workflow rather than completing either an application or a no-op. This matches the existing interactive workspace convention and lets automation distinguish cancellation from a completed command.
+
+No-op output SHALL distinguish: all registry facets current; newer releases exist but authored ranges permit none; and the project has no registry facets. Unsupported git/local rows SHALL be named rather than counted as current.
+
+**Alternatives considered:** Returning non-zero merely because dry-run found updates would conflict with the CLI's `1 = user-facing failure` convention and with existing self-update preview behavior. Hiding exact pins from interactive mode would make the Target/Latest toggle unable to perform its primary override use case. Both alternatives are rejected.
+
+### D5. Extend CLI metadata once, then derive parsing and help from it
+
+`FlagDef` SHALL gain a canonical short-alias field consumed by both `run.ts` and `help.ts`. The per-command parser SHALL pass aliases to `@bomb.sh/args`, normalize parsed values onto long names, and exclude short names from undeclared-flag passthrough. Help SHALL render long and short forms from the same flag definition. No second alias map or command-local manual normalization SHALL be introduced.
+
+The update command SHALL define `--latest`/`-L`, `--interactive`/`-i`, `--dry-run`, and the shared install-pipeline `--verbose` and `--accept-mcp` flags. It SHALL reject positional arguments. It SHALL not expose `--frozen-lockfile`. `facet upgrade` SHALL be declared only in `updateCommand.aliases`, never as another registry key, so canonical and alias invocations share behavior and canonical help.
+
+The command SHALL reject `--interactive` in a non-interactive terminal using `canPromptInteractively()` before starting discovery. The standalone update picker SHALL reuse the established `InstallPicker` keyboard conventions and the collision workspace's non-color focus markers and always-active interrupt handling. Installation progress and final per-facet outcomes SHALL reuse `InstallView` with an `update` mode rather than introducing a second progress renderer.
+
+Exit behavior SHALL remain:
+
+- `0` for applied updates, no-op, or successful dry-run;
+- `1` for invalid invocation, non-TTY interactive use, interactive cancellation, stale plan, discovery failure, or application failure;
+- `2` only for an unexpected error escaping the command boundary.
+
+Errors SHALL use the existing three-line stderr format and registry/install failure translators. Help, tables, picker frames, progress, and summaries SHALL use stdout. Cancellation SHALL report that nothing was applied and SHALL not report success.
+
+**Alternatives considered:** Treating `-L` and `-i` as undeclared passthrough keys would leave aliases undocumented and force each handler to interpret two names. Registering `upgrade` as a second command object would duplicate help, tests, and behavior. A new update-specific progress pipeline would duplicate the install view. These alternatives are rejected.
+
+### D6. Reconcile documentation around one canonical update workflow
+
+Implementation SHALL update every affected user- and agent-facing source rather than leaving the old roadmap promise as a second contract:
+
+- Create `docs/cli/update.mdx` with usage, range behavior, Current/Target/Latest terminology, flags, TTY requirements, dry-run scope, outcomes, exit codes—including interactive cancellation as `1`—source limitations, and self-update disambiguation.
+- Convert `docs/cli/upgrade.mdx` from an unimplemented placeholder into a concise alias page that points to `facet update`. Keep the page so existing links remain valid, but remove it from the primary Facet Management navigation in `docs/docs.json` and add `cli/update` there.
+- Update `docs/cli/self-update.mdx` to distinguish facet-package update/upgrade from CLI-binary self-update/self-upgrade and the facet registry from `FACET_CLI_REGISTRY`'s npm registry.
+- Update both human and agent sections of `docs/guides/install-facets.mdx`; update `docs/cli/index.mdx`, `docs/roadmap/alpha.mdx`, `docs/roadmap/beta.mdx`, `docs/roadmap/stable.mdx`, and root `README.md`. The beta promise “surface what changed” SHALL be narrowed to version transitions and the normal installation summary; changelog and content diffs are not part of this change.
+- Update `docs/specification/commit.mdx` so resolution has an explicit update mode and the manifest-write policy covers style-preserving latest selection. Add cross-links from `docs/cli/add.mdx` and `docs/cli/list.mdx` rather than duplicating install outcomes or adding network behavior to list. Verify the existing materialization documentation remains accurate.
+- Add update guidance to `packages/cli/src/prompts/overview.txt` and `packages/cli/src/prompts/usage.txt`, with companion instruction-prompt tests.
+- Add one new top-of-file entry to `docs/changelog/index.mdx` following its one-entry-per-day and RSS rules. The entry SHALL call out that `facet upgrade` changes from a non-mutating unimplemented stub into a live alias that applies facet updates. The historical sentence saying install shipped “without a separate `facet update` command” SHALL remain unchanged because it describes that release at that time; the new entry supersedes it without rewriting historical headings.
+
+The OpenSpec delta SHALL modify `cli` and `installation`. It SHALL reuse the existing `protocol__version-spec` grammar rather than restating it.
+
+**Alternatives considered:** Redirecting away `cli/upgrade` would preserve URLs but remove a useful explanation that the typed command remains a supported alias. Keeping both pages in primary navigation would make two names appear to be independent workflows. Duplicating installation outcome definitions on the update page would create competing sources of truth. These alternatives are rejected.
+
+## Risks / Trade-offs
+
+- **[A plan can become stale while a user is deciding]** → Preparation revalidates after network discovery, and application compares exact manifest and lockfile states again under the install lock before any side effect.
+- **[Lock-free preparation can observe concurrent project activity]** → Exact post-discovery re-reads reject detected changes; the authoritative apply gate under the lock prevents stale writes even if preparation raced in an undetectable instant.
+- **[Private or authorization-relative resolution can produce different targets for different callers]** → Discovery carries the same optional credentials as other registry reads and treats the registry’s Target and Latest resolutions as caller-relative. It does not use Current availability as an update precondition, and only advancing choices can be selected.
+- **[`--latest` can intentionally widen a bounded range]** → The flag is explicit, dry-run and interactive display both range Target and Latest, specifier style is preserved, and all selected changes remain transactional.
+- **[Discovery metadata could bypass the lockfile trust model]** → Target and Latest metadata come through the existing registry resolution boundary and selected content still passes through the existing three-check integrity chain; old lock integrity is never reused as the anchor for new content.
+- **[Updates may introduce collisions or MCP configuration]** → Application reuses complete-set composition, consent, takeover, transaction, and rollback. Dry-run documents that it previews versions, not downstream asset or configuration effects.
+- **[Short-flag support affects every command]** → Alias parsing and help derive from one `FlagDef` field and receive router-level unit and end-to-end coverage, including undeclared dynamic flags.
+- **[Holding prepared file bytes increases in-memory plan size]** → Only two small project files are retained, and exact bytes provide the strongest existing concurrent-edit precondition without a duplicate hash format.
+- **[Four similar update/upgrade names can confuse users]** → Canonical help groups aliases, docs lead with `facet update`, and self-update documentation explicitly names the binary/package boundary and registry distinction.
+- **[The `upgrade` alias changes an existing invocation from inert to mutating]** → Global help, the retained alias page, and the release changelog SHALL identify `update` as canonical and state that `facet upgrade` now applies the same project changes instead of printing the former stub notice.
+
+## Migration Plan
+
+1. Give `resolveRegistryMetadataBatch` its 100-specifier contract, remove its stale exact-or-latest-only assumption, and add two-specifier-per-facet discovery with concurrent groups, target pairing, and tagged plan types. Engine unit tests SHALL cover all five `VersionSpec` kinds, exact response validation, range satisfaction, the 100-specifier boundary, concurrent multi-group resolution, all-or-nothing and input-order behavior, every unusable-local-state reason, and reuse of discovered metadata without a second lookup.
+2. Refactor install input to the tagged operation union, add snapshot validation and exact update resolution overrides, and cover manifest preservation, metadata confirmation, transaction, rollback, stale-plan, and mixed selected/unselected behavior.
+3. Add short-flag metadata support, register `update` with the `upgrade` alias, implement static and interactive presentation, extend install progress/failure wording, and add CLI unit, Ink, and end-to-end tests.
+4. Add the `cli` and `installation` delta specifications, then update all documentation and agent prompts named in D6.
+5. Run `bun check` as the canonical verification, including unit, type, lint, and end-to-end suites.
+
+No persisted-data migration is required. Updated projects continue to use existing valid manifest specifiers, lockfile entries, and receipt schemas. If the feature must be rolled back, the command and alias can be removed without rewriting projects; projects already updated remain consumable by the existing install path.
+
+## Open Questions
+
+None. The proposal and this design settle preview exit behavior, missing local state, concurrency, aliasing, registry transport, and documentation treatment before specification authoring.

--- a/openspec/changes/add-facet-update-command/proposal.md
+++ b/openspec/changes/add-facet-update-command/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Projects currently have no single command that discovers and applies newer releases of their declared facets. Users must manually inspect registry versions, edit `facets.json`, and reinstall, so the CLI needs one update workflow that preserves declared version intent by default while still allowing deliberate upgrades to the registry's latest releases. The workflow is already promised by the unimplemented `docs/cli/upgrade.mdx` placeholder and the beta roadmap, making this both a user-facing gap and an outstanding documented commitment.
+
+## What Changes
+
+- Add `facet update` as the canonical command for discovering and applying updates to registry-backed facets declared in `facets.json`.
+- With no flags, the command SHALL update each facet to the highest published version permitted by its manifest specifier. Exact pins SHALL remain unchanged, major and minor wildcards SHALL remain within their declared ranges, and `*` or `latest` SHALL resolve to the registry's latest version. If no declared range permits a newer version, the command SHALL succeed as a no-op and distinguish “nothing allowed by the current ranges” from a failed check.
+- Add `--latest` with alias `-L`. This mode SHALL ignore current version constraints and update registry facets to their latest published versions. Rewritten manifest specifiers SHALL preserve their existing style: exact pins remain exact at the selected version, major wildcards advance to the selected major, minor wildcards advance to the selected major and minor, and `*` or `latest` remain unchanged.
+- Add `--interactive` with alias `-i`. Interactive mode SHALL complete discovery before performing any update and SHALL show each outdated registry facet's manifest specifier, Current version, range-respecting Target, and registry Latest version.
+- The interactive interface SHALL follow Bun's established update-selection model: users can navigate the list, select facets, confirm the selected updates, and toggle an individual facet between Target and Latest with `l`. Combining `--interactive` with `--latest` SHALL make Latest the initial target while retaining the per-facet toggle.
+- Interactive cancellation SHALL leave all project files, materialized assets, native configuration, and machine-local state unchanged. No update SHALL begin until the user confirms the selection.
+- Add `--dry-run` as a non-interactive preview path. It SHALL print the complete proposed update plan—including each facet's manifest specifier, Current version, range-respecting Target, and registry Latest version—and SHALL leave all project and machine-local state unchanged. It SHALL respect `--latest`; when combined with `--interactive`, the confirmed selection SHALL be previewed but not applied.
+- Applying updates SHALL preserve existing materialization overrides and use the normal verified installation transaction to update facet contents, `facets.json` when its version intent changes, `facets.lock`, the install receipt, materialized assets, and native configuration. All selected updates SHALL commit together or roll back together.
+- Registry facets missing usable local resolution state and git or local sources that cannot be checked against the registry SHALL be identified explicitly rather than reported as current.
+- Discovery SHALL produce a complete project-wide answer. If any required registry lookup fails, the command SHALL fail before presenting an actionable update plan or writing state; users and automation must not act on an incomplete inventory.
+- The command SHALL document successful application, no-op, updates-available dry-run, interactive cancellation, discovery failure, and application failure outcomes with meaningful exit behavior.
+- `facet upgrade` SHALL become an alias of `facet update`, replacing its unimplemented placeholder while keeping existing command usage and documentation links valid. Help and documentation SHALL distinguish facet-package `update`/`upgrade` from CLI-binary `facet self-update`.
+
+## Non-goals
+
+- Adding any check-only mode beyond `--dry-run`. Default and interactive modes apply updates; dry-run is the single preview-without-write path.
+- Supporting positional facet filters, wildcard name filters, or dependency-group filters in the initial command. These selectors are deferred; the initial non-interactive command considers the complete manifest, while interactive mode provides per-facet selection.
+- Detecting or applying updates for git and local facet sources.
+- Adding a server-side batch registry endpoint. Update discovery SHALL use the existing `resolveRegistryMetadataBatch` boundary in groups of at most 100 specifiers; the real registry batch endpoint is planned separately.
+- Changing project-manifest, lockfile, or version-spec grammar.
+- Implementing `facet upgrade` as an independent workflow; it is an alias of `facet update`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli`: Define `facet update`, the `facet upgrade` alias, `--latest`/`-L`, `--interactive`/`-i`, and `--dry-run`; the Current/Target/Latest presentation and selection controls; application, preview, no-op, cancellation, and failure outcomes; help; and the distinction from `facet self-update`.
+- `installation`: Define range-respecting and latest target selection, manifest-specifier rewriting, preservation of materialization intent, and transactional application of selected facet updates.
+
+## Impact
+
+- **CLI:** Command registration, aliasing, dispatch, argument parsing, help, Ink-based interactive selection, dry-run presentation, summaries, structured errors, exit behavior, and command tests will gain the update workflow. The existing unimplemented `upgrade` stub will become an alias of `update`.
+- **Engine:** Update discovery will combine manifest and lockfile state with the existing registry metadata resolver by requesting each authored specifier and `latest`. The returned exact metadata will carry directly into the verified installation transaction rather than introducing a version-list client or a second metadata lookup.
+- **Protocol and persisted state:** No schema or grammar changes are required. Existing comment-preserving manifest mutation and transactional lockfile/receipt writes will carry any selected version changes.
+- **Registry:** No deployment or OpenAPI change is required. Existing metadata resolution is assumed to support the manifest `VersionSpec` forms. A true server-side batch endpoint is planned separately.
+- **Documentation:** This proposal was informed by `docs/cli/upgrade.mdx`, `docs/cli/self-update.mdx`, `docs/guides/install-facets.mdx`, and `docs/roadmap/beta.mdx`, plus Bun's `update` and interactive-update documentation. Add `docs/cli/update.mdx` and its navigation entry, convert `docs/cli/upgrade.mdx` into an alias pointer, update `docs/cli/self-update.mdx` to clarify the command-name distinction, and revise the guide and roadmap for default ranges, `--latest`, `--interactive`, and `--dry-run`.

--- a/openspec/changes/add-facet-update-command/specs/cli/spec.md
+++ b/openspec/changes/add-facet-update-command/specs/cli/spec.md
@@ -1,0 +1,283 @@
+## ADDED Requirements
+
+### Requirement: Users can invoke project facet updates
+
+The system SHALL register `update` as the canonical command for updating registry-backed facets declared by a project. The system SHALL accept `upgrade` as an alias with identical output, side effects, and exit behavior. Both names SHALL operate on project facets and SHALL NOT update the CLI binary.
+
+The command SHALL accept `--latest` with short alias `-L`, `--interactive` with short alias `-i`, `--dry-run`, `--verbose`, and `--accept-mcp`. It SHALL accept no positional arguments and SHALL NOT expose `--frozen-lockfile`.
+
+#### Scenario: Update command is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the output SHALL list `update` as the canonical project-facet update command
+- **AND** the output SHALL identify `upgrade` as its alias
+
+#### Scenario: Upgrade alias performs the same operation
+
+- **WHEN** a user runs `facet upgrade` with the same flags and project state as a corresponding `facet update` invocation
+- **THEN** the system SHALL produce the same output, side effects, and exit code as `facet update`
+- **AND** the invocation SHALL NOT report that the command is unimplemented
+
+#### Scenario: Update rejects positional arguments
+
+- **WHEN** a user runs `facet update` with one or more positional arguments
+- **THEN** the system SHALL print a usage error
+- **AND** the error SHALL direct the user to `--interactive` for per-facet selection
+- **AND** the process SHALL exit with code 1
+
+#### Scenario: Update help lists supported flags
+
+- **WHEN** a user runs `facet update --help`
+- **THEN** the help SHALL list `--latest` with `-L`
+- **AND** the help SHALL list `--interactive` with `-i`
+- **AND** the help SHALL list `--dry-run`, `--verbose`, and `--accept-mcp`
+- **AND** the help SHALL NOT list `--frozen-lockfile`
+
+#### Scenario: Update help distinguishes project facets from the CLI binary
+
+- **WHEN** a user runs `facet update --help`
+- **THEN** the help SHALL describe `update` as operating on facets declared by the project
+- **AND** the help SHALL name `self-update` as the command for updating the CLI binary
+
+### Requirement: Update presentations distinguish Current Target and Latest
+
+Whenever the update command presents discovered choices, it SHALL identify each checkable registry facet's manifest specifier, locked Current version, range-respecting Target version, and registry Latest version. Git and local facets SHALL be named as unsupported sources rather than counted as current.
+
+#### Scenario: Preview shows all version choices
+
+- **WHEN** a project facet is locked at `1.2.0`, its authored specifier resolves to Target `1.4.0`, and the registry resolves Latest `2.0.0`
+- **AND** a user requests an update preview
+- **THEN** the output SHALL identify `1.2.0` as Current, `1.4.0` as Target, and `2.0.0` as Latest
+- **AND** the output SHALL include the authored specifier
+
+#### Scenario: Unsupported sources are named
+
+- **WHEN** a project contains git or local facets alongside registry facets
+- **AND** the update command presents discovery results
+- **THEN** the output SHALL name each git or local facet as unsupported for update discovery
+- **AND** it SHALL NOT report those facets as current registry facets
+
+### Requirement: Users can select updates interactively
+
+The `--interactive` mode SHALL present every registry facet for which Target or Latest is newer than Current. Range Target SHALL be the initial choice unless `--latest` is also supplied, in which case Latest SHALL be initial. Users SHALL be able to navigate rows, select or deselect facets, and toggle the focused row between Target and Latest with `l`. A choice that does not advance Current SHALL NOT be selectable, and confirmation SHALL require at least one selected advancing choice.
+
+Interactive selection SHALL occur before adapter selection or update application. The command SHALL reject interactive mode before discovery when the terminal cannot prompt. Cancelling or interrupting the picker SHALL apply nothing, SHALL report that nothing was applied, and SHALL exit with code 1.
+
+#### Scenario: Interactive mode starts with range targets
+
+- **WHEN** a user runs `facet update --interactive`
+- **AND** a facet has both an advancing Target and an advancing Latest
+- **THEN** the facet's initial choice SHALL be Target
+- **AND** pressing `l` on that row SHALL change its choice to Latest
+
+#### Scenario: Latest interactive mode starts with latest targets
+
+- **WHEN** a user runs `facet update --interactive --latest`
+- **AND** a facet has both an advancing Target and an advancing Latest
+- **THEN** the facet's initial choice SHALL be Latest
+- **AND** pressing `l` on that row SHALL change its choice to Target
+
+#### Scenario: Non-advancing choice cannot be selected
+
+- **WHEN** a facet's Target equals Current but its Latest is newer
+- **THEN** the Target choice SHALL NOT be selectable
+- **AND** the user SHALL be able to toggle to and select Latest
+
+#### Scenario: Confirmation requires a selection
+
+- **WHEN** no advancing update is selected in the interactive picker
+- **THEN** the system SHALL prevent confirmation
+
+#### Scenario: Interactive mode requires a prompt-capable terminal
+
+- **WHEN** a user runs `facet update --interactive` in a non-interactive terminal
+- **THEN** the system SHALL fail before registry discovery
+- **AND** the process SHALL exit with code 1
+
+#### Scenario: Cancelling interactive update changes nothing
+
+- **WHEN** a user cancels or interrupts the update picker before confirmation
+- **THEN** the project manifest, lockfile, receipt, materialized assets, native configuration, cache, and adapter selection SHALL remain unchanged
+- **AND** the output SHALL state that nothing was applied
+- **AND** the process SHALL exit with code 1
+
+### Requirement: Users can preview facet updates without applying them
+
+The `--dry-run` flag SHALL present the update choices that the selected mode would apply and SHALL NOT modify project or machine-local state. Without `--interactive`, it SHALL present the complete discovered plan using the default Target choices or the `--latest` choices. With `--interactive`, it SHALL present the user's confirmed selection and stop before adapter selection or application. A successful preview SHALL exit with code 0 whether updates are available or not.
+
+#### Scenario: Default dry run previews range targets
+
+- **WHEN** a user runs `facet update --dry-run`
+- **THEN** the output SHALL present the complete discovered plan using each facet's range-respecting Target
+- **AND** no project or machine-local state SHALL change
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Latest dry run previews latest targets
+
+- **WHEN** a user runs `facet update --latest --dry-run`
+- **THEN** the output SHALL present the complete discovered plan using each facet's Latest choice
+- **AND** the output SHALL show every manifest specifier rewrite the selected updates would commit
+- **AND** no project or machine-local state SHALL change
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Interactive dry run stops after confirmed preview
+
+- **WHEN** a user confirms a non-empty selection in `facet update --interactive --dry-run`
+- **THEN** the output SHALL present that confirmed selection
+- **AND** the system SHALL stop before adapter selection or application
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Dry run with no available update succeeds
+
+- **WHEN** a user runs an update dry run and no selected mode permits an advancing choice
+- **THEN** the output SHALL report the applicable no-op reason
+- **AND** the process SHALL exit with code 0
+
+### Requirement: Update no-op outcomes are distinguishable
+
+A successful update that applies nothing SHALL distinguish among a project with no registry facets, a project whose registry facets are all current, and a project for which newer releases exist but the authored ranges permit no advancing Target. Each no-op SHALL exit with code 0. Invalid invocation, non-interactive use of `--interactive`, cancellation, stale plans, discovery failures, and application failures SHALL exit with code 1; unexpected failures escaping command handling SHALL exit with code 2.
+
+#### Scenario: Project has no registry facets
+
+- **WHEN** a user runs `facet update` in a project containing no registry-backed facets
+- **THEN** the output SHALL state that the project has no registry facets to update
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Every registry facet is current
+
+- **WHEN** every registry facet's Current version equals both available choices
+- **THEN** the output SHALL state that all registry facets are current
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Authored ranges permit no update
+
+- **WHEN** at least one facet has a Latest version newer than Current
+- **AND** no facet has a Target newer than Current
+- **AND** the user runs `facet update` without `--latest`
+- **THEN** the output SHALL state that newer releases exist but the current ranges permit no update
+- **AND** the output SHALL identify `--latest` as the mode that can select those releases
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Expected update failure uses exit code one
+
+- **WHEN** update fails because discovery or application cannot complete
+- **THEN** the process SHALL exit with code 1
+- **AND** the error SHALL be written to stderr
+
+### Requirement: Applied updates use the shared installation presentation
+
+After a non-dry-run selection is confirmed or derived, the update command SHALL present the same per-facet progress stages, collision and consent surfaces, rollback reporting, and final version-transition summaries used by other facet installation operations. `--verbose` SHALL add diagnostics on stderr. In non-interactive use, `--accept-mcp` SHALL be the sole flag that pre-approves otherwise valid MCP configuration work and SHALL NOT authorize asset takeover.
+
+#### Scenario: Update shows per-facet installation progress
+
+- **WHEN** a user applies one or more facet updates
+- **THEN** the output SHALL show progress for each selected facet
+- **AND** the final summary SHALL identify each previous and installed version
+
+#### Scenario: Update verbose output uses stderr
+
+- **WHEN** a user runs an applying update with `--verbose`
+- **THEN** installation progress SHALL remain on stdout
+- **AND** additional diagnostics SHALL be written to stderr
+
+#### Scenario: Non-interactive MCP work requires explicit acceptance
+
+- **WHEN** a non-interactive update would apply unapproved MCP configuration
+- **AND** `--accept-mcp` is not supplied
+- **THEN** the command SHALL fail before mutation with the complete consent information
+- **AND** when `--accept-mcp` is supplied, the command SHALL proceed without prompting if the work is otherwise valid
+
+## MODIFIED Requirements
+
+### Requirement: Commands declare per-command flags
+
+The system SHALL support per-command flag declarations on command definitions. The router SHALL parse per-command flags via the argument parser and pass the parsed values to command handlers alongside positional arguments. A declared flag MAY define a short alias; the long and short forms SHALL set the same canonical flag value, and the short form SHALL NOT be exposed to handlers as a second independent value.
+
+#### Scenario: Command with declared boolean flag
+
+- **WHEN** a command declares a boolean flag (e.g., `--force`)
+- **AND** a user provides that flag on the command line
+- **THEN** the command handler SHALL receive the flag value as `true`
+
+#### Scenario: Command with declared string flag
+
+- **WHEN** a command declares a string flag (e.g., `--registry`)
+- **AND** a user provides that flag with a value on the command line
+- **THEN** the command handler SHALL receive the flag value as the provided string
+
+#### Scenario: Declared short alias sets the canonical flag
+
+- **WHEN** a command declares `-i` as the short alias of `--interactive`
+- **AND** a user provides `-i`
+- **THEN** the command handler SHALL receive `interactive` as `true`
+- **AND** the handler SHALL NOT receive `i` as a separate flag value
+
+#### Scenario: Undeclared flags are ignored
+
+- **WHEN** a user provides a flag that is not declared by the command and is not a declared short alias
+- **THEN** the command handler SHALL NOT receive that flag
+
+### Requirement: Per-command help displays usage and flags
+
+The system SHALL render per-command help text from command metadata including usage syntax, flag descriptions, and declared short aliases. Authors SHALL NOT need to maintain a separate alias map or duplicate flag help text manually.
+
+#### Scenario: Per-command help shows usage line
+
+- **WHEN** a user runs `<command> --help` for a command that declares a `usage` field
+- **THEN** the help output SHALL display the usage syntax (e.g., `Usage: facet create [directory] [options]`)
+
+#### Scenario: Per-command help lists declared flags
+
+- **WHEN** a user runs `<command> --help` for a command that declares flags
+- **THEN** the help output SHALL list each declared flag with its description under an Options section
+- **AND** the `--help` flag SHALL also appear in the Options section
+
+#### Scenario: Per-command help shows a declared short alias
+
+- **WHEN** a command declares `-L` as the short alias of `--latest`
+- **AND** a user requests that command's help
+- **THEN** the Options section SHALL present `-L` and `--latest` together from the same declaration
+
+### Requirement: The `self-` prefix is reserved for CLI-binary operations
+
+The system SHALL reserve commands prefixed with `self-` for operations that act on the CLI binary itself. Commands without the `self-` prefix that share a verb, including `update` and `upgrade`, SHALL NOT act on the CLI binary; they SHALL operate on facet packages declared by the current project.
+
+#### Scenario: self-update acts on the CLI binary
+
+- **WHEN** a user runs `facet self-update`
+- **THEN** the system SHALL update the CLI binary
+- **AND** the system SHALL NOT modify any facet package or facet manifest
+
+#### Scenario: Bare update or upgrade acts on project facets
+
+- **WHEN** a user runs `facet update` or `facet upgrade`
+- **THEN** the system SHALL perform the project-facet update workflow
+- **AND** the system SHALL NOT update the CLI binary
+
+### Requirement: A failed operation reports what it left on disk, by path
+
+When an add, install, remove, or update operation fails, the command SHALL report whether the project was fully restored, and the process SHALL exit with a non-zero code. When any file could not be returned to its prior state, the command SHALL name every such file on the error stream.
+
+The report SHALL distinguish a file deliberately left alone — because something else changed it after this run wrote it — from one whose restoration genuinely failed, and SHALL give each the remedy that applies to it. A preserved concurrent edit SHALL NOT be described as damage to hunt for.
+
+The command SHALL NOT prompt about a contested file, and SHALL NOT offer to overwrite one, in interactive or non-interactive use alike. Whatever the other writer left SHALL remain exactly as they left it.
+
+An interactive option to force restoration over a contested file is intentionally deferred rather than omitted by oversight. Adding one would ask a user to choose between two states during failure handling, on the least informed footing they will ever have; reporting the path lets them compare the two deliberately afterward. Reporting is therefore the floor a later option would build on, never something it would replace.
+
+#### Scenario: Failed operation that fully rolls back
+
+- **WHEN** an operation fails and every file it changed is restored
+- **THEN** the rendered view SHALL indicate that the project state is unchanged
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Failed operation that could not restore a file
+
+- **WHEN** an operation fails and a file could not be returned to its prior state
+- **THEN** the command SHALL name that file on the error stream
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: A preserved concurrent edit is reported without a prompt
+
+- **WHEN** something else changed a file after the run wrote it, and the run then failed
+- **THEN** the command SHALL name that file and say it was left as it is
+- **AND** the command SHALL NOT ask whether to overwrite it

--- a/openspec/changes/add-facet-update-command/specs/installation/spec.md
+++ b/openspec/changes/add-facet-update-command/specs/installation/spec.md
@@ -1,0 +1,248 @@
+## ADDED Requirements
+
+### Requirement: Update discovery reports registry-resolved choices
+
+For every registry-backed manifest entry with usable local resolution state, the system SHALL report the exact locked version as Current, the exact version resolved from the authored specifier as Target, and the exact version resolved from `latest` as Latest. Target SHALL satisfy the authored specifier. Registry resolution SHALL remain caller-relative and SHALL use the same available credentials as other registry reads.
+
+The system SHALL treat the registry as authoritative for resolving each supported manifest specifier and `latest`. Returned facet identities and versions SHALL be validated before they are presented or selected; a mismatched identity, unsupported exact-version form, unusable integrity value, or Target that does not satisfy its authored specifier SHALL fail discovery.
+
+#### Scenario: Exact pin has a fixed Target
+
+- **WHEN** a manifest pins `1.2.0`, the lockfile records Current `1.2.0`, and the registry resolves Latest `2.0.0`
+- **THEN** discovery SHALL report Target `1.2.0`
+- **AND** discovery SHALL report Latest `2.0.0`
+
+#### Scenario: Major wildcard resolves its Target
+
+- **WHEN** a manifest declares `1.*` and the registry resolves that specifier to `1.8.0`
+- **THEN** discovery SHALL report Target `1.8.0`
+
+#### Scenario: Minor wildcard resolves its Target
+
+- **WHEN** a manifest declares `1.4.*` and the registry resolves that specifier to `1.4.7`
+- **THEN** discovery SHALL report Target `1.4.7`
+
+#### Scenario: Bare wildcard and latest use registry latest
+
+- **WHEN** a manifest declares `*` or `latest`
+- **AND** the registry resolves Latest to `3.0.0`
+- **THEN** discovery SHALL report `3.0.0` as both Target and Latest
+
+#### Scenario: Invalid resolved target fails discovery
+
+- **WHEN** the registry response identifies another facet, returns a non-supported exact version, omits usable integrity, or returns a Target outside the authored specifier
+- **THEN** discovery SHALL fail before presenting an actionable plan
+- **AND** no project or machine-local state SHALL change
+
+### Requirement: Update discovery requires usable local resolution state
+
+A registry facet SHALL be checkable only when the lockfile contains a matching, valid registry entry whose exact Current version satisfies the manifest specifier. Update discovery SHALL NOT re-resolve Current or require the locked version to remain available from the registry. If any registry facet has missing, mismatched, invalid, or drifted local resolution state, discovery SHALL fail with every affected facet name and SHALL direct the user to run `facet install`.
+
+Git and local facet sources SHALL be reported as unsupported for update discovery and SHALL NOT prevent otherwise valid registry facets from being checked or updated.
+
+#### Scenario: Missing lock entry requires install
+
+- **WHEN** the manifest declares a registry facet that has no matching lockfile entry
+- **THEN** update discovery SHALL fail and name that facet
+- **AND** the failure SHALL direct the user to run `facet install`
+
+#### Scenario: Every unusable registry entry is reported
+
+- **WHEN** multiple registry facets have missing, mismatched, invalid, or drifted local resolution state
+- **THEN** one discovery failure SHALL identify every affected facet
+- **AND** no actionable update plan SHALL be presented
+
+#### Scenario: Locked Current need not remain available
+
+- **WHEN** a valid lockfile entry records an exact Current version satisfying the manifest specifier
+- **AND** that exact version is no longer available from the registry
+- **THEN** update discovery SHALL still use the locked version as Current
+- **AND** it SHALL NOT fail solely because Current cannot be resolved again
+
+#### Scenario: Unsupported sources do not block registry updates
+
+- **WHEN** a project contains usable registry facets together with git or local facets
+- **THEN** discovery SHALL mark the git and local facets unsupported
+- **AND** it SHALL continue checking the usable registry facets
+
+### Requirement: Update discovery is complete or fails without a partial plan
+
+The system SHALL complete every required Target and Latest lookup before presenting an actionable update plan. If any required lookup fails, the complete discovery SHALL fail and SHALL NOT present the successful subset as actionable. Discovery SHALL preserve project order when pairing results with facets and determining which lookup failure to report.
+
+#### Scenario: One lookup failure rejects the whole discovery
+
+- **WHEN** Target and Latest resolution succeeds for some registry facets but a required resolution fails for another
+- **THEN** the system SHALL fail discovery
+- **AND** it SHALL NOT present the successful subset as an actionable update plan
+- **AND** no project or machine-local state SHALL change
+
+#### Scenario: Concurrent failures have deterministic reporting order
+
+- **WHEN** more than one required registry lookup fails
+- **THEN** the system SHALL report the first failure according to the original project lookup order
+- **AND** network completion order SHALL NOT change which failure is reported
+
+### Requirement: Update modes select only advancing versions
+
+Plain update SHALL select Target for every registry facet whose Target is newer than Current. Latest mode SHALL select Latest for every registry facet whose Latest is newer than Current, regardless of whether the authored specifier permits Latest. No mode SHALL select a version equal to or older than Current.
+
+#### Scenario: Plain update respects a bounded range
+
+- **WHEN** Current is `1.2.0`, Target is `1.8.0`, and Latest is `2.0.0`
+- **AND** the user requests plain update
+- **THEN** the selected version SHALL be `1.8.0`
+
+#### Scenario: Latest mode crosses a bounded range
+
+- **WHEN** Current is `1.2.0`, Target is `1.8.0`, and Latest is `2.0.0`
+- **AND** the user requests latest mode
+- **THEN** the selected version SHALL be `2.0.0`
+
+#### Scenario: Exact pin is unchanged by plain update
+
+- **WHEN** an exact manifest pin makes Target equal Current
+- **AND** Latest is newer than Current
+- **THEN** plain update SHALL leave that facet unselected
+- **AND** latest mode MAY select Latest
+
+#### Scenario: Older registry choices never downgrade Current
+
+- **WHEN** Target or Latest is equal to or older than Current
+- **THEN** that choice SHALL NOT be selectable or applied
+
+### Requirement: Latest selection preserves manifest specifier style
+
+When Latest is selected, the system SHALL preserve the authored specifier's style while changing only the version components needed to include the selected exact version. An exact pin SHALL become the selected exact version. A major wildcard SHALL become the selected major followed by `.*`. A minor wildcard SHALL become the selected major and minor followed by `.*`. The authored `*` and `latest` forms SHALL remain unchanged. Selecting Target SHALL leave the authored specifier unchanged.
+
+#### Scenario: Target preserves authored range
+
+- **WHEN** a facet authored as `1.*` selects Target `1.8.0`
+- **THEN** the committed manifest specifier SHALL remain `1.*`
+
+#### Scenario: Latest rewrites an exact pin
+
+- **WHEN** a facet authored as `1.2.0` selects Latest `2.4.1`
+- **THEN** the committed manifest specifier SHALL be `2.4.1`
+
+#### Scenario: Latest rewrites a major wildcard
+
+- **WHEN** a facet authored as `1.*` selects Latest `2.4.1`
+- **THEN** the committed manifest specifier SHALL be `2.*`
+
+#### Scenario: Latest rewrites a minor wildcard
+
+- **WHEN** a facet authored as `1.2.*` selects Latest `2.4.1`
+- **THEN** the committed manifest specifier SHALL be `2.4.*`
+
+#### Scenario: Floating forms remain unchanged
+
+- **WHEN** a facet authored as `*` or `latest` selects a newer exact version
+- **THEN** the committed manifest SHALL preserve the authored `*` or `latest` form unchanged
+
+### Requirement: Selected updates install exactly the reviewed versions
+
+Application SHALL install the exact Target or Latest version selected from the prepared plan and SHALL use the registry integrity information obtained during discovery. It SHALL NOT repeat version resolution for a selected target. A newer release published after discovery SHALL NOT change the selected exact version.
+
+For selected facets, application SHALL ignore the old lock entry as a version anchor while retaining it for ownership reconciliation and the previous-version summary. Unselected facets SHALL continue to reproduce their satisfying locked versions. Existing materialization overrides SHALL remain attached to every selected facet.
+
+#### Scenario: Publication after discovery does not change selection
+
+- **WHEN** a user reviews and selects Target `1.5.0`
+- **AND** `1.6.0` is published before application begins
+- **THEN** application SHALL install `1.5.0`
+- **AND** it SHALL NOT repeat range resolution and substitute `1.6.0`
+
+#### Scenario: Selected facet does not reuse its old lock anchor
+
+- **WHEN** a selected facet is locked at `1.2.0` and its reviewed target is `1.5.0`
+- **THEN** application SHALL resolve content for exact version `1.5.0`
+- **AND** the resulting summary SHALL identify the transition from `1.2.0` to `1.5.0`
+
+#### Scenario: Unselected facet remains reproducible
+
+- **WHEN** one candidate facet is selected and another candidate facet is not selected
+- **THEN** application SHALL update only the selected facet
+- **AND** the unselected facet SHALL continue to use its satisfying locked version
+
+#### Scenario: Materialization overrides survive a version update
+
+- **WHEN** a selected facet has existing alias or omission overrides
+- **THEN** application SHALL preserve those overrides in the project manifest
+- **AND** the selected version's contributions SHALL be materialized using the preserved intent
+
+#### Scenario: Alias disposition is recorded at the updated version
+
+- **WHEN** a selected facet whose skill `review` is aliased to `vendor-review` updates to a newer version that still contains that skill
+- **THEN** the skill SHALL remain materialized as `vendor-review`
+- **AND** the lockfile SHALL record the alias disposition with the facet's new exact version
+
+#### Scenario: Omission disposition is recorded at the updated version
+
+- **WHEN** a selected facet with an omitted asset updates to a newer version that still contains that asset
+- **THEN** the asset SHALL remain omitted
+- **AND** the lockfile SHALL list the asset with its omitted disposition and the facet's new exact version
+
+### Requirement: Selected facet updates are one verified transaction
+
+All selected facets SHALL pass the same cache audit, content download, integrity verification, complete-set collision evaluation, MCP consent, asset takeover, ownership reconciliation, receipt update, materialization, native configuration, and rollback requirements as other installation operations. The project manifest, lockfile, receipt, materialized assets, and native configuration SHALL commit together for the complete selected set or SHALL roll back together on a handled failure.
+
+#### Scenario: Multiple selected updates commit together
+
+- **WHEN** every selected facet resolves, verifies, composes, and materializes successfully
+- **THEN** all selected version transitions and project records SHALL commit in one operation
+
+#### Scenario: One selected update fails verification
+
+- **WHEN** one selected facet fails integrity verification
+- **THEN** no selected update SHALL remain committed
+- **AND** the project SHALL report whether every touched file was restored
+
+#### Scenario: Updated content introduces a collision
+
+- **WHEN** selected versions introduce an unresolved asset or MCP server collision
+- **THEN** the system SHALL follow the existing interactive or non-interactive collision behavior before committing project state
+- **AND** cancellation or unresolved failure SHALL leave the project unchanged
+
+#### Scenario: Updated content requires MCP consent
+
+- **WHEN** selected versions introduce unapproved MCP declarations
+- **THEN** the system SHALL follow the existing consent requirements before mutation
+- **AND** declining or lacking required consent SHALL leave the project unchanged
+
+### Requirement: Prepared updates reject stale project state
+
+Update discovery and selection SHALL remain read-only and SHALL capture the exact observed states of the project manifest and lockfile. Discovery SHALL re-check both files before returning a plan and SHALL reject the plan if either changed during discovery. Before application performs resolution, cache writes, downloads, or transaction creation, it SHALL acquire the project install lock and compare the current manifest and lockfile states with the reviewed states. Any mismatch SHALL fail as a stale plan, SHALL direct the user to rerun update, and SHALL leave project and machine-local state unchanged.
+
+#### Scenario: Manifest changes during discovery
+
+- **WHEN** the project manifest changes while update discovery is resolving registry choices
+- **THEN** discovery SHALL fail without returning an actionable plan
+- **AND** no project or machine-local state SHALL change
+
+#### Scenario: Lockfile changes after the plan is reviewed
+
+- **WHEN** the lockfile changes after discovery but before application acquires the project lock
+- **THEN** application SHALL fail as a stale plan
+- **AND** the failure SHALL direct the user to rerun update
+- **AND** no cache, project, materialized, adapter, or native configuration state SHALL change
+
+#### Scenario: Unchanged reviewed state may be applied
+
+- **WHEN** the manifest and lockfile exactly match the states captured by discovery when application acquires the project lock
+- **THEN** application MAY proceed with the selected exact versions
+
+### Requirement: Discovery and preview are free of installation side effects
+
+Preparing an update plan, presenting interactive selection, cancelling selection, and completing a dry run SHALL NOT download facet content, populate the facet cache, install or select adapters, create persistent project-lock state, or modify the project manifest, lockfile, receipt, materialized assets, or native configuration.
+
+#### Scenario: Discovery performs no content work
+
+- **WHEN** the system successfully discovers Target and Latest choices
+- **THEN** it SHALL NOT download facet archives or populate the facet cache
+- **AND** it SHALL NOT modify project or adapter state
+
+#### Scenario: Dry run performs no installation work
+
+- **WHEN** a user completes a non-interactive or interactive update dry run
+- **THEN** no adapter SHALL be installed or selected
+- **AND** no project, cache, materialized, or native configuration state SHALL change

--- a/openspec/changes/add-facet-update-command/tasks.md
+++ b/openspec/changes/add-facet-update-command/tasks.md
@@ -1,0 +1,126 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+- **Pause** → PAUSE, NO TOOL. A model-switch pause. Emit this exact line of plain text and nothing else:
+  "Switch models if desired, then send any message to continue."
+  Then end the turn. Do NOT call the `question` tool, and do NOT tell the user to run a command.
+  An affirmative continuation resumes execution; a stop, revise-plan, or
+  question message is handled without advancing.
+
+## 1. Registry Discovery and Update Planning — Research
+
+- [x] 1.1 Explore: Inspect `packages/engine/src/registry/resolve-metadata.ts`, `registry/types.ts`, `registry/index.ts`, `src/__tests__/registry.test.ts`, and resolver-specific tests for the 100-specifier contract, result-valued failures, credentials, retry/timeout behavior, runtime response validation, and current callers.
+- [x] 1.2 Explore: Inspect `packages/engine/src/manifest/project-files.ts`, `install/lockfile-io.ts`, `install/lockfile-guard.ts`, `install/detect-lockfile-drift.ts`, `install/parse-locked-version.ts`, and `packages/protocol/src/sources/version-spec.ts` for exact file-state capture, source classification, all five version forms, satisfaction, and ordering.
+- [x] 1.3 Explore: Inspect `packages/engine/src/install/add/`, `install/remove/`, engine export conventions in `src/index.ts`, and existing install test helpers for two-phase workflows, tagged results, public-surface discipline, and side-effect assertions.
+- [x] 1.4 Propose: Define the cohesive engine approach for metadata grouping, deterministic failure ordering, plan types, version comparison, manifest-source rewriting, preparation snapshots, and unit-test coverage.
+- [x] 1.5 Pause: Model-switch boundary before engine discovery implementation.
+
+## 2. Registry Discovery and Update Planning — Implementation
+
+- [x] 2.1 Implement: Give registry metadata resolution a result-valued 100-specifier limit, remove the stale exact-or-latest-only assumption, validate response facet identity, exact version syntax, and integrity fields, and leave an explicit TODO to replace per-specifier requests with the registry's planned batch endpoint.
+- [x] 2.2 Implement: Add pure exact-version ordering and manifest-source rewriting helpers covering all five supported `VersionSpec` forms without duplicating the protocol grammar.
+- [x] 2.3 Implement: Add tagged update-plan row and preparation result types that make candidate, current, unsupported-source, and complete local-state failure outcomes explicit.
+- [x] 2.4 Implement: Add read-only update discovery using authored-specifier and `latest` metadata pairs, concurrent groups of at most 100 specifiers, stable result pairing, range-satisfaction validation, no-downgrade classification, and deterministic all-or-nothing failures.
+- [x] 2.5 Implement: Add `prepareFacetUpdate` with exact manifest and lockfile snapshots, post-discovery revalidation, no Current re-resolution, and no content, cache, adapter, lock-directory, or project-state side effects.
+- [x] 2.6 Implement: Export only the update planning API and structured types consumed by the CLI, retaining internal helpers behind the engine boundary.
+- [x] 2.7 Implement: Add engine tests for the resolver limit and response contract, all five specifier forms, numeric ordering, concurrent multi-group behavior, input-ordered failures, every unusable-local-state reason, unsupported git/local rows, no-downgrade behavior, exact pins tagged as candidates when Latest advances while remaining unchanged by plain update, and preparation side-effect freedom.
+- [x] 2.8 Verify: Run the targeted engine registry and update-planning tests and typecheck the engine package.
+- [ ] 2.9 Pause: Model-switch boundary before transaction research.
+
+## 3. Transactional Update Application — Research
+
+- [ ] 3.1 Explore: Inventory `packages/engine/src/install/types.ts`, `run-install.ts`, `commit/delta.ts`, engine add/remove front doors, `packages/cli/src/commands/install/index.ts`, and every `InstallDelta` or `frozenLockfile` call site that must migrate to the tagged operation union without behavior changes.
+- [ ] 3.2 Explore: Trace `install/commit/resolve-all.ts`, `resolve-facet.ts`, `effective-locked.ts`, `resolve-registry.ts`, `registry-support.ts`, `compose.ts`, `classify-outcome.ts`, `applyDesiredFacets`, and the project-file tri-write to separate selected exact metadata from prior lock ownership.
+- [ ] 3.3 Explore: Trace `install/lockfile-guard.ts`, file-state equality, `install/commit/tri-write.ts`, receipt ownership, disposition persistence, and filesystem transaction rollback to place stale-plan checks before every side effect.
+- [ ] 3.4 Propose: Define the cohesive transaction refactor for operation types, update resolution intent, prefetched metadata reuse, stale gates, manifest mutation, rollback, and migration of existing tests.
+- [ ] 3.5 Pause: Model-switch boundary before transaction implementation.
+
+## 4. Transactional Update Application — Implementation
+
+- [ ] 4.1 Implement: Replace permissive install delta and frozen option combinations with mutually exclusive reproduce, add, remove, and non-empty update operation arms, then migrate existing engine and CLI callers and remove impossible conflict failures.
+- [ ] 4.2 Implement: Extend in-memory manifest merging so selected updates preserve overrides, persist the chosen final manifest source through the existing comment-preserving `applyDesiredFacets` path only during the manifest/lockfile/receipt tri-write, bypass the prior lock only as a version anchor, and retain prior entries for ownership and old-to-new outcomes.
+- [ ] 4.3 Implement: Thread per-facet update resolution intent through the resolver and seed selected registry resolution with discovery metadata so application installs the reviewed exact version without another metadata lookup.
+- [ ] 4.4 Implement: Add the under-lock exact snapshot gate and structured `UPDATE_PLAN_STALE` outcome before cache writes, downloads, transaction creation, or any other mutation.
+- [ ] 4.5 Implement: Add selection validation and `runPreparedFacetUpdate`, rejecting duplicate, unknown, unsupported, and non-advancing choices while deriving final manifest sources from the shared helper.
+- [ ] 4.6 Implement: Add transaction tests for stale manifest and lockfile snapshots, publication after discovery, no secondary metadata request, mixed selected/unselected facets, comment and override preservation, alias and omission lockfile dispositions, old-to-new summaries, exact pins versus range and latest choices, and compile-time/runtime proof that frozen mode is representable only by the reproduce operation.
+- [ ] 4.7 Implement: Add failure-path tests proving multi-facet atomicity, integrity failure rollback, collision and MCP consent behavior, takeover handling, and path-level restoration reporting remain identical to other installation operations.
+- [ ] 4.8 Verify: Run targeted install/update tests plus engine and CLI typechecks to verify the operation-union migration and application path.
+- [ ] 4.9 Pause: Model-switch boundary before short-flag research.
+
+## 5. CLI Short-Flag Metadata — Research
+
+- [ ] 5.1 Explore: Inspect `packages/cli/src/commands.ts`, `run.ts`, `help.ts`, `commands/shared/flags.ts`, parser alias support, undeclared dynamic-flag passthrough, help alignment, and existing alias tests.
+- [ ] 5.2 Propose: Define the canonical short-alias field, parser normalization, exclusion of short keys from handler passthrough, shared help rendering, and router-level regression coverage.
+- [ ] 5.3 Pause: Model-switch boundary before short-flag implementation.
+
+## 6. CLI Short-Flag Metadata — Implementation
+
+- [ ] 6.1 Implement: Add canonical short aliases to command flag metadata and derive parser aliases from that field while preserving undeclared dynamic flags and exposing only canonical long-name values to handlers.
+- [ ] 6.2 Implement: Render long and short forms together in per-command help from the same declaration without a second alias map.
+- [ ] 6.3 Implement: Add router and help tests proving `-i` and `-L` set only their canonical values, undeclared dynamic flags retain existing behavior, and existing commands' help remains correctly aligned.
+- [ ] 6.4 Verify: Run targeted router/help tests and typecheck the CLI package.
+- [ ] 6.5 Pause: Model-switch boundary before update-command research.
+
+## 7. Update Command and Presentation — Research
+
+- [ ] 7.1 Explore: Inspect command registration and alias dispatch in `packages/cli/src/commands.ts`, `run.ts`, and `help.ts`, using `commands/self-update.ts` and `commands/remove/index.ts` as canonical alias examples.
+- [ ] 7.2 Explore: Inspect add/install/remove orchestration, `commands/shared/ensure-adapters.ts`, TTY gates, error translators, cancellation handling, and process-exit boundaries needed to preserve update ordering and exit semantics.
+- [ ] 7.3 Explore: Inspect static list rendering, `commands/adapter/install-picker.tsx`, `tui/views/install/collision/workspace.tsx`, `tui/views/install/install-view.tsx`, failure rendering, and Ink test utilities needed for preview, selection, progress, and rollback output.
+- [ ] 7.4 Propose: Define the cohesive update-command approach for registration, mode derivation, no-op and dry-run rendering, tagged picker rows, adapter ordering, shared installation presentation, error translation, and test coverage.
+- [ ] 7.5 Pause: Model-switch boundary before update-command implementation.
+
+## 8. Update Command and Presentation — Implementation
+
+- [ ] 8.1 Implement: Register implemented `update` with `upgrade` only as its alias, remove the inert upgrade stub, define the supported flag surface, reject positional arguments with `--interactive` guidance, and distinguish project updates from `self-update` in help.
+- [ ] 8.2 Implement: Add static Current/Target/Latest plan rendering, unsupported-source rows, latest-mode manifest rewrite previews, and distinct successful no-op messages including the actionable `--latest` hint.
+- [ ] 8.3 Implement: Add the standalone update picker by reusing `install-picker.tsx` keyboard conventions and collision-workspace focus/interrupt behavior, with tagged selected/unselected rows, mode-specific initial choices, focused `l` toggling, non-advancing protection, and reliable cancellation.
+- [ ] 8.4 Implement: Add command orchestration in the required order: positional and TTY validation, preparation, optional interactive selection, dry-run stop, adapter selection, and guarded application with the complete 0/1/2 exit contract.
+- [ ] 8.5 Implement: Extend `InstallView`, shared summaries, failure remedies, stale-plan rendering, and path-level rollback detail for update mode without introducing a second progress pipeline.
+- [ ] 8.6 Implement: Add registration, help, command, static-view, picker, and install-view unit tests covering canonical/alias identity, mode defaults, cancellation, no-op output, output streams, and `--accept-mcp` boundaries.
+- [ ] 8.7 Implement: Add CLI end-to-end tests for global and per-command help, `upgrade` alias behavior, positional and non-TTY failures, dry-run without adapters, interactive cancellation before adapter installation, applied old-to-new summaries, stale plans, and expected exit codes.
+- [ ] 8.8 Verify: Run targeted CLI command, Ink, and end-to-end tests and typecheck the CLI package.
+- [ ] 8.9 Pause: Model-switch boundary before documentation research.
+
+## 9. Documentation and Agent Guidance — Research
+
+- [ ] 9.1 Explore: Inspect `docs/cli/update.mdx` requirements and reference-page conventions together with existing `docs/cli/upgrade.mdx`, `docs/cli/self-update.mdx`, `docs/cli/index.mdx`, `docs/cli/add.mdx`, `docs/cli/list.mdx`, and `docs/docs.json`; verify whether retaining the upgrade alias page outside primary navigation passes Mintlify validation.
+- [ ] 9.2 Explore: Inspect `docs/guides/install-facets.mdx`, `docs/guides/troubleshooting.mdx`, `docs/roadmap/alpha.mdx`, `docs/roadmap/beta.mdx`, `docs/roadmap/stable.mdx`, `docs/specification/commit.mdx`, `docs/specification/materialization.mdx`, and root `README.md` for stale promises, update remedies, and package-versus-binary ambiguity.
+- [ ] 9.3 Explore: Inspect `packages/cli/src/prompts/overview.txt`, `packages/cli/src/prompts/usage.txt`, prompt generation, and instruction-prompt unit/e2e tests so guidance is added without duplicating topic lists, adapter API support sets, or materialization schemas.
+- [ ] 9.4 Explore: Inspect `docs/changelog/index.mdx`, its RSS rules, `.changeset/`, and contribution conventions for the required inert-stub-to-live-alias disclosure and package changeset.
+- [ ] 9.5 Propose: Define the cohesive documentation, prompt, changelog, navigation, and validation approach while preserving historical changelog text and `facet list`'s offline contract.
+- [ ] 9.6 Pause: Model-switch boundary before documentation implementation.
+
+## 10. Documentation and Agent Guidance — Implementation
+
+- [ ] 10.1 Implement: Create `docs/cli/update.mdx`, convert `docs/cli/upgrade.mdx` into a concise alias page, update `docs/cli/self-update.mdx` and `docs/cli/index.mdx`, and revise `docs/docs.json` so canonical behavior, flags, TTY rules, preview scope, no-op/failure outcomes, and package-versus-binary distinctions have one source of truth.
+- [ ] 10.2 Implement: Update both audiences in `docs/guides/install-facets.mdx`, add remedies to `docs/guides/troubleshooting.mdx`, update `docs/roadmap/alpha.mdx`, `beta.mdx`, and `stable.mdx`, update root `README.md`, and add cross-links from `docs/cli/add.mdx` and `docs/cli/list.mdx` while retaining list's offline contract and narrowing the beta promise.
+- [ ] 10.3 Implement: Update `docs/specification/commit.mdx` for prepared exact resolution and style-preserving Latest selection, and verify `docs/specification/materialization.mdx` remains accurate without duplicating override rules.
+- [ ] 10.4 Implement: Update `packages/cli/src/prompts/overview.txt` and `usage.txt` with project update, alias, non-TTY, dry-run, `--accept-mcp`, and `facet install` recovery guidance, then add companion unit and end-to-end prompt assertions.
+- [ ] 10.5 Implement: Add the newest `docs/changelog/index.mdx` entry with the stub-to-live-alias warning while preserving historical entries, and add the appropriate `agent-facets` changeset without editing generated package changelogs.
+- [ ] 10.6 Verify: Run prompt tests, Mintlify validation, and broken-link checks for all documentation and agent-guidance changes.
+- [ ] 10.7 Pause: Model-switch boundary before integrated acceptance research.
+
+## 11. Integrated Acceptance — Research
+
+- [ ] 11.1 Explore: Map every reconciled CLI and installation scenario to an automated test or explicit documentation check and identify any remaining coverage gaps across engine, CLI, transaction, prompts, and docs.
+- [ ] 11.2 Explore: Review the complete implementation for single-source-of-truth violations, representable illegal states, escaping expected errors, accidental registry-current checks, secondary metadata resolution, or dry-run side effects.
+- [ ] 11.3 Propose: Define the final acceptance pass and the smallest fixes needed to close all uncovered specification and regression gaps.
+- [ ] 11.4 Pause: Model-switch boundary before final acceptance implementation.
+
+## 12. Integrated Acceptance — Implementation
+
+- [ ] 12.1 Implement: Add or adjust the remaining focused tests and documentation checks identified by the acceptance matrix without duplicating coverage already owned by lower-level suites.
+- [ ] 12.2 Verify: Run `bun check`; if any test, type, lint, formatting, documentation, or end-to-end check fails, stop and report the failures.
+- [ ] 12.3 Verify: Validate the completed OpenSpec change against its schema and confirm every implementation task and reconciled scenario is accounted for before verification and archive.


### PR DESCRIPTION
### Why

Projects currently have no single command to discover and apply newer releases of declared facets. Users must manually inspect registry versions, edit `facets.json`, and reinstall. This gap is also an outstanding documented commitment — `docs/cli/upgrade.mdx` exists as an unimplemented placeholder and the beta roadmap promises the feature.

### Details

This change introduces `facet update` as the canonical command for updating registry-backed facets, with `facet upgrade` becoming a true alias rather than an inert stub.

**Discovery** uses a two-phase, read-only preparation model. `prepareFacetUpdate` loads and snapshots `facets.json` and `facets.lock`, resolves each registry facet's authored specifier and `latest` concurrently in groups of at most 100 specifiers, re-reads both files after network resolution, and returns a tagged plan distinguishing `candidate`, `current`, and `unsupported-source` rows. Git and local sources are named as unsupported rather than silently skipped or counted as current. If any required lookup fails, the entire discovery fails — no partial plans are presented.

**Application** via `runPreparedFacetUpdate` acquires the install lock, compares the current manifest and lockfile states against the preparation snapshot, and fails with a structured `UPDATE_PLAN_STALE` error before any mutation if either file changed. Selected facets install the exact reviewed version using registry integrity metadata obtained during discovery — no second metadata lookup occurs. Unselected facets reproduce their satisfying locked versions normally. All selected updates commit or roll back together through the existing verified install transaction.

**Modes:**
- Plain `facet update` selects each facet's range-respecting Target when it advances Current.
- `--latest`/`-L` selects Latest regardless of the authored range, rewriting specifier style (exact pins become the new exact version, major wildcards advance to the new major, minor wildcards advance to the new major and minor, `*`/`latest` remain unchanged).
- `--interactive`/`-i` presents a Bun-style picker with per-row `l` toggling between Target and Latest; non-advancing choices are not selectable; cancellation exits `1` and leaves all state unchanged.
- `--dry-run` previews the complete plan without downloading content, populating the cache, selecting adapters, or mutating any project or machine-local state.

**Install input** is refactored from a permissive delta struct into a tagged union with mutually exclusive `reproduce`, `add`, `remove`, and `update` arms, eliminating previously representable illegal combinations.

**Short-flag support** is generalized: `FlagDef` gains a canonical short-alias field consumed by both the argument parser and help renderer, so `-i` and `-L` are declared once and never appear as independent handler values.

**Documentation** adds `docs/cli/update.mdx`, converts `docs/cli/upgrade.mdx` into an alias pointer, updates `docs/cli/self-update.mdx` to clarify the package-versus-binary boundary, and revises the install guide, roadmap, specification, agent prompts, and changelog. The changelog entry explicitly calls out that `facet upgrade` changes from a non-mutating stub into a live alias.

### Verification

The migration plan runs in four implementation phases, each ending with targeted test verification, followed by a full `bun check` (unit, type, lint, and end-to-end) as the canonical acceptance gate. Engine tests cover all five `VersionSpec` forms, concurrent multi-group resolution, input-ordered failure determinism, every unusable-local-state reason, and preparation side-effect freedom. Transaction tests cover stale snapshots, publication-after-discovery immutability, mixed selected/unselected facets, alias and omission disposition preservation, and rollback atomicity. CLI tests cover canonical/alias identity, mode defaults, cancellation, no-op output variants, dry-run stream separation, and all expected exit codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added specifications for the upcoming `facet update` command and `facet upgrade` alias.
  - Documented version selection, interactive updates, previews, dry-run behavior, progress reporting, and error handling.
  - Defined safeguards for stale project state, transactional installation, rollback, integrity verification, and preservation of local configuration.
  - Added guidance for supported sources, command options, exit outcomes, and MCP consent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->