### PR TITLE
Add short-flag aliases to CLI flag metadata, parser, and help rendering

### DIFF
--- a/openspec/changes/add-facet-update-command/tasks.md
+++ b/openspec/changes/add-facet-update-command/tasks.md
@@ -57,20 +57,20 @@
 - [x] 4.6 Implement: Add transaction tests for stale manifest and lockfile snapshots, publication after discovery, no secondary metadata request, mixed selected/unselected facets, comment and override preservation, alias and omission lockfile dispositions, old-to-new summaries, exact pins versus range and latest choices, and compile-time/runtime proof that frozen mode is representable only by the reproduce operation.
 - [x] 4.7 Implement: Add failure-path tests proving multi-facet atomicity, integrity failure rollback, collision and MCP consent behavior, takeover handling, and path-level restoration reporting remain identical to other installation operations.
 - [x] 4.8 Verify: Run targeted install/update tests plus engine and CLI typechecks to verify the operation-union migration and application path.
-- [ ] 4.9 Pause: Model-switch boundary before short-flag research.
+- [x] 4.9 Pause: Model-switch boundary before short-flag research.
 
 ## 5. CLI Short-Flag Metadata — Research
 
-- [ ] 5.1 Explore: Inspect `packages/cli/src/commands.ts`, `run.ts`, `help.ts`, `commands/shared/flags.ts`, parser alias support, undeclared dynamic-flag passthrough, help alignment, and existing alias tests.
-- [ ] 5.2 Propose: Define the canonical short-alias field, parser normalization, exclusion of short keys from handler passthrough, shared help rendering, and router-level regression coverage.
-- [ ] 5.3 Pause: Model-switch boundary before short-flag implementation.
+- [x] 5.1 Explore: Inspect `packages/cli/src/commands.ts`, `run.ts`, `help.ts`, `commands/shared/flags.ts`, parser alias support, undeclared dynamic-flag passthrough, help alignment, and existing alias tests.
+- [x] 5.2 Propose: Define the canonical short-alias field, parser normalization, exclusion of short keys from handler passthrough, shared help rendering, and router-level regression coverage.
+- [x] 5.3 Pause: Model-switch boundary before short-flag implementation.
 
 ## 6. CLI Short-Flag Metadata — Implementation
 
-- [ ] 6.1 Implement: Add canonical short aliases to command flag metadata and derive parser aliases from that field while preserving undeclared dynamic flags and exposing only canonical long-name values to handlers.
-- [ ] 6.2 Implement: Render long and short forms together in per-command help from the same declaration without a second alias map.
-- [ ] 6.3 Implement: Add router and help tests proving `-i` and `-L` set only their canonical values, undeclared dynamic flags retain existing behavior, and existing commands' help remains correctly aligned.
-- [ ] 6.4 Verify: Run targeted router/help tests and typecheck the CLI package.
+- [x] 6.1 Implement: Add canonical short aliases to command flag metadata and derive parser aliases from that field while preserving undeclared dynamic flags and exposing only canonical long-name values to handlers.
+- [x] 6.2 Implement: Render long and short forms together in per-command help from the same declaration without a second alias map.
+- [x] 6.3 Implement: Add router and help tests proving `-i` and `-L` set only their canonical values, undeclared dynamic flags retain existing behavior, and existing commands' help remains correctly aligned.
+- [x] 6.4 Verify: Run targeted router/help tests and typecheck the CLI package.
 - [ ] 6.5 Pause: Model-switch boundary before update-command research.
 
 ## 7. Update Command and Presentation — Research

--- a/packages/cli/src/__tests__/help.test.ts
+++ b/packages/cli/src/__tests__/help.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test'
+import type { Command } from '../commands.ts'
+import { printCommandHelp } from '../help.ts'
+import { captureLog } from './helpers/capture-log.ts'
+
+function helpFor(flags: Command['flags']): string {
+  return captureLog(() => {
+    printCommandHelp({
+      name: 'demo',
+      description: 'test command',
+      implemented: true,
+      ...(flags ? { flags } : {}),
+      run: async () => 0,
+    })
+  })
+}
+
+/**
+ * The Options block, as `[label, description]` pairs plus the column the
+ * description starts at. Alignment is asserted by comparing those columns
+ * to each other rather than by hardcoding a width, so the test says
+ * "these line up" instead of restating the padding arithmetic.
+ */
+function optionRows(help: string): { label: string; descriptionColumn: number }[] {
+  const lines = help.split('\n')
+  const start = lines.indexOf('Options:')
+  expect(start).toBeGreaterThanOrEqual(0)
+  return lines
+    .slice(start + 1)
+    .filter((line) => line.trim() !== '')
+    .map((line) => {
+      const match = /^ {2}(\S.*?) {2,}(\S.*)$/.exec(line)
+      if (match === null) expect.unreachable()
+      const [, label, description] = match
+      if (label === undefined || description === undefined) expect.unreachable()
+      return { label, descriptionColumn: line.indexOf(description) }
+    })
+}
+
+describe('per-command help — short aliases', () => {
+  test('a short alias renders with its long form from one declaration', () => {
+    const out = helpFor({
+      latest: { type: 'boolean', short: 'L', description: 'Update to the latest version' },
+    })
+    expect(out).toMatch(/^ +-L, --latest\s+Update to the latest version$/m)
+  })
+
+  test('descriptions stay aligned when a short-aliased label is the longest', () => {
+    const out = helpFor({
+      latest: { type: 'boolean', short: 'L', description: 'Update to the latest version' },
+      interactive: { type: 'boolean', short: 'i', description: 'Choose facets to update' },
+      'dry-run': { type: 'boolean', description: 'Preview without applying' },
+    })
+    const rows = optionRows(out)
+    // Four declared/implicit rows: three flags plus --help.
+    expect(rows.map((r) => r.label)).toEqual(['-L, --latest', '-i, --interactive', '--dry-run', '--help'])
+    const columns = new Set(rows.map((r) => r.descriptionColumn))
+    expect(columns.size).toBe(1)
+  })
+
+  test('a command with no short aliases renders exactly as before', () => {
+    const out = helpFor({
+      force: { type: 'boolean', description: 'Overwrite existing files' },
+      name: { type: 'string', description: 'Facet name' },
+    })
+    const rows = optionRows(out)
+    expect(rows.map((r) => r.label)).toEqual(['--force', '--name', '--help'])
+    expect(new Set(rows.map((r) => r.descriptionColumn)).size).toBe(1)
+    expect(out).not.toContain('-f,')
+  })
+
+  test('a command with no flags still documents --help', () => {
+    const out = helpFor(undefined)
+    expect(out).toMatch(/--help\s+Show help/)
+  })
+})

--- a/packages/cli/src/__tests__/helpers/capture-log.ts
+++ b/packages/cli/src/__tests__/helpers/capture-log.ts
@@ -1,0 +1,20 @@
+/**
+ * Capture `console.log` output during a synchronous body.
+ *
+ * `help.ts` writes through `console.log` rather than `process.stdout.write`,
+ * so the `capture-std` helpers cannot see it. Anything asserting on rendered
+ * help needs this one instead.
+ */
+export function captureLog(fn: () => void): string {
+  const original = console.log
+  let captured = ''
+  console.log = (...parts: unknown[]) => {
+    captured += `${parts.join(' ')}\n`
+  }
+  try {
+    fn()
+  } finally {
+    console.log = original
+  }
+  return captured
+}

--- a/packages/cli/src/__tests__/run-flags.test.ts
+++ b/packages/cli/src/__tests__/run-flags.test.ts
@@ -50,6 +50,69 @@ describe('run — undeclared flag passthrough', () => {
     await run(['demo', 'skill', 'greet', '--adapter-claude-code', '{"a":1}'], registry)
     expect(captured()?.flags['adapter-claude-code']).toBe('{"a":1}')
   })
+
+  // Declaring short aliases changes how the parser is configured, so the
+  // open-ended flags `modify` depends on have to keep working alongside them.
+  test('a command that declares short aliases still forwards open-ended flags', async () => {
+    const { registry, captured } = captureRegistry({
+      interactive: { type: 'boolean', short: 'i', description: 'interactive' },
+    })
+    await run(['demo', '--adapter-claude-code', '{"a":1}'], registry)
+    expect(captured()?.flags).toEqual({ 'adapter-claude-code': '{"a":1}' })
+  })
+})
+
+describe('run — declared short aliases', () => {
+  const SHORT_FLAGS = {
+    interactive: { type: 'boolean', short: 'i', description: 'interactive' },
+    latest: { type: 'boolean', short: 'L', description: 'latest' },
+  } as const satisfies Command['flags']
+
+  test('-i sets the canonical flag and nothing else', async () => {
+    const { registry, captured } = captureRegistry(SHORT_FLAGS)
+    await run(['demo', '-i'], registry)
+    expect(captured()?.flags).toEqual({ interactive: true })
+  })
+
+  test('-L sets the canonical flag and nothing else', async () => {
+    const { registry, captured } = captureRegistry(SHORT_FLAGS)
+    await run(['demo', '-L'], registry)
+    expect(captured()?.flags).toEqual({ latest: true })
+  })
+
+  test('the short and long spellings are indistinguishable to the handler', async () => {
+    const short = captureRegistry(SHORT_FLAGS)
+    await run(['demo', '-i', '-L'], short.registry)
+    const long = captureRegistry(SHORT_FLAGS)
+    await run(['demo', '--interactive', '--latest'], long.registry)
+    expect(short.captured()?.flags).toEqual(long.captured()?.flags ?? {})
+  })
+
+  // The parser types a token by the name as typed, before it rewrites
+  // aliases. A short boolean that isn't also declared boolean reads the next
+  // argument as its value, which would quietly eat a positional.
+  test('a short boolean does not consume the following positional', async () => {
+    const { registry, captured } = captureRegistry(SHORT_FLAGS)
+    await run(['demo', '-i', 'alpha'], registry)
+    expect(captured()?.args).toEqual(['alpha'])
+    expect(captured()?.flags).toEqual({ interactive: true })
+  })
+
+  test('a short string flag keeps its value a string', async () => {
+    const { registry, captured } = captureRegistry({
+      tag: { type: 'string', short: 't', description: 'tag' },
+    })
+    await run(['demo', '-t', '1.5'], registry)
+    expect(captured()?.flags.tag).toBe('1.5')
+  })
+
+  test('a short array flag collects alongside its long form', async () => {
+    const { registry, captured } = captureRegistry({
+      skill: { type: 'array', short: 's', description: 'skills' },
+    })
+    await run(['demo', '--skill', 'a', '-s', 'b'], registry)
+    expect(captured()?.flags).toEqual({ skill: ['a', 'b'] })
+  })
 })
 
 describe('run — global --version is positional-aware', () => {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -15,8 +15,51 @@ import { searchCommand } from './commands/search/index.ts'
 import { selfUpdateCommand } from './commands/self-update.ts'
 import { whoamiCommand } from './commands/whoami/index.ts'
 
+type LowercaseLetter =
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | 'j'
+  | 'k'
+  | 'l'
+  | 'm'
+  | 'n'
+  | 'o'
+  | 'p'
+  | 'q'
+  | 'r'
+  | 's'
+  | 't'
+  | 'u'
+  | 'v'
+  | 'w'
+  | 'x'
+  | 'y'
+  | 'z'
+
+/**
+ * A flag's single-character short form. Spelled as a letter union rather
+ * than `string` so `short: 'latest'` — which would parse as five clustered
+ * one-letter flags, not one long one — cannot be written in the first
+ * place.
+ */
+export type ShortFlagName = LowercaseLetter | Uppercase<LowercaseLetter>
+
 export type FlagDef = {
   type: 'boolean' | 'string' | 'array'
+  /**
+   * Optional one-character alias. `-L` and `--latest` are the same flag:
+   * the router hands the handler only the canonical long name, and help
+   * renders both forms from this one declaration. There is deliberately
+   * no second alias map to keep in sync.
+   */
+  short?: ShortFlagName
   description: string
 }
 

--- a/packages/cli/src/commands/__tests__/self-update.test.ts
+++ b/packages/cli/src/commands/__tests__/self-update.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, type Mock, spyOn, test } from 'bun:test'
 import * as coreModule from '@agent-facets/engine'
+import { captureLog } from '../../__tests__/helpers/capture-log.ts'
 import { allCommandNames, commands, resolveCommand } from '../../commands.ts'
 import { printCommandHelp, printGlobalHelp } from '../../help.ts'
 import { findClosestCommand } from '../../suggest.ts'
@@ -128,21 +129,6 @@ describe('selfUpdateCommand.run flag forwarding', () => {
 })
 
 // ─── Help rendering ──────────────────────────────────────────────────────
-
-/** Capture console.log output during a synchronous body. */
-function captureLog(fn: () => void): string {
-  const original = console.log
-  let captured = ''
-  console.log = (...parts: unknown[]) => {
-    captured += `${parts.join(' ')}\n`
-  }
-  try {
-    fn()
-  } finally {
-    console.log = original
-  }
-  return captured
-}
 
 describe('global help rendering', () => {
   test('lists self-update with self-upgrade as a comma-joined alias', () => {

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,4 +1,4 @@
-import type { Command } from './commands.ts'
+import type { Command, FlagDef } from './commands.ts'
 import { version } from './version.ts'
 
 /**
@@ -10,6 +10,16 @@ import { version } from './version.ts'
 function commandLabel(c: Command): string {
   if (c.aliases === undefined || c.aliases.length === 0) return c.name
   return [c.name, ...c.aliases].join(', ')
+}
+
+/**
+ * Render a flag's label in per-command help: `--latest`, or `-L, --latest`
+ * when the flag declares a short form. The same string is used to measure
+ * the Options column and to print the row, so a short alias can never
+ * shift a description out of alignment.
+ */
+function flagLabel(name: string, def: FlagDef): string {
+  return def.short === undefined ? `--${name}` : `-${def.short}, --${name}`
 }
 
 export function printGlobalHelp(commands: Record<string, Command>): void {
@@ -53,14 +63,16 @@ export function printCommandHelp(command: Command): void {
   const lines = [`Usage: facet ${command.name}${usage} [options]`, '', `  ${command.description}`, '', 'Options:']
 
   if (command.flags) {
-    const flagEntries = Object.entries(command.flags)
-    const maxFlagLength = Math.max(...flagEntries.map(([name]) => `--${name}`.length), '--help'.length)
+    const rows = Object.entries(command.flags).map(([name, def]) => ({
+      label: flagLabel(name, def),
+      description: def.description,
+    }))
+    rows.push({ label: '--help', description: 'Show help' })
 
-    for (const [name, def] of flagEntries) {
-      lines.push(`  ${`--${name}`.padEnd(maxFlagLength + 4)}${def.description}`)
+    const maxFlagLength = Math.max(...rows.map((row) => row.label.length))
+    for (const row of rows) {
+      lines.push(`  ${row.label.padEnd(maxFlagLength + 4)}${row.description}`)
     }
-
-    lines.push(`  ${'--help'.padEnd(maxFlagLength + 4)}Show help`)
   } else {
     lines.push('  --help    Show help')
   }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -62,16 +62,32 @@ export async function run(argv: string[], commands: Record<string, Command>): Pr
     return 0
   }
 
-  // Build per-command flag parsing config
+  // Build per-command flag parsing config.
+  //
+  // A flag that declares a short alias contributes BOTH spellings to its
+  // type bucket, and an `alias` entry pointing the short one at the long
+  // one. Both halves are needed: the parser decides whether a token takes a
+  // value from the name as typed, before it applies aliases, so a `-i` that
+  // is aliased but not also declared boolean would swallow the next argument
+  // as its value instead of leaving it a positional.
   const booleanFlags: string[] = []
   const stringFlags: string[] = []
   const arrayFlags: string[] = []
+  // Canonical long names only — what handlers are allowed to see.
+  const scalarNames: string[] = []
+  const arrayNames: string[] = []
+  const alias: Record<string, string> = {}
 
   if (command.flags) {
     for (const [name, def] of Object.entries(command.flags)) {
-      if (def.type === 'boolean') booleanFlags.push(name)
-      else if (def.type === 'string') stringFlags.push(name)
-      else if (def.type === 'array') arrayFlags.push(name)
+      const bucket = def.type === 'boolean' ? booleanFlags : def.type === 'string' ? stringFlags : arrayFlags
+      bucket.push(name)
+      if (def.type === 'array') arrayNames.push(name)
+      else scalarNames.push(name)
+      if (def.short !== undefined) {
+        bucket.push(def.short)
+        alias[def.short] = name
+      }
     }
   }
 
@@ -81,13 +97,14 @@ export async function run(argv: string[], commands: Record<string, Command>): Pr
     boolean: booleanFlags,
     string: stringFlags,
     array: arrayFlags,
+    alias,
   })
 
   // Build positional args and flags
   const positionalArgs = parsed._.map(String)
   const flags: Record<string, unknown> = {}
 
-  for (const name of [...booleanFlags, ...stringFlags]) {
+  for (const name of scalarNames) {
     if (parsed[name] !== undefined) {
       flags[name] = parsed[name]
     }
@@ -96,7 +113,7 @@ export async function run(argv: string[], commands: Record<string, Command>): Pr
   // Array flags always surface as `string[]`. The parser yields a bare value
   // for a single occurrence and an array for multiple; normalize both to an
   // array so command handlers never branch on arity.
-  for (const name of arrayFlags) {
+  for (const name of arrayNames) {
     const value = parsed[name]
     if (value === undefined) continue
     flags[name] = Array.isArray(value) ? value.map(String) : [String(value)]
@@ -106,6 +123,9 @@ export async function run(argv: string[], commands: Record<string, Command>): Pr
   // modify` uses open-ended `--adapter-<name>` / `--remove-adapter-<name>`
   // flags whose names can't be declared up front; it reads them from here.
   // Commands that declare all their flags simply never look at the extras.
+  //
+  // Short aliases are in these buckets too, so a declared short name can
+  // never reach a handler as a second, independent value.
   const declared = new Set([...booleanFlags, ...stringFlags, ...arrayFlags])
   for (const [key, value] of Object.entries(parsed)) {
     if (key === '_' || declared.has(key) || flags[key] !== undefined) continue


### PR DESCRIPTION
### Why

Commands need a way to declare single-character short aliases (e.g. `-i` for `--interactive`, `-L` for `--latest`) so users can type less without the CLI growing a separate alias map to maintain.

### Details

`FlagDef` gains an optional `short` field typed as `ShortFlagName` — a union of single uppercase and lowercase letters — so multi-character strings like `'latest'` are rejected at compile time before they can be silently parsed as clustered one-letter flags.

The parser configuration now registers both the short and long spellings in the appropriate type bucket (`boolean`, `string`, or `array`) and adds an `alias` entry pointing the short name at the long one. Both registrations are required: minimist resolves whether a token consumes the next argument from the name *as typed*, before alias rewriting, so a `-i` that is aliased but not declared boolean would silently eat the following positional.

Handler-visible flags are collected only from canonical long names (`scalarNames` / `arrayNames`), so a short alias can never appear as a second independent key in the flags object. The undeclared dynamic-flag passthrough that `modify` depends on is preserved: short names land in the `declared` set and are therefore excluded from the extras loop.

Help rendering derives the label (`-L, --latest` or `--latest`) from the same `FlagDef` that declares the flag, measures column width across all labels including `--help`, and pads uniformly — so adding a short alias to the longest flag cannot push descriptions out of alignment.

`captureLog` is extracted from the `self-update` test file into a shared helper so the new help tests can use it without duplicating the implementation.

### Verification

New tests in `run-flags.test.ts` cover: short booleans setting only the canonical key, short and long spellings producing identical handler input, short booleans not consuming following positionals, short string and array flags, and open-ended passthrough continuing to work alongside declared short aliases. New tests in `help.test.ts` cover: correct label rendering, description column alignment when a short-aliased label is the longest, no regression for commands with no short aliases, and `--help` always appearing. CI runs the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for short aliases for command-line flags, including boolean, string, and array options.
  * Short and long flag forms now resolve consistently to the same option.
  * Added automatic `--help` entries for commands and improved flag descriptions and alignment.

* **Bug Fixes**
  * Undeclared flags are now forwarded correctly when commands use short aliases.
  * Prevented duplicate values when aliases and full flag names are combined.

* **Tests**
  * Expanded coverage for aliases, help output, and flag parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->