### PR TITLE
Add update discovery, `prepareFacetUpdate`, and `TOO_MANY_SPECIFIERS` guard

### DIFF
--- a/openspec/changes/.gitignore
+++ b/openspec/changes/.gitignore
@@ -1,1 +1,2 @@
 archive/
+/*/adversarial/

--- a/openspec/changes/add-facet-update-command/.openspec.yaml
+++ b/openspec/changes/add-facet-update-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/add-facet-update-command/design.md
+++ b/openspec/changes/add-facet-update-command/design.md
@@ -1,0 +1,184 @@
+## Context
+
+`facet install` intentionally reproduces a satisfying `facets.lock` entry, while an explicit non-exact `facet add` request re-resolves that one facet. There is no project-wide operation that resolves every registry-backed manifest entry against both its authored version intent and the registry’s latest release, lets the user choose targets, and then applies those targets through the verified install transaction.
+
+The required behavior crosses the CLI router and Ink UI, the engine registry client, manifest and lockfile loading, and the install transaction. The existing protocol version-spec grammar, manifest schema, lockfile schema, cache, materialization planner, MCP reconciliation, and file transaction remain authoritative. No persisted format or registry deployment changes are required.
+
+Relevant constraints are:
+
+- `facets.json` values preserve user-authored version intent and comment metadata; updates MUST use the existing normalized mutation and transactional write path rather than rebuilding JSON.
+- A satisfying lockfile entry anchors reproduction, so an update MUST carry an explicit target into resolution rather than relying on ordinary install behavior.
+- Discovery, dry-run, and interactive selection MUST NOT download facet content, populate the cache, install adapters, or mutate project or machine-local configuration.
+- Registry discovery MUST be complete or fail closed. The existing metadata resolver accepts caller-relative version specifiers but has no server-side batch transport yet.
+- Selected updates MUST retain the existing integrity, collision, MCP-consent, ownership, receipt, rollback, and concurrent-write guarantees.
+- Engine failures MUST remain structured values; the CLI owns rendering and exit codes.
+
+Stakeholders are project users updating facets, automation previewing updates, registry users with caller-relative private-version visibility, and maintainers of the install transaction and CLI documentation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide one engine-owned discovery model containing each checkable registry facet's manifest specifier, Current version, range-respecting Target, and registry Latest version.
+- Support range-respecting application, explicit latest application, Bun-style interactive selection, and write-free dry-run from the same discovered plan.
+- Preserve manifest specifier style and materialization overrides while forcing each selected exact target through registry confirmation and the existing install transaction.
+- Detect a plan that became stale between discovery and application before any mutation.
+- Make `facet upgrade` a true alias of `facet update` and keep facet-package updates distinct from CLI-binary self-update.
+- Align user, agent, roadmap, and specification documentation with the shipped behavior.
+
+**Non-Goals:**
+
+- Updating git or local facet sources.
+- Adding positional, wildcard-name, or dependency-group selectors.
+- Adding another check-only mode, JSON output, changelog retrieval, package diffs, or asset-level previews.
+- Adding a registry batch endpoint or changing the registry OpenAPI contract.
+- Changing version-spec grammar, project-manifest schema, lockfile schema, receipt schema, cache layout, or archive formats.
+- Making `facet upgrade` an independent implementation.
+- Changing `facet list` into a network-backed outdated check.
+
+## Decisions
+
+### D1. Separate read-only preparation from guarded application
+
+The engine SHALL expose a two-phase update workflow:
+
+1. `prepareFacetUpdate` SHALL load and validate `facets.json` and `facets.lock`, capture their exact `FileState` values, perform registry version discovery, re-read both files, and return either a structured preparation failure or a `PreparedFacetUpdate` containing the display plan and its snapshot.
+2. `runPreparedFacetUpdate` SHALL accept that prepared value, selected target choices, adapters, and the normal install callbacks. It SHALL validate the selection, select the exact metadata already carried by the prepared plan for every chosen target, and invoke the install transaction with an update operation bound to the captured snapshot.
+
+Preparation SHALL remain lock-free and read-only. This avoids holding the project install lock while a user reviews an interactive screen and ensures dry-run or cancellation leaves no persistent lock-directory, cache, adapter, receipt, manifest, lockfile, materialization, or native-configuration change. The post-network re-read SHALL reject a plan if either file changed during discovery.
+
+Application SHALL acquire the existing install lock before reading project state. Under that lock it SHALL compare the newly loaded manifest and lockfile states with the preparation snapshot using exact file-state equality. A mismatch SHALL return a structured `UPDATE_PLAN_STALE` failure before resolution, content download, cache writes, or transaction creation and SHALL direct the user to rerun the command. Exact selected targets are immutable registry identities, so a version published after discovery SHALL not silently change an already-confirmed plan.
+
+The CLI SHALL perform interactive selection before calling adapter selection. Therefore cancelling the update picker SHALL not install an adapter as a side effect. Default application MAY obtain adapters immediately after preparation because the user requested application without a selection gate.
+
+**Alternatives considered:** Holding the install lock through network discovery and the interactive picker would eliminate the snapshot handoff but could block every other facet operation indefinitely and would make a preview acquire persistent machine-local lock infrastructure. Discovering before application without a snapshot precondition would allow a confirmed plan to overwrite or merge against state the user never saw. Both alternatives are rejected.
+
+### D2. Build one validated, tagged discovery plan through existing metadata resolution
+
+Discovery SHALL construct exactly two `RegistrySpec` inputs for each registry-backed manifest entry: one using the authored `VersionSpec` to resolve Target and one using `latest` to resolve Latest. It SHALL flatten those pairs in manifest order, divide them into groups of at most 100 specifiers, and invoke `resolveRegistryMetadataBatch` for every group concurrently. A full group therefore covers 50 facets. `resolveRegistryMetadataBatch` SHALL accept at most 100 specifiers per invocation and SHALL run its current per-specifier requests concurrently.
+
+After every group settles, discovery SHALL inspect group results in original input order and return the first input-ordered failure rather than a partial plan. Successful metadata SHALL be paired back to facets in manifest order. The client SHALL validate that each response matches the requested facet name, contains usable integrity fields, and resolves to an exact supported `MAJOR.MINOR.PATCH`; Target SHALL additionally satisfy the authored specifier. The registry is authoritative for resolving the authored specifier and `latest`.
+
+**TODO:** Replace the internal per-specifier requests in `resolveRegistryMetadataBatch` with the registry’s planned batch endpoint when it becomes available.
+
+Discovery SHALL parse and classify every manifest entry before presenting a plan:
+
+- A registry entry is checkable only when it has a matching, usable registry lockfile entry whose exact Current version satisfies the manifest specifier.
+- Update SHALL not re-resolve Current or use registry availability of the locked version as a discovery precondition. Repairing an unavailable installed version remains the responsibility of `facet install`.
+- A registry entry with missing, mismatched, invalid, or drifted local resolution state SHALL make preparation fail with all affected facet names and a remedy to run `facet install`. It SHALL never be reported as current and update SHALL not become a second drift-repair command.
+- Git and local entries SHALL appear as tagged `unsupported-source` rows for dry-run output but SHALL not block updates to checkable registry facets.
+- A checkable registry row SHALL carry the exact Target and Latest metadata returned by discovery and SHALL be tagged as `candidate` when either resolved version is newer than Current, otherwise as `current`. Exact pins therefore remain unchanged by default but still appear as candidates when a newer Latest can be selected interactively or with `--latest`.
+
+Target SHALL be the exact version returned for the authored specifier. Latest SHALL be the exact version returned for `latest`. Only a choice newer than Current SHALL be selectable, so update SHALL never downgrade an installed facet. A registry lookup failure SHALL fail the whole preparation before any actionable plan is rendered.
+
+The plan types SHALL use tagged unions rather than optional fields to distinguish `candidate`, `current`, and `unsupported-source` rows. CLI rendering and application SHALL consume this one engine result; the CLI SHALL NOT reimplement version matching, ordering, or specifier rewriting.
+
+**Alternatives considered:** Creating a dedicated version-list discovery client would duplicate an existing registry boundary and fetch information update does not use. Resolving selected targets again during application would repeat discovery without adding trust because exact published versions are immutable. Treating absent lock state as current would produce false clean reports. Proceeding with checkable facets while merely listing registry facets with unusable local state would make one invocation look complete while silently omitting facets that require install or repair. Returning partial registry lookup successes would likewise let users apply a plan known to omit failures. These alternatives are rejected.
+
+### D3. Represent update as a distinct install operation and resolve selected versions exactly
+
+Adding optional update fields to the existing `InstallDelta` would permit illegal combinations such as additions, removals, and snapshot-bound updates in one value. The install input SHALL instead become a tagged operation with mutually exclusive `reproduce`, `add`, `remove`, and `update` arms. Frozen-lockfile mode SHALL be representable only with `reproduce`; `update` SHALL always be non-frozen. Existing add and remove front doors SHALL construct their corresponding arms, preserving current behavior while removing the existing add/remove conflict state.
+
+An update operation SHALL carry:
+
+- the exact prepared manifest and lockfile states;
+- a non-empty set of selected facets;
+- for each facet, its exact selected metadata and its final manifest source string.
+
+`runPreparedFacetUpdate` SHALL validate each selected choice against the prepared rows and attach the corresponding Target or Latest `RegistryMetadata` already returned by discovery. It SHALL NOT perform a second registry metadata request. Exact published versions are immutable, so the selected metadata remains the authoritative registry confirmation supplied to content resolution.
+
+For each selected facet, the install merge SHALL preserve existing overrides, write only the chosen manifest source in memory, and provide the selected exact version as a resolution override. Resolution SHALL ignore the old lock anchor for that facet and SHALL use the prefetched metadata as registry confirmation. Non-selected facets SHALL follow normal reproduction semantics. The prior lock entry SHALL remain available to ownership diffing and outcome classification, so existing `updated` summaries retain the old and new versions.
+
+The final manifest source SHALL be derived by one pure engine helper shared by all modes:
+
+- Range Target keeps the authored source unchanged.
+- Latest chosen from an exact pin writes the selected exact version.
+- Latest chosen from a major wildcard writes the selected major plus `.*`.
+- Latest chosen from a minor wildcard writes the selected major and minor plus `.*`.
+- Latest chosen from `*` or `latest` leaves that token unchanged.
+
+The existing comment-preserving `applyDesiredFacets` path SHALL apply this in-memory intent only during the manifest/lockfile/receipt tri-write. Selected content SHALL continue through cache audit or download, registry integrity confirmation, verified plan construction, complete-set collision detection, MCP consent and takeover handling, materialization, native configuration, and one `FileTransaction`. All selected updates SHALL therefore commit or roll back together.
+
+**Alternatives considered:** Encoding a selected target as an ordinary exact addition would collapse two independent values: the exact version to install and the source string to persist in `facets.json`. For example, installing exact Target `1.5.0` for an authored `1.*` entry must resolve and verify `1.5.0` while preserving `1.*` in the manifest. An exact addition would overwrite the range; a range addition would resolve again during application, could select a version published after discovery, and would discard the metadata already reviewed. Adding optional update-only fields to `Addition` would permit mismatched source, metadata, and snapshot combinations, while adding another tagged variant inside additions would bury operation-wide snapshot and non-empty-selection requirements inside a nested union. The top-level `update` arm keeps those requirements together while still reusing the existing install transaction. Patching the manifest after resolution would create two sources of truth for desired intent. Building a separate updater transaction would duplicate integrity, ownership, rollback, and concurrent-write guarantees. These alternatives are rejected.
+
+### D4. Keep target choice and preview semantics explicit
+
+The engine SHALL accept selected choices as facet name plus `range` or `latest`; it SHALL reject duplicates, unknown names, unsupported rows, and choices that do not advance Current as structured selection failures. Selection validation and manifest rewriting SHALL occur in engine so dry-run display and application cannot disagree.
+
+The CLI SHALL derive mode defaults from the prepared candidates:
+
+- Plain `facet update` SHALL select every candidate whose range Target is newer than Current.
+- `facet update --latest` SHALL select every candidate whose Latest is newer than Current.
+- `--interactive` SHALL show every candidate for which either choice is newer. Range SHALL be the initial choice unless `--latest` is present; `l` SHALL toggle the focused row between Range Target and Latest.
+- A row whose displayed choice equals Current SHALL not be selectable until the user toggles to an advancing choice. Interactive row state SHALL be a tagged selected/unselected union so a selected no-op choice is not representable.
+- Confirm SHALL require at least one selected advancing target. Escape or Ctrl-C SHALL cancel before application.
+- `--dry-run` without `--interactive` SHALL render the complete prepared plan using the mode's default choices. With `--interactive`, it SHALL render the user's confirmed selection and then stop before adapter selection or application.
+
+Dry-run is a successful preview, not a drift-check contract. It SHALL exit `0` both when updates are available and when no update is selected, matching `self-update --dry-run`; real preparation failures SHALL exit non-zero. A future check mode MAY define a distinct updates-available exit contract, but is outside this change.
+
+Interactive cancellation SHALL exit `1`, not `0`, because the user abandoned the requested workflow rather than completing either an application or a no-op. This matches the existing interactive workspace convention and lets automation distinguish cancellation from a completed command.
+
+No-op output SHALL distinguish: all registry facets current; newer releases exist but authored ranges permit none; and the project has no registry facets. Unsupported git/local rows SHALL be named rather than counted as current.
+
+**Alternatives considered:** Returning non-zero merely because dry-run found updates would conflict with the CLI's `1 = user-facing failure` convention and with existing self-update preview behavior. Hiding exact pins from interactive mode would make the Target/Latest toggle unable to perform its primary override use case. Both alternatives are rejected.
+
+### D5. Extend CLI metadata once, then derive parsing and help from it
+
+`FlagDef` SHALL gain a canonical short-alias field consumed by both `run.ts` and `help.ts`. The per-command parser SHALL pass aliases to `@bomb.sh/args`, normalize parsed values onto long names, and exclude short names from undeclared-flag passthrough. Help SHALL render long and short forms from the same flag definition. No second alias map or command-local manual normalization SHALL be introduced.
+
+The update command SHALL define `--latest`/`-L`, `--interactive`/`-i`, `--dry-run`, and the shared install-pipeline `--verbose` and `--accept-mcp` flags. It SHALL reject positional arguments. It SHALL not expose `--frozen-lockfile`. `facet upgrade` SHALL be declared only in `updateCommand.aliases`, never as another registry key, so canonical and alias invocations share behavior and canonical help.
+
+The command SHALL reject `--interactive` in a non-interactive terminal using `canPromptInteractively()` before starting discovery. The standalone update picker SHALL reuse the established `InstallPicker` keyboard conventions and the collision workspace's non-color focus markers and always-active interrupt handling. Installation progress and final per-facet outcomes SHALL reuse `InstallView` with an `update` mode rather than introducing a second progress renderer.
+
+Exit behavior SHALL remain:
+
+- `0` for applied updates, no-op, or successful dry-run;
+- `1` for invalid invocation, non-TTY interactive use, interactive cancellation, stale plan, discovery failure, or application failure;
+- `2` only for an unexpected error escaping the command boundary.
+
+Errors SHALL use the existing three-line stderr format and registry/install failure translators. Help, tables, picker frames, progress, and summaries SHALL use stdout. Cancellation SHALL report that nothing was applied and SHALL not report success.
+
+**Alternatives considered:** Treating `-L` and `-i` as undeclared passthrough keys would leave aliases undocumented and force each handler to interpret two names. Registering `upgrade` as a second command object would duplicate help, tests, and behavior. A new update-specific progress pipeline would duplicate the install view. These alternatives are rejected.
+
+### D6. Reconcile documentation around one canonical update workflow
+
+Implementation SHALL update every affected user- and agent-facing source rather than leaving the old roadmap promise as a second contract:
+
+- Create `docs/cli/update.mdx` with usage, range behavior, Current/Target/Latest terminology, flags, TTY requirements, dry-run scope, outcomes, exit codes—including interactive cancellation as `1`—source limitations, and self-update disambiguation.
+- Convert `docs/cli/upgrade.mdx` from an unimplemented placeholder into a concise alias page that points to `facet update`. Keep the page so existing links remain valid, but remove it from the primary Facet Management navigation in `docs/docs.json` and add `cli/update` there.
+- Update `docs/cli/self-update.mdx` to distinguish facet-package update/upgrade from CLI-binary self-update/self-upgrade and the facet registry from `FACET_CLI_REGISTRY`'s npm registry.
+- Update both human and agent sections of `docs/guides/install-facets.mdx`; update `docs/cli/index.mdx`, `docs/roadmap/alpha.mdx`, `docs/roadmap/beta.mdx`, `docs/roadmap/stable.mdx`, and root `README.md`. The beta promise “surface what changed” SHALL be narrowed to version transitions and the normal installation summary; changelog and content diffs are not part of this change.
+- Update `docs/specification/commit.mdx` so resolution has an explicit update mode and the manifest-write policy covers style-preserving latest selection. Add cross-links from `docs/cli/add.mdx` and `docs/cli/list.mdx` rather than duplicating install outcomes or adding network behavior to list. Verify the existing materialization documentation remains accurate.
+- Add update guidance to `packages/cli/src/prompts/overview.txt` and `packages/cli/src/prompts/usage.txt`, with companion instruction-prompt tests.
+- Add one new top-of-file entry to `docs/changelog/index.mdx` following its one-entry-per-day and RSS rules. The entry SHALL call out that `facet upgrade` changes from a non-mutating unimplemented stub into a live alias that applies facet updates. The historical sentence saying install shipped “without a separate `facet update` command” SHALL remain unchanged because it describes that release at that time; the new entry supersedes it without rewriting historical headings.
+
+The OpenSpec delta SHALL modify `cli` and `installation`. It SHALL reuse the existing `protocol__version-spec` grammar rather than restating it.
+
+**Alternatives considered:** Redirecting away `cli/upgrade` would preserve URLs but remove a useful explanation that the typed command remains a supported alias. Keeping both pages in primary navigation would make two names appear to be independent workflows. Duplicating installation outcome definitions on the update page would create competing sources of truth. These alternatives are rejected.
+
+## Risks / Trade-offs
+
+- **[A plan can become stale while a user is deciding]** → Preparation revalidates after network discovery, and application compares exact manifest and lockfile states again under the install lock before any side effect.
+- **[Lock-free preparation can observe concurrent project activity]** → Exact post-discovery re-reads reject detected changes; the authoritative apply gate under the lock prevents stale writes even if preparation raced in an undetectable instant.
+- **[Private or authorization-relative resolution can produce different targets for different callers]** → Discovery carries the same optional credentials as other registry reads and treats the registry’s Target and Latest resolutions as caller-relative. It does not use Current availability as an update precondition, and only advancing choices can be selected.
+- **[`--latest` can intentionally widen a bounded range]** → The flag is explicit, dry-run and interactive display both range Target and Latest, specifier style is preserved, and all selected changes remain transactional.
+- **[Discovery metadata could bypass the lockfile trust model]** → Target and Latest metadata come through the existing registry resolution boundary and selected content still passes through the existing three-check integrity chain; old lock integrity is never reused as the anchor for new content.
+- **[Updates may introduce collisions or MCP configuration]** → Application reuses complete-set composition, consent, takeover, transaction, and rollback. Dry-run documents that it previews versions, not downstream asset or configuration effects.
+- **[Short-flag support affects every command]** → Alias parsing and help derive from one `FlagDef` field and receive router-level unit and end-to-end coverage, including undeclared dynamic flags.
+- **[Holding prepared file bytes increases in-memory plan size]** → Only two small project files are retained, and exact bytes provide the strongest existing concurrent-edit precondition without a duplicate hash format.
+- **[Four similar update/upgrade names can confuse users]** → Canonical help groups aliases, docs lead with `facet update`, and self-update documentation explicitly names the binary/package boundary and registry distinction.
+- **[The `upgrade` alias changes an existing invocation from inert to mutating]** → Global help, the retained alias page, and the release changelog SHALL identify `update` as canonical and state that `facet upgrade` now applies the same project changes instead of printing the former stub notice.
+
+## Migration Plan
+
+1. Give `resolveRegistryMetadataBatch` its 100-specifier contract, remove its stale exact-or-latest-only assumption, and add two-specifier-per-facet discovery with concurrent groups, target pairing, and tagged plan types. Engine unit tests SHALL cover all five `VersionSpec` kinds, exact response validation, range satisfaction, the 100-specifier boundary, concurrent multi-group resolution, all-or-nothing and input-order behavior, every unusable-local-state reason, and reuse of discovered metadata without a second lookup.
+2. Refactor install input to the tagged operation union, add snapshot validation and exact update resolution overrides, and cover manifest preservation, metadata confirmation, transaction, rollback, stale-plan, and mixed selected/unselected behavior.
+3. Add short-flag metadata support, register `update` with the `upgrade` alias, implement static and interactive presentation, extend install progress/failure wording, and add CLI unit, Ink, and end-to-end tests.
+4. Add the `cli` and `installation` delta specifications, then update all documentation and agent prompts named in D6.
+5. Run `bun check` as the canonical verification, including unit, type, lint, and end-to-end suites.
+
+No persisted-data migration is required. Updated projects continue to use existing valid manifest specifiers, lockfile entries, and receipt schemas. If the feature must be rolled back, the command and alias can be removed without rewriting projects; projects already updated remain consumable by the existing install path.
+
+## Open Questions
+
+None. The proposal and this design settle preview exit behavior, missing local state, concurrency, aliasing, registry transport, and documentation treatment before specification authoring.

--- a/openspec/changes/add-facet-update-command/proposal.md
+++ b/openspec/changes/add-facet-update-command/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Projects currently have no single command that discovers and applies newer releases of their declared facets. Users must manually inspect registry versions, edit `facets.json`, and reinstall, so the CLI needs one update workflow that preserves declared version intent by default while still allowing deliberate upgrades to the registry's latest releases. The workflow is already promised by the unimplemented `docs/cli/upgrade.mdx` placeholder and the beta roadmap, making this both a user-facing gap and an outstanding documented commitment.
+
+## What Changes
+
+- Add `facet update` as the canonical command for discovering and applying updates to registry-backed facets declared in `facets.json`.
+- With no flags, the command SHALL update each facet to the highest published version permitted by its manifest specifier. Exact pins SHALL remain unchanged, major and minor wildcards SHALL remain within their declared ranges, and `*` or `latest` SHALL resolve to the registry's latest version. If no declared range permits a newer version, the command SHALL succeed as a no-op and distinguish “nothing allowed by the current ranges” from a failed check.
+- Add `--latest` with alias `-L`. This mode SHALL ignore current version constraints and update registry facets to their latest published versions. Rewritten manifest specifiers SHALL preserve their existing style: exact pins remain exact at the selected version, major wildcards advance to the selected major, minor wildcards advance to the selected major and minor, and `*` or `latest` remain unchanged.
+- Add `--interactive` with alias `-i`. Interactive mode SHALL complete discovery before performing any update and SHALL show each outdated registry facet's manifest specifier, Current version, range-respecting Target, and registry Latest version.
+- The interactive interface SHALL follow Bun's established update-selection model: users can navigate the list, select facets, confirm the selected updates, and toggle an individual facet between Target and Latest with `l`. Combining `--interactive` with `--latest` SHALL make Latest the initial target while retaining the per-facet toggle.
+- Interactive cancellation SHALL leave all project files, materialized assets, native configuration, and machine-local state unchanged. No update SHALL begin until the user confirms the selection.
+- Add `--dry-run` as a non-interactive preview path. It SHALL print the complete proposed update plan—including each facet's manifest specifier, Current version, range-respecting Target, and registry Latest version—and SHALL leave all project and machine-local state unchanged. It SHALL respect `--latest`; when combined with `--interactive`, the confirmed selection SHALL be previewed but not applied.
+- Applying updates SHALL preserve existing materialization overrides and use the normal verified installation transaction to update facet contents, `facets.json` when its version intent changes, `facets.lock`, the install receipt, materialized assets, and native configuration. All selected updates SHALL commit together or roll back together.
+- Registry facets missing usable local resolution state and git or local sources that cannot be checked against the registry SHALL be identified explicitly rather than reported as current.
+- Discovery SHALL produce a complete project-wide answer. If any required registry lookup fails, the command SHALL fail before presenting an actionable update plan or writing state; users and automation must not act on an incomplete inventory.
+- The command SHALL document successful application, no-op, updates-available dry-run, interactive cancellation, discovery failure, and application failure outcomes with meaningful exit behavior.
+- `facet upgrade` SHALL become an alias of `facet update`, replacing its unimplemented placeholder while keeping existing command usage and documentation links valid. Help and documentation SHALL distinguish facet-package `update`/`upgrade` from CLI-binary `facet self-update`.
+
+## Non-goals
+
+- Adding any check-only mode beyond `--dry-run`. Default and interactive modes apply updates; dry-run is the single preview-without-write path.
+- Supporting positional facet filters, wildcard name filters, or dependency-group filters in the initial command. These selectors are deferred; the initial non-interactive command considers the complete manifest, while interactive mode provides per-facet selection.
+- Detecting or applying updates for git and local facet sources.
+- Adding a server-side batch registry endpoint. Update discovery SHALL use the existing `resolveRegistryMetadataBatch` boundary in groups of at most 100 specifiers; the real registry batch endpoint is planned separately.
+- Changing project-manifest, lockfile, or version-spec grammar.
+- Implementing `facet upgrade` as an independent workflow; it is an alias of `facet update`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli`: Define `facet update`, the `facet upgrade` alias, `--latest`/`-L`, `--interactive`/`-i`, and `--dry-run`; the Current/Target/Latest presentation and selection controls; application, preview, no-op, cancellation, and failure outcomes; help; and the distinction from `facet self-update`.
+- `installation`: Define range-respecting and latest target selection, manifest-specifier rewriting, preservation of materialization intent, and transactional application of selected facet updates.
+
+## Impact
+
+- **CLI:** Command registration, aliasing, dispatch, argument parsing, help, Ink-based interactive selection, dry-run presentation, summaries, structured errors, exit behavior, and command tests will gain the update workflow. The existing unimplemented `upgrade` stub will become an alias of `update`.
+- **Engine:** Update discovery will combine manifest and lockfile state with the existing registry metadata resolver by requesting each authored specifier and `latest`. The returned exact metadata will carry directly into the verified installation transaction rather than introducing a version-list client or a second metadata lookup.
+- **Protocol and persisted state:** No schema or grammar changes are required. Existing comment-preserving manifest mutation and transactional lockfile/receipt writes will carry any selected version changes.
+- **Registry:** No deployment or OpenAPI change is required. Existing metadata resolution is assumed to support the manifest `VersionSpec` forms. A true server-side batch endpoint is planned separately.
+- **Documentation:** This proposal was informed by `docs/cli/upgrade.mdx`, `docs/cli/self-update.mdx`, `docs/guides/install-facets.mdx`, and `docs/roadmap/beta.mdx`, plus Bun's `update` and interactive-update documentation. Add `docs/cli/update.mdx` and its navigation entry, convert `docs/cli/upgrade.mdx` into an alias pointer, update `docs/cli/self-update.mdx` to clarify the command-name distinction, and revise the guide and roadmap for default ranges, `--latest`, `--interactive`, and `--dry-run`.

--- a/openspec/changes/add-facet-update-command/specs/cli/spec.md
+++ b/openspec/changes/add-facet-update-command/specs/cli/spec.md
@@ -1,0 +1,283 @@
+## ADDED Requirements
+
+### Requirement: Users can invoke project facet updates
+
+The system SHALL register `update` as the canonical command for updating registry-backed facets declared by a project. The system SHALL accept `upgrade` as an alias with identical output, side effects, and exit behavior. Both names SHALL operate on project facets and SHALL NOT update the CLI binary.
+
+The command SHALL accept `--latest` with short alias `-L`, `--interactive` with short alias `-i`, `--dry-run`, `--verbose`, and `--accept-mcp`. It SHALL accept no positional arguments and SHALL NOT expose `--frozen-lockfile`.
+
+#### Scenario: Update command is available in help
+
+- **WHEN** a user runs the CLI with `--help`
+- **THEN** the output SHALL list `update` as the canonical project-facet update command
+- **AND** the output SHALL identify `upgrade` as its alias
+
+#### Scenario: Upgrade alias performs the same operation
+
+- **WHEN** a user runs `facet upgrade` with the same flags and project state as a corresponding `facet update` invocation
+- **THEN** the system SHALL produce the same output, side effects, and exit code as `facet update`
+- **AND** the invocation SHALL NOT report that the command is unimplemented
+
+#### Scenario: Update rejects positional arguments
+
+- **WHEN** a user runs `facet update` with one or more positional arguments
+- **THEN** the system SHALL print a usage error
+- **AND** the error SHALL direct the user to `--interactive` for per-facet selection
+- **AND** the process SHALL exit with code 1
+
+#### Scenario: Update help lists supported flags
+
+- **WHEN** a user runs `facet update --help`
+- **THEN** the help SHALL list `--latest` with `-L`
+- **AND** the help SHALL list `--interactive` with `-i`
+- **AND** the help SHALL list `--dry-run`, `--verbose`, and `--accept-mcp`
+- **AND** the help SHALL NOT list `--frozen-lockfile`
+
+#### Scenario: Update help distinguishes project facets from the CLI binary
+
+- **WHEN** a user runs `facet update --help`
+- **THEN** the help SHALL describe `update` as operating on facets declared by the project
+- **AND** the help SHALL name `self-update` as the command for updating the CLI binary
+
+### Requirement: Update presentations distinguish Current Target and Latest
+
+Whenever the update command presents discovered choices, it SHALL identify each checkable registry facet's manifest specifier, locked Current version, range-respecting Target version, and registry Latest version. Git and local facets SHALL be named as unsupported sources rather than counted as current.
+
+#### Scenario: Preview shows all version choices
+
+- **WHEN** a project facet is locked at `1.2.0`, its authored specifier resolves to Target `1.4.0`, and the registry resolves Latest `2.0.0`
+- **AND** a user requests an update preview
+- **THEN** the output SHALL identify `1.2.0` as Current, `1.4.0` as Target, and `2.0.0` as Latest
+- **AND** the output SHALL include the authored specifier
+
+#### Scenario: Unsupported sources are named
+
+- **WHEN** a project contains git or local facets alongside registry facets
+- **AND** the update command presents discovery results
+- **THEN** the output SHALL name each git or local facet as unsupported for update discovery
+- **AND** it SHALL NOT report those facets as current registry facets
+
+### Requirement: Users can select updates interactively
+
+The `--interactive` mode SHALL present every registry facet for which Target or Latest is newer than Current. Range Target SHALL be the initial choice unless `--latest` is also supplied, in which case Latest SHALL be initial. Users SHALL be able to navigate rows, select or deselect facets, and toggle the focused row between Target and Latest with `l`. A choice that does not advance Current SHALL NOT be selectable, and confirmation SHALL require at least one selected advancing choice.
+
+Interactive selection SHALL occur before adapter selection or update application. The command SHALL reject interactive mode before discovery when the terminal cannot prompt. Cancelling or interrupting the picker SHALL apply nothing, SHALL report that nothing was applied, and SHALL exit with code 1.
+
+#### Scenario: Interactive mode starts with range targets
+
+- **WHEN** a user runs `facet update --interactive`
+- **AND** a facet has both an advancing Target and an advancing Latest
+- **THEN** the facet's initial choice SHALL be Target
+- **AND** pressing `l` on that row SHALL change its choice to Latest
+
+#### Scenario: Latest interactive mode starts with latest targets
+
+- **WHEN** a user runs `facet update --interactive --latest`
+- **AND** a facet has both an advancing Target and an advancing Latest
+- **THEN** the facet's initial choice SHALL be Latest
+- **AND** pressing `l` on that row SHALL change its choice to Target
+
+#### Scenario: Non-advancing choice cannot be selected
+
+- **WHEN** a facet's Target equals Current but its Latest is newer
+- **THEN** the Target choice SHALL NOT be selectable
+- **AND** the user SHALL be able to toggle to and select Latest
+
+#### Scenario: Confirmation requires a selection
+
+- **WHEN** no advancing update is selected in the interactive picker
+- **THEN** the system SHALL prevent confirmation
+
+#### Scenario: Interactive mode requires a prompt-capable terminal
+
+- **WHEN** a user runs `facet update --interactive` in a non-interactive terminal
+- **THEN** the system SHALL fail before registry discovery
+- **AND** the process SHALL exit with code 1
+
+#### Scenario: Cancelling interactive update changes nothing
+
+- **WHEN** a user cancels or interrupts the update picker before confirmation
+- **THEN** the project manifest, lockfile, receipt, materialized assets, native configuration, cache, and adapter selection SHALL remain unchanged
+- **AND** the output SHALL state that nothing was applied
+- **AND** the process SHALL exit with code 1
+
+### Requirement: Users can preview facet updates without applying them
+
+The `--dry-run` flag SHALL present the update choices that the selected mode would apply and SHALL NOT modify project or machine-local state. Without `--interactive`, it SHALL present the complete discovered plan using the default Target choices or the `--latest` choices. With `--interactive`, it SHALL present the user's confirmed selection and stop before adapter selection or application. A successful preview SHALL exit with code 0 whether updates are available or not.
+
+#### Scenario: Default dry run previews range targets
+
+- **WHEN** a user runs `facet update --dry-run`
+- **THEN** the output SHALL present the complete discovered plan using each facet's range-respecting Target
+- **AND** no project or machine-local state SHALL change
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Latest dry run previews latest targets
+
+- **WHEN** a user runs `facet update --latest --dry-run`
+- **THEN** the output SHALL present the complete discovered plan using each facet's Latest choice
+- **AND** the output SHALL show every manifest specifier rewrite the selected updates would commit
+- **AND** no project or machine-local state SHALL change
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Interactive dry run stops after confirmed preview
+
+- **WHEN** a user confirms a non-empty selection in `facet update --interactive --dry-run`
+- **THEN** the output SHALL present that confirmed selection
+- **AND** the system SHALL stop before adapter selection or application
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Dry run with no available update succeeds
+
+- **WHEN** a user runs an update dry run and no selected mode permits an advancing choice
+- **THEN** the output SHALL report the applicable no-op reason
+- **AND** the process SHALL exit with code 0
+
+### Requirement: Update no-op outcomes are distinguishable
+
+A successful update that applies nothing SHALL distinguish among a project with no registry facets, a project whose registry facets are all current, and a project for which newer releases exist but the authored ranges permit no advancing Target. Each no-op SHALL exit with code 0. Invalid invocation, non-interactive use of `--interactive`, cancellation, stale plans, discovery failures, and application failures SHALL exit with code 1; unexpected failures escaping command handling SHALL exit with code 2.
+
+#### Scenario: Project has no registry facets
+
+- **WHEN** a user runs `facet update` in a project containing no registry-backed facets
+- **THEN** the output SHALL state that the project has no registry facets to update
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Every registry facet is current
+
+- **WHEN** every registry facet's Current version equals both available choices
+- **THEN** the output SHALL state that all registry facets are current
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Authored ranges permit no update
+
+- **WHEN** at least one facet has a Latest version newer than Current
+- **AND** no facet has a Target newer than Current
+- **AND** the user runs `facet update` without `--latest`
+- **THEN** the output SHALL state that newer releases exist but the current ranges permit no update
+- **AND** the output SHALL identify `--latest` as the mode that can select those releases
+- **AND** the process SHALL exit with code 0
+
+#### Scenario: Expected update failure uses exit code one
+
+- **WHEN** update fails because discovery or application cannot complete
+- **THEN** the process SHALL exit with code 1
+- **AND** the error SHALL be written to stderr
+
+### Requirement: Applied updates use the shared installation presentation
+
+After a non-dry-run selection is confirmed or derived, the update command SHALL present the same per-facet progress stages, collision and consent surfaces, rollback reporting, and final version-transition summaries used by other facet installation operations. `--verbose` SHALL add diagnostics on stderr. In non-interactive use, `--accept-mcp` SHALL be the sole flag that pre-approves otherwise valid MCP configuration work and SHALL NOT authorize asset takeover.
+
+#### Scenario: Update shows per-facet installation progress
+
+- **WHEN** a user applies one or more facet updates
+- **THEN** the output SHALL show progress for each selected facet
+- **AND** the final summary SHALL identify each previous and installed version
+
+#### Scenario: Update verbose output uses stderr
+
+- **WHEN** a user runs an applying update with `--verbose`
+- **THEN** installation progress SHALL remain on stdout
+- **AND** additional diagnostics SHALL be written to stderr
+
+#### Scenario: Non-interactive MCP work requires explicit acceptance
+
+- **WHEN** a non-interactive update would apply unapproved MCP configuration
+- **AND** `--accept-mcp` is not supplied
+- **THEN** the command SHALL fail before mutation with the complete consent information
+- **AND** when `--accept-mcp` is supplied, the command SHALL proceed without prompting if the work is otherwise valid
+
+## MODIFIED Requirements
+
+### Requirement: Commands declare per-command flags
+
+The system SHALL support per-command flag declarations on command definitions. The router SHALL parse per-command flags via the argument parser and pass the parsed values to command handlers alongside positional arguments. A declared flag MAY define a short alias; the long and short forms SHALL set the same canonical flag value, and the short form SHALL NOT be exposed to handlers as a second independent value.
+
+#### Scenario: Command with declared boolean flag
+
+- **WHEN** a command declares a boolean flag (e.g., `--force`)
+- **AND** a user provides that flag on the command line
+- **THEN** the command handler SHALL receive the flag value as `true`
+
+#### Scenario: Command with declared string flag
+
+- **WHEN** a command declares a string flag (e.g., `--registry`)
+- **AND** a user provides that flag with a value on the command line
+- **THEN** the command handler SHALL receive the flag value as the provided string
+
+#### Scenario: Declared short alias sets the canonical flag
+
+- **WHEN** a command declares `-i` as the short alias of `--interactive`
+- **AND** a user provides `-i`
+- **THEN** the command handler SHALL receive `interactive` as `true`
+- **AND** the handler SHALL NOT receive `i` as a separate flag value
+
+#### Scenario: Undeclared flags are ignored
+
+- **WHEN** a user provides a flag that is not declared by the command and is not a declared short alias
+- **THEN** the command handler SHALL NOT receive that flag
+
+### Requirement: Per-command help displays usage and flags
+
+The system SHALL render per-command help text from command metadata including usage syntax, flag descriptions, and declared short aliases. Authors SHALL NOT need to maintain a separate alias map or duplicate flag help text manually.
+
+#### Scenario: Per-command help shows usage line
+
+- **WHEN** a user runs `<command> --help` for a command that declares a `usage` field
+- **THEN** the help output SHALL display the usage syntax (e.g., `Usage: facet create [directory] [options]`)
+
+#### Scenario: Per-command help lists declared flags
+
+- **WHEN** a user runs `<command> --help` for a command that declares flags
+- **THEN** the help output SHALL list each declared flag with its description under an Options section
+- **AND** the `--help` flag SHALL also appear in the Options section
+
+#### Scenario: Per-command help shows a declared short alias
+
+- **WHEN** a command declares `-L` as the short alias of `--latest`
+- **AND** a user requests that command's help
+- **THEN** the Options section SHALL present `-L` and `--latest` together from the same declaration
+
+### Requirement: The `self-` prefix is reserved for CLI-binary operations
+
+The system SHALL reserve commands prefixed with `self-` for operations that act on the CLI binary itself. Commands without the `self-` prefix that share a verb, including `update` and `upgrade`, SHALL NOT act on the CLI binary; they SHALL operate on facet packages declared by the current project.
+
+#### Scenario: self-update acts on the CLI binary
+
+- **WHEN** a user runs `facet self-update`
+- **THEN** the system SHALL update the CLI binary
+- **AND** the system SHALL NOT modify any facet package or facet manifest
+
+#### Scenario: Bare update or upgrade acts on project facets
+
+- **WHEN** a user runs `facet update` or `facet upgrade`
+- **THEN** the system SHALL perform the project-facet update workflow
+- **AND** the system SHALL NOT update the CLI binary
+
+### Requirement: A failed operation reports what it left on disk, by path
+
+When an add, install, remove, or update operation fails, the command SHALL report whether the project was fully restored, and the process SHALL exit with a non-zero code. When any file could not be returned to its prior state, the command SHALL name every such file on the error stream.
+
+The report SHALL distinguish a file deliberately left alone — because something else changed it after this run wrote it — from one whose restoration genuinely failed, and SHALL give each the remedy that applies to it. A preserved concurrent edit SHALL NOT be described as damage to hunt for.
+
+The command SHALL NOT prompt about a contested file, and SHALL NOT offer to overwrite one, in interactive or non-interactive use alike. Whatever the other writer left SHALL remain exactly as they left it.
+
+An interactive option to force restoration over a contested file is intentionally deferred rather than omitted by oversight. Adding one would ask a user to choose between two states during failure handling, on the least informed footing they will ever have; reporting the path lets them compare the two deliberately afterward. Reporting is therefore the floor a later option would build on, never something it would replace.
+
+#### Scenario: Failed operation that fully rolls back
+
+- **WHEN** an operation fails and every file it changed is restored
+- **THEN** the rendered view SHALL indicate that the project state is unchanged
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: Failed operation that could not restore a file
+
+- **WHEN** an operation fails and a file could not be returned to its prior state
+- **THEN** the command SHALL name that file on the error stream
+- **AND** the process SHALL exit with a non-zero code
+
+#### Scenario: A preserved concurrent edit is reported without a prompt
+
+- **WHEN** something else changed a file after the run wrote it, and the run then failed
+- **THEN** the command SHALL name that file and say it was left as it is
+- **AND** the command SHALL NOT ask whether to overwrite it

--- a/openspec/changes/add-facet-update-command/specs/installation/spec.md
+++ b/openspec/changes/add-facet-update-command/specs/installation/spec.md
@@ -1,0 +1,248 @@
+## ADDED Requirements
+
+### Requirement: Update discovery reports registry-resolved choices
+
+For every registry-backed manifest entry with usable local resolution state, the system SHALL report the exact locked version as Current, the exact version resolved from the authored specifier as Target, and the exact version resolved from `latest` as Latest. Target SHALL satisfy the authored specifier. Registry resolution SHALL remain caller-relative and SHALL use the same available credentials as other registry reads.
+
+The system SHALL treat the registry as authoritative for resolving each supported manifest specifier and `latest`. Returned facet identities and versions SHALL be validated before they are presented or selected; a mismatched identity, unsupported exact-version form, unusable integrity value, or Target that does not satisfy its authored specifier SHALL fail discovery.
+
+#### Scenario: Exact pin has a fixed Target
+
+- **WHEN** a manifest pins `1.2.0`, the lockfile records Current `1.2.0`, and the registry resolves Latest `2.0.0`
+- **THEN** discovery SHALL report Target `1.2.0`
+- **AND** discovery SHALL report Latest `2.0.0`
+
+#### Scenario: Major wildcard resolves its Target
+
+- **WHEN** a manifest declares `1.*` and the registry resolves that specifier to `1.8.0`
+- **THEN** discovery SHALL report Target `1.8.0`
+
+#### Scenario: Minor wildcard resolves its Target
+
+- **WHEN** a manifest declares `1.4.*` and the registry resolves that specifier to `1.4.7`
+- **THEN** discovery SHALL report Target `1.4.7`
+
+#### Scenario: Bare wildcard and latest use registry latest
+
+- **WHEN** a manifest declares `*` or `latest`
+- **AND** the registry resolves Latest to `3.0.0`
+- **THEN** discovery SHALL report `3.0.0` as both Target and Latest
+
+#### Scenario: Invalid resolved target fails discovery
+
+- **WHEN** the registry response identifies another facet, returns a non-supported exact version, omits usable integrity, or returns a Target outside the authored specifier
+- **THEN** discovery SHALL fail before presenting an actionable plan
+- **AND** no project or machine-local state SHALL change
+
+### Requirement: Update discovery requires usable local resolution state
+
+A registry facet SHALL be checkable only when the lockfile contains a matching, valid registry entry whose exact Current version satisfies the manifest specifier. Update discovery SHALL NOT re-resolve Current or require the locked version to remain available from the registry. If any registry facet has missing, mismatched, invalid, or drifted local resolution state, discovery SHALL fail with every affected facet name and SHALL direct the user to run `facet install`.
+
+Git and local facet sources SHALL be reported as unsupported for update discovery and SHALL NOT prevent otherwise valid registry facets from being checked or updated.
+
+#### Scenario: Missing lock entry requires install
+
+- **WHEN** the manifest declares a registry facet that has no matching lockfile entry
+- **THEN** update discovery SHALL fail and name that facet
+- **AND** the failure SHALL direct the user to run `facet install`
+
+#### Scenario: Every unusable registry entry is reported
+
+- **WHEN** multiple registry facets have missing, mismatched, invalid, or drifted local resolution state
+- **THEN** one discovery failure SHALL identify every affected facet
+- **AND** no actionable update plan SHALL be presented
+
+#### Scenario: Locked Current need not remain available
+
+- **WHEN** a valid lockfile entry records an exact Current version satisfying the manifest specifier
+- **AND** that exact version is no longer available from the registry
+- **THEN** update discovery SHALL still use the locked version as Current
+- **AND** it SHALL NOT fail solely because Current cannot be resolved again
+
+#### Scenario: Unsupported sources do not block registry updates
+
+- **WHEN** a project contains usable registry facets together with git or local facets
+- **THEN** discovery SHALL mark the git and local facets unsupported
+- **AND** it SHALL continue checking the usable registry facets
+
+### Requirement: Update discovery is complete or fails without a partial plan
+
+The system SHALL complete every required Target and Latest lookup before presenting an actionable update plan. If any required lookup fails, the complete discovery SHALL fail and SHALL NOT present the successful subset as actionable. Discovery SHALL preserve project order when pairing results with facets and determining which lookup failure to report.
+
+#### Scenario: One lookup failure rejects the whole discovery
+
+- **WHEN** Target and Latest resolution succeeds for some registry facets but a required resolution fails for another
+- **THEN** the system SHALL fail discovery
+- **AND** it SHALL NOT present the successful subset as an actionable update plan
+- **AND** no project or machine-local state SHALL change
+
+#### Scenario: Concurrent failures have deterministic reporting order
+
+- **WHEN** more than one required registry lookup fails
+- **THEN** the system SHALL report the first failure according to the original project lookup order
+- **AND** network completion order SHALL NOT change which failure is reported
+
+### Requirement: Update modes select only advancing versions
+
+Plain update SHALL select Target for every registry facet whose Target is newer than Current. Latest mode SHALL select Latest for every registry facet whose Latest is newer than Current, regardless of whether the authored specifier permits Latest. No mode SHALL select a version equal to or older than Current.
+
+#### Scenario: Plain update respects a bounded range
+
+- **WHEN** Current is `1.2.0`, Target is `1.8.0`, and Latest is `2.0.0`
+- **AND** the user requests plain update
+- **THEN** the selected version SHALL be `1.8.0`
+
+#### Scenario: Latest mode crosses a bounded range
+
+- **WHEN** Current is `1.2.0`, Target is `1.8.0`, and Latest is `2.0.0`
+- **AND** the user requests latest mode
+- **THEN** the selected version SHALL be `2.0.0`
+
+#### Scenario: Exact pin is unchanged by plain update
+
+- **WHEN** an exact manifest pin makes Target equal Current
+- **AND** Latest is newer than Current
+- **THEN** plain update SHALL leave that facet unselected
+- **AND** latest mode MAY select Latest
+
+#### Scenario: Older registry choices never downgrade Current
+
+- **WHEN** Target or Latest is equal to or older than Current
+- **THEN** that choice SHALL NOT be selectable or applied
+
+### Requirement: Latest selection preserves manifest specifier style
+
+When Latest is selected, the system SHALL preserve the authored specifier's style while changing only the version components needed to include the selected exact version. An exact pin SHALL become the selected exact version. A major wildcard SHALL become the selected major followed by `.*`. A minor wildcard SHALL become the selected major and minor followed by `.*`. The authored `*` and `latest` forms SHALL remain unchanged. Selecting Target SHALL leave the authored specifier unchanged.
+
+#### Scenario: Target preserves authored range
+
+- **WHEN** a facet authored as `1.*` selects Target `1.8.0`
+- **THEN** the committed manifest specifier SHALL remain `1.*`
+
+#### Scenario: Latest rewrites an exact pin
+
+- **WHEN** a facet authored as `1.2.0` selects Latest `2.4.1`
+- **THEN** the committed manifest specifier SHALL be `2.4.1`
+
+#### Scenario: Latest rewrites a major wildcard
+
+- **WHEN** a facet authored as `1.*` selects Latest `2.4.1`
+- **THEN** the committed manifest specifier SHALL be `2.*`
+
+#### Scenario: Latest rewrites a minor wildcard
+
+- **WHEN** a facet authored as `1.2.*` selects Latest `2.4.1`
+- **THEN** the committed manifest specifier SHALL be `2.4.*`
+
+#### Scenario: Floating forms remain unchanged
+
+- **WHEN** a facet authored as `*` or `latest` selects a newer exact version
+- **THEN** the committed manifest SHALL preserve the authored `*` or `latest` form unchanged
+
+### Requirement: Selected updates install exactly the reviewed versions
+
+Application SHALL install the exact Target or Latest version selected from the prepared plan and SHALL use the registry integrity information obtained during discovery. It SHALL NOT repeat version resolution for a selected target. A newer release published after discovery SHALL NOT change the selected exact version.
+
+For selected facets, application SHALL ignore the old lock entry as a version anchor while retaining it for ownership reconciliation and the previous-version summary. Unselected facets SHALL continue to reproduce their satisfying locked versions. Existing materialization overrides SHALL remain attached to every selected facet.
+
+#### Scenario: Publication after discovery does not change selection
+
+- **WHEN** a user reviews and selects Target `1.5.0`
+- **AND** `1.6.0` is published before application begins
+- **THEN** application SHALL install `1.5.0`
+- **AND** it SHALL NOT repeat range resolution and substitute `1.6.0`
+
+#### Scenario: Selected facet does not reuse its old lock anchor
+
+- **WHEN** a selected facet is locked at `1.2.0` and its reviewed target is `1.5.0`
+- **THEN** application SHALL resolve content for exact version `1.5.0`
+- **AND** the resulting summary SHALL identify the transition from `1.2.0` to `1.5.0`
+
+#### Scenario: Unselected facet remains reproducible
+
+- **WHEN** one candidate facet is selected and another candidate facet is not selected
+- **THEN** application SHALL update only the selected facet
+- **AND** the unselected facet SHALL continue to use its satisfying locked version
+
+#### Scenario: Materialization overrides survive a version update
+
+- **WHEN** a selected facet has existing alias or omission overrides
+- **THEN** application SHALL preserve those overrides in the project manifest
+- **AND** the selected version's contributions SHALL be materialized using the preserved intent
+
+#### Scenario: Alias disposition is recorded at the updated version
+
+- **WHEN** a selected facet whose skill `review` is aliased to `vendor-review` updates to a newer version that still contains that skill
+- **THEN** the skill SHALL remain materialized as `vendor-review`
+- **AND** the lockfile SHALL record the alias disposition with the facet's new exact version
+
+#### Scenario: Omission disposition is recorded at the updated version
+
+- **WHEN** a selected facet with an omitted asset updates to a newer version that still contains that asset
+- **THEN** the asset SHALL remain omitted
+- **AND** the lockfile SHALL list the asset with its omitted disposition and the facet's new exact version
+
+### Requirement: Selected facet updates are one verified transaction
+
+All selected facets SHALL pass the same cache audit, content download, integrity verification, complete-set collision evaluation, MCP consent, asset takeover, ownership reconciliation, receipt update, materialization, native configuration, and rollback requirements as other installation operations. The project manifest, lockfile, receipt, materialized assets, and native configuration SHALL commit together for the complete selected set or SHALL roll back together on a handled failure.
+
+#### Scenario: Multiple selected updates commit together
+
+- **WHEN** every selected facet resolves, verifies, composes, and materializes successfully
+- **THEN** all selected version transitions and project records SHALL commit in one operation
+
+#### Scenario: One selected update fails verification
+
+- **WHEN** one selected facet fails integrity verification
+- **THEN** no selected update SHALL remain committed
+- **AND** the project SHALL report whether every touched file was restored
+
+#### Scenario: Updated content introduces a collision
+
+- **WHEN** selected versions introduce an unresolved asset or MCP server collision
+- **THEN** the system SHALL follow the existing interactive or non-interactive collision behavior before committing project state
+- **AND** cancellation or unresolved failure SHALL leave the project unchanged
+
+#### Scenario: Updated content requires MCP consent
+
+- **WHEN** selected versions introduce unapproved MCP declarations
+- **THEN** the system SHALL follow the existing consent requirements before mutation
+- **AND** declining or lacking required consent SHALL leave the project unchanged
+
+### Requirement: Prepared updates reject stale project state
+
+Update discovery and selection SHALL remain read-only and SHALL capture the exact observed states of the project manifest and lockfile. Discovery SHALL re-check both files before returning a plan and SHALL reject the plan if either changed during discovery. Before application performs resolution, cache writes, downloads, or transaction creation, it SHALL acquire the project install lock and compare the current manifest and lockfile states with the reviewed states. Any mismatch SHALL fail as a stale plan, SHALL direct the user to rerun update, and SHALL leave project and machine-local state unchanged.
+
+#### Scenario: Manifest changes during discovery
+
+- **WHEN** the project manifest changes while update discovery is resolving registry choices
+- **THEN** discovery SHALL fail without returning an actionable plan
+- **AND** no project or machine-local state SHALL change
+
+#### Scenario: Lockfile changes after the plan is reviewed
+
+- **WHEN** the lockfile changes after discovery but before application acquires the project lock
+- **THEN** application SHALL fail as a stale plan
+- **AND** the failure SHALL direct the user to rerun update
+- **AND** no cache, project, materialized, adapter, or native configuration state SHALL change
+
+#### Scenario: Unchanged reviewed state may be applied
+
+- **WHEN** the manifest and lockfile exactly match the states captured by discovery when application acquires the project lock
+- **THEN** application MAY proceed with the selected exact versions
+
+### Requirement: Discovery and preview are free of installation side effects
+
+Preparing an update plan, presenting interactive selection, cancelling selection, and completing a dry run SHALL NOT download facet content, populate the facet cache, install or select adapters, create persistent project-lock state, or modify the project manifest, lockfile, receipt, materialized assets, or native configuration.
+
+#### Scenario: Discovery performs no content work
+
+- **WHEN** the system successfully discovers Target and Latest choices
+- **THEN** it SHALL NOT download facet archives or populate the facet cache
+- **AND** it SHALL NOT modify project or adapter state
+
+#### Scenario: Dry run performs no installation work
+
+- **WHEN** a user completes a non-interactive or interactive update dry run
+- **THEN** no adapter SHALL be installed or selected
+- **AND** no project, cache, materialized, or native configuration state SHALL change

--- a/openspec/changes/add-facet-update-command/tasks.md
+++ b/openspec/changes/add-facet-update-command/tasks.md
@@ -1,0 +1,126 @@
+> **Before executing any tasks below**, load the `viper-execution-rules` skill for the full VIPER step protocol (step types, execution rules, gating, and hard constraints).
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+- **Pause** → PAUSE, NO TOOL. A model-switch pause. Emit this exact line of plain text and nothing else:
+  "Switch models if desired, then send any message to continue."
+  Then end the turn. Do NOT call the `question` tool, and do NOT tell the user to run a command.
+  An affirmative continuation resumes execution; a stop, revise-plan, or
+  question message is handled without advancing.
+
+## 1. Registry Discovery and Update Planning — Research
+
+- [x] 1.1 Explore: Inspect `packages/engine/src/registry/resolve-metadata.ts`, `registry/types.ts`, `registry/index.ts`, `src/__tests__/registry.test.ts`, and resolver-specific tests for the 100-specifier contract, result-valued failures, credentials, retry/timeout behavior, runtime response validation, and current callers.
+- [x] 1.2 Explore: Inspect `packages/engine/src/manifest/project-files.ts`, `install/lockfile-io.ts`, `install/lockfile-guard.ts`, `install/detect-lockfile-drift.ts`, `install/parse-locked-version.ts`, and `packages/protocol/src/sources/version-spec.ts` for exact file-state capture, source classification, all five version forms, satisfaction, and ordering.
+- [x] 1.3 Explore: Inspect `packages/engine/src/install/add/`, `install/remove/`, engine export conventions in `src/index.ts`, and existing install test helpers for two-phase workflows, tagged results, public-surface discipline, and side-effect assertions.
+- [x] 1.4 Propose: Define the cohesive engine approach for metadata grouping, deterministic failure ordering, plan types, version comparison, manifest-source rewriting, preparation snapshots, and unit-test coverage.
+- [x] 1.5 Pause: Model-switch boundary before engine discovery implementation.
+
+## 2. Registry Discovery and Update Planning — Implementation
+
+- [x] 2.1 Implement: Give registry metadata resolution a result-valued 100-specifier limit, remove the stale exact-or-latest-only assumption, validate response facet identity, exact version syntax, and integrity fields, and leave an explicit TODO to replace per-specifier requests with the registry's planned batch endpoint.
+- [x] 2.2 Implement: Add pure exact-version ordering and manifest-source rewriting helpers covering all five supported `VersionSpec` forms without duplicating the protocol grammar.
+- [x] 2.3 Implement: Add tagged update-plan row and preparation result types that make candidate, current, unsupported-source, and complete local-state failure outcomes explicit.
+- [x] 2.4 Implement: Add read-only update discovery using authored-specifier and `latest` metadata pairs, concurrent groups of at most 100 specifiers, stable result pairing, range-satisfaction validation, no-downgrade classification, and deterministic all-or-nothing failures.
+- [x] 2.5 Implement: Add `prepareFacetUpdate` with exact manifest and lockfile snapshots, post-discovery revalidation, no Current re-resolution, and no content, cache, adapter, lock-directory, or project-state side effects.
+- [x] 2.6 Implement: Export only the update planning API and structured types consumed by the CLI, retaining internal helpers behind the engine boundary.
+- [x] 2.7 Implement: Add engine tests for the resolver limit and response contract, all five specifier forms, numeric ordering, concurrent multi-group behavior, input-ordered failures, every unusable-local-state reason, unsupported git/local rows, no-downgrade behavior, exact pins tagged as candidates when Latest advances while remaining unchanged by plain update, and preparation side-effect freedom.
+- [x] 2.8 Verify: Run the targeted engine registry and update-planning tests and typecheck the engine package.
+- [ ] 2.9 Pause: Model-switch boundary before transaction research.
+
+## 3. Transactional Update Application — Research
+
+- [ ] 3.1 Explore: Inventory `packages/engine/src/install/types.ts`, `run-install.ts`, `commit/delta.ts`, engine add/remove front doors, `packages/cli/src/commands/install/index.ts`, and every `InstallDelta` or `frozenLockfile` call site that must migrate to the tagged operation union without behavior changes.
+- [ ] 3.2 Explore: Trace `install/commit/resolve-all.ts`, `resolve-facet.ts`, `effective-locked.ts`, `resolve-registry.ts`, `registry-support.ts`, `compose.ts`, `classify-outcome.ts`, `applyDesiredFacets`, and the project-file tri-write to separate selected exact metadata from prior lock ownership.
+- [ ] 3.3 Explore: Trace `install/lockfile-guard.ts`, file-state equality, `install/commit/tri-write.ts`, receipt ownership, disposition persistence, and filesystem transaction rollback to place stale-plan checks before every side effect.
+- [ ] 3.4 Propose: Define the cohesive transaction refactor for operation types, update resolution intent, prefetched metadata reuse, stale gates, manifest mutation, rollback, and migration of existing tests.
+- [ ] 3.5 Pause: Model-switch boundary before transaction implementation.
+
+## 4. Transactional Update Application — Implementation
+
+- [ ] 4.1 Implement: Replace permissive install delta and frozen option combinations with mutually exclusive reproduce, add, remove, and non-empty update operation arms, then migrate existing engine and CLI callers and remove impossible conflict failures.
+- [ ] 4.2 Implement: Extend in-memory manifest merging so selected updates preserve overrides, persist the chosen final manifest source through the existing comment-preserving `applyDesiredFacets` path only during the manifest/lockfile/receipt tri-write, bypass the prior lock only as a version anchor, and retain prior entries for ownership and old-to-new outcomes.
+- [ ] 4.3 Implement: Thread per-facet update resolution intent through the resolver and seed selected registry resolution with discovery metadata so application installs the reviewed exact version without another metadata lookup.
+- [ ] 4.4 Implement: Add the under-lock exact snapshot gate and structured `UPDATE_PLAN_STALE` outcome before cache writes, downloads, transaction creation, or any other mutation.
+- [ ] 4.5 Implement: Add selection validation and `runPreparedFacetUpdate`, rejecting duplicate, unknown, unsupported, and non-advancing choices while deriving final manifest sources from the shared helper.
+- [ ] 4.6 Implement: Add transaction tests for stale manifest and lockfile snapshots, publication after discovery, no secondary metadata request, mixed selected/unselected facets, comment and override preservation, alias and omission lockfile dispositions, old-to-new summaries, exact pins versus range and latest choices, and compile-time/runtime proof that frozen mode is representable only by the reproduce operation.
+- [ ] 4.7 Implement: Add failure-path tests proving multi-facet atomicity, integrity failure rollback, collision and MCP consent behavior, takeover handling, and path-level restoration reporting remain identical to other installation operations.
+- [ ] 4.8 Verify: Run targeted install/update tests plus engine and CLI typechecks to verify the operation-union migration and application path.
+- [ ] 4.9 Pause: Model-switch boundary before short-flag research.
+
+## 5. CLI Short-Flag Metadata — Research
+
+- [ ] 5.1 Explore: Inspect `packages/cli/src/commands.ts`, `run.ts`, `help.ts`, `commands/shared/flags.ts`, parser alias support, undeclared dynamic-flag passthrough, help alignment, and existing alias tests.
+- [ ] 5.2 Propose: Define the canonical short-alias field, parser normalization, exclusion of short keys from handler passthrough, shared help rendering, and router-level regression coverage.
+- [ ] 5.3 Pause: Model-switch boundary before short-flag implementation.
+
+## 6. CLI Short-Flag Metadata — Implementation
+
+- [ ] 6.1 Implement: Add canonical short aliases to command flag metadata and derive parser aliases from that field while preserving undeclared dynamic flags and exposing only canonical long-name values to handlers.
+- [ ] 6.2 Implement: Render long and short forms together in per-command help from the same declaration without a second alias map.
+- [ ] 6.3 Implement: Add router and help tests proving `-i` and `-L` set only their canonical values, undeclared dynamic flags retain existing behavior, and existing commands' help remains correctly aligned.
+- [ ] 6.4 Verify: Run targeted router/help tests and typecheck the CLI package.
+- [ ] 6.5 Pause: Model-switch boundary before update-command research.
+
+## 7. Update Command and Presentation — Research
+
+- [ ] 7.1 Explore: Inspect command registration and alias dispatch in `packages/cli/src/commands.ts`, `run.ts`, and `help.ts`, using `commands/self-update.ts` and `commands/remove/index.ts` as canonical alias examples.
+- [ ] 7.2 Explore: Inspect add/install/remove orchestration, `commands/shared/ensure-adapters.ts`, TTY gates, error translators, cancellation handling, and process-exit boundaries needed to preserve update ordering and exit semantics.
+- [ ] 7.3 Explore: Inspect static list rendering, `commands/adapter/install-picker.tsx`, `tui/views/install/collision/workspace.tsx`, `tui/views/install/install-view.tsx`, failure rendering, and Ink test utilities needed for preview, selection, progress, and rollback output.
+- [ ] 7.4 Propose: Define the cohesive update-command approach for registration, mode derivation, no-op and dry-run rendering, tagged picker rows, adapter ordering, shared installation presentation, error translation, and test coverage.
+- [ ] 7.5 Pause: Model-switch boundary before update-command implementation.
+
+## 8. Update Command and Presentation — Implementation
+
+- [ ] 8.1 Implement: Register implemented `update` with `upgrade` only as its alias, remove the inert upgrade stub, define the supported flag surface, reject positional arguments with `--interactive` guidance, and distinguish project updates from `self-update` in help.
+- [ ] 8.2 Implement: Add static Current/Target/Latest plan rendering, unsupported-source rows, latest-mode manifest rewrite previews, and distinct successful no-op messages including the actionable `--latest` hint.
+- [ ] 8.3 Implement: Add the standalone update picker by reusing `install-picker.tsx` keyboard conventions and collision-workspace focus/interrupt behavior, with tagged selected/unselected rows, mode-specific initial choices, focused `l` toggling, non-advancing protection, and reliable cancellation.
+- [ ] 8.4 Implement: Add command orchestration in the required order: positional and TTY validation, preparation, optional interactive selection, dry-run stop, adapter selection, and guarded application with the complete 0/1/2 exit contract.
+- [ ] 8.5 Implement: Extend `InstallView`, shared summaries, failure remedies, stale-plan rendering, and path-level rollback detail for update mode without introducing a second progress pipeline.
+- [ ] 8.6 Implement: Add registration, help, command, static-view, picker, and install-view unit tests covering canonical/alias identity, mode defaults, cancellation, no-op output, output streams, and `--accept-mcp` boundaries.
+- [ ] 8.7 Implement: Add CLI end-to-end tests for global and per-command help, `upgrade` alias behavior, positional and non-TTY failures, dry-run without adapters, interactive cancellation before adapter installation, applied old-to-new summaries, stale plans, and expected exit codes.
+- [ ] 8.8 Verify: Run targeted CLI command, Ink, and end-to-end tests and typecheck the CLI package.
+- [ ] 8.9 Pause: Model-switch boundary before documentation research.
+
+## 9. Documentation and Agent Guidance — Research
+
+- [ ] 9.1 Explore: Inspect `docs/cli/update.mdx` requirements and reference-page conventions together with existing `docs/cli/upgrade.mdx`, `docs/cli/self-update.mdx`, `docs/cli/index.mdx`, `docs/cli/add.mdx`, `docs/cli/list.mdx`, and `docs/docs.json`; verify whether retaining the upgrade alias page outside primary navigation passes Mintlify validation.
+- [ ] 9.2 Explore: Inspect `docs/guides/install-facets.mdx`, `docs/guides/troubleshooting.mdx`, `docs/roadmap/alpha.mdx`, `docs/roadmap/beta.mdx`, `docs/roadmap/stable.mdx`, `docs/specification/commit.mdx`, `docs/specification/materialization.mdx`, and root `README.md` for stale promises, update remedies, and package-versus-binary ambiguity.
+- [ ] 9.3 Explore: Inspect `packages/cli/src/prompts/overview.txt`, `packages/cli/src/prompts/usage.txt`, prompt generation, and instruction-prompt unit/e2e tests so guidance is added without duplicating topic lists, adapter API support sets, or materialization schemas.
+- [ ] 9.4 Explore: Inspect `docs/changelog/index.mdx`, its RSS rules, `.changeset/`, and contribution conventions for the required inert-stub-to-live-alias disclosure and package changeset.
+- [ ] 9.5 Propose: Define the cohesive documentation, prompt, changelog, navigation, and validation approach while preserving historical changelog text and `facet list`'s offline contract.
+- [ ] 9.6 Pause: Model-switch boundary before documentation implementation.
+
+## 10. Documentation and Agent Guidance — Implementation
+
+- [ ] 10.1 Implement: Create `docs/cli/update.mdx`, convert `docs/cli/upgrade.mdx` into a concise alias page, update `docs/cli/self-update.mdx` and `docs/cli/index.mdx`, and revise `docs/docs.json` so canonical behavior, flags, TTY rules, preview scope, no-op/failure outcomes, and package-versus-binary distinctions have one source of truth.
+- [ ] 10.2 Implement: Update both audiences in `docs/guides/install-facets.mdx`, add remedies to `docs/guides/troubleshooting.mdx`, update `docs/roadmap/alpha.mdx`, `beta.mdx`, and `stable.mdx`, update root `README.md`, and add cross-links from `docs/cli/add.mdx` and `docs/cli/list.mdx` while retaining list's offline contract and narrowing the beta promise.
+- [ ] 10.3 Implement: Update `docs/specification/commit.mdx` for prepared exact resolution and style-preserving Latest selection, and verify `docs/specification/materialization.mdx` remains accurate without duplicating override rules.
+- [ ] 10.4 Implement: Update `packages/cli/src/prompts/overview.txt` and `usage.txt` with project update, alias, non-TTY, dry-run, `--accept-mcp`, and `facet install` recovery guidance, then add companion unit and end-to-end prompt assertions.
+- [ ] 10.5 Implement: Add the newest `docs/changelog/index.mdx` entry with the stub-to-live-alias warning while preserving historical entries, and add the appropriate `agent-facets` changeset without editing generated package changelogs.
+- [ ] 10.6 Verify: Run prompt tests, Mintlify validation, and broken-link checks for all documentation and agent-guidance changes.
+- [ ] 10.7 Pause: Model-switch boundary before integrated acceptance research.
+
+## 11. Integrated Acceptance — Research
+
+- [ ] 11.1 Explore: Map every reconciled CLI and installation scenario to an automated test or explicit documentation check and identify any remaining coverage gaps across engine, CLI, transaction, prompts, and docs.
+- [ ] 11.2 Explore: Review the complete implementation for single-source-of-truth violations, representable illegal states, escaping expected errors, accidental registry-current checks, secondary metadata resolution, or dry-run side effects.
+- [ ] 11.3 Propose: Define the final acceptance pass and the smallest fixes needed to close all uncovered specification and regression gaps.
+- [ ] 11.4 Pause: Model-switch boundary before final acceptance implementation.
+
+## 12. Integrated Acceptance — Implementation
+
+- [ ] 12.1 Implement: Add or adjust the remaining focused tests and documentation checks identified by the acceptance matrix without duplicating coverage already owned by lower-level suites.
+- [ ] 12.2 Verify: Run `bun check`; if any test, type, lint, formatting, documentation, or end-to-end check fails, stop and report the failures.
+- [ ] 12.3 Verify: Validate the completed OpenSpec change against its schema and confirm every implementation task and reconciled scenario is accounted for before verification and archive.

--- a/packages/cli/src/util/__tests__/registry-errors.test.ts
+++ b/packages/cli/src/util/__tests__/registry-errors.test.ts
@@ -68,6 +68,15 @@ describe('translateEngineRegistryError — registry-dumb rendering', () => {
     expect(retried.detail).toContain('after 3 attempts')
   })
 
+  test('TOO_MANY_SPECIFIERS blames the CLI, not the registry or the project', () => {
+    const cli = translateEngineRegistryError({ code: 'TOO_MANY_SPECIFIERS', limit: 100, received: 142 })
+
+    expect(cli.detail).toContain('142')
+    expect(cli.detail).toContain('100')
+    expect(cli.fix).toContain('file a bug')
+    expect(cli.docsUrl).toBeUndefined()
+  })
+
   test('UNEXPECTED_ERROR surfaces the cause and asks the user to file a bug', () => {
     const cli = translateEngineRegistryError({ code: 'UNEXPECTED_ERROR', cause: 'TypeError: boom' })
 

--- a/packages/cli/src/util/registry-errors.ts
+++ b/packages/cli/src/util/registry-errors.ts
@@ -56,6 +56,16 @@ export function translateEngineRegistryError(err: RegistryError): CliError {
         detail: err.cause,
         fix: 'try again; if persistent, file a bug',
       }
+    case 'TOO_MANY_SPECIFIERS':
+      // Not something the registry said, and not something the user did:
+      // a command asked for more lookups in one call than the batch
+      // boundary accepts. Say so plainly rather than dressing it up as a
+      // registry problem the user could act on.
+      return {
+        what: 'the CLI asked the registry to resolve too many facets at once',
+        detail: `${err.received} versions requested in one call (limit ${err.limit})`,
+        fix: 'file a bug — this is a defect in the CLI, not your project',
+      }
     case 'UNSUPPORTED_ARCHIVE':
       // The single compatibility table names the minimum supporting release
       // for a known newer format, or advises updating to latest for an

--- a/packages/engine/src/__tests__/registry.test.ts
+++ b/packages/engine/src/__tests__/registry.test.ts
@@ -162,6 +162,74 @@ describe('resolveRegistryMetadataBatch', () => {
     expect(result.error.cause).toContain('fetch failed')
   })
 
+  test('a full batch of 100 specifiers is accepted', async () => {
+    let calls = 0
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calls++
+      const name = captureUrl(input).split('/').at(-2) ?? 'unknown'
+      return new Response(JSON.stringify(fixtures.versionMetadata({ name, version: '1.0.0' })), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const specs = Array.from({ length: 100 }, (_, index) => ({
+      name: `facet-${index}`,
+      version: { kind: 'latest' as const },
+    }))
+    const result = await resolveRegistryMetadataBatch(specs)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) expect.unreachable()
+    expect(result.value).toHaveLength(100)
+    expect(calls).toBe(100)
+  })
+
+  test('more than 100 specifiers is refused before any request is issued', async () => {
+    let calls = 0
+    globalThis.fetch = (async () => {
+      calls++
+      return new Response(JSON.stringify(fixtures.versionMetadata()), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const specs = Array.from({ length: 101 }, (_, index) => ({
+      name: `facet-${index}`,
+      version: { kind: 'latest' as const },
+    }))
+    const result = await resolveRegistryMetadataBatch(specs)
+
+    if (result.ok) expect.unreachable()
+    if (result.error.code !== 'TOO_MANY_SPECIFIERS') expect.unreachable()
+    expect(result.error.limit).toBe(100)
+    expect(result.error.received).toBe(101)
+    expect(calls).toBe(0)
+  })
+
+  test('a response for a different facet is refused', async () => {
+    // A misrouted request or a mixed-up cache key would otherwise install
+    // one facet's content under another facet's name.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(fixtures.versionMetadata({ name: 'somebody-else', version: '1.0.0' })), {
+        status: 200,
+      })) as unknown as typeof fetch
+
+    const result = await resolveRegistryMetadataBatch([{ name: 'cowsay', version: { kind: 'latest' } }])
+
+    if (result.ok) expect.unreachable()
+    if (result.error.code !== 'UNEXPECTED_ERROR') expect.unreachable()
+    expect(result.error.cause).toContain('cowsay')
+  })
+
+  test('a resolved version that is not an exact release is refused', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(fixtures.versionMetadata({ name: 'cowsay', version: '1.2' })), {
+        status: 200,
+      })) as unknown as typeof fetch
+
+    const result = await resolveRegistryMetadataBatch([{ name: 'cowsay', version: { kind: 'latest' } }])
+
+    if (result.ok) expect.unreachable()
+    if (result.error.code !== 'UNEXPECTED_ERROR') expect.unreachable()
+    expect(result.error.cause).toContain('exact')
+  })
+
   test('multi-spec batch fans out and short-circuits on first failure', async () => {
     let calls = 0
     globalThis.fetch = (async (input: string | URL | Request) => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -264,6 +264,22 @@ export type {
 // failure shapes carry one, so anything rendering `RunInstallFailure` needs
 // the constructor to build a fixture -- exported alongside the type.
 export { assetIdentity } from './install/types.ts'
+// update planning (owns every version question `facet update` renders)
+export type {
+  AdvancingChoices,
+  AuthoredSpecifier,
+  CheckableRegistryFacet,
+  ExactVersion,
+  PreparedFacetUpdate,
+  PrepareFacetUpdateFailure,
+  PrepareFacetUpdateResult,
+  ResolvedChoice,
+  UnusableFacetState,
+  UnusableStateReason,
+  UpdateChoice,
+  UpdatePlanRow,
+} from './install/update/index.ts'
+export { prepareFacetUpdate } from './install/update/index.ts'
 // loaders. Note: `ResolvedFacetManifest` and `FACET_MANIFEST_FILE` are
 // part of `@agent-facets/protocol`'s public surface, not engine's. CLI
 // imports them directly from protocol; we don't re-export them here to

--- a/packages/engine/src/install/commit/resolve-facet.ts
+++ b/packages/engine/src/install/commit/resolve-facet.ts
@@ -1,8 +1,7 @@
 import type { Adapter } from '@agent-facets/adapter'
 import type { SupportedLockfile } from '@agent-facets/protocol'
-import { parseFacetSource } from '../../sources/facet/parse-source.ts'
-import { parseVersionSpec } from '../../sources/facet/parse-version.ts'
 import { ownEntry } from '../own-entry.ts'
+import { parseManifestFacetSource } from '../parse-manifest-source.ts'
 import type { OnLog, StageEvent } from '../types.ts'
 import { resolveEffectiveLocked } from './effective-locked.ts'
 import { resolveGitFacet } from './resolve-git.ts'
@@ -40,8 +39,7 @@ export async function resolveFacet(args: ResolveFacetArgs): Promise<ResolveFacet
   const { facetName, specifier, projectRoot, adapters, frozenLockfile, onStage, onLog } = args
 
   onStage({ kind: 'facet-stage', facet: facetName, stage: 'parse' })
-  const sourceString = parseVersionSpec(specifier).ok ? `${facetName}@${specifier}` : specifier
-  const parsed = parseFacetSource(sourceString)
+  const parsed = parseManifestFacetSource(facetName, specifier)
   if (!parsed.ok) {
     return {
       ok: false,

--- a/packages/engine/src/install/detect-lockfile-drift.ts
+++ b/packages/engine/src/install/detect-lockfile-drift.ts
@@ -1,10 +1,9 @@
 import type { SupportedLockfile } from '@agent-facets/protocol'
 import { satisfies } from '@agent-facets/protocol'
 import type { NormalizedFacetEntry } from '../manifest/mutations.ts'
-import { parseFacetSource } from '../sources/facet/parse-source.ts'
-import { parseVersionSpec } from '../sources/facet/parse-version.ts'
 import { ownEntry } from './own-entry.ts'
 import { parseLockedVersion } from './parse-locked-version.ts'
+import { parseManifestFacetSource } from './parse-manifest-source.ts'
 import { sourceMatchesLockedSource } from './source-matches.ts'
 import type { LockfileDriftEntry } from './types.ts'
 
@@ -36,8 +35,7 @@ export function detectLockfileDrift(
       drift.push({ name, reason: 'no-entry', manifestSpec: specifier })
       continue
     }
-    const sourceString = parseVersionSpec(specifier).ok ? `${name}@${specifier}` : specifier
-    const parsed = parseFacetSource(sourceString)
+    const parsed = parseManifestFacetSource(name, specifier)
     if (parsed.ok && parsed.value.kind === 'registry') {
       if (!satisfies(parseLockedVersion(locked.version), parsed.value.version)) {
         drift.push({ name, reason: 'unsatisfied', manifestSpec: specifier, lockedVersion: locked.version })

--- a/packages/engine/src/install/parse-manifest-source.ts
+++ b/packages/engine/src/install/parse-manifest-source.ts
@@ -1,0 +1,29 @@
+import { parseFacetSource } from '../sources/facet/parse-source.ts'
+import { parseVersionSpec } from '../sources/facet/parse-version.ts'
+import type { ParseResult, Source } from '../sources/facet/types.ts'
+
+/**
+ * Parse one `facets.json` entry into a `Source`.
+ *
+ * The manifest is a `name → value` map, and the value means different
+ * things depending on where the facet comes from. For a registry source
+ * the value is a bare version specifier (`1.2.3`, `1.*`, `*`, `latest`)
+ * and the facet name lives in the KEY, so a value that parses as a bare
+ * `VersionSpec` is recombined into `${facetName}@${value}`. For git and
+ * local sources the value is a self-contained source string (a URL, a
+ * `file:` path) and the key is just a label, so it is parsed standalone.
+ *
+ * This keeps `facets.json` values semver-shaped for registry entries —
+ * what the user sees is `1.2.3`, not `cowsay@1.2.3` — while still
+ * round-tripping through source resolution.
+ *
+ * Every reader of the manifest must apply this rule identically: commit
+ * resolution, drift detection, and update discovery all decide what kind
+ * of source an entry is, and a disagreement between them would mean one
+ * subsystem thinking a facet is a registry entry while another treats
+ * the same text as a path.
+ */
+export function parseManifestFacetSource(facetName: string, value: string): ParseResult<Source> {
+  const sourceString = parseVersionSpec(value).ok ? `${facetName}@${value}` : value
+  return parseFacetSource(sourceString)
+}

--- a/packages/engine/src/install/update/__tests__/discover.test.ts
+++ b/packages/engine/src/install/update/__tests__/discover.test.ts
@@ -1,0 +1,603 @@
+import { describe, expect, test } from 'bun:test'
+import type { SupportedLockfile } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../../../manifest/mutations.ts'
+import { MAX_REGISTRY_METADATA_SPECIFIERS } from '../../../registry/resolve-metadata.ts'
+import type { RegistryMetadata, RegistryResult, RegistrySpec } from '../../../registry/types.ts'
+import { discoverUpdates, type ResolveMetadataBatch } from '../discover.ts'
+import type { UpdatePlanRow } from '../types.ts'
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Prototype-safe record builder: `__proto__` and `constructor` are legal
+ * facet names, and a plain object literal would either swallow them or
+ * answer an inherited value for a key nobody set.
+ */
+function record<T>(entries: Array<[string, T]>): Record<string, T> {
+  const out = Object.create(null) as Record<string, T>
+  for (const [key, value] of entries) {
+    Object.defineProperty(out, key, { value, enumerable: true, writable: true, configurable: true })
+  }
+  return out
+}
+
+function manifest(entries: Array<[string, string]>): Record<string, NormalizedFacetEntry> {
+  return record(entries.map(([name, source]) => [name, { source, overrides: undefined }]))
+}
+
+function lockedRegistry(version: string) {
+  return {
+    source: { kind: 'registry' as const, registry: 'https://registry.test' },
+    version,
+    integrity: 'sha256:aaaa',
+    assets: [],
+  }
+}
+
+function lockfile(entries: Array<[string, ReturnType<typeof lockedRegistry>]>): SupportedLockfile {
+  return { lockfileVersion: 0.3, facets: record(entries) } as SupportedLockfile
+}
+
+const EMPTY_LOCKFILE = lockfile([])
+
+/**
+ * A resolver that answers from a `name@spec → version` table, recording
+ * every group it was handed so grouping and concurrency are observable.
+ */
+function resolverFor(
+  versions: Record<string, string>,
+  options: { groups?: RegistrySpec[][] } = {},
+): ResolveMetadataBatch {
+  return async (specs) => {
+    options.groups?.push([...specs])
+    const value: RegistryMetadata[] = []
+    for (const spec of specs) {
+      const key = `${spec.name}@${renderSpec(spec)}`
+      const version = versions[key]
+      if (version === undefined) {
+        return { ok: false, error: { code: 'NOT_FOUND', name: spec.name, spec: renderSpec(spec) } }
+      }
+      value.push({
+        name: spec.name,
+        version,
+        transportHash: 'sha256:transport',
+        contentFingerprint: 'sha256:content',
+      })
+    }
+    return { ok: true, value }
+  }
+}
+
+function renderSpec(spec: RegistrySpec): string {
+  switch (spec.version.kind) {
+    case 'exact':
+      return `${spec.version.major}.${spec.version.minor}.${spec.version.patch}`
+    case 'majorWildcard':
+      return `${spec.version.major}.*`
+    case 'minorWildcard':
+      return `${spec.version.major}.${spec.version.minor}.*`
+    case 'wildcard':
+      return '*'
+    case 'latest':
+      return 'latest'
+  }
+}
+
+function candidateNames(plan: readonly UpdatePlanRow[]): string[] {
+  return plan.flatMap((row) => (row.kind === 'candidate' ? [row.facet.name] : []))
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+describe('discoverUpdates — classifying resolved facets', () => {
+  test('reports current, target and latest for a bounded range', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({ 'cowsay@1.*': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    const row = result.plan[0]
+    if (row?.kind !== 'candidate') expect.unreachable()
+    expect(row.facet.current).toEqual({ kind: 'exact', major: 1, minor: 2, patch: 0 })
+    expect(row.facet.target.version).toEqual({ kind: 'exact', major: 1, minor: 8, patch: 0 })
+    expect(row.facet.latest.version).toEqual({ kind: 'exact', major: 2, minor: 0, patch: 0 })
+    expect(row.advancing).toBe('range-and-latest')
+    expect(row.facet.authored.source).toBe('1.*')
+  })
+
+  test('an exact pin is a candidate when only latest advances', async () => {
+    // The pin means plain update has nothing to do, but the row still has
+    // to appear: `--latest` and the interactive toggle exist precisely to
+    // move a pinned facet, and hiding it would make them useless.
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.2.0']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({ 'cowsay@1.2.0': '1.2.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    const row = result.plan[0]
+    if (row?.kind !== 'candidate') expect.unreachable()
+    expect(row.advancing).toBe('latest-only')
+  })
+
+  test('a facet already at latest is current, not a candidate', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '2.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('2.0.0')]]),
+      resolve: resolverFor({ 'cowsay@2.*': '2.0.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.plan[0]?.kind).toBe('current')
+  })
+
+  test('an older registry answer never becomes a downgrade candidate', async () => {
+    // Unpublished releases and caller-relative visibility can both make
+    // the registry answer with something older than what is installed.
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('2.0.0')]]),
+      resolve: resolverFor({ 'cowsay@*': '1.5.0', 'cowsay@latest': '1.5.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.plan[0]?.kind).toBe('current')
+  })
+
+  test.each([
+    ['1.2.0', '1.2.0', '1.2.0'],
+    ['1.*', '1.0.0', '1.8.0'],
+    ['1.2.*', '1.2.0', '1.2.7'],
+    ['*', '1.0.0', '3.0.0'],
+    ['latest', '1.0.0', '3.0.0'],
+  ])('resolves the authored form %p to its target', async (source, locked, target) => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', source]]),
+      lockfile: lockfile([['cowsay', lockedRegistry(locked)]]),
+      resolve: resolverFor({ [`cowsay@${source}`]: target, 'cowsay@latest': '3.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    const row = result.plan[0]
+    if (row?.kind !== 'candidate') expect.unreachable()
+    expect(row.facet.target.metadata.version).toBe(target)
+  })
+
+  test('carries the resolved metadata so application needs no second lookup', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({ 'cowsay@1.*': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    const row = result.plan[0]
+    if (row?.kind !== 'candidate') expect.unreachable()
+    expect(row.facet.target.metadata).toEqual({
+      name: 'cowsay',
+      version: '1.8.0',
+      transportHash: 'sha256:transport',
+      contentFingerprint: 'sha256:content',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sources
+// ---------------------------------------------------------------------------
+
+describe('discoverUpdates — unsupported sources', () => {
+  test('git and local facets are named, not silently treated as current', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([
+        ['from-git', 'https://example.com/cowsay.git'],
+        ['from-disk', 'file:../local-facet'],
+      ]),
+      lockfile: EMPTY_LOCKFILE,
+      resolve: resolverFor({}),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.plan).toEqual([
+      { kind: 'unsupported-source', name: 'from-git', source: 'https://example.com/cowsay.git', sourceKind: 'git' },
+      { kind: 'unsupported-source', name: 'from-disk', source: 'file:../local-facet', sourceKind: 'local' },
+    ])
+  })
+
+  test('unsupported sources do not block registry facets, and plan order is manifest order', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([
+        ['from-git', 'https://example.com/cowsay.git'],
+        ['cowsay', '1.*'],
+        ['from-disk', 'file:../local-facet'],
+        ['zebra', '1.*'],
+      ]),
+      lockfile: lockfile([
+        ['cowsay', lockedRegistry('1.2.0')],
+        ['zebra', lockedRegistry('1.0.0')],
+      ]),
+      resolve: resolverFor({
+        'cowsay@1.*': '1.8.0',
+        'cowsay@latest': '2.0.0',
+        'zebra@1.*': '1.0.0',
+        'zebra@latest': '1.0.0',
+      }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.plan.map((row) => (row.kind === 'unsupported-source' ? row.name : row.facet.name))).toEqual([
+      'from-git',
+      'cowsay',
+      'from-disk',
+      'zebra',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unusable local state
+// ---------------------------------------------------------------------------
+
+describe('discoverUpdates — unusable local state', () => {
+  test('a registry facet with no lock entry fails discovery', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: EMPTY_LOCKFILE,
+      resolve: resolverFor({}),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'unusable-facet-state') expect.unreachable()
+    expect(result.failure.facets).toEqual([{ name: 'cowsay', reason: { code: 'missing-lock-entry' } }])
+  })
+
+  test('a lock entry of another source kind is a mismatch, not a fresh install', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([
+        [
+          'cowsay',
+          {
+            source: { kind: 'git', url: 'https://example.com/c.git', commit: 'a'.repeat(40) },
+            version: '1.2.0',
+            integrity: 'sha256:aaaa',
+            assets: [],
+          } as unknown as ReturnType<typeof lockedRegistry>,
+        ],
+      ]),
+      resolve: resolverFor({}),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'unusable-facet-state') expect.unreachable()
+    expect(result.failure.facets[0]?.reason).toEqual({ code: 'lock-source-mismatch', locked: 'git' })
+  })
+
+  test('a hand-edited locked version is reported rather than thrown', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('not-a-version')]]),
+      resolve: resolverFor({}),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'unusable-facet-state') expect.unreachable()
+    expect(result.failure.facets[0]?.reason).toEqual({ code: 'invalid-locked-version', version: 'not-a-version' })
+  })
+
+  test('a locked version outside the authored range is drift, not an update', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '2.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({}),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'unusable-facet-state') expect.unreachable()
+    expect(result.failure.facets[0]?.reason).toEqual({
+      code: 'locked-version-unsatisfying',
+      version: '1.2.0',
+      source: '2.*',
+    })
+  })
+
+  test('an unparseable manifest source is reported with the parser problem', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '^1.2.3']]),
+      lockfile: EMPTY_LOCKFILE,
+      resolve: resolverFor({}),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'unusable-facet-state') expect.unreachable()
+    const reason = result.failure.facets[0]?.reason
+    if (reason?.code !== 'unparseable-source') expect.unreachable()
+    expect(reason.source).toBe('^1.2.3')
+    expect(reason.problem.length).toBeGreaterThan(0)
+  })
+
+  test('every affected facet is reported in one failure, in project order', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([
+        ['alpha', '1.*'],
+        ['beta', '1.*'],
+        ['gamma', '1.*'],
+      ]),
+      lockfile: lockfile([['beta', lockedRegistry('bad')]]),
+      resolve: resolverFor({}),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'unusable-facet-state') expect.unreachable()
+    expect(result.failure.facets.map((facet) => facet.name)).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  test('no registry request is made when local state is unusable', async () => {
+    let calls = 0
+    const counting: ResolveMetadataBatch = async (specs) => {
+      calls += 1
+      return resolverFor({})(specs)
+    }
+    await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: EMPTY_LOCKFILE,
+      resolve: counting,
+    })
+    expect(calls).toBe(0)
+  })
+
+  test('the locked version need not still be resolvable from the registry', async () => {
+    // Repairing a yanked installed version belongs to `facet install`.
+    // Update only needs to know what is installed, which the lockfile
+    // already says.
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.4.0')]]),
+      resolve: resolverFor({ 'cowsay@1.*': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    const row = result.plan[0]
+    if (row?.kind !== 'candidate') expect.unreachable()
+    expect(row.facet.current).toEqual({ kind: 'exact', major: 1, minor: 4, patch: 0 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Grouping and failure ordering
+// ---------------------------------------------------------------------------
+
+describe('discoverUpdates — batching', () => {
+  test('asks for two adjacent specifiers per facet', async () => {
+    const groups: RegistrySpec[][] = []
+    await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({ 'cowsay@1.*': '1.8.0', 'cowsay@latest': '2.0.0' }, { groups }),
+    })
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.map(renderSpec)).toEqual(['1.*', 'latest'])
+  })
+
+  test('splits into groups no larger than the resolver limit', async () => {
+    const count = 60 // 120 specifiers → two groups
+    const names = Array.from({ length: count }, (_, index) => `facet-${String(index).padStart(3, '0')}`)
+    const versions: Record<string, string> = {}
+    for (const name of names) {
+      versions[`${name}@1.*`] = '1.8.0'
+      versions[`${name}@latest`] = '2.0.0'
+    }
+
+    const groups: RegistrySpec[][] = []
+    const result = await discoverUpdates({
+      facets: manifest(names.map((name) => [name, '1.*'])),
+      lockfile: lockfile(names.map((name) => [name, lockedRegistry('1.2.0')])),
+      resolve: resolverFor(versions, { groups }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(groups).toHaveLength(2)
+    expect(groups[0]).toHaveLength(MAX_REGISTRY_METADATA_SPECIFIERS)
+    expect(groups[1]).toHaveLength(20)
+    for (const group of groups) {
+      expect(group.length).toBeLessThanOrEqual(MAX_REGISTRY_METADATA_SPECIFIERS)
+    }
+    expect(candidateNames(result.plan)).toEqual(names)
+  })
+
+  test('pairs results back to facets across a group boundary', async () => {
+    // 50 facets fill exactly one group, so facet 50 is the first entry of
+    // the second group — the place an off-by-one in pairing would show up.
+    const count = 51
+    const names = Array.from({ length: count }, (_, index) => `facet-${String(index).padStart(3, '0')}`)
+    const versions: Record<string, string> = {}
+    names.forEach((name, index) => {
+      versions[`${name}@1.*`] = `1.${index}.0`
+      versions[`${name}@latest`] = `2.${index}.0`
+    })
+
+    const result = await discoverUpdates({
+      facets: manifest(names.map((name) => [name, '1.*'])),
+      lockfile: lockfile(names.map((name) => [name, lockedRegistry('1.0.0')])),
+      resolve: resolverFor(versions),
+    })
+
+    if (!result.ok) expect.unreachable()
+    const last = result.plan[count - 1]
+    if (last?.kind !== 'candidate') expect.unreachable()
+    expect(last.facet.name).toBe('facet-050')
+    expect(last.facet.target.metadata.version).toBe('1.50.0')
+    expect(last.facet.latest.metadata.version).toBe('2.50.0')
+  })
+
+  test('groups are issued concurrently', async () => {
+    const names = Array.from({ length: 60 }, (_, index) => `facet-${String(index).padStart(3, '0')}`)
+    const versions: Record<string, string> = {}
+    for (const name of names) {
+      versions[`${name}@1.*`] = '1.8.0'
+      versions[`${name}@latest`] = '2.0.0'
+    }
+
+    let inFlight = 0
+    let peak = 0
+    const answer = resolverFor(versions)
+    const concurrent: ResolveMetadataBatch = async (specs) => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      const result = await answer(specs)
+      inFlight -= 1
+      return result
+    }
+
+    await discoverUpdates({
+      facets: manifest(names.map((name) => [name, '1.*'])),
+      lockfile: lockfile(names.map((name) => [name, lockedRegistry('1.2.0')])),
+      resolve: concurrent,
+    })
+
+    expect(peak).toBe(2)
+  })
+
+  test('one lookup failure rejects the whole discovery', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([
+        ['good', '1.*'],
+        ['bad', '1.*'],
+      ]),
+      lockfile: lockfile([
+        ['good', lockedRegistry('1.0.0')],
+        ['bad', lockedRegistry('1.0.0')],
+      ]),
+      resolve: resolverFor({ 'good@1.*': '1.8.0', 'good@latest': '2.0.0' }),
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.reason).toBe('discovery-failed')
+  })
+
+  test('the reported failure follows project order, not completion order', async () => {
+    const names = Array.from({ length: 60 }, (_, index) => `facet-${String(index).padStart(3, '0')}`)
+    const versions: Record<string, string> = {}
+    for (const name of names) {
+      versions[`${name}@1.*`] = '1.8.0'
+      versions[`${name}@latest`] = '2.0.0'
+    }
+    // Fail one facet in each group; the earlier one must win even though
+    // the later group is made to settle first.
+    delete versions['facet-005@1.*']
+    delete versions['facet-055@1.*']
+
+    const answer = resolverFor(versions)
+    const staggered: ResolveMetadataBatch = async (specs) => {
+      const isFirstGroup = specs[0]?.name === 'facet-000'
+      await new Promise((resolve) => setTimeout(resolve, isFirstGroup ? 20 : 1))
+      return answer(specs)
+    }
+
+    const result = await discoverUpdates({
+      facets: manifest(names.map((name) => [name, '1.*'])),
+      lockfile: lockfile(names.map((name) => [name, lockedRegistry('1.2.0')])),
+      resolve: staggered,
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'discovery-failed') expect.unreachable()
+    if (result.failure.error.code !== 'NOT_FOUND') expect.unreachable()
+    expect(result.failure.error.name).toBe('facet-005')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Incoherent registry answers
+// ---------------------------------------------------------------------------
+
+describe('discoverUpdates — incoherent registry answers', () => {
+  test('a target outside the authored range fails discovery', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({ 'cowsay@1.*': '2.0.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'target-outside-range') expect.unreachable()
+    expect(result.failure.facet).toBe('cowsay')
+    expect(result.failure.source).toBe('1.*')
+    expect(result.failure.version).toBe('2.0.0')
+  })
+
+  test('a non-exact resolved version fails discovery', async () => {
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: resolverFor({ 'cowsay@1.*': '1.8.0', 'cowsay@latest': 'latest' }),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'invalid-resolved-version') expect.unreachable()
+    expect(result.failure.lookup).toBe('latest')
+    expect(result.failure.version).toBe('latest')
+  })
+
+  test('a short result array is reported as a boundary failure', async () => {
+    const truncating: ResolveMetadataBatch = async (): Promise<RegistryResult<ReadonlyArray<RegistryMetadata>>> => ({
+      ok: true,
+      value: [{ name: 'cowsay', version: '1.8.0', transportHash: 'x', contentFingerprint: 'y' }],
+    })
+
+    const result = await discoverUpdates({
+      facets: manifest([['cowsay', '1.*']]),
+      lockfile: lockfile([['cowsay', lockedRegistry('1.2.0')]]),
+      resolve: truncating,
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'discovery-failed') expect.unreachable()
+    expect(result.failure.error.code).toBe('UNEXPECTED_ERROR')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty projects
+// ---------------------------------------------------------------------------
+
+describe('discoverUpdates — nothing to do', () => {
+  test('an empty manifest produces an empty plan without asking the registry', async () => {
+    let calls = 0
+    const counting: ResolveMetadataBatch = async () => {
+      calls += 1
+      return { ok: true, value: [] }
+    }
+    const result = await discoverUpdates({ facets: manifest([]), lockfile: EMPTY_LOCKFILE, resolve: counting })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.plan).toEqual([])
+    expect(calls).toBe(0)
+  })
+
+  test('a project of only git and local facets never reaches the registry', async () => {
+    let calls = 0
+    const counting: ResolveMetadataBatch = async () => {
+      calls += 1
+      return { ok: true, value: [] }
+    }
+    const result = await discoverUpdates({
+      facets: manifest([['from-git', 'https://example.com/c.git']]),
+      lockfile: EMPTY_LOCKFILE,
+      resolve: counting,
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.plan).toHaveLength(1)
+    expect(calls).toBe(0)
+  })
+})

--- a/packages/engine/src/install/update/__tests__/manifest-source.test.ts
+++ b/packages/engine/src/install/update/__tests__/manifest-source.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+import { parseVersionSpec } from '../../../sources/facet/parse-version.ts'
+import { finalManifestSource, type UpdateChoice } from '../manifest-source.ts'
+import { parseExactVersion } from '../version-order.ts'
+
+/** Build the authored specifier from the text a user would have written. */
+function authored(source: string) {
+  const spec = parseVersionSpec(source)
+  if (!spec.ok) expect.unreachable()
+  return { source, spec: spec.value }
+}
+
+function rewrite(source: string, choice: UpdateChoice, selected: string): string {
+  const version = parseExactVersion(selected)
+  if (version === undefined) expect.unreachable()
+  return finalManifestSource({ authored: authored(source), choice, selected: version })
+}
+
+describe('finalManifestSource — choosing the range target', () => {
+  test.each(['1.2.0', '1.*', '1.2.*', '*', 'latest'])('leaves the authored form %p untouched', (source) => {
+    expect(rewrite(source, 'range', '1.8.0')).toBe(source)
+  })
+})
+
+describe('finalManifestSource — choosing latest', () => {
+  test('an exact pin becomes the selected version', () => {
+    expect(rewrite('1.2.0', 'latest', '2.4.1')).toBe('2.4.1')
+  })
+
+  test('a major wildcard advances its major and stays a major wildcard', () => {
+    expect(rewrite('1.*', 'latest', '2.4.1')).toBe('2.*')
+  })
+
+  test('a minor wildcard advances major and minor and stays a minor wildcard', () => {
+    expect(rewrite('1.2.*', 'latest', '2.4.1')).toBe('2.4.*')
+  })
+
+  test('a bare wildcard already floats, so nothing is rewritten', () => {
+    expect(rewrite('*', 'latest', '2.4.1')).toBe('*')
+  })
+
+  test('the latest tag keeps its spelling rather than becoming a wildcard', () => {
+    // `*` and `latest` resolve identically but are distinct authored
+    // forms; rewriting one into the other would edit a file the user
+    // never asked to have reworded.
+    expect(rewrite('latest', 'latest', '2.4.1')).toBe('latest')
+  })
+
+  test('widening within the same major keeps the wildcard shape', () => {
+    expect(rewrite('1.*', 'latest', '1.9.0')).toBe('1.*')
+    expect(rewrite('1.2.*', 'latest', '1.2.9')).toBe('1.2.*')
+  })
+})

--- a/packages/engine/src/install/update/__tests__/prepare.test.ts
+++ b/packages/engine/src/install/update/__tests__/prepare.test.ts
@@ -1,0 +1,252 @@
+/**
+ * `prepareFacetUpdate` on a real project tree.
+ *
+ * Two things are proved here that a pure test cannot: that preparation
+ * writes absolutely nothing, and that a plan built while the project was
+ * being edited underneath it is withdrawn rather than offered.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { RegistryMetadata } from '../../../registry/types.ts'
+import type { ResolveMetadataBatch } from '../discover.ts'
+import { prepareFacetUpdate } from '../prepare.ts'
+
+let projectRoot: string
+let fakeHome: string
+const ORIGINAL_HOME = process.env.HOME
+const ORIGINAL_FACET_DIR = process.env.FACET_DIR
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'facet-update-prepare-'))
+  fakeHome = mkdtempSync(join(tmpdir(), 'facet-update-home-'))
+  process.env.HOME = fakeHome
+  process.env.FACET_DIR = join(fakeHome, '.facet')
+})
+
+afterEach(() => {
+  rmSync(projectRoot, { recursive: true, force: true })
+  rmSync(fakeHome, { recursive: true, force: true })
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME
+  else process.env.HOME = ORIGINAL_HOME
+  if (ORIGINAL_FACET_DIR === undefined) delete process.env.FACET_DIR
+  else process.env.FACET_DIR = ORIGINAL_FACET_DIR
+})
+
+function writeManifest(facets: Record<string, unknown>, extra = ''): void {
+  const body = JSON.stringify({ manifestVersion: 0.2, facets }, null, 2)
+  writeFileSync(join(projectRoot, 'facets.json'), extra === '' ? body : `${extra}\n${body}`)
+}
+
+function writeLockfile(facets: Record<string, unknown>): void {
+  writeFileSync(join(projectRoot, 'facets.lock'), JSON.stringify({ lockfileVersion: 0.3, facets }, null, 2))
+}
+
+function lockedRegistry(version: string) {
+  return {
+    source: { kind: 'registry', registry: 'https://registry.test' },
+    version,
+    integrity: 'sha256:aaaa',
+    assets: [],
+  }
+}
+
+/** Answers every specifier, optionally running a side effect first. */
+function resolver(versions: Record<string, string>, before?: () => void): ResolveMetadataBatch {
+  return async (specs) => {
+    before?.()
+    const value: RegistryMetadata[] = specs.map((spec) => ({
+      name: spec.name,
+      version: versions[spec.version.kind === 'latest' ? `${spec.name}@latest` : `${spec.name}@target`] ?? '1.0.0',
+      transportHash: 'sha256:transport',
+      contentFingerprint: 'sha256:content',
+    }))
+    return { ok: true, value }
+  }
+}
+
+function projectBytes(): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const name of readdirSync(projectRoot)) {
+    out[name] = readFileSync(join(projectRoot, name), 'utf8')
+  }
+  return out
+}
+
+describe('prepareFacetUpdate — producing a plan', () => {
+  test('returns a plan bound to the bytes it was built from', async () => {
+    writeManifest({ cowsay: '1.*' })
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.prepared.projectRoot).toBe(projectRoot)
+    expect(result.prepared.manifestState.kind).toBe('regular-file')
+    expect(result.prepared.lockfileState.kind).toBe('regular-file')
+    const row = result.prepared.plan[0]
+    if (row?.kind !== 'candidate') expect.unreachable()
+    expect(row.facet.target.version).toEqual({ kind: 'exact', major: 1, minor: 8, patch: 0 })
+  })
+
+  test('an absent lockfile is a snapshot state, not a crash', async () => {
+    writeManifest({ cowsay: '1.*' })
+
+    const result = await prepareFacetUpdate({ projectRoot, resolve: resolver({}) })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.reason).toBe('unusable-facet-state')
+  })
+
+  test('a project with no facets prepares an empty plan', async () => {
+    writeManifest({})
+    writeLockfile({})
+
+    const result = await prepareFacetUpdate({ projectRoot, resolve: resolver({}) })
+
+    if (!result.ok) expect.unreachable()
+    expect(result.prepared.plan).toEqual([])
+  })
+})
+
+describe('prepareFacetUpdate — side-effect freedom', () => {
+  test('leaves every project file byte-for-byte unchanged', async () => {
+    writeManifest({ cowsay: '1.*' }, '')
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+    const before = projectBytes()
+
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    if (!result.ok) expect.unreachable()
+    expect(projectBytes()).toEqual(before)
+  })
+
+  test('creates no receipt, cache, or lock-directory state', async () => {
+    writeManifest({ cowsay: '1.*' })
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+
+    await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    // Nothing under the fake FACET_DIR: no cache entries, and above all no
+    // lock directory, which a preview must never leave behind.
+    expect(existsSync(join(fakeHome, '.facet'))).toBe(false)
+    expect(readdirSync(projectRoot).sort()).toEqual(['facets.json', 'facets.lock'])
+  })
+
+  test('preserves manifest formatting and comments it never rewrites', async () => {
+    const authored = `{
+  // the talking cow
+  "manifestVersion": 0.2,
+  "facets": { "cowsay": "1.*" }
+}
+`
+    writeFileSync(join(projectRoot, 'facets.json'), authored)
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+
+    await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }),
+    })
+
+    expect(readFileSync(join(projectRoot, 'facets.json'), 'utf8')).toBe(authored)
+  })
+})
+
+describe('prepareFacetUpdate — the project moving underneath', () => {
+  test('withdraws the plan when the manifest changes during discovery', async () => {
+    writeManifest({ cowsay: '1.*' })
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }, () => {
+        writeManifest({ cowsay: '2.*' })
+      }),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'project-changed-during-discovery') expect.unreachable()
+    expect(result.failure.file).toBe('manifest')
+  })
+
+  test('withdraws the plan when the lockfile changes during discovery', async () => {
+    writeManifest({ cowsay: '1.*' })
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }, () => {
+        writeLockfile({ cowsay: lockedRegistry('1.3.0') })
+      }),
+    })
+
+    if (result.ok) expect.unreachable()
+    if (result.failure.reason !== 'project-changed-during-discovery') expect.unreachable()
+    expect(result.failure.file).toBe('lockfile')
+  })
+
+  test('a whitespace-only manifest edit still withdraws the plan', async () => {
+    // The precondition is the exact bytes, not the parsed meaning: the
+    // commit writes against those bytes, so anything that changed them
+    // invalidates the snapshot.
+    writeManifest({ cowsay: '1.*' })
+    writeLockfile({ cowsay: lockedRegistry('1.2.0') })
+
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: resolver({ 'cowsay@target': '1.8.0', 'cowsay@latest': '2.0.0' }, () => {
+        const path = join(projectRoot, 'facets.json')
+        writeFileSync(path, `${readFileSync(path, 'utf8')}\n`)
+      }),
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.reason).toBe('project-changed-during-discovery')
+  })
+})
+
+describe('prepareFacetUpdate — unreadable project files', () => {
+  test('an invalid manifest fails before any registry work', async () => {
+    writeFileSync(join(projectRoot, 'facets.json'), '{ not json')
+    let calls = 0
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: async () => {
+        calls += 1
+        return { ok: true, value: [] }
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.reason).toBe('manifest-read')
+    expect(calls).toBe(0)
+  })
+
+  test('an invalid lockfile fails before any registry work', async () => {
+    writeManifest({ cowsay: '1.*' })
+    writeFileSync(join(projectRoot, 'facets.lock'), '{ not json')
+    let calls = 0
+    const result = await prepareFacetUpdate({
+      projectRoot,
+      resolve: async () => {
+        calls += 1
+        return { ok: true, value: [] }
+      },
+    })
+
+    if (result.ok) expect.unreachable()
+    expect(result.failure.reason).toBe('lockfile-read')
+    expect(calls).toBe(0)
+  })
+})

--- a/packages/engine/src/install/update/__tests__/version-order.test.ts
+++ b/packages/engine/src/install/update/__tests__/version-order.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import { compareExactVersions, isNewerThan, parseExactVersion } from '../version-order.ts'
+
+const at = (major: number, minor: number, patch: number) => ({ kind: 'exact' as const, major, minor, patch })
+
+describe('parseExactVersion', () => {
+  test('accepts an exact MAJOR.MINOR.PATCH', () => {
+    expect(parseExactVersion('1.2.3')).toEqual(at(1, 2, 3))
+  })
+
+  test.each(['1.*', '1.2.*', '*', 'latest'])('rejects the non-exact form %p', (form) => {
+    expect(parseExactVersion(form)).toBeUndefined()
+  })
+
+  test.each([
+    '',
+    '1.2',
+    '1.2.3.4',
+    'v1.2.3',
+    '1.2.3-rc.1',
+    '^1.2.3',
+    'nonsense',
+  ])('rejects the unusable value %p', (value) => {
+    expect(parseExactVersion(value)).toBeUndefined()
+  })
+
+  test('never throws on hand-edited lockfile text', () => {
+    // The point of this parser existing alongside `parseLockedVersion`:
+    // that one throws, because the lockfile schema promised it wouldn't
+    // have to. This one is handed values nothing has narrowed yet.
+    expect(() => parseExactVersion('garbage')).not.toThrow()
+  })
+})
+
+describe('compareExactVersions', () => {
+  test('orders by major first', () => {
+    expect(compareExactVersions(at(2, 0, 0), at(1, 9, 9))).toBeGreaterThan(0)
+  })
+
+  test('orders by minor when majors match', () => {
+    expect(compareExactVersions(at(1, 2, 0), at(1, 3, 0))).toBeLessThan(0)
+  })
+
+  test('orders by patch when major and minor match', () => {
+    expect(compareExactVersions(at(1, 2, 5), at(1, 2, 4))).toBeGreaterThan(0)
+  })
+
+  test('is zero for the same release', () => {
+    expect(compareExactVersions(at(1, 2, 3), at(1, 2, 3))).toBe(0)
+  })
+
+  test('compares components numerically, not as text', () => {
+    // The trap `compareCodeUnits` would fall into: "1.10.0" sorts below
+    // "1.9.0" as a string, which would hide a real update.
+    expect(compareExactVersions(at(1, 10, 0), at(1, 9, 0))).toBeGreaterThan(0)
+    expect(compareExactVersions(at(10, 0, 0), at(9, 0, 0))).toBeGreaterThan(0)
+    expect(compareExactVersions(at(1, 2, 10), at(1, 2, 9))).toBeGreaterThan(0)
+  })
+})
+
+describe('isNewerThan', () => {
+  test('is true only for a strictly newer version', () => {
+    expect(isNewerThan(at(1, 3, 0), at(1, 2, 0))).toBe(true)
+  })
+
+  test('is false for the same version', () => {
+    expect(isNewerThan(at(1, 2, 0), at(1, 2, 0))).toBe(false)
+  })
+
+  test('is false for an older version, so nothing can be downgraded', () => {
+    expect(isNewerThan(at(1, 1, 0), at(1, 2, 0))).toBe(false)
+  })
+})

--- a/packages/engine/src/install/update/discover.ts
+++ b/packages/engine/src/install/update/discover.ts
@@ -1,0 +1,263 @@
+/**
+ * Read-only update discovery.
+ *
+ * Answers, for a whole project at once, what each registry facet is
+ * installed at and what it could move to. Nothing here writes: no
+ * downloads, no cache, no lock directory, no project files. The result
+ * is either one complete plan or one failure — never a partial answer,
+ * because a user shown nine of ten facets has no way to know the tenth
+ * was omitted.
+ */
+
+import type { SupportedLockfile } from '@agent-facets/protocol'
+import { satisfies } from '@agent-facets/protocol'
+import type { NormalizedFacetEntry } from '../../manifest/mutations.ts'
+import { MAX_REGISTRY_METADATA_SPECIFIERS, resolveRegistryMetadataBatch } from '../../registry/resolve-metadata.ts'
+import type { RegistryMetadata, RegistryResult, RegistrySpec } from '../../registry/types.ts'
+import { ownEntry } from '../own-entry.ts'
+import { parseManifestFacetSource } from '../parse-manifest-source.ts'
+import type { AuthoredSpecifier } from './manifest-source.ts'
+import type {
+  AdvancingChoices,
+  CheckableRegistryFacet,
+  PrepareFacetUpdateFailure,
+  ResolvedChoice,
+  UnusableFacetState,
+  UpdatePlanRow,
+} from './types.ts'
+import { type ExactVersion, isNewerThan, parseExactVersion } from './version-order.ts'
+
+/** The batch-resolution boundary, injectable so grouping can be tested. */
+export type ResolveMetadataBatch = (
+  specs: ReadonlyArray<RegistrySpec>,
+) => Promise<RegistryResult<ReadonlyArray<RegistryMetadata>>>
+
+/** Everything discovery alone can fail with. */
+export type DiscoverUpdatesFailure = Extract<
+  PrepareFacetUpdateFailure,
+  { reason: 'unusable-facet-state' | 'discovery-failed' | 'invalid-resolved-version' | 'target-outside-range' }
+>
+
+export type DiscoverUpdatesResult =
+  | { ok: true; plan: readonly UpdatePlanRow[] }
+  | { ok: false; failure: DiscoverUpdatesFailure }
+
+export interface DiscoverUpdatesArgs {
+  facets: Readonly<Record<string, NormalizedFacetEntry>>
+  lockfile: SupportedLockfile
+  resolve?: ResolveMetadataBatch
+}
+
+/** A registry facet that passed local-state checks and needs resolving. */
+interface PendingFacet {
+  name: string
+  authored: AuthoredSpecifier
+  current: ExactVersion
+}
+
+/**
+ * A manifest entry's place in the plan: either a row already decided
+ * without the registry, or a facet still waiting on resolution.
+ *
+ * Slots exist so the finished plan comes back in manifest order.
+ * Appending resolved rows after the unresolvable ones would reorder the
+ * user's project in the output for no reason other than the order the
+ * code happened to learn things.
+ */
+type PlanSlot = { kind: 'settled'; row: UpdatePlanRow } | { kind: 'pending' }
+
+/**
+ * Build the update plan for a project.
+ *
+ * Local state is settled first and completely: every registry facet is
+ * either checkable or collected as unusable, and a single unusable facet
+ * fails the whole run before a byte crosses the network. That ordering
+ * is deliberate — asking the registry about a project that cannot say
+ * what it currently has would spend the user's time to produce an answer
+ * that still has to be thrown away.
+ */
+export async function discoverUpdates(args: DiscoverUpdatesArgs): Promise<DiscoverUpdatesResult> {
+  const resolve = args.resolve ?? resolveRegistryMetadataBatch
+
+  const slots: PlanSlot[] = []
+  const pending: PendingFacet[] = []
+  const unusable: UnusableFacetState[] = []
+
+  for (const [name, entry] of Object.entries(args.facets)) {
+    const source = entry.source
+    const parsed = parseManifestFacetSource(name, source)
+    if (!parsed.ok) {
+      unusable.push({ name, reason: { code: 'unparseable-source', source, problem: parsed.error.what } })
+      continue
+    }
+
+    if (parsed.value.kind !== 'registry') {
+      slots.push({ kind: 'settled', row: { kind: 'unsupported-source', name, source, sourceKind: parsed.value.kind } })
+      continue
+    }
+
+    const authored: AuthoredSpecifier = { source, spec: parsed.value.version }
+    const locked = ownEntry(args.lockfile.facets, name)
+    if (locked === undefined) {
+      unusable.push({ name, reason: { code: 'missing-lock-entry' } })
+      continue
+    }
+    if (locked.source.kind !== 'registry') {
+      unusable.push({ name, reason: { code: 'lock-source-mismatch', locked: locked.source.kind } })
+      continue
+    }
+    // Parsed here rather than through `parseLockedVersion`, which throws
+    // on a value the lockfile schema was supposed to have narrowed. A
+    // lockfile can be hand-edited; update reports that as a repairable
+    // state instead of crashing out of a function that promises values.
+    const current = parseExactVersion(locked.version)
+    if (current === undefined) {
+      unusable.push({ name, reason: { code: 'invalid-locked-version', version: locked.version } })
+      continue
+    }
+    if (!satisfies(current, authored.spec)) {
+      unusable.push({ name, reason: { code: 'locked-version-unsatisfying', version: locked.version, source } })
+      continue
+    }
+
+    slots.push({ kind: 'pending' })
+    pending.push({ name, authored, current })
+  }
+
+  if (unusable.length > 0) {
+    return { ok: false, failure: { reason: 'unusable-facet-state', facets: unusable } }
+  }
+
+  const resolved = await resolvePendingFacets(pending, resolve)
+  if (!resolved.ok) return resolved
+
+  const plan: UpdatePlanRow[] = []
+  let next = 0
+  for (const slot of slots) {
+    if (slot.kind === 'settled') {
+      plan.push(slot.row)
+      continue
+    }
+    const row = resolved.rows[next]
+    next += 1
+    if (row === undefined) return malformedBatch(pending.length * 2, next)
+    plan.push(row)
+  }
+
+  return { ok: true, plan }
+}
+
+/**
+ * Resolve both choices for every pending facet and classify the result.
+ *
+ * Each facet contributes two adjacent specifiers — its authored one for
+ * Target, `latest` for Latest — so a full group of 100 covers 50 facets.
+ * Groups are issued concurrently but inspected in order, which is what
+ * makes the reported failure the same on every run no matter which
+ * request happened to lose the race.
+ */
+async function resolvePendingFacets(
+  pending: readonly PendingFacet[],
+  resolve: ResolveMetadataBatch,
+): Promise<{ ok: true; rows: readonly UpdatePlanRow[] } | { ok: false; failure: DiscoverUpdatesFailure }> {
+  if (pending.length === 0) return { ok: true, rows: [] }
+
+  const specs: RegistrySpec[] = []
+  for (const facet of pending) {
+    specs.push({ name: facet.name, version: facet.authored.spec })
+    specs.push({ name: facet.name, version: { kind: 'latest' } })
+  }
+
+  const groups: RegistrySpec[][] = []
+  for (let at = 0; at < specs.length; at += MAX_REGISTRY_METADATA_SPECIFIERS) {
+    groups.push(specs.slice(at, at + MAX_REGISTRY_METADATA_SPECIFIERS))
+  }
+
+  const settled = await Promise.all(groups.map((group) => resolve(group)))
+
+  const metadata: RegistryMetadata[] = []
+  for (const group of settled) {
+    if (!group.ok) return { ok: false, failure: { reason: 'discovery-failed', error: group.error } }
+    metadata.push(...group.value)
+  }
+
+  const rows: UpdatePlanRow[] = []
+  for (const [index, facet] of pending.entries()) {
+    const targetMeta = metadata[index * 2]
+    const latestMeta = metadata[index * 2 + 1]
+    if (targetMeta === undefined || latestMeta === undefined) {
+      return malformedBatch(specs.length, metadata.length)
+    }
+
+    const target = toChoice(facet.name, 'target', targetMeta)
+    if (!target.ok) return target
+    const latest = toChoice(facet.name, 'latest', latestMeta)
+    if (!latest.ok) return latest
+
+    if (!satisfies(target.choice.version, facet.authored.spec)) {
+      return {
+        ok: false,
+        failure: {
+          reason: 'target-outside-range',
+          facet: facet.name,
+          source: facet.authored.source,
+          version: targetMeta.version,
+        },
+      }
+    }
+
+    rows.push(classify({ ...facet, target: target.choice, latest: latest.choice }))
+  }
+
+  return { ok: true, rows }
+}
+
+/**
+ * The resolver returned a different number of results than it was asked
+ * for. That is the boundary breaking its own contract rather than the
+ * registry saying anything, so it surfaces as an unexpected error with
+ * both counts rather than being attributed to a facet.
+ */
+function malformedBatch(requested: number, received: number): { ok: false; failure: DiscoverUpdatesFailure } {
+  return {
+    ok: false,
+    failure: {
+      reason: 'discovery-failed',
+      error: {
+        code: 'UNEXPECTED_ERROR',
+        cause: `registry metadata resolution returned ${received} results for ${requested} requested specifiers`,
+      },
+    },
+  }
+}
+
+/** Pair resolved metadata with its parsed exact version. */
+function toChoice(
+  facet: string,
+  lookup: 'target' | 'latest',
+  metadata: RegistryMetadata,
+): { ok: true; choice: ResolvedChoice } | { ok: false; failure: DiscoverUpdatesFailure } {
+  const version = parseExactVersion(metadata.version)
+  if (version === undefined) {
+    return { ok: false, failure: { reason: 'invalid-resolved-version', facet, lookup, version: metadata.version } }
+  }
+  return { ok: true, choice: { version, metadata } }
+}
+
+/**
+ * Decide whether a resolved facet is a candidate, and for which choices.
+ *
+ * Only a strictly newer version counts, so a facet whose registry
+ * answers moved backwards — an unpublished release, a narrower view of
+ * the registry than the one that installed it — is reported as current
+ * rather than offered as a downgrade.
+ */
+function classify(facet: CheckableRegistryFacet): UpdatePlanRow {
+  const rangeAdvances = isNewerThan(facet.target.version, facet.current)
+  const latestAdvances = isNewerThan(facet.latest.version, facet.current)
+  if (!rangeAdvances && !latestAdvances) return { kind: 'current', facet }
+
+  const advancing: AdvancingChoices =
+    rangeAdvances && latestAdvances ? 'range-and-latest' : rangeAdvances ? 'range-only' : 'latest-only'
+  return { kind: 'candidate', facet, advancing }
+}

--- a/packages/engine/src/install/update/index.ts
+++ b/packages/engine/src/install/update/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Update planning: the engine surface `facet update` is built on.
+ *
+ * Only the two-phase entry point and the shapes the CLI has to render
+ * are re-exported. Discovery, grouping, version ordering, and specifier
+ * rewriting stay behind this boundary on purpose — every one of them is
+ * a question the engine answers once so the CLI cannot answer it a
+ * second, slightly different way.
+ */
+
+export type { AuthoredSpecifier, UpdateChoice } from './manifest-source.ts'
+export { type PrepareFacetUpdateArgs, prepareFacetUpdate } from './prepare.ts'
+export type {
+  AdvancingChoices,
+  CheckableRegistryFacet,
+  PreparedFacetUpdate,
+  PrepareFacetUpdateFailure,
+  PrepareFacetUpdateResult,
+  ResolvedChoice,
+  UnusableFacetState,
+  UnusableStateReason,
+  UpdatePlanRow,
+} from './types.ts'
+export type { ExactVersion } from './version-order.ts'

--- a/packages/engine/src/install/update/manifest-source.ts
+++ b/packages/engine/src/install/update/manifest-source.ts
@@ -1,0 +1,80 @@
+/**
+ * Deriving the `facets.json` value an update commits.
+ *
+ * Two independent things change when a facet is updated: the exact
+ * version that gets installed, and the specifier the project keeps
+ * declaring. They are not the same value and must not be conflated —
+ * installing `1.5.0` for an entry authored as `1.*` has to preserve
+ * `1.*` in the manifest. This module owns the second one, alone, so
+ * dry-run previews and real application cannot disagree about what a
+ * selection would write.
+ */
+
+import type { VersionSpec } from '@agent-facets/protocol'
+import { describeVersionSpec } from '../../registry/describe.ts'
+import type { ExactVersion } from './version-order.ts'
+
+/**
+ * A manifest entry's declared version intent, as both the verbatim
+ * string the user wrote and its parsed form.
+ *
+ * Both are carried because both are load-bearing: the parsed spec
+ * decides how a rewrite should be shaped, while the original string is
+ * what gets preserved byte-for-byte whenever the rewrite is a no-op.
+ * Re-rendering an unchanged specifier from its parsed form would be a
+ * silent reformat of something the user typed.
+ */
+export interface AuthoredSpecifier {
+  source: string
+  spec: VersionSpec
+}
+
+/**
+ * Which of a row's two resolved versions the user picked.
+ *
+ * `range` is the version the authored specifier itself resolves to;
+ * `latest` is the registry's newest release regardless of that
+ * specifier.
+ */
+export type UpdateChoice = 'range' | 'latest'
+
+/**
+ * The `facets.json` value to commit for a selected update.
+ *
+ * Choosing `range` never rewrites anything: the authored specifier
+ * already permits the selected version, so the declared intent is
+ * unchanged and the original string is returned verbatim.
+ *
+ * Choosing `latest` may cross the authored range, so the specifier is
+ * widened by the smallest edit that includes the selected version while
+ * preserving how the user chose to express intent:
+ *
+ *   - `1.2.0`  + `2.4.1` → `2.4.1`  (a pin stays a pin, at the new version)
+ *   - `1.*`    + `2.4.1` → `2.*`    (major-pinned stays major-pinned)
+ *   - `1.2.*`  + `2.4.1` → `2.4.*`  (minor-pinned stays minor-pinned)
+ *   - `*`      + `2.4.1` → `*`      (already floats; nothing to widen)
+ *   - `latest` + `2.4.1` → `latest` (likewise, and the spelling is kept)
+ *
+ * The floating forms return the authored string rather than a rendered
+ * one so `*` and `latest` each survive as written.
+ */
+export function finalManifestSource(args: {
+  authored: AuthoredSpecifier
+  choice: UpdateChoice
+  selected: ExactVersion
+}): string {
+  const { authored, choice, selected } = args
+  if (choice === 'range') return authored.source
+
+  switch (authored.spec.kind) {
+    case 'exact':
+      return describeVersionSpec(selected)
+    case 'majorWildcard':
+      return describeVersionSpec({ kind: 'majorWildcard', major: selected.major })
+    case 'minorWildcard':
+      return describeVersionSpec({ kind: 'minorWildcard', major: selected.major, minor: selected.minor })
+    case 'wildcard':
+    case 'latest':
+      return authored.source
+  }
+}

--- a/packages/engine/src/install/update/prepare.ts
+++ b/packages/engine/src/install/update/prepare.ts
@@ -1,0 +1,82 @@
+/**
+ * Phase one of updating: work out what could change, touching nothing.
+ *
+ * Preparation deliberately runs without the project install lock. A user
+ * reading an interactive picker, or an automation printing a dry run,
+ * should not hold machine-wide lock state for as long as they take to
+ * decide — and a preview that created lock infrastructure would not be
+ * much of a preview. The cost of staying lock-free is that the project
+ * can move underneath a plan, which is why the exact bytes both files
+ * were read at travel with the plan and get checked again before
+ * anything is written.
+ */
+
+import { fileStatesEqual } from '@agent-facets/common'
+import { loadProjectManifest, manifestLoadFailure } from '../../manifest/project-files.ts'
+import { loadLockfile } from '../lockfile-io.ts'
+import { discoverUpdates, type ResolveMetadataBatch } from './discover.ts'
+import type { PrepareFacetUpdateResult } from './types.ts'
+
+export interface PrepareFacetUpdateArgs {
+  projectRoot: string
+  /** Injectable batch resolver; defaults to the real registry client. */
+  resolve?: ResolveMetadataBatch
+}
+
+/**
+ * Load the project, resolve every registry facet's choices, and return a
+ * plan bound to the state it was built from.
+ *
+ * The installed version of each facet is read from the lockfile and
+ * never re-resolved. Update does not ask the registry whether what you
+ * already have still exists: a yanked release is a real situation that
+ * `facet install` is responsible for, and treating it as an update
+ * precondition would turn one command into a second drift repairer.
+ *
+ * Performs no writes of any kind — no downloads, no cache population, no
+ * adapter installation or selection, no lock directory, and no change to
+ * the manifest, lockfile, receipt, materialized assets, or native
+ * configuration.
+ */
+export async function prepareFacetUpdate(args: PrepareFacetUpdateArgs): Promise<PrepareFacetUpdateResult> {
+  const { projectRoot } = args
+
+  const manifest = loadProjectManifest(projectRoot)
+  if (!manifest.ok) return { ok: false, failure: manifestLoadFailure(projectRoot, manifest) }
+
+  const lockfile = loadLockfile(projectRoot)
+  if (!lockfile.ok) return { ok: false, failure: { reason: 'lockfile-read', error: lockfile.error } }
+
+  const discovered = await discoverUpdates({
+    facets: manifest.manifest.facets,
+    lockfile: lockfile.parsed.lockfile,
+    ...(args.resolve ? { resolve: args.resolve } : {}),
+  })
+  if (!discovered.ok) return { ok: false, failure: discovered.failure }
+
+  // Re-read both files now that the network round trip is over. A change
+  // during discovery means the plan describes a project that no longer
+  // exists, and the honest move is to withdraw it rather than show the
+  // user choices derived from bytes someone has already replaced.
+  const manifestAfter = loadProjectManifest(projectRoot)
+  if (!manifestAfter.ok) return { ok: false, failure: manifestLoadFailure(projectRoot, manifestAfter) }
+  if (!fileStatesEqual(manifest.state, manifestAfter.state)) {
+    return { ok: false, failure: { reason: 'project-changed-during-discovery', file: 'manifest' } }
+  }
+
+  const lockfileAfter = loadLockfile(projectRoot)
+  if (!lockfileAfter.ok) return { ok: false, failure: { reason: 'lockfile-read', error: lockfileAfter.error } }
+  if (!fileStatesEqual(lockfile.state, lockfileAfter.state)) {
+    return { ok: false, failure: { reason: 'project-changed-during-discovery', file: 'lockfile' } }
+  }
+
+  return {
+    ok: true,
+    prepared: {
+      projectRoot,
+      plan: discovered.plan,
+      manifestState: manifest.state,
+      lockfileState: lockfile.state,
+    },
+  }
+}

--- a/packages/engine/src/install/update/types.ts
+++ b/packages/engine/src/install/update/types.ts
@@ -1,0 +1,156 @@
+/**
+ * The shapes update planning hands to the CLI.
+ *
+ * Two rules shape everything here. First, the engine answers every
+ * version question once — which releases exist, which of them advance,
+ * what the manifest would say afterwards — so the CLI renders a decision
+ * rather than recomputing one. Second, the answers are tagged unions
+ * rather than optional fields, so "a facet with no target", "a git facet
+ * that was checked anyway", or "a candidate that advances nothing" are
+ * not values anyone can construct.
+ */
+
+import type { FileState } from '@agent-facets/common'
+import type { ManifestLoadFailure } from '../../manifest/project-files.ts'
+import type { RegistryError, RegistryMetadata } from '../../registry/types.ts'
+import type { AuthoredSpecifier } from './manifest-source.ts'
+import type { ExactVersion } from './version-order.ts'
+
+/**
+ * One version the registry resolved for a facet, ready to be both shown
+ * and installed.
+ *
+ * `version` is the parsed form of `metadata.version`. They are two
+ * representations of one fact rather than two facts: discovery is the
+ * only place a `ResolvedChoice` is built, and it refuses any response
+ * whose version is not an exact `MAJOR.MINOR.PATCH`, so the pair is
+ * established together at that boundary. Carrying the parsed form is
+ * what lets ordering and display stay parse-free; carrying the metadata
+ * is what lets application install this exact release without asking
+ * the registry a second time.
+ */
+export interface ResolvedChoice {
+  version: ExactVersion
+  metadata: RegistryMetadata
+}
+
+/**
+ * A registry facet whose local state is good enough to answer update
+ * questions about: the manifest declares it, the lockfile records an
+ * exact version, and that version satisfies what the manifest declares.
+ */
+export interface CheckableRegistryFacet {
+  name: string
+  authored: AuthoredSpecifier
+  /** The installed version, read from the lockfile and never re-resolved. */
+  current: ExactVersion
+  /** What the authored specifier resolves to now. */
+  target: ResolvedChoice
+  /** What the registry's newest release is, ignoring the authored specifier. */
+  latest: ResolvedChoice
+}
+
+/**
+ * Which of a candidate's two choices are newer than what is installed.
+ *
+ * In practice Latest is never older than Target — both come from the
+ * same published set, and Target is drawn from a subset of it — so
+ * `range-only` should not occur. It stays representable anyway: that
+ * ordering is a property of the registry's answers, not of this type,
+ * and a state the registry can produce should not be one the CLI has to
+ * call unreachable.
+ */
+export type AdvancingChoices = 'range-and-latest' | 'range-only' | 'latest-only'
+
+/**
+ * One line of the update plan.
+ *
+ * `candidate` and `current` split what a single "outdated?" boolean
+ * would blur, and `candidate` carries which choices actually advance so
+ * no caller has to re-derive it: plain update takes the rows whose range
+ * advances, `--latest` takes the rows whose latest advances, and the
+ * picker refuses to select a choice that is not among them.
+ */
+export type UpdatePlanRow =
+  | { kind: 'candidate'; facet: CheckableRegistryFacet; advancing: AdvancingChoices }
+  | { kind: 'current'; facet: CheckableRegistryFacet }
+  | { kind: 'unsupported-source'; name: string; source: string; sourceKind: 'git' | 'local' }
+
+/**
+ * Why a registry facet could not be checked at all.
+ *
+ * Each of these means the project cannot answer "what is installed?"
+ * from its own files, which is a question update refuses to guess at:
+ * reporting such a facet as current would be a false clean report, and
+ * repairing it is `facet install`'s job, not update's.
+ */
+export type UnusableStateReason =
+  | { code: 'unparseable-source'; source: string; problem: string }
+  | { code: 'missing-lock-entry' }
+  | { code: 'lock-source-mismatch'; locked: 'git' | 'local' }
+  | { code: 'invalid-locked-version'; version: string }
+  | { code: 'locked-version-unsatisfying'; version: string; source: string }
+
+/** A named facet together with the reason it could not be checked. */
+export interface UnusableFacetState {
+  name: string
+  reason: UnusableStateReason
+}
+
+/**
+ * Everything that can stop a plan from being produced.
+ *
+ * `unusable-facet-state` carries every affected facet rather than the
+ * first one, so a single run tells the user the whole repair list.
+ *
+ * `discovery-failed` names no facet on purpose. The batch resolver
+ * reports the first failure in input order — which is what makes the
+ * reported error stable across runs — but it does not say which
+ * specifier produced it, and a `NETWORK_ERROR` genuinely belongs to no
+ * single facet. Inventing an attribution here would be a guess the user
+ * could act on wrongly; the registry's own error already names the facet
+ * whenever the registry knew one.
+ *
+ * `invalid-resolved-version` and `target-outside-range` are the registry
+ * answering incoherently rather than failing: a version that is not an
+ * exact release, or a Target that does not satisfy the specifier it was
+ * resolved from. Both are refusals to plan against an answer that cannot
+ * be true.
+ *
+ * `project-changed-during-discovery` exists because discovery is
+ * deliberately lock-free: the files are re-read afterwards, and a plan
+ * built against bytes that no longer exist is withdrawn instead of
+ * offered. A re-read that fails outright surfaces as the ordinary read
+ * failure for that file — it is a genuine read problem, not a race.
+ */
+export type PrepareFacetUpdateFailure =
+  | ManifestLoadFailure
+  | { reason: 'lockfile-read'; error: string }
+  | { reason: 'unusable-facet-state'; facets: readonly UnusableFacetState[] }
+  | { reason: 'discovery-failed'; error: RegistryError }
+  | { reason: 'invalid-resolved-version'; facet: string; lookup: 'target' | 'latest'; version: string }
+  | { reason: 'target-outside-range'; facet: string; source: string; version: string }
+  | { reason: 'project-changed-during-discovery'; file: 'manifest' | 'lockfile' }
+
+/**
+ * A reviewed plan plus the exact project bytes it was built from.
+ *
+ * The snapshots are the whole reason this type exists. Preparation runs
+ * without the install lock so a user can read an interactive screen
+ * without blocking every other facet operation on the machine; the
+ * price is that the project can change while they read. Carrying the
+ * exact `FileState` of both files lets application re-check, under the
+ * lock and before any mutation, that it is about to act on the same
+ * project the user was shown.
+ */
+export interface PreparedFacetUpdate {
+  projectRoot: string
+  plan: readonly UpdatePlanRow[]
+  manifestState: FileState
+  lockfileState: FileState
+}
+
+/** Outcome of preparing an update plan. Never throws. */
+export type PrepareFacetUpdateResult =
+  | { ok: true; prepared: PreparedFacetUpdate }
+  | { ok: false; failure: PrepareFacetUpdateFailure }

--- a/packages/engine/src/install/update/version-order.ts
+++ b/packages/engine/src/install/update/version-order.ts
@@ -1,0 +1,70 @@
+/**
+ * Exact-version identity and ordering for update planning.
+ *
+ * Update is the first operation in the CLI that has to answer "is this
+ * version newer than that one". Everything before it only ever asked
+ * "does this version satisfy that specifier", which protocol's
+ * `satisfies` answers by equality on the components a specifier pins.
+ * Ordering is a genuinely different question and needs its own
+ * primitive — but not its own grammar, which is why the parsing here
+ * routes through the same version-spec parser the manifest uses.
+ */
+
+import type { VersionSpec } from '@agent-facets/protocol'
+import { parseVersionSpec } from '../../sources/facet/parse-version.ts'
+
+/**
+ * An exact published version — the single `VersionSpec` arm that names
+ * one immutable release.
+ *
+ * Derived from `VersionSpec` rather than declared as a fresh
+ * `{ major, minor, patch }` interface so it stays structurally
+ * identical to the parsed form, passes to protocol's `satisfies`
+ * unchanged, and cannot drift if the grammar ever grows a component.
+ */
+export type ExactVersion = Extract<VersionSpec, { kind: 'exact' }>
+
+/**
+ * Parse an exact `MAJOR.MINOR.PATCH` string, or `undefined` when the
+ * value is any other version form.
+ *
+ * `undefined` rather than a tagged failure: there is exactly one way to
+ * not be an exact version, and callers uniformly turn that into their
+ * own domain failure (an unusable lockfile version, a non-conforming
+ * registry response) with context this function does not have.
+ *
+ * Unlike `parseLockedVersion`, this never throws. It is meant for
+ * strings whose shape has not already been narrowed by a schema —
+ * lockfile entries read from disk, versions returned over the wire.
+ */
+export function parseExactVersion(value: string): ExactVersion | undefined {
+  const parsed = parseVersionSpec(value)
+  if (!parsed.ok || parsed.value.kind !== 'exact') return undefined
+  return parsed.value
+}
+
+/**
+ * Order two exact versions: negative when `a` precedes `b`, zero when
+ * they are the same release, positive when `a` follows `b`.
+ *
+ * Numeric per component, so `1.10.0` correctly follows `1.9.0` — the
+ * trap that makes `compareCodeUnits` (used for lockfile key ordering)
+ * the wrong tool for versions.
+ */
+export function compareExactVersions(a: ExactVersion, b: ExactVersion): number {
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  return a.patch - b.patch
+}
+
+/**
+ * True when `candidate` is strictly newer than `current`.
+ *
+ * The strictness is the point: update never selects a version equal to
+ * or older than what is installed, so every "can this be chosen"
+ * question in discovery, selection, and application resolves through
+ * this one predicate.
+ */
+export function isNewerThan(candidate: ExactVersion, current: ExactVersion): boolean {
+  return compareExactVersions(candidate, current) > 0
+}

--- a/packages/engine/src/registry/__tests__/resolve-metadata.test.ts
+++ b/packages/engine/src/registry/__tests__/resolve-metadata.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { metadataFromWire } from '../resolve-metadata.ts'
+import type { RegistrySpec } from '../types.ts'
 
 const VALID = {
   name: 'cowsay',
@@ -20,9 +21,15 @@ const VALID = {
   content_integrity: 'sha256:2222222222222222222222222222222222222222222222222222222222222222',
 }
 
+/** The request `VALID` is the response to. */
+const REQUESTED: RegistrySpec = {
+  name: 'cowsay',
+  version: { kind: 'exact', major: 0, minor: 0, patch: 1 },
+}
+
 describe('metadataFromWire — runtime guard on the two hash fields', () => {
   test('maps a conforming body to domain-explicit names', () => {
-    const result = metadataFromWire(VALID)
+    const result = metadataFromWire(VALID, REQUESTED)
     if (!result.ok) expect.unreachable()
     expect(result.value).toEqual({
       name: 'cowsay',
@@ -34,7 +41,7 @@ describe('metadataFromWire — runtime guard on the two hash fields', () => {
 
   test('fails closed when content_integrity is missing (stale CDN shape)', () => {
     const stale = { ...VALID, content_integrity: undefined } as unknown as typeof VALID
-    const result = metadataFromWire(stale)
+    const result = metadataFromWire(stale, REQUESTED)
     if (result.ok) expect.unreachable()
     expect(result.error.code).toBe('UNEXPECTED_ERROR')
     if (result.error.code !== 'UNEXPECTED_ERROR') expect.unreachable()
@@ -43,14 +50,14 @@ describe('metadataFromWire — runtime guard on the two hash fields', () => {
   })
 
   test('fails closed when content_integrity is an empty string', () => {
-    const result = metadataFromWire({ ...VALID, content_integrity: '' })
+    const result = metadataFromWire({ ...VALID, content_integrity: '' }, REQUESTED)
     if (result.ok) expect.unreachable()
     expect(result.error.code).toBe('UNEXPECTED_ERROR')
   })
 
   test('fails closed when content_hash is missing', () => {
     const stale = { ...VALID, content_hash: undefined } as unknown as typeof VALID
-    const result = metadataFromWire(stale)
+    const result = metadataFromWire(stale, REQUESTED)
     if (result.ok) expect.unreachable()
     expect(result.error.code).toBe('UNEXPECTED_ERROR')
     if (result.error.code !== 'UNEXPECTED_ERROR') expect.unreachable()
@@ -59,8 +66,57 @@ describe('metadataFromWire — runtime guard on the two hash fields', () => {
 
   test('fails closed when a hash field is a non-string value', () => {
     const mangled = { ...VALID, content_integrity: 42 } as unknown as typeof VALID
-    const result = metadataFromWire(mangled)
+    const result = metadataFromWire(mangled, REQUESTED)
     if (result.ok) expect.unreachable()
     expect(result.error.code).toBe('UNEXPECTED_ERROR')
+  })
+})
+
+describe('metadataFromWire — checking the response against the request', () => {
+  test('refuses a body describing a different facet', () => {
+    const result = metadataFromWire({ ...VALID, name: 'not-cowsay' }, REQUESTED)
+    if (result.ok) expect.unreachable()
+    if (result.error.code !== 'UNEXPECTED_ERROR') expect.unreachable()
+    expect(result.error.cause).toContain('cowsay')
+  })
+
+  test('refuses a missing or non-string name', () => {
+    const nameless = { ...VALID, name: undefined } as unknown as typeof VALID
+    const result = metadataFromWire(nameless, REQUESTED)
+    if (result.ok) expect.unreachable()
+    expect(result.error.code).toBe('UNEXPECTED_ERROR')
+  })
+
+  test.each(['latest', '1.2', '1.*', '', 'v1.0.0'])('refuses the non-exact resolved version %p', (version) => {
+    const result = metadataFromWire({ ...VALID, version }, REQUESTED)
+    if (result.ok) expect.unreachable()
+    expect(result.error.code).toBe('UNEXPECTED_ERROR')
+  })
+
+  test('accepts a wildcard request answered with an exact version', () => {
+    // The whole point of a wildcard: the server picks. What it picks
+    // still has to be a concrete release.
+    const result = metadataFromWire(
+      { ...VALID, version: '3.1.4' },
+      {
+        name: 'cowsay',
+        version: { kind: 'majorWildcard', major: 3 },
+      },
+    )
+    if (!result.ok) expect.unreachable()
+    expect(result.value.version).toBe('3.1.4')
+  })
+
+  test('does not check that the version satisfies the request', () => {
+    // Range satisfaction is the caller's question, answered in discovery
+    // where the authored specifier and its meaning are known.
+    const result = metadataFromWire(
+      { ...VALID, version: '9.9.9' },
+      {
+        name: 'cowsay',
+        version: { kind: 'majorWildcard', major: 1 },
+      },
+    )
+    expect(result.ok).toBe(true)
   })
 })

--- a/packages/engine/src/registry/index.ts
+++ b/packages/engine/src/registry/index.ts
@@ -26,7 +26,7 @@ export type { RetryConfig } from './middleware/retry.ts'
 export type { TimeoutConfig } from './middleware/timeout.ts'
 export type { PublishArgs, PublishResult } from './publish.ts'
 export { publishFacetVersion } from './publish.ts'
-export { resolveRegistryMetadataBatch } from './resolve-metadata.ts'
+export { MAX_REGISTRY_METADATA_SPECIFIERS, resolveRegistryMetadataBatch } from './resolve-metadata.ts'
 export type { RegistryError, RegistryMetadata, RegistryResult, RegistrySpec } from './types.ts'
 export type {
   WireAssetCounts,

--- a/packages/engine/src/registry/resolve-metadata.ts
+++ b/packages/engine/src/registry/resolve-metadata.ts
@@ -1,8 +1,20 @@
+import { parseVersionSpec } from '../sources/facet/parse-version.ts'
 import { createRegistryClient, translateThrownError, translateWireError } from './client.ts'
 import { resolveCredential } from './credentials.ts'
 import { describeVersionSpec } from './describe.ts'
 import { facetNameToRoute } from './http.ts'
 import type { RegistryMetadata, RegistryResult, RegistrySpec } from './types.ts'
+
+/**
+ * Most specifiers one `resolveRegistryMetadataBatch` call accepts.
+ *
+ * The cap exists so a caller with an unbounded amount of work (update
+ * discovery, which asks for two specifiers per registry facet) has to
+ * decide how to group and pace that work instead of opening one socket
+ * per manifest entry. Callers import this constant rather than
+ * hard-coding 100, so the grouping and the limit can never disagree.
+ */
+export const MAX_REGISTRY_METADATA_SPECIFIERS = 100
 
 // Note on path-parameter encoding:
 //
@@ -14,28 +26,47 @@ import type { RegistryMetadata, RegistryResult, RegistrySpec } from './types.ts'
 /**
  * Resolve registry metadata for a batch of `(name, version)` pairs.
  *
- * V0 fans out concurrent per-spec fetches (no batch endpoint server-side
- * yet). Returns one RegistryMetadata per input spec in input order, or
- * surfaces NOT_FOUND / NETWORK_ERROR for the first failure encountered —
- * all-or-nothing semantics keep the caller-side branching simple. (No
- * partial-failure surface area in V0; if the demo is the use case, a
- * single facet is being resolved at a time anyway.)
+ * Returns one `RegistryMetadata` per input spec, in input order, or the
+ * first failure in that same order. All-or-nothing: a caller never gets
+ * a partially resolved set it could mistake for a complete answer.
+ * Because the failure is chosen by input position rather than by which
+ * request happened to settle first, the reported error is the same on
+ * every run regardless of network timing.
  *
- * Empty input returns `{ ok: true, value: [] }`.
+ * Empty input returns `{ ok: true, value: [] }` without resolving a
+ * credential or touching the network. More than
+ * `MAX_REGISTRY_METADATA_SPECIFIERS` specifiers returns
+ * `TOO_MANY_SPECIFIERS`, also before any request is issued.
+ *
+ * TODO: the registry has no batch metadata endpoint yet, so this fans
+ * out one concurrent request per specifier behind a single client. When
+ * the planned batch endpoint ships, replace the fan-out here; callers
+ * are already shaped for it because they group to the limit above.
  *
  * Version specs are sent verbatim in the form the user wrote (`1.2.3`,
- * `1.*`, `1.2.*`, `*`, `latest`). The server is the authority on which
- * forms it can resolve; the client must not silently widen a constrained
- * spec. V0 currently only resolves exact versions and `latest` — every
- * other form returns NOT_FOUND, which we surface unchanged. (Once the
- * server gains range-resolution support, this code does not need to
- * change.) The semantic correctness of the contract belongs on the
- * client; the limits of what's resolvable belong on the server.
+ * `1.*`, `1.2.*`, `*`, `latest`) — all five forms the registry resolves,
+ * with the server choosing which published version satisfies a wildcard.
+ * The client must not silently widen a constrained spec: the semantic
+ * correctness of the request belongs here, and the limits of what is
+ * resolvable belong on the server.
+ *
+ * Every response is checked against the request that produced it before
+ * it becomes a `RegistryMetadata` — see `metadataFromWire`.
  */
 export async function resolveRegistryMetadataBatch(
   specs: ReadonlyArray<RegistrySpec>,
 ): Promise<RegistryResult<ReadonlyArray<RegistryMetadata>>> {
   if (specs.length === 0) return { ok: true, value: [] }
+  if (specs.length > MAX_REGISTRY_METADATA_SPECIFIERS) {
+    return {
+      ok: false,
+      error: {
+        code: 'TOO_MANY_SPECIFIERS',
+        limit: MAX_REGISTRY_METADATA_SPECIFIERS,
+        received: specs.length,
+      },
+    }
+  }
 
   // Reads carry the credential opportunistically: when one is
   // available it earns the authenticated rate-limit tier; when absent
@@ -45,17 +76,17 @@ export async function resolveRegistryMetadataBatch(
     credential: cred.source === 'absent' ? undefined : cred.token,
   })
   const results = await Promise.all(specs.map((spec) => fetchOne(client, spec)))
-  for (const r of results) {
-    if (!r.ok) return r
+
+  // One pass in input order: the first failure wins, and the success
+  // list is built from the same narrowing that proved it. Scanning for
+  // failures and then re-narrowing in a second pass would leave a
+  // branch the compiler can't discharge and that can't happen.
+  const resolved: RegistryMetadata[] = []
+  for (const result of results) {
+    if (!result.ok) return result
+    resolved.push(result.value)
   }
-  return {
-    ok: true,
-    value: results.map((r) => {
-      // Type narrowing for the all-ok case.
-      if (!r.ok) throw new Error('unreachable: failure should have short-circuited')
-      return r.value
-    }),
-  }
+  return { ok: true, value: resolved }
 }
 
 /**
@@ -115,38 +146,73 @@ async function fetchOne(
       }
     }
 
-    return metadataFromWire(data)
+    return metadataFromWire(data, spec)
   } catch (err) {
     return { ok: false, error: translateThrownError(err) }
   }
 }
 
 /**
- * Map a wire metadata body to the internal `RegistryMetadata`, with a
- * runtime guard on the two hash fields.
+ * Map a wire metadata body to the internal `RegistryMetadata`, checking
+ * it against the request that produced it.
  *
- * The generated types declare `content_hash` and `content_integrity`
- * as required strings, but `openapi-fetch` performs no response
- * validation — a stale CDN-cached pre-migration object (camelCase, no
- * `content_integrity`) deserializes with those fields `undefined`.
- * Propagating `undefined` into the integrity chain would silently
- * disable confirmation, so a missing or empty hash field fails closed
- * as a structured contract violation. Never fall back to the other
- * hash or skip the check (design D3a risk note).
+ * `openapi-fetch` performs no response validation — the generated types
+ * are a compile-time claim about the schema, not a runtime guarantee
+ * about the bytes that arrived. Four things are therefore established
+ * here, all failing closed as structured contract violations:
+ *
+ *   - **Identity.** The body must describe the facet that was asked
+ *     for. A response for some other name — a misrouted request, a
+ *     mixed-up cache key — would otherwise install one facet's content
+ *     under another facet's entry.
+ *   - **Exact version.** The resolved version must be an exact
+ *     `MAJOR.MINOR.PATCH` this CLI understands, parsed through the same
+ *     grammar the manifest uses. A wildcard or tag coming back where a
+ *     concrete version belongs means nothing downstream can treat the
+ *     result as an immutable published identity.
+ *   - **`content_hash`** and **`content_integrity`.** A stale
+ *     CDN-cached pre-migration object (camelCase, no
+ *     `content_integrity`) deserializes with these `undefined`.
+ *     Propagating `undefined` into the integrity chain would silently
+ *     disable confirmation, so a missing or empty hash fails closed.
+ *     Never fall back to the other hash or skip the check (design D3a
+ *     risk note).
+ *
+ * This does not check that the version *satisfies* the requested spec.
+ * Whether `1.*` should have produced `1.8.0` is a question about the
+ * caller's intent, and the caller that cares (update discovery) holds
+ * the authored specifier and answers it there.
  *
  * Exported for unit testing.
  */
-export function metadataFromWire(body: {
-  name: string
-  version: string
-  content_hash: string
-  content_integrity: string
-}): RegistryResult<RegistryMetadata> {
+export function metadataFromWire(
+  body: {
+    name: string
+    version: string
+    content_hash: string
+    content_integrity: string
+  },
+  requested: RegistrySpec,
+): RegistryResult<RegistryMetadata> {
+  if (!isNonEmptyString(body.name) || body.name !== requested.name) {
+    return contractViolation(
+      body,
+      `identifies a different facet than the requested "${requested.name}"; ` +
+        'refusing to resolve a facet the caller did not ask for',
+    )
+  }
+  if (!isNonEmptyString(body.version) || !isExactVersion(body.version)) {
+    return contractViolation(
+      body,
+      `did not resolve to an exact MAJOR.MINOR.PATCH version (requested ${describeVersionSpec(requested.version)}); ` +
+        'refusing to proceed without an immutable published version',
+    )
+  }
   if (!isNonEmptyString(body.content_hash)) {
-    return contractViolation(body, 'content_hash')
+    return missingHashField(body, 'content_hash')
   }
   if (!isNonEmptyString(body.content_integrity)) {
-    return contractViolation(body, 'content_integrity')
+    return missingHashField(body, 'content_integrity')
   }
   return {
     ok: true,
@@ -163,17 +229,34 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0
 }
 
-function contractViolation(
+/**
+ * True when a version string is an exact `MAJOR.MINOR.PATCH`.
+ *
+ * Reuses the manifest version-spec grammar rather than a local regex so
+ * there is one definition of what an exact version looks like across
+ * manifests, lockfiles, and registry responses.
+ */
+function isExactVersion(value: string): boolean {
+  const parsed = parseVersionSpec(value)
+  return parsed.ok && parsed.value.kind === 'exact'
+}
+
+function missingHashField(
   body: { name: string; version: string },
   field: 'content_hash' | 'content_integrity',
 ): RegistryResult<RegistryMetadata> {
+  return contractViolation(
+    body,
+    `is missing a usable ${field} (stale CDN-cached or non-conforming response); refusing to proceed without it`,
+  )
+}
+
+function contractViolation(body: { name: string; version: string }, detail: string): RegistryResult<RegistryMetadata> {
   return {
     ok: false,
     error: {
       code: 'UNEXPECTED_ERROR',
-      cause:
-        `registry metadata for ${body.name}@${body.version} is missing a usable ${field} ` +
-        '(stale CDN-cached or non-conforming response); refusing to proceed without it',
+      cause: `registry metadata for ${body.name}@${body.version} ${detail}`,
     },
   }
 }

--- a/packages/engine/src/registry/types.ts
+++ b/packages/engine/src/registry/types.ts
@@ -73,6 +73,13 @@ export interface RegistrySpec {
  *     `facetVersion` this CLI cannot verify. Carries the observed and
  *     supported versions so the CLI can render upgrade guidance from
  *     its compatibility table.
+ *   - `TOO_MANY_SPECIFIERS`: a batch metadata call passed more
+ *     specifiers than one invocation accepts. This is a caller-contract
+ *     violation rather than anything the registry said — it is a value
+ *     instead of a throw so the limit is part of the function's return
+ *     type and callers that fan out (update discovery) are forced to
+ *     group before they ever reach the network. Carries both numbers so
+ *     the message can name the limit that was exceeded and by how much.
  */
 export type RegistryError =
   | { code: 'REGISTRY_REJECTED'; wireCode: string; error: string; fix: string; docsUrl: string }
@@ -81,6 +88,7 @@ export type RegistryError =
   | { code: 'NETWORK_ERROR'; cause: string; attempts: number }
   | { code: 'UNEXPECTED_ERROR'; cause: string }
   | { code: 'UNSUPPORTED_ARCHIVE'; observed: number | undefined; supported: readonly number[] }
+  | { code: 'TOO_MANY_SPECIFIERS'; limit: number; received: number }
 
 /**
  * Result type for registry operations. Discriminated by `ok`.


### PR DESCRIPTION
### Why

`facet update` needs a read-only planning phase that can tell the user what each registry facet is currently installed at and what it could move to, without touching any project files, cache, or lock infrastructure.

### Details

**Update planning (`packages/engine/src/install/update/`)**

A new `prepareFacetUpdate` entry point runs in two phases. First, it validates local state entirely — every registry facet must have a lockfile entry whose version satisfies the authored specifier, or the whole run fails before any network request is issued. Second, it fans out registry lookups for two specifiers per facet (the authored one for "target", and `latest`), groups them to stay within the batch limit, and issues the groups concurrently. Results are paired back to facets in manifest order so the plan is stable regardless of which request settled first.

The plan is returned alongside the exact `FileState` of both `facets.json` and `facets.lock` at the time it was built. Because preparation runs without the install lock, the project can change while a user reads an interactive picker or a dry-run preview. The commit phase re-reads both files under the lock and compares states; if anything changed, the plan is withdrawn rather than applied against bytes the user was never shown.

**`TOO_MANY_SPECIFIERS` error code**

`resolveRegistryMetadataBatch` now enforces a hard cap of 100 specifiers per call (`MAX_REGISTRY_METADATA_SPECIFIERS`), returning a structured `TOO_MANY_SPECIFIERS` error before issuing any request. This forces callers with unbounded work (update discovery) to group explicitly, and makes the limit part of the function's return type rather than an implicit assumption. The CLI translates this error as a CLI defect rather than a registry or project problem.

**`metadataFromWire` hardening**

The wire-to-domain mapping now checks two additional invariants: the response must name the same facet that was requested (guarding against misrouted requests or mixed-up cache keys), and the resolved version must be an exact `MAJOR.MINOR.PATCH` (guarding against a wildcard or tag coming back where a concrete immutable identity is required). Range satisfaction — whether `1.*` should have produced `1.8.0` — is left to the caller that holds the authored specifier.

**`parseManifestFacetSource` consolidation**

The logic for interpreting a `facets.json` value (bare version specifier vs. self-contained source string) was duplicated across commit resolution and drift detection. It is now a single named function that all three subsystems — commit, drift, and update discovery — call identically.

### Verification

CI. The new modules are covered by unit tests for version ordering, specifier rewriting, discovery classification, batching and concurrency, and the full `prepareFacetUpdate` lifecycle against a real temporary project tree (including side-effect freedom and the project-changed-during-discovery withdrawal).