### PR TITLE
Implement `facet update` command with interactive picker, dry-run preview, and `upgrade` alias

### DIFF
--- a/openspec/changes/add-facet-update-command/tasks.md
+++ b/openspec/changes/add-facet-update-command/tasks.md
@@ -71,26 +71,26 @@
 - [x] 6.2 Implement: Render long and short forms together in per-command help from the same declaration without a second alias map.
 - [x] 6.3 Implement: Add router and help tests proving `-i` and `-L` set only their canonical values, undeclared dynamic flags retain existing behavior, and existing commands' help remains correctly aligned.
 - [x] 6.4 Verify: Run targeted router/help tests and typecheck the CLI package.
-- [ ] 6.5 Pause: Model-switch boundary before update-command research.
+- [x] 6.5 Pause: Model-switch boundary before update-command research.
 
 ## 7. Update Command and Presentation — Research
 
-- [ ] 7.1 Explore: Inspect command registration and alias dispatch in `packages/cli/src/commands.ts`, `run.ts`, and `help.ts`, using `commands/self-update.ts` and `commands/remove/index.ts` as canonical alias examples.
-- [ ] 7.2 Explore: Inspect add/install/remove orchestration, `commands/shared/ensure-adapters.ts`, TTY gates, error translators, cancellation handling, and process-exit boundaries needed to preserve update ordering and exit semantics.
-- [ ] 7.3 Explore: Inspect static list rendering, `commands/adapter/install-picker.tsx`, `tui/views/install/collision/workspace.tsx`, `tui/views/install/install-view.tsx`, failure rendering, and Ink test utilities needed for preview, selection, progress, and rollback output.
-- [ ] 7.4 Propose: Define the cohesive update-command approach for registration, mode derivation, no-op and dry-run rendering, tagged picker rows, adapter ordering, shared installation presentation, error translation, and test coverage.
-- [ ] 7.5 Pause: Model-switch boundary before update-command implementation.
+- [x] 7.1 Explore: Inspect command registration and alias dispatch in `packages/cli/src/commands.ts`, `run.ts`, and `help.ts`, using `commands/self-update.ts` and `commands/remove/index.ts` as canonical alias examples.
+- [x] 7.2 Explore: Inspect add/install/remove orchestration, `commands/shared/ensure-adapters.ts`, TTY gates, error translators, cancellation handling, and process-exit boundaries needed to preserve update ordering and exit semantics.
+- [x] 7.3 Explore: Inspect static list rendering, `commands/adapter/install-picker.tsx`, `tui/views/install/collision/workspace.tsx`, `tui/views/install/install-view.tsx`, failure rendering, and Ink test utilities needed for preview, selection, progress, and rollback output.
+- [x] 7.4 Propose: Define the cohesive update-command approach for registration, mode derivation, no-op and dry-run rendering, tagged picker rows, adapter ordering, shared installation presentation, error translation, and test coverage.
+- [x] 7.5 Pause: Model-switch boundary before update-command implementation.
 
 ## 8. Update Command and Presentation — Implementation
 
-- [ ] 8.1 Implement: Register implemented `update` with `upgrade` only as its alias, remove the inert upgrade stub, define the supported flag surface, reject positional arguments with `--interactive` guidance, and distinguish project updates from `self-update` in help.
-- [ ] 8.2 Implement: Add static Current/Target/Latest plan rendering, unsupported-source rows, latest-mode manifest rewrite previews, and distinct successful no-op messages including the actionable `--latest` hint.
-- [ ] 8.3 Implement: Add the standalone update picker by reusing `install-picker.tsx` keyboard conventions and collision-workspace focus/interrupt behavior, with tagged selected/unselected rows, mode-specific initial choices, focused `l` toggling, non-advancing protection, and reliable cancellation.
-- [ ] 8.4 Implement: Add command orchestration in the required order: positional and TTY validation, preparation, optional interactive selection, dry-run stop, adapter selection, and guarded application with the complete 0/1/2 exit contract.
-- [ ] 8.5 Implement: Extend `InstallView`, shared summaries, failure remedies, stale-plan rendering, and path-level rollback detail for update mode without introducing a second progress pipeline.
-- [ ] 8.6 Implement: Add registration, help, command, static-view, picker, and install-view unit tests covering canonical/alias identity, mode defaults, cancellation, no-op output, output streams, and `--accept-mcp` boundaries.
-- [ ] 8.7 Implement: Add CLI end-to-end tests for global and per-command help, `upgrade` alias behavior, positional and non-TTY failures, dry-run without adapters, interactive cancellation before adapter installation, applied old-to-new summaries, stale plans, and expected exit codes.
-- [ ] 8.8 Verify: Run targeted CLI command, Ink, and end-to-end tests and typecheck the CLI package.
+- [x] 8.1 Implement: Register implemented `update` with `upgrade` only as its alias, remove the inert upgrade stub, define the supported flag surface, reject positional arguments with `--interactive` guidance, and distinguish project updates from `self-update` in help.
+- [x] 8.2 Implement: Add static Current/Target/Latest plan rendering, unsupported-source rows, latest-mode manifest rewrite previews, and distinct successful no-op messages including the actionable `--latest` hint.
+- [x] 8.3 Implement: Add the standalone update picker by reusing `install-picker.tsx` keyboard conventions and collision-workspace focus/interrupt behavior, with tagged selected/unselected rows, mode-specific initial choices, focused `l` toggling, non-advancing protection, and reliable cancellation.
+- [x] 8.4 Implement: Add command orchestration in the required order: positional and TTY validation, preparation, optional interactive selection, dry-run stop, adapter selection, and guarded application with the complete 0/1/2 exit contract.
+- [x] 8.5 Implement: Extend `InstallView`, shared summaries, failure remedies, stale-plan rendering, and path-level rollback detail for update mode without introducing a second progress pipeline.
+- [x] 8.6 Implement: Add registration, help, command, static-view, picker, and install-view unit tests covering canonical/alias identity, mode defaults, cancellation, no-op output, output streams, and `--accept-mcp` boundaries.
+- [x] 8.7 Implement: Add CLI end-to-end tests for global and per-command help, `upgrade` alias behavior, positional and non-TTY failures, dry-run without adapters, interactive cancellation before adapter installation, applied old-to-new summaries, stale plans, and expected exit codes.
+- [x] 8.8 Verify: Run targeted CLI command, Ink, and end-to-end tests and typecheck the CLI package.
 - [ ] 8.9 Pause: Model-switch boundary before documentation research.
 
 ## 9. Documentation and Agent Guidance — Research

--- a/packages/cli/src/__tests__/cli.e2e.test.ts
+++ b/packages/cli/src/__tests__/cli.e2e.test.ts
@@ -20,11 +20,16 @@ const IMPLEMENTED_COMMAND_NAMES = [
   'remove',
   'search',
   'self-update',
+  'update',
   'whoami',
 ]
 // Stubs — invocable (to surface "did you mean…" suggestions) but hidden from
 // the global help listing (Adjustment K).
-const STUB_COMMAND_NAMES = ['info', 'upgrade']
+//
+// `upgrade` used to be one of these. It is now an alias of `update`, which
+// is why it no longer appears here: it is not a hidden command, it is a
+// second spelling of a listed one.
+const STUB_COMMAND_NAMES = ['info']
 
 const runCli = (...args: string[]) => spawnCli(args)
 

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -1954,3 +1954,95 @@ describe('InstallView — declaration secrecy', () => {
     instance.unmount()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Update mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Update runs the same pipeline as everything else, so what is tested
+ * here is only what a user reading the screen would otherwise get wrong:
+ * which operation is running, and which version each facet ended up on.
+ */
+describe('InstallView — update mode', () => {
+  const updateResult: RunInstallResult = {
+    ok: true,
+    lockfile: { lockfileVersion: CURRENT_LOCKFILE_VERSION, facets: {} },
+    summary: {
+      facets: { installed: 0, updated: 2, repaired: 0, unchanged: 1, removed: 0 },
+      textAssets: { written: 4, removed: 0 },
+      mcp: NO_MCP_COUNTS,
+    },
+    perFacet: [
+      { kind: 'updated', name: 'alpha', oldVersion: '1.2.0', newVersion: '1.8.0' },
+      { kind: 'updated', name: 'beta', oldVersion: '1.2.0', newVersion: '3.4.1' },
+      { kind: 'unchanged', name: 'gamma', version: '4.0.0' },
+    ],
+    mcp: NO_MCP,
+  }
+
+  test('names the operation while it runs', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 2 }], updateResult),
+      }),
+    )
+    // The header is only on screen before the result replaces it.
+    await settle()
+    expect(instance.frames.some((frame) => visibleTerminalText(frame ?? '').includes('Updating facets:'))).toBe(true)
+    instance.unmount()
+  })
+
+  // "2 updated" says how many moved, not what anyone now has. The
+  // transition per facet is the answer to the question the command was
+  // run to ask.
+  test('names every version transition it applied', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 2 }], updateResult),
+      }),
+    )
+    await settle()
+    const frame = visibleTerminalText(visibleContentFrame(instance.frames))
+    expect(frame).toContain('Update complete.')
+    expect(frame).toContain('alpha 1.2.0 → 1.8.0')
+    expect(frame).toContain('beta 1.2.0 → 3.4.1')
+    // A facet that was left alone is counted, not narrated as a move.
+    expect(frame).not.toContain('gamma 4.0.0 →')
+    instance.unmount()
+  })
+
+  test('the timer counts facets moved, not facets touched', async () => {
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        run: makeFakeRun([{ kind: 'install-start', totalFacets: 2 }], updateResult),
+      }),
+    )
+    await settle()
+    expect(visibleTerminalText(visibleContentFrame(instance.frames))).toContain('Updated 2 facets')
+    instance.unmount()
+  })
+
+  test('a stale plan is reported as a failure, with the disk state', async () => {
+    const stale: RunInstallResult = {
+      ok: false,
+      failure: { code: 'UPDATE_PLAN_STALE', files: ['manifest'] },
+      rollback: NO_ROLLBACK,
+    }
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        run: makeFakeRun([], stale),
+      }),
+    )
+    await settle()
+    const frame = visibleTerminalText(visibleContentFrame(instance.frames))
+    expect(frame).toContain('facets.json')
+    expect(frame).toContain(visibleTerminalText(diskStateSentence(NO_ROLLBACK)))
+    expect(frame).not.toContain('Update complete.')
+    instance.unmount()
+  })
+})

--- a/packages/cli/src/__tests__/update.e2e.test.ts
+++ b/packages/cli/src/__tests__/update.e2e.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnCli } from './helpers/cli-process.ts'
+
+/**
+ * `facet update` through the compiled binary.
+ *
+ * Everything asserted here is something only the real process can show:
+ * which stream a message lands on, what the exit code is, and that two
+ * spellings of the command produce byte-identical output. The applying
+ * paths — resolution, the transaction, stale plans, rollback — are
+ * driven against a real project tree by the engine's own suite, which
+ * can do it without standing up a registry.
+ *
+ * No test here reaches the network. Each project is arranged so update
+ * fails or completes before any registry lookup would be issued.
+ */
+
+const projects: string[] = []
+
+function project(manifest: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'facet-update-e2e-'))
+  projects.push(dir)
+  writeFileSync(join(dir, 'facets.json'), JSON.stringify(manifest, null, 2))
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of projects.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('facet update — the command surface', () => {
+  test('global help lists update with upgrade as its alias', async () => {
+    const result = await spawnCli(['--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toMatch(/update,\s*upgrade/)
+  })
+
+  test('per-command help lists every supported flag, in both spellings', async () => {
+    const result = await spawnCli(['update', '--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Usage: facet update')
+    expect(result.stdout).toMatch(/-L, --latest\s+/)
+    expect(result.stdout).toMatch(/-i, --interactive\s+/)
+    expect(result.stdout).toMatch(/--dry-run\s+/)
+    expect(result.stdout).toMatch(/--verbose\s+/)
+    expect(result.stdout).toMatch(/--accept-mcp\s+/)
+  })
+
+  test('help does not offer a frozen mode, which update has no meaning for', async () => {
+    const result = await spawnCli(['update', '--help'])
+    expect(result.stdout).not.toContain('--frozen-lockfile')
+  })
+
+  test('help distinguishes project facets from the CLI binary', async () => {
+    const result = await spawnCli(['update', '--help'])
+    expect(result.stdout).toContain('self-update')
+  })
+
+  test('the alias produces byte-identical help', async () => {
+    const canonical = await spawnCli(['update', '--help'], { trim: false })
+    const alias = await spawnCli(['upgrade', '--help'], { trim: false })
+    expect(alias.exitCode).toBe(0)
+    expect(alias.stdout).toBe(canonical.stdout)
+  })
+
+  test('upgrade no longer reports itself as unimplemented', async () => {
+    const dir = project({ facets: {} })
+    const result = await spawnCli(['upgrade'], { cwd: dir })
+    expect(result.stdout).not.toContain('not yet implemented')
+    expect(result.exitCode).toBe(0)
+  })
+})
+
+describe('facet update — refused invocations', () => {
+  test('a positional argument exits 1 and points at --interactive', async () => {
+    const dir = project({ facets: {} })
+    const result = await spawnCli(['update', 'cowsay'], { cwd: dir })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('does not accept positional arguments')
+    expect(result.stderr).toContain('--interactive')
+    expect(result.stdout).toBe('')
+  })
+
+  // stdin is closed by the spawn helper, so this is the real
+  // non-interactive case rather than a simulated one.
+  test('--interactive without a terminal exits 1 on stderr', async () => {
+    const dir = project({ facets: {} })
+    const result = await spawnCli(['update', '--interactive'], { cwd: dir })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('interactive terminal')
+  })
+
+  test('the short alias reaches the same gate', async () => {
+    const dir = project({ facets: {} })
+    const long = await spawnCli(['update', '--interactive'], { cwd: dir })
+    const short = await spawnCli(['update', '-i'], { cwd: dir })
+    expect(short.exitCode).toBe(long.exitCode)
+    expect(short.stderr).toBe(long.stderr)
+  })
+
+  test('a malformed facets.json exits 1 and names the file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'facet-update-e2e-'))
+    projects.push(dir)
+    writeFileSync(join(dir, 'facets.json'), '{not json')
+    const result = await spawnCli(['update'], { cwd: dir })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('facets.json')
+  })
+})
+
+describe('facet update — successful no-ops', () => {
+  test('an empty project says there is nothing to check and exits 0', async () => {
+    const dir = project({ facets: {} })
+    const result = await spawnCli(['update'], { cwd: dir })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('No registry facets to update')
+    expect(result.stderr).toBe('')
+  })
+
+  test('git and local facets are named as unsupported, not reported as current', async () => {
+    const dir = project({ facets: { plans: 'github:agent-facets/viper-plans#main' } })
+    const result = await spawnCli(['update'], { cwd: dir })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('No registry facets to update')
+    expect(result.stdout).not.toContain('current')
+  })
+
+  // A directory with no facets.json declares no facets, which is the
+  // same fact as declaring none — not an error to report.
+  test('a directory that is not a project yet has nothing to update', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'facet-update-e2e-'))
+    projects.push(dir)
+    const result = await spawnCli(['update'], { cwd: dir })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('No registry facets to update')
+  })
+
+  test('a dry run over a project with nothing to check exits 0 and installs no adapter', async () => {
+    const dir = project({ facets: {} })
+    const result = await spawnCli(['update', '--dry-run'], { cwd: dir })
+    expect(result.exitCode).toBe(0)
+    // Adapter discovery is downstream of the preview; reaching it would
+    // have written this line.
+    expect(result.stderr).not.toContain('no adapters installed')
+  })
+})
+
+describe('facet update — a project that cannot be checked', () => {
+  // Update refuses to guess what is installed. Repairing that is
+  // `facet install`'s job, and this run has to say so rather than
+  // reporting a facet it never checked as current.
+  test('a declared registry facet with no lockfile entry exits 1 and sends the user to install', async () => {
+    const dir = project({ facets: { cowsay: '1.*', fortune: '2.*' } })
+    const result = await spawnCli(['update'], { cwd: dir })
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('cowsay')
+    expect(result.stderr).toContain('fortune')
+    expect(result.stderr).toContain('facet install')
+  })
+
+  test('the same project fails the same way under --latest and --dry-run', async () => {
+    const dir = project({ facets: { cowsay: '1.*' } })
+    const latest = await spawnCli(['update', '--latest'], { cwd: dir })
+    const preview = await spawnCli(['update', '--dry-run'], { cwd: dir })
+    expect(latest.exitCode).toBe(1)
+    expect(preview.exitCode).toBe(1)
+    expect(preview.stderr).toContain('facet install')
+  })
+})

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -13,6 +13,7 @@ import { publishCommand } from './commands/publish/index.ts'
 import { removeCommand } from './commands/remove/index.ts'
 import { searchCommand } from './commands/search/index.ts'
 import { selfUpdateCommand } from './commands/self-update.ts'
+import { updateCommand } from './commands/update/index.ts'
 import { whoamiCommand } from './commands/whoami/index.ts'
 
 type LowercaseLetter =
@@ -113,7 +114,11 @@ export const commands: Record<string, Command> = {
   remove: removeCommand,
   search: searchCommand,
   'self-update': selfUpdateCommand,
-  upgrade: stubCommand('upgrade', 'Upgrade installed facets'),
+  // `upgrade` is deliberately NOT a second key here. It is an alias on
+  // `updateCommand`, so both names resolve to one object with one help
+  // page and one behavior — the thing two registry entries could not
+  // promise.
+  update: updateCommand,
   whoami: whoamiCommand,
 }
 

--- a/packages/cli/src/commands/shared/install-failure.ts
+++ b/packages/cli/src/commands/shared/install-failure.ts
@@ -8,6 +8,15 @@ import {
 import { ACCEPT_MCP_FLAG } from './flags.ts'
 
 /**
+ * The four front doors to the install pipeline.
+ *
+ * Named once because every remedy below ends by telling the user which
+ * command to run again, and a literal union repeated at three signatures
+ * is three places to forget the fourth door.
+ */
+export type InstallCommandName = 'add' | 'install' | 'remove' | 'update'
+
+/**
  * The `detail:` line for a failed install-pipeline run.
  *
  * The failure code is the part scripts branch on, so it stays first and
@@ -47,10 +56,7 @@ export function installFailureDetail(failure: RunInstallFailure): string {
  * was stale is the defect this replaces; the ordinary non-frozen run is the
  * one action that does both jobs, so it is what a mixed failure recommends.
  */
-function lockfileDriftFix(
-  facets: readonly { readonly reason: string }[],
-  command: 'add' | 'install' | 'remove',
-): string {
+function lockfileDriftFix(facets: readonly { readonly reason: string }[], command: InstallCommandName): string {
   const stale = facets.filter((entry) => entry.reason === 'stale-override').length
 
   // An empty set cannot happen through the frozen gates, which only report
@@ -77,7 +83,7 @@ function lockfileDriftFix(
 function mcpCapabilityFix(
   failure: McpServerCapabilityFailure,
   rollback: RollbackOutcome,
-  command: 'add' | 'install' | 'remove',
+  command: InstallCommandName,
 ): string {
   const state = describeDiskState(rollback)
   if (failure.code !== 'conflict') {
@@ -94,7 +100,7 @@ function mcpCapabilityFix(
 export function installFailureFix(
   failure: RunInstallFailure,
   rollback: RollbackOutcome,
-  command: 'add' | 'install' | 'remove',
+  command: InstallCommandName,
 ): string {
   // An incomplete rollback outranks everything: whatever caused the failure
   // matters less than the fact that some file is not back where it started.
@@ -158,6 +164,13 @@ export function installFailureFix(
       return `deselect one of the adapters listed above, then re-run 'facet ${command}'`
     case 'MCP_NATIVE_STATE_DRIFT':
       return `${describeDiskState(rollback)}. Review the file listed above, then re-run 'facet ${command}'`
+    case 'UPDATE_PLAN_STALE':
+      // Nothing is broken and nothing needs repairing: the project moved
+      // between the plan being shown and being applied, so the only
+      // sensible action is to look at a plan built from what is there
+      // now. Sending this to the default arm's "fix the underlying
+      // issue" would invent a problem to hunt for.
+      return `${describeDiskState(rollback)}. Re-run 'facet ${command}' to plan against the current project state`
     default:
       // Most codes that land here failed BEFORE the journal opened —
       // `LOCK_HELD`, `FACETS_JSON_NOT_FOUND`, `FROZEN_WITH_DELTA`,

--- a/packages/cli/src/commands/update/__tests__/command.test.ts
+++ b/packages/cli/src/commands/update/__tests__/command.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, afterEach, describe, expect, type Mock, spyOn, test } from 'bun:test'
+import * as engine from '@agent-facets/engine'
+import { captureStderr, captureStdout } from '../../../__tests__/helpers/capture-std.ts'
+import { withTTY } from '../../../__tests__/helpers/with-tty.ts'
+import * as adapterModule from '../../shared/ensure-adapters.ts'
+import { updateCommand } from '../index.ts'
+import { candidate, current, unsupported } from './fixtures.ts'
+
+type Prepare = typeof engine.prepareFacetUpdate
+const prepareSpy = spyOn(engine, 'prepareFacetUpdate') as unknown as Mock<Prepare>
+const adaptersSpy = spyOn(adapterModule, 'ensureAdapters')
+
+// Cleared, not restored: `mockRestore` retires the spy for good, and
+// every test after the first would then run against the real engine.
+afterEach(() => {
+  prepareSpy.mockClear()
+  adaptersSpy.mockClear()
+})
+
+afterAll(() => {
+  prepareSpy.mockRestore()
+  adaptersSpy.mockRestore()
+})
+
+function preparing(plan: engine.UpdatePlanRow[]): void {
+  prepareSpy.mockResolvedValue({
+    ok: true,
+    prepared: {
+      projectRoot: '/tmp/project',
+      plan,
+      manifestState: { kind: 'absent' },
+      lockfileState: { kind: 'absent' },
+    },
+  })
+}
+
+const BOUNDED = candidate({
+  name: 'alpha',
+  source: '1.*',
+  current: '1.2.0',
+  target: '1.8.0',
+  latest: '2.0.0',
+  advancing: 'range-and-latest',
+})
+
+const PINNED = candidate({
+  name: 'beta',
+  source: '1.2.0',
+  current: '1.2.0',
+  target: '1.2.0',
+  latest: '3.4.1',
+  advancing: 'latest-only',
+})
+
+describe('facet update — refusing the invocation', () => {
+  test('a positional argument is refused, pointing at the flag that replaces it', async () => {
+    const { stderr, result } = await captureStderr(() => updateCommand.run(['alpha'], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('does not accept positional arguments')
+    expect(stderr).toContain('--interactive')
+    // Refused before anything looked at the project.
+    expect(prepareSpy).not.toHaveBeenCalled()
+  })
+
+  // The gate is before discovery on purpose: waiting through every
+  // registry lookup to be told the screen cannot open is the one
+  // ordering that wastes the user's time and the registry's.
+  test('--interactive without a terminal fails before any registry lookup', async () => {
+    const { stderr, result } = await withTTY(false, () =>
+      captureStderr(() => updateCommand.run([], { interactive: true })),
+    )
+    expect(result).toBe(1)
+    expect(stderr).toContain('interactive terminal')
+    expect(prepareSpy).not.toHaveBeenCalled()
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('facet update — preparation failures', () => {
+  test('an unusable project names every affected facet and sends the user to install', async () => {
+    prepareSpy.mockResolvedValue({
+      ok: false,
+      failure: {
+        reason: 'unusable-facet-state',
+        facets: [
+          { name: 'alpha', reason: { code: 'missing-lock-entry' } },
+          { name: 'beta', reason: { code: 'invalid-locked-version', version: 'not-a-version' } },
+        ],
+      },
+    })
+    const { stderr, result } = await captureStderr(() => updateCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('alpha')
+    expect(stderr).toContain('beta')
+    expect(stderr).toContain('facet install')
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+
+  test('a registry failure is reported in the registry’s own words', async () => {
+    prepareSpy.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'discovery-failed', error: { code: 'NETWORK_ERROR', cause: 'ECONNREFUSED', attempts: 3 } },
+    })
+    const { stderr, result } = await captureStderr(() => updateCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('could not reach the registry')
+    expect(stderr).toContain('ECONNREFUSED')
+  })
+
+  test('a project that moved during discovery says so, and says to re-run', async () => {
+    prepareSpy.mockResolvedValue({
+      ok: false,
+      failure: { reason: 'project-changed-during-discovery', file: 'lockfile' },
+    })
+    const { stderr, result } = await captureStderr(() => updateCommand.run([], {}))
+    expect(result).toBe(1)
+    expect(stderr).toContain('facets.lock changed')
+    expect(stderr).toContain("re-run 'facet update'")
+  })
+})
+
+describe('facet update — successful runs that apply nothing', () => {
+  test('a project with no registry facets says so and succeeds', async () => {
+    preparing([unsupported('delta', 'github:a/b', 'git')])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('No registry facets to update')
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+
+  test('everything current says so and succeeds', async () => {
+    preparing([current({ name: 'gamma', source: '*', version: '4.0.0' })])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('All registry facets are current')
+  })
+
+  test('a blocked range names --latest, and does not pretend to be current', async () => {
+    preparing([PINNED])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('facet update --latest')
+    expect(stdout).not.toContain('are current')
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('facet update — dry run', () => {
+  test('prints the plan, installs no adapter, and succeeds', async () => {
+    preparing([BOUNDED, PINNED])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], { 'dry-run': true }))
+    expect(result).toBe(0)
+    expect(stdout).toContain('alpha')
+    expect(stdout).toContain('1.8.0')
+    // The whole point of a preview: nothing that could install anything
+    // has been reached.
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+
+  test('latest mode previews the manifest edits it would commit', async () => {
+    preparing([BOUNDED, PINNED])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], { 'dry-run': true, latest: true }))
+    expect(result).toBe(0)
+    expect(stdout).toContain('facets.json')
+    expect(stdout).toContain('2.*')
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+
+  test('a dry run with nothing to do still succeeds', async () => {
+    preparing([current({ name: 'gamma', source: '*', version: '4.0.0' })])
+    const { result } = await captureStdout(() => updateCommand.run([], { 'dry-run': true }))
+    expect(result).toBe(0)
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/commands/update/__tests__/fixtures.ts
+++ b/packages/cli/src/commands/update/__tests__/fixtures.ts
@@ -1,0 +1,73 @@
+import { type AdvancingChoices, type ExactVersion, parseVersionSpec, type UpdatePlanRow } from '@agent-facets/engine'
+
+/**
+ * Plan rows for the CLI's own tests.
+ *
+ * The engine builds these from real registry answers; everything here
+ * only needs them to be well-formed, so versions are parsed rather than
+ * hand-shaped and the specifier goes through the real grammar.
+ */
+export function exact(version: string): ExactVersion {
+  const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number)
+  return { kind: 'exact', major, minor, patch }
+}
+
+function choice(name: string, version: string) {
+  return {
+    version: exact(version),
+    metadata: {
+      name,
+      version,
+      transportHash: `transport-${name}-${version}`,
+      contentFingerprint: `content-${name}-${version}`,
+    },
+  }
+}
+
+function authored(source: string) {
+  const spec = parseVersionSpec(source)
+  if (!spec.ok) throw new Error(`test fixture declares an invalid specifier: ${source}`)
+  return { source, spec: spec.value }
+}
+
+export function candidate(args: {
+  name: string
+  source: string
+  current: string
+  target: string
+  latest: string
+  advancing: AdvancingChoices
+}): Extract<UpdatePlanRow, { kind: 'candidate' }> {
+  return {
+    kind: 'candidate',
+    advancing: args.advancing,
+    facet: {
+      name: args.name,
+      authored: authored(args.source),
+      current: exact(args.current),
+      target: choice(args.name, args.target),
+      latest: choice(args.name, args.latest),
+    },
+  }
+}
+
+export function current(args: {
+  name: string
+  source: string
+  version: string
+}): Extract<UpdatePlanRow, { kind: 'current' }> {
+  return {
+    kind: 'current',
+    facet: {
+      name: args.name,
+      authored: authored(args.source),
+      current: exact(args.version),
+      target: choice(args.name, args.version),
+      latest: choice(args.name, args.version),
+    },
+  }
+}
+
+export function unsupported(name: string, source: string, sourceKind: 'git' | 'local'): UpdatePlanRow {
+  return { kind: 'unsupported-source', name, source, sourceKind }
+}

--- a/packages/cli/src/commands/update/__tests__/picker.test.tsx
+++ b/packages/cli/src/commands/update/__tests__/picker.test.tsx
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test'
+import type { FacetUpdateSelection } from '@agent-facets/engine'
+import { render } from 'ink-testing-library'
+import { createElement } from 'react'
+import { visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
+import { UpdatePicker } from '../picker.tsx'
+import type { UpdateMode } from '../selection.ts'
+import { candidate, current } from './fixtures.ts'
+
+const KEY = {
+  up: '\u001B[A',
+  down: '\u001B[B',
+  enter: '\r',
+  space: ' ',
+  escape: '\u001B',
+  ctrlC: '\u0003',
+} as const
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+// Ink needs a grace period after a bare ESC byte to tell it apart from
+// the start of an escape sequence like the arrow keys.
+function afterEsc(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 60))
+}
+
+const BOUNDED = candidate({
+  name: 'alpha',
+  source: '1.*',
+  current: '1.2.0',
+  target: '1.8.0',
+  latest: '2.0.0',
+  advancing: 'range-and-latest',
+})
+
+const PINNED = candidate({
+  name: 'beta',
+  source: '1.2.0',
+  current: '1.2.0',
+  target: '1.2.0',
+  latest: '3.0.0',
+  advancing: 'latest-only',
+})
+
+function mount(plan: Parameters<typeof UpdatePicker>[0]['plan'], mode: UpdateMode = 'range') {
+  const state: { confirmed: FacetUpdateSelection[] | null; aborted: boolean } = { confirmed: null, aborted: false }
+  const app = render(
+    createElement(UpdatePicker, {
+      plan,
+      mode,
+      onConfirm: (selections) => {
+        state.confirmed = selections
+      },
+      onAbort: () => {
+        state.aborted = true
+      },
+    }),
+  )
+  return { app, state }
+}
+
+async function press(app: ReturnType<typeof render>, ...keys: string[]): Promise<void> {
+  for (const key of keys) {
+    app.stdin.write(key)
+    await nextTick()
+  }
+}
+
+describe('UpdatePicker — what it offers', () => {
+  test('shows only candidates, with both versions on every row', async () => {
+    const { app } = mount([BOUNDED, PINNED, current({ name: 'gamma', source: '*', version: '4.0.0' })])
+    await nextTick()
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('alpha')
+    expect(frame).toContain('beta')
+    // A facet with nothing newer has no decision to offer.
+    expect(frame).not.toContain('gamma')
+    app.unmount()
+  })
+
+  test('plain mode starts on the range target', async () => {
+    const { app } = mount([BOUNDED])
+    await nextTick()
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('1.2.0 → 1.8.0')
+    expect(frame).toContain('(target)')
+    expect(frame).toContain('1 of 1 selected')
+    app.unmount()
+  })
+
+  test('latest mode starts on the latest release', async () => {
+    const { app } = mount([BOUNDED], 'latest')
+    await nextTick()
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('1.2.0 → 2.0.0')
+    expect(frame).toContain('(latest)')
+    app.unmount()
+  })
+
+  // The row `--latest` exists for: its range cannot move, so plain mode
+  // shows it unselected and says why.
+  test('a row whose displayed choice is already installed starts unselected', async () => {
+    const { app } = mount([PINNED])
+    await nextTick()
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('unchanged')
+    expect(frame).toContain('0 of 1 selected')
+    app.unmount()
+  })
+})
+
+describe('UpdatePicker — choosing', () => {
+  test('l toggles the focused row between target and latest', async () => {
+    const { app } = mount([BOUNDED])
+    await nextTick()
+    await press(app, 'l')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1.2.0 → 2.0.0')
+    await press(app, 'l')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1.2.0 → 1.8.0')
+    app.unmount()
+  })
+
+  test('space deselects and reselects a row', async () => {
+    const { app, state } = mount([BOUNDED])
+    await nextTick()
+    await press(app, KEY.space)
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('0 of 1 selected')
+    await press(app, KEY.space, KEY.enter)
+    expect(state.confirmed).toEqual([{ facetName: 'alpha', choice: 'range' }])
+    app.unmount()
+  })
+
+  test('a non-advancing choice cannot be selected, and says what to press', async () => {
+    const { app, state } = mount([PINNED])
+    await nextTick()
+    await press(app, KEY.space)
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('already installed')
+    expect(frame).toContain('0 of 1 selected')
+    // Enter is refused too — there is nothing selected to confirm.
+    await press(app, KEY.enter)
+    expect(state.confirmed).toBeNull()
+    app.unmount()
+  })
+
+  test('toggling to the advancing choice makes the same row selectable', async () => {
+    const { app, state } = mount([PINNED])
+    await nextTick()
+    await press(app, 'l', KEY.space, KEY.enter)
+    expect(state.confirmed).toEqual([{ facetName: 'beta', choice: 'latest' }])
+    app.unmount()
+  })
+
+  // Selection is not carried across a toggle onto a version that would
+  // change nothing: the state that says "selected" cannot hold it.
+  test('toggling a selected row onto a stationary choice deselects it', async () => {
+    const { app } = mount([PINNED], 'latest')
+    await nextTick()
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1 of 1 selected')
+    await press(app, 'l')
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('0 of 1 selected')
+    expect(frame).toContain('unchanged')
+    app.unmount()
+  })
+
+  test('arrows move the focus between rows', async () => {
+    const { app, state } = mount([BOUNDED, PINNED])
+    await nextTick()
+    // Move to beta, toggle it to latest, select it, and confirm both.
+    await press(app, KEY.down, 'l', KEY.space, KEY.enter)
+    expect(state.confirmed).toEqual([
+      { facetName: 'alpha', choice: 'range' },
+      { facetName: 'beta', choice: 'latest' },
+    ])
+    app.unmount()
+  })
+
+  test('the focus wraps at both ends', async () => {
+    const { app, state } = mount([BOUNDED, PINNED])
+    await nextTick()
+    // Up from the first row lands on the last one.
+    await press(app, KEY.up, 'l', KEY.space, KEY.enter)
+    expect(state.confirmed).toContainEqual({ facetName: 'beta', choice: 'latest' })
+    app.unmount()
+  })
+})
+
+describe('UpdatePicker — leaving without applying', () => {
+  test('confirming nothing is refused with a hint', async () => {
+    const { app, state } = mount([BOUNDED])
+    await nextTick()
+    await press(app, KEY.space, KEY.enter)
+    expect(state.confirmed).toBeNull()
+    expect(state.aborted).toBe(false)
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('Select at least one facet')
+    app.unmount()
+  })
+
+  test('escape cancels', async () => {
+    const { app, state } = mount([BOUNDED])
+    await nextTick()
+    app.stdin.write(KEY.escape)
+    await afterEsc()
+    expect(state.aborted).toBe(true)
+    expect(state.confirmed).toBeNull()
+    app.unmount()
+  })
+
+  test('ctrl-c cancels', async () => {
+    const { app, state } = mount([BOUNDED])
+    await nextTick()
+    await press(app, KEY.ctrlC)
+    expect(state.aborted).toBe(true)
+    expect(state.confirmed).toBeNull()
+    app.unmount()
+  })
+})

--- a/packages/cli/src/commands/update/__tests__/plan-view.test.tsx
+++ b/packages/cli/src/commands/update/__tests__/plan-view.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+import { validateFacetUpdateSelections } from '@agent-facets/engine'
+import { render } from 'ink-testing-library'
+import { createElement } from 'react'
+import { stripTerminalControls, visibleTerminalText } from '../../../__tests__/helpers/terminal-output.ts'
+import { UpdatePlanView } from '../../../tui/views/update/plan-view.tsx'
+import { buildPreview } from '../preview.ts'
+import { defaultSelections, type UpdateMode } from '../selection.ts'
+import { candidate, current, unsupported } from './fixtures.ts'
+
+const BOUNDED = candidate({
+  name: 'alpha',
+  source: '1.*',
+  current: '1.2.0',
+  target: '1.8.0',
+  latest: '2.0.0',
+  advancing: 'range-and-latest',
+})
+
+const PINNED = candidate({
+  name: 'beta',
+  source: '1.2.0',
+  current: '1.2.0',
+  target: '1.2.0',
+  latest: '3.4.1',
+  advancing: 'latest-only',
+})
+
+const MINOR = candidate({
+  name: 'gamma',
+  source: '1.2.*',
+  current: '1.2.0',
+  target: '1.2.9',
+  latest: '3.4.1',
+  advancing: 'range-and-latest',
+})
+
+/** Render exactly what the command renders: engine-derived preview data. */
+function frameFor(plan: Parameters<typeof buildPreview>[0], mode: UpdateMode): string {
+  const selections = defaultSelections(plan, mode)
+  const validated = validateFacetUpdateSelections(plan, selections)
+  const preview = buildPreview(plan, selections, validated.ok ? validated.selections : [])
+  const instance = render(createElement(UpdatePlanView, { plan, ...preview }))
+  const frame = instance.lastFrame() ?? ''
+  instance.unmount()
+  return frame
+}
+
+describe('UpdatePlanView', () => {
+  test('shows the declared range, current, target, and latest for each facet', () => {
+    const frame = visibleTerminalText(frameFor([BOUNDED], 'range'))
+    expect(frame).toContain('alpha')
+    expect(frame).toContain('1.*')
+    expect(frame).toContain('1.2.0')
+    expect(frame).toContain('1.8.0')
+    expect(frame).toContain('2.0.0')
+  })
+
+  // The row that explains itself: nothing is selected, and both versions
+  // are on screen so the user can see that only Latest is ahead.
+  test('shows a facet whose range permits nothing, unselected', () => {
+    const frame = stripTerminalControls(frameFor([PINNED], 'range'))
+    expect(frame).toMatch(/beta.*1\.2\.0.*3\.4\.1/)
+    expect(frame).not.toMatch(/▸\s*beta/)
+  })
+
+  test('marks the rows a run would move', () => {
+    const frame = stripTerminalControls(frameFor([BOUNDED, PINNED], 'range'))
+    expect(frame).toMatch(/▸\s*alpha/)
+    expect(frame).not.toMatch(/▸\s*beta/)
+  })
+
+  test('git and local facets are named as unchecked, not counted as current', () => {
+    const frame = visibleTerminalText(frameFor([BOUNDED, unsupported('delta', 'github:a/b', 'git')], 'range'))
+    expect(frame).toContain('delta — git source (github:a/b); not checked for updates')
+  })
+
+  test('a project of only current facets still lists them', () => {
+    const frame = visibleTerminalText(frameFor([current({ name: 'gamma', source: '*', version: '4.0.0' })], 'range'))
+    expect(frame).toContain('gamma')
+    expect(frame).toContain('4.0.0')
+  })
+})
+
+describe('UpdatePlanView — manifest rewrites', () => {
+  // Every rewrite shown here comes from the engine's own derivation, so
+  // the preview cannot describe an edit the write would not make.
+  test('latest mode previews the smallest edit that admits the new version', () => {
+    const frame = visibleTerminalText(frameFor([BOUNDED, PINNED, MINOR], 'latest'))
+    expect(frame).toContain('facets.json 1.* → 2.*')
+    expect(frame).toContain('facets.json 1.2.0 → 3.4.1')
+    expect(frame).toContain('facets.json 1.2.* → 3.4.*')
+  })
+
+  test('a range selection rewrites nothing, so nothing is shown', () => {
+    const frame = visibleTerminalText(frameFor([BOUNDED], 'range'))
+    expect(frame).not.toContain('facets.json')
+  })
+
+  test('a floating specifier survives a latest selection unchanged', () => {
+    const floating = candidate({
+      name: 'epsilon',
+      source: 'latest',
+      current: '1.0.0',
+      target: '2.0.0',
+      latest: '2.0.0',
+      advancing: 'range-and-latest',
+    })
+    expect(visibleTerminalText(frameFor([floating], 'latest'))).not.toContain('facets.json')
+  })
+})

--- a/packages/cli/src/commands/update/__tests__/registration.test.ts
+++ b/packages/cli/src/commands/update/__tests__/registration.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import { captureLog } from '../../../__tests__/helpers/capture-log.ts'
+import { allCommandNames, commands, resolveCommand } from '../../../commands.ts'
+import { printCommandHelp, printGlobalHelp } from '../../../help.ts'
+import { findClosestCommand } from '../../../suggest.ts'
+import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS } from '../../shared/flags.ts'
+import { updateCommand } from '../index.ts'
+
+describe('update registration', () => {
+  test('update is the canonical name and upgrade is only an alias', () => {
+    expect(commands.update).toBe(updateCommand)
+    // Not a second registry key: one object, one help page, one behavior.
+    expect(commands.upgrade).toBeUndefined()
+    expect(updateCommand.aliases).toContain('upgrade')
+  })
+
+  test('both names resolve to the same command object', () => {
+    expect(resolveCommand(commands, 'update')).toBe(updateCommand)
+    expect(resolveCommand(commands, 'upgrade')).toBe(updateCommand)
+  })
+
+  test('upgrade is no longer an unimplemented stub', () => {
+    expect(updateCommand.implemented).toBe(true)
+  })
+
+  test('typo suggestions know both names', () => {
+    expect(allCommandNames(commands)).toContain('update')
+    expect(allCommandNames(commands)).toContain('upgrade')
+    expect(findClosestCommand('upgrad', allCommandNames(commands))).toBe('upgrade')
+  })
+
+  test('the shared install-pipeline flags are shared, not copied', () => {
+    expect(updateCommand.flags?.verbose).toBe(INSTALL_PIPELINE_FLAGS.verbose)
+    expect(updateCommand.flags?.[ACCEPT_MCP_FLAG]).toBe(INSTALL_PIPELINE_FLAGS[ACCEPT_MCP_FLAG])
+  })
+
+  test('the flag surface is exactly what the command supports', () => {
+    expect(updateCommand.flags?.latest?.short).toBe('L')
+    expect(updateCommand.flags?.interactive?.short).toBe('i')
+    expect(updateCommand.flags?.['dry-run']).toBeDefined()
+    // Reproducing a lockfile is `facet install`'s mode, and it is the
+    // opposite of what update does.
+    expect(updateCommand.flags?.['frozen-lockfile']).toBeUndefined()
+  })
+})
+
+describe('update help', () => {
+  test('global help lists update with upgrade on one line', () => {
+    const out = captureLog(() => {
+      printGlobalHelp(commands)
+    })
+    expect(out).toMatch(/update,\s*upgrade\s+Update the facets/)
+    expect(out.match(/update,\s*upgrade/g) ?? []).toHaveLength(1)
+  })
+
+  test('per-command help shows both spellings of each short-aliased flag', () => {
+    const out = captureLog(() => {
+      printCommandHelp(updateCommand)
+    })
+    expect(out).toMatch(/-L, --latest\s+/)
+    expect(out).toMatch(/-i, --interactive\s+/)
+    expect(out).toMatch(/--dry-run\s+/)
+    expect(out).toMatch(/--verbose\s+/)
+    expect(out).toContain(`--${ACCEPT_MCP_FLAG}`)
+    expect(out).not.toContain('--frozen-lockfile')
+  })
+
+  test('help says which command updates the CLI instead', () => {
+    const out = captureLog(() => {
+      printCommandHelp(updateCommand)
+    })
+    expect(out).toContain('self-update')
+    expect(out).toContain('facets this project declares')
+  })
+
+  test('help invoked through the alias still names the canonical command', () => {
+    const command = resolveCommand(commands, 'upgrade')
+    if (command === undefined) expect.unreachable()
+    const out = captureLog(() => {
+      printCommandHelp(command)
+    })
+    expect(out).toContain('Usage: facet update')
+    expect(out).not.toContain('Usage: facet upgrade')
+  })
+})

--- a/packages/cli/src/commands/update/__tests__/selection.test.ts
+++ b/packages/cli/src/commands/update/__tests__/selection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+import { classifyNoOp, defaultSelections, describeNoOp } from '../selection.ts'
+import { candidate, current, unsupported } from './fixtures.ts'
+
+const BOUNDED = candidate({
+  name: 'alpha',
+  source: '1.*',
+  current: '1.2.0',
+  target: '1.8.0',
+  latest: '2.0.0',
+  advancing: 'range-and-latest',
+})
+
+// An exact pin: the range cannot move, but a newer release exists.
+const PINNED = candidate({
+  name: 'beta',
+  source: '1.2.0',
+  current: '1.2.0',
+  target: '1.2.0',
+  latest: '3.0.0',
+  advancing: 'latest-only',
+})
+
+describe('defaultSelections', () => {
+  test('plain update takes the range target of every advancing candidate', () => {
+    expect(defaultSelections([BOUNDED, PINNED], 'range')).toEqual([{ facetName: 'alpha', choice: 'range' }])
+  })
+
+  test('latest mode takes the latest release, including across a bounded range', () => {
+    expect(defaultSelections([BOUNDED, PINNED], 'latest')).toEqual([
+      { facetName: 'alpha', choice: 'latest' },
+      { facetName: 'beta', choice: 'latest' },
+    ])
+  })
+
+  test('current and unsupported rows are never selected', () => {
+    const plan = [current({ name: 'gamma', source: '*', version: '4.0.0' }), unsupported('delta', './local', 'local')]
+    expect(defaultSelections(plan, 'range')).toEqual([])
+    expect(defaultSelections(plan, 'latest')).toEqual([])
+  })
+})
+
+describe('classifyNoOp', () => {
+  test('work to do is not a no-op', () => {
+    expect(classifyNoOp([BOUNDED], 'range', [{ facetName: 'alpha', choice: 'range' }])).toBeNull()
+  })
+
+  test('a project with only git and local facets has nothing to check', () => {
+    const noOp = classifyNoOp([unsupported('delta', 'github:a/b', 'git')], 'range', [])
+    expect(noOp).toEqual({ reason: 'no-registry-facets' })
+    expect(describeNoOp({ reason: 'no-registry-facets' })).toContain('No registry facets')
+  })
+
+  test('every registry facet current is its own outcome', () => {
+    const noOp = classifyNoOp([current({ name: 'gamma', source: '*', version: '4.0.0' })], 'range', [])
+    expect(noOp).toEqual({ reason: 'all-current' })
+    expect(describeNoOp({ reason: 'all-current' })).toContain('current')
+  })
+
+  // The case a single "nothing to update" would hide: there IS something
+  // newer, and the user has a flag that would take it.
+  test('a blocked range names --latest as the way past it', () => {
+    const noOp = classifyNoOp([PINNED], 'range', [])
+    expect(noOp).toEqual({ reason: 'ranges-permit-none' })
+    const message = describeNoOp({ reason: 'ranges-permit-none' })
+    expect(message).toContain('facet update --latest')
+  })
+
+  test('latest mode with nothing newer suggests nothing', () => {
+    const noOp = classifyNoOp([PINNED], 'latest', [])
+    expect(noOp).toEqual({ reason: 'latest-permits-none' })
+    expect(describeNoOp({ reason: 'latest-permits-none' })).not.toContain('--latest')
+  })
+})

--- a/packages/cli/src/commands/update/errors.ts
+++ b/packages/cli/src/commands/update/errors.ts
@@ -1,0 +1,116 @@
+import type { PrepareFacetUpdateFailure, UnusableFacetState, UpdateSelectionFailure } from '@agent-facets/engine'
+import type { CliError } from '../../util/errors.ts'
+import { translateEngineRegistryError } from '../../util/registry-errors.ts'
+import { unsupportedManifestVersionError } from '../../util/unsupported-manifest-version.ts'
+
+/**
+ * Why an update could not even be planned, in the CLI's words.
+ *
+ * Returns the error rather than writing it, so the `switch` has to
+ * produce a value: a `void` switch with no `default` compiles happily
+ * when the engine grows a new failure reason, and then prints nothing
+ * for it.
+ */
+export function updatePrepareCliError(failure: PrepareFacetUpdateFailure): CliError {
+  switch (failure.reason) {
+    case 'manifest-read':
+      return {
+        what: 'could not read facets.json',
+        detail: failure.error,
+        fix: 'run this command inside a project with a valid facets.json',
+      }
+    case 'manifest-unsupported-version':
+      return unsupportedManifestVersionError(failure)
+    case 'lockfile-read':
+      return {
+        what: 'could not read facets.lock',
+        detail: failure.error,
+        fix: "repair facets.lock, or delete it and run 'facet install' to rebuild it",
+      }
+    case 'unusable-facet-state':
+      // Update refuses to guess what is installed. Every affected facet is
+      // named because the remedy is one `facet install` covering all of
+      // them, and a list that stopped at the first would send the user
+      // round the same loop for each.
+      return {
+        what: 'this project cannot be checked for updates yet',
+        detail: failure.facets.map(describeUnusableFacet).join('; '),
+        fix: "run 'facet install' to bring facets.lock in line with facets.json, then update again",
+      }
+    case 'discovery-failed':
+      // The registry's own words, through the shared translator. Update has
+      // nothing to add: a lookup failure here is the same failure any other
+      // registry read would report.
+      return translateEngineRegistryError(failure.error)
+    case 'invalid-resolved-version':
+      return {
+        what: `the registry returned an unusable ${failure.lookup} version for ${failure.facet}`,
+        detail: `"${failure.version}" is not an exact MAJOR.MINOR.PATCH release`,
+        fix: 'try again in a moment; if it persists, report it with the facet name above',
+      }
+    case 'target-outside-range':
+      return {
+        what: `the registry resolved ${failure.facet} outside its declared range`,
+        detail: `facets.json declares ${failure.source}, which ${failure.version} does not satisfy`,
+        fix: 'try again in a moment; if it persists, report it with the facet name above',
+      }
+    case 'project-changed-during-discovery':
+      return {
+        what: `${failure.file === 'manifest' ? 'facets.json' : 'facets.lock'} changed while update was checking versions`,
+        detail: 'the plan would have described a project that no longer exists, so it was withdrawn',
+        fix: "re-run 'facet update' once the other change has finished",
+      }
+  }
+}
+
+/** One facet's unusable local state, phrased for a single-line list. */
+function describeUnusableFacet(entry: UnusableFacetState): string {
+  const { name, reason } = entry
+  switch (reason.code) {
+    case 'unparseable-source':
+      return `${name}: facets.json declares "${reason.source}" (${reason.problem})`
+    case 'missing-lock-entry':
+      return `${name}: not in facets.lock`
+    case 'lock-source-mismatch':
+      return `${name}: facets.lock records a ${reason.locked} source`
+    case 'invalid-locked-version':
+      return `${name}: facets.lock records "${reason.version}", which is not an exact release`
+    case 'locked-version-unsatisfying':
+      return `${name}: installed ${reason.version} does not satisfy ${reason.source}`
+  }
+}
+
+/**
+ * Why a set of chosen updates could not be applied.
+ *
+ * Every arm here is the command asking for something the reviewed plan
+ * cannot answer, so each one is a defect in this CLI rather than
+ * something the user typed — except the empty selection, which the
+ * command is expected to have classified as a no-op before ever getting
+ * here.
+ */
+export function updateSelectionCliError(failure: UpdateSelectionFailure): CliError {
+  const bug = 'file a bug — this is a defect in the CLI, not your project'
+  switch (failure.reason) {
+    case 'empty-selection':
+      return { what: 'nothing was selected to update', detail: 'the update plan selected no facets', fix: bug }
+    case 'duplicate-facet':
+      return { what: 'a facet was selected twice', detail: failure.facet, fix: bug }
+    case 'unknown-facet':
+      return { what: 'a selected facet is not in the update plan', detail: failure.facet, fix: bug }
+    case 'unsupported-source':
+      return {
+        what: `${failure.facet} cannot be updated from the registry`,
+        detail: `facets.json declares it as a ${failure.sourceKind} source`,
+        fix: 'update git and local facets by changing their source in facets.json',
+      }
+    case 'not-a-candidate':
+      return { what: `${failure.facet} has no newer release to install`, detail: 'it is already current', fix: bug }
+    case 'choice-does-not-advance':
+      return {
+        what: `the ${failure.choice === 'range' ? 'range target' : 'latest release'} for ${failure.facet} is not newer`,
+        detail: `${failure.version} does not advance the installed ${failure.current}`,
+        fix: bug,
+      }
+  }
+}

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -1,0 +1,252 @@
+import {
+  prepareFacetUpdate,
+  type RunPreparedFacetUpdateResult,
+  runPreparedFacetUpdate,
+  validateFacetUpdateSelections,
+} from '@agent-facets/engine'
+import { render } from 'ink'
+import { createElement } from 'react'
+import type { Command } from '../../commands.ts'
+import { InstallView } from '../../tui/views/install/install-view.tsx'
+import { UpdatePlanView } from '../../tui/views/update/plan-view.tsx'
+import { writeCliError } from '../../util/errors.ts'
+import { writeInstallFailureDetail } from '../../util/install-detail.ts'
+import { canPromptInteractively } from '../../util/interactive.ts'
+import { ensureAdapters } from '../shared/ensure-adapters.ts'
+import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS, mcpConsentPolicy } from '../shared/flags.ts'
+import { installFailureDetail, installFailureFix } from '../shared/install-failure.ts'
+import { updatePrepareCliError, updateSelectionCliError } from './errors.ts'
+import { buildPreview } from './preview.ts'
+import { runUpdatePicker } from './run-picker.ts'
+import { classifyNoOp, defaultSelections, describeNoOp, type UpdateMode } from './selection.ts'
+
+/**
+ * `facet update` (alias: `facet upgrade`) — move the project's
+ * registry-backed facets to newer releases.
+ *
+ * Deliberately not `self-update`: this command changes the facets a
+ * project declares, and never the CLI binary. The two live one keystroke
+ * apart, so both help texts say which is which.
+ *
+ * The work is split in two by the engine. `prepareFacetUpdate` resolves
+ * every facet's range target and the registry's latest release without
+ * taking the project lock, so a user can read the plan — or an
+ * automation can print it — without blocking every other facet operation
+ * on the machine. `runPreparedFacetUpdate` then applies the reviewed
+ * choices through the ordinary install transaction, re-checking under
+ * the lock that the project has not moved in the meantime.
+ *
+ * This file owns only the order those happen in, and it matters: nothing
+ * that could install an adapter, take a lock, or write a file may run
+ * before the user has confirmed a selection they can still cancel.
+ */
+export const updateCommand: Command = {
+  name: 'update',
+  aliases: ['upgrade'],
+  description: 'Update the facets this project declares (see self-update for the CLI itself)',
+  implemented: true,
+  flags: {
+    ...INSTALL_PIPELINE_FLAGS,
+    latest: {
+      type: 'boolean',
+      short: 'L',
+      description: "Update to each facet's latest release, ignoring the range in facets.json",
+    },
+    interactive: {
+      type: 'boolean',
+      short: 'i',
+      description: 'Choose which facets to update, and which version each one takes',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print the plan; do not modify any files',
+    },
+  },
+  run: async (args, flags) => {
+    // No positional filter yet — interactive selection is how a user
+    // updates some facets but not others, so say that rather than
+    // rejecting the argument with nothing to offer instead.
+    if (args.length > 0) {
+      writeCliError({
+        what: `facet update does not accept positional arguments (got "${args[0]}")`,
+        detail: 'update considers every facet declared in facets.json',
+        fix: "run 'facet update --interactive' to choose which facets to update",
+      })
+      return 1
+    }
+
+    const interactive = flags.interactive === true
+
+    // Checked before discovery on purpose: a user who asked to pick from
+    // a list should not wait through every registry lookup to be told the
+    // list can never be shown.
+    if (interactive && !canPromptInteractively()) {
+      writeCliError({
+        what: 'facet update --interactive needs an interactive terminal',
+        detail: 'this environment cannot prompt, so the selection screen cannot run here',
+        fix: "run 'facet update' or 'facet update --latest' to apply updates without prompting",
+      })
+      return 1
+    }
+
+    const dryRun = flags['dry-run'] === true
+    const mode: UpdateMode = flags.latest === true ? 'latest' : 'range'
+
+    const prepared = await prepareFacetUpdate({ projectRoot: process.cwd() })
+    if (!prepared.ok) {
+      writeCliError(updatePrepareCliError(prepared.failure))
+      return 1
+    }
+    const { plan } = prepared.prepared
+
+    // The mode's own answer, before the user gets a say. In interactive
+    // mode this is only the starting position of the picker; otherwise it
+    // is the selection.
+    const defaults = defaultSelections(plan, mode)
+
+    // A run that applies nothing still succeeded. Which KIND of nothing
+    // it is decides whether the user has anything to do about it, so the
+    // message says which one rather than a single "nothing to update".
+    //
+    // Checked before the picker for a reason: a screen with no selectable
+    // row is not a choice, it is a dead end with no explanation on it.
+    const noOp = classifyNoOp(plan, mode, defaults)
+    if (noOp !== null) {
+      process.stdout.write(`${describeNoOp(noOp)}\n`)
+      return 0
+    }
+
+    let selections = defaults
+    if (interactive) {
+      // Before adapters, before the lock, before anything that writes:
+      // cancelling here must cost the user nothing at all.
+      const outcome = await runUpdatePicker(plan, mode)
+      if (outcome.kind === 'cancelled') {
+        process.stdout.write('Update cancelled. Nothing was applied.\n')
+        return 1
+      }
+      selections = outcome.selections
+    }
+
+    // The engine derives what each choice installs and what it would
+    // write to facets.json. Doing it here would give the preview its own
+    // opinion, and the preview is the thing a user approves.
+    const validated = validateFacetUpdateSelections(plan, selections)
+    if (!validated.ok) {
+      writeCliError(updateSelectionCliError(validated.failure))
+      return 1
+    }
+
+    if (dryRun) {
+      renderPlan(plan, selections, validated.selections)
+      return 0
+    }
+
+    // Only now: adapters can trigger a picker and an install of their
+    // own, which is a side effect a preview or a cancellation must never
+    // have paid for.
+    const adapters = await ensureAdapters()
+    if (adapters === null) {
+      // ensureAdapters already wrote the appropriate CLI error.
+      return 1
+    }
+
+    const verbose = flags.verbose === true
+    const acceptMcp = flags[ACCEPT_MCP_FLAG] === true
+    const mayPrompt = canPromptInteractively()
+
+    // SIGINT reaches the engine as an abort rather than killing the
+    // process, so a run interrupted mid-write unwinds through its own
+    // rollback and releases the project lock.
+    const controller = new AbortController()
+    const sigintHandler = () => {
+      process.stderr.write('\nInterrupted. Stopping safely...\n')
+      controller.abort()
+    }
+    process.on('SIGINT', sigintHandler)
+
+    let captured: RunPreparedFacetUpdateResult | undefined
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        signal: controller.signal,
+        run: async ({ onStage, onLog, resolveCollisions, resolveMcpConsent, resolveAssetTakeover }) => {
+          const result = await runPreparedFacetUpdate({
+            prepared: prepared.prepared,
+            selections,
+            adapters,
+            onStage,
+            mcpConsent: mcpConsentPolicy({ acceptMcp, mayPrompt, resolve: resolveMcpConsent }),
+            ...(verbose ? { onLog } : {}),
+            ...(mayPrompt ? { resolveCollisions, resolveAssetTakeover } : {}),
+            signal: controller.signal,
+          })
+          captured = result
+          if (result.ok) return result.install
+          if (result.phase === 'install') return result.install
+          // A selection failure has no install result to render. It is
+          // reported on stderr after unmount, where its remedy lives.
+          throw new UpdateSelectionRejected()
+        },
+        onComplete: () => {
+          // `captured` is already the richer result, set inside `run`.
+        },
+      }),
+      // See `install`: Ctrl-C has to reach the workspace so the engine's
+      // pending resolver call is settled and the lock released.
+      { exitOnCtrlC: false },
+    )
+
+    try {
+      await instance.waitUntilExit()
+    } catch {
+      // Ink rejects on view-level failure; we have the captured result.
+    } finally {
+      process.off('SIGINT', sigintHandler)
+    }
+
+    if (!captured) {
+      writeCliError({
+        what: 'update failed',
+        detail: 'the update pipeline returned no result',
+        fix: 'this is a bug; please file an issue with the verbose log',
+      })
+      return 1
+    }
+
+    if (captured.ok) return 0
+
+    if (captured.phase === 'selection') {
+      writeCliError(updateSelectionCliError(captured.failure))
+      return 1
+    }
+
+    writeInstallFailureDetail(captured.install.failure, captured.install.rollback)
+    writeCliError({
+      what: 'update failed',
+      detail: installFailureDetail(captured.install.failure),
+      fix: installFailureFix(captured.install.failure, captured.install.rollback, 'update'),
+    })
+    return 1
+  },
+}
+
+/**
+ * Unmounts the view when the engine refuses the selection.
+ *
+ * The view renders `RunInstallResult`-shaped values and a selection
+ * failure is not one. Throwing ends the mount; the structured failure is
+ * already captured and is reported on stderr by the caller.
+ */
+class UpdateSelectionRejected extends Error {}
+
+/** Draw the plan once and tear the mount down; nothing here is live. */
+function renderPlan(
+  plan: Parameters<typeof buildPreview>[0],
+  selections: Parameters<typeof buildPreview>[1],
+  validated: Parameters<typeof buildPreview>[2],
+): void {
+  const { selected, rewrites } = buildPreview(plan, selections, validated)
+  const instance = render(createElement(UpdatePlanView, { plan, selected, rewrites }))
+  instance.unmount()
+}

--- a/packages/cli/src/commands/update/picker.tsx
+++ b/packages/cli/src/commands/update/picker.tsx
@@ -1,0 +1,228 @@
+import type { FacetUpdateSelection, UpdateChoice, UpdatePlanRow } from '@agent-facets/engine'
+import { Box, Text, useApp, useInput } from 'ink'
+import { useMemo, useState } from 'react'
+import { THEME } from '../../tui/theme.ts'
+import { choiceAdvances, type UpdateMode } from './selection.ts'
+
+type Candidate = Extract<UpdatePlanRow, { kind: 'candidate' }>
+
+/**
+ * A row's displayed choice, tagged by whether taking it would actually
+ * move the facet.
+ *
+ * The tag exists so the selected state below can require an advancing
+ * one. Without it, "selected, showing a version equal to what is already
+ * installed" is representable, and the picker would happily confirm a
+ * selection the engine is obliged to reject.
+ */
+type DisplayChoice = { kind: 'advancing'; choice: UpdateChoice } | { kind: 'stationary'; choice: UpdateChoice }
+
+/**
+ * One row's state.
+ *
+ * Selection and displayed choice are one value rather than two, because
+ * the legal combinations are not a product: a selected row must be
+ * showing an advancing choice, while an unselected row may be showing
+ * anything. Toggling to a stationary choice therefore *produces* the
+ * unselected arm, instead of leaving a boolean behind that disagrees
+ * with what is on screen.
+ */
+type RowState =
+  | { kind: 'selected'; displayed: Extract<DisplayChoice, { kind: 'advancing' }> }
+  | { kind: 'unselected'; displayed: DisplayChoice }
+
+export interface UpdatePickerProps {
+  plan: readonly UpdatePlanRow[]
+  /** Which version each row starts on: `--latest` starts on Latest. */
+  mode: UpdateMode
+  /** Fires once, with at least one advancing selection. */
+  onConfirm: (selections: FacetUpdateSelection[]) => void
+  /** Fires once when the user abandons the picker (Esc / Ctrl-C). */
+  onAbort: () => void
+}
+
+/**
+ * Choose which facets to update, and which release each one takes.
+ *
+ * Only candidates appear: a facet with nothing newer has no decision to
+ * offer. Both versions stay visible on every row, because the choice
+ * this screen exists for — take the range target, or cross the range to
+ * the latest release — cannot be made from one of them.
+ *
+ * Keys follow the adapter picker (↑↓ / Space / Enter / Esc) so the two
+ * selection screens in this CLI do not have separate vocabularies, plus
+ * `l` for the toggle this one needs.
+ */
+export function UpdatePicker({ plan, mode, onConfirm, onAbort }: UpdatePickerProps) {
+  const { exit } = useApp()
+  const candidates = useMemo(() => plan.filter((row): row is Candidate => row.kind === 'candidate'), [plan])
+
+  const [rows, setRows] = useState<RowState[]>(() => candidates.map((row) => initialState(row, mode)))
+  const [cursor, setCursor] = useState(0)
+  const [hint, setHint] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  const selectedCount = rows.filter((row) => row.kind === 'selected').length
+
+  const finish = (action: () => void) => {
+    setDone(true)
+    exit()
+    action()
+  }
+
+  useInput((input, key) => {
+    if (done) return
+    if (hint !== null) setHint(null)
+
+    if (key.escape || (key.ctrl && input === 'c')) {
+      finish(onAbort)
+      return
+    }
+
+    if (key.upArrow) {
+      setCursor((c) => (c === 0 ? candidates.length - 1 : c - 1))
+      return
+    }
+    if (key.downArrow) {
+      setCursor((c) => (c + 1) % candidates.length)
+      return
+    }
+
+    if (input === ' ') {
+      const row = rows[cursor]
+      const candidate = candidates[cursor]
+      if (row === undefined || candidate === undefined) return
+      if (row.kind === 'selected') {
+        setRows(replace(rows, cursor, { kind: 'unselected', displayed: row.displayed }))
+        return
+      }
+      if (row.displayed.kind === 'stationary') {
+        // Refused rather than silently ignored: the version on screen is
+        // the one already installed, and the user pressing Space is
+        // asking for something this row cannot do until they toggle.
+        setHint(`${candidate.facet.name} ${describeChoice(row.displayed.choice)} is already installed — press l first.`)
+        return
+      }
+      setRows(replace(rows, cursor, { kind: 'selected', displayed: row.displayed }))
+      return
+    }
+
+    if (input === 'l' || input === 'L') {
+      const row = rows[cursor]
+      const candidate = candidates[cursor]
+      if (row === undefined || candidate === undefined) return
+      const flipped = other(row.displayed.choice)
+      setRows(replace(rows, cursor, stateFor(candidate, flipped, row.kind === 'selected')))
+      return
+    }
+
+    if (key.return) {
+      const selections: FacetUpdateSelection[] = []
+      for (const [index, row] of rows.entries()) {
+        const candidate = candidates[index]
+        if (row.kind !== 'selected' || candidate === undefined) continue
+        selections.push({ facetName: candidate.facet.name, choice: row.displayed.choice })
+      }
+      if (selections.length === 0) {
+        setHint('Select at least one facet with Space, or press Esc to cancel.')
+        return
+      }
+      finish(() => onConfirm(selections))
+    }
+  })
+
+  const nameWidth = candidates.reduce((max, row) => Math.max(max, row.facet.name.length), 0)
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Text>Choose which facets to update.</Text>
+      <Box height={1} />
+      {candidates.map((candidate, index) => {
+        const row = rows[index]
+        if (row === undefined) return null
+        return (
+          <PickerRow
+            key={candidate.facet.name}
+            candidate={candidate}
+            state={row}
+            focused={index === cursor}
+            nameWidth={nameWidth}
+          />
+        )
+      })}
+      <Box height={1} />
+      <Text color={THEME.keyword}>↑↓ move · Space toggle · l target/latest · Enter confirm · Esc cancel</Text>
+      <Text color={THEME.hint}>
+        {selectedCount} of {candidates.length} selected
+      </Text>
+      {hint !== null && <Text color={THEME.caution}>{hint}</Text>}
+    </Box>
+  )
+}
+
+function PickerRow({
+  candidate,
+  state,
+  focused,
+  nameWidth,
+}: {
+  candidate: Candidate
+  state: RowState
+  focused: boolean
+  nameWidth: number
+}) {
+  const chosen = state.displayed.choice
+  const version = chosen === 'range' ? candidate.facet.target : candidate.facet.latest
+  const label = describeChoice(chosen)
+  const stationary = state.displayed.kind === 'stationary'
+
+  return (
+    <Box>
+      <Text color={focused ? THEME.focus : THEME.hint}>{focused ? '▸ ' : '  '}</Text>
+      <Text color={state.kind === 'selected' ? THEME.secondary : undefined}>
+        {state.kind === 'selected' ? '●' : '○'}
+      </Text>
+      <Text bold color={THEME.brand}>
+        {' '}
+        {candidate.facet.name.padEnd(nameWidth)}
+      </Text>
+      <Text color={THEME.hint}> {describeExact(candidate.facet.current)} → </Text>
+      <Text color={stationary ? THEME.hint : THEME.success}>{version.metadata.version}</Text>
+      <Text color={THEME.hint}>
+        {' '}
+        ({label}
+        {stationary ? ', unchanged' : ''})
+      </Text>
+    </Box>
+  )
+}
+
+function initialState(candidate: Candidate, mode: UpdateMode): RowState {
+  // Selected by default when the mode's own choice already advances: the
+  // user asked for this mode, so its answer is the one they came for.
+  return stateFor(candidate, mode, true)
+}
+
+function stateFor(candidate: Candidate, choice: UpdateChoice, select: boolean): RowState {
+  const displayed: DisplayChoice = choiceAdvances(candidate, choice)
+    ? { kind: 'advancing', choice }
+    : { kind: 'stationary', choice }
+  if (select && displayed.kind === 'advancing') return { kind: 'selected', displayed }
+  return { kind: 'unselected', displayed }
+}
+
+function replace(rows: readonly RowState[], index: number, next: RowState): RowState[] {
+  return rows.map((row, i) => (i === index ? next : row))
+}
+
+function other(choice: UpdateChoice): UpdateChoice {
+  return choice === 'range' ? 'latest' : 'range'
+}
+
+function describeChoice(choice: UpdateChoice): string {
+  return choice === 'range' ? 'target' : 'latest'
+}
+
+function describeExact(version: { major: number; minor: number; patch: number }): string {
+  return `${version.major}.${version.minor}.${version.patch}`
+}

--- a/packages/cli/src/commands/update/preview.ts
+++ b/packages/cli/src/commands/update/preview.ts
@@ -1,0 +1,42 @@
+import type { FacetUpdateSelection, SelectedFacetUpdate, UpdateChoice, UpdatePlanRow } from '@agent-facets/engine'
+import type { ManifestRewrite } from '../../tui/views/update/plan-view.tsx'
+
+/**
+ * What the plan view needs to draw a selection: which choice each facet
+ * takes, and which `facets.json` values would change.
+ *
+ * Both are derived from the engine's validated selections rather than
+ * recomputed, so a preview cannot describe an edit the write would not
+ * make.
+ */
+export interface UpdatePreview {
+  selected: ReadonlyMap<string, UpdateChoice>
+  rewrites: ReadonlyMap<string, ManifestRewrite>
+}
+
+export function buildPreview(
+  plan: readonly UpdatePlanRow[],
+  selections: readonly FacetUpdateSelection[],
+  validated: readonly SelectedFacetUpdate[],
+): UpdatePreview {
+  const selected = new Map<string, UpdateChoice>()
+  for (const selection of selections) selected.set(selection.facetName, selection.choice)
+
+  const authored = new Map<string, string>()
+  for (const row of plan) {
+    if (row.kind === 'unsupported-source') continue
+    authored.set(row.facet.name, row.facet.authored.source)
+  }
+
+  const rewrites = new Map<string, ManifestRewrite>()
+  for (const selection of validated) {
+    const from = authored.get(selection.facetName)
+    // An unchanged specifier is not a rewrite. Rendering `1.* → 1.*` for
+    // every range selection would bury the handful of lines that do
+    // change what the project declares.
+    if (from === undefined || from === selection.manifestSource) continue
+    rewrites.set(selection.facetName, { from, to: selection.manifestSource })
+  }
+
+  return { selected, rewrites }
+}

--- a/packages/cli/src/commands/update/run-picker.ts
+++ b/packages/cli/src/commands/update/run-picker.ts
@@ -1,0 +1,47 @@
+import type { FacetUpdateSelection, UpdatePlanRow } from '@agent-facets/engine'
+import { render } from 'ink'
+import { createElement } from 'react'
+import { UpdatePicker } from './picker.tsx'
+import type { UpdateMode } from './selection.ts'
+
+/**
+ * Cancellation is its own arm, not an empty selection.
+ *
+ * An empty confirm is impossible — the picker refuses it — so `[]` would
+ * only ever mean "cancelled", and a caller reading it as "nothing to do"
+ * would report success for a run the user abandoned.
+ */
+export type UpdatePickerOutcome = { kind: 'confirmed'; selections: FacetUpdateSelection[] } | { kind: 'cancelled' }
+
+/**
+ * Mount the picker, wait for it, and hand back what the user decided.
+ *
+ * Ctrl-C is handled inside the component rather than by Ink, so the
+ * mount always unwinds through the same path and the caller always gets
+ * an outcome.
+ */
+export async function runUpdatePicker(plan: readonly UpdatePlanRow[], mode: UpdateMode): Promise<UpdatePickerOutcome> {
+  const state: { outcome: UpdatePickerOutcome } = { outcome: { kind: 'cancelled' } }
+
+  const instance = render(
+    createElement(UpdatePicker, {
+      plan,
+      mode,
+      onConfirm: (selections) => {
+        state.outcome = { kind: 'confirmed', selections }
+      },
+      onAbort: () => {
+        state.outcome = { kind: 'cancelled' }
+      },
+    }),
+    { exitOnCtrlC: false },
+  )
+
+  try {
+    await instance.waitUntilExit()
+  } finally {
+    instance.unmount()
+  }
+
+  return state.outcome
+}

--- a/packages/cli/src/commands/update/selection.ts
+++ b/packages/cli/src/commands/update/selection.ts
@@ -1,0 +1,92 @@
+import type { FacetUpdateSelection, UpdateChoice, UpdatePlanRow } from '@agent-facets/engine'
+
+/**
+ * Which version a non-interactive run takes for each facet.
+ *
+ * `range` respects what `facets.json` declares; `latest` ignores it. The
+ * flag is the whole difference, so it is the whole type.
+ */
+export type UpdateMode = UpdateChoice
+
+/**
+ * Whether a candidate's chosen version is actually newer than what is
+ * installed.
+ *
+ * Read from the engine's `advancing` tag rather than compared here. The
+ * engine resolved both versions and already answered this question; a
+ * second comparison in the CLI is a second answer waiting to disagree
+ * with the one application enforces.
+ */
+export function choiceAdvances(row: Extract<UpdatePlanRow, { kind: 'candidate' }>, choice: UpdateChoice): boolean {
+  switch (row.advancing) {
+    case 'range-and-latest':
+      return true
+    case 'range-only':
+      return choice === 'range'
+    case 'latest-only':
+      return choice === 'latest'
+  }
+}
+
+/** Every candidate whose chosen version advances, in project order. */
+export function defaultSelections(plan: readonly UpdatePlanRow[], mode: UpdateMode): FacetUpdateSelection[] {
+  const selections: FacetUpdateSelection[] = []
+  for (const row of plan) {
+    if (row.kind !== 'candidate') continue
+    if (!choiceAdvances(row, mode)) continue
+    selections.push({ facetName: row.facet.name, choice: mode })
+  }
+  return selections
+}
+
+/**
+ * Why a successful run is about to apply nothing.
+ *
+ * Four distinct facts, and a user acts on each of them differently: add
+ * a facet, do nothing, pass `--latest`, or (the last one) nothing at
+ * all. Collapsing them into "no updates available" is what makes the
+ * third case — releases exist, the declared ranges just forbid them —
+ * look like the second.
+ */
+export type UpdateNoOp =
+  | { reason: 'no-registry-facets' }
+  | { reason: 'all-current' }
+  | { reason: 'ranges-permit-none' }
+  | { reason: 'latest-permits-none' }
+
+/**
+ * Classify an empty selection. Returns `null` when there is work to do,
+ * so the caller cannot reach a no-op message while holding selections.
+ */
+export function classifyNoOp(
+  plan: readonly UpdatePlanRow[],
+  mode: UpdateMode,
+  selections: readonly FacetUpdateSelection[],
+): UpdateNoOp | null {
+  if (selections.length > 0) return null
+
+  const registryRows = plan.filter((row) => row.kind !== 'unsupported-source')
+  if (registryRows.length === 0) return { reason: 'no-registry-facets' }
+
+  const candidates = plan.filter((row) => row.kind === 'candidate')
+  if (candidates.length === 0) return { reason: 'all-current' }
+
+  // Something newer exists and this mode cannot reach it. Under plain
+  // update that is the authored range's doing and `--latest` is the way
+  // past it; under `--latest` there is nothing left to suggest.
+  return mode === 'range' ? { reason: 'ranges-permit-none' } : { reason: 'latest-permits-none' }
+}
+
+/** The message for each no-op, including the one that has a next step. */
+export function describeNoOp(noOp: UpdateNoOp): string {
+  switch (noOp.reason) {
+    case 'no-registry-facets':
+      return 'No registry facets to update. Only registry-backed facets can be checked for newer releases.'
+    case 'all-current':
+      return 'All registry facets are current.'
+    case 'ranges-permit-none':
+      return 'Newer releases exist, but the ranges in facets.json permit none of them. Run `facet update --latest` to take them anyway.'
+    case 'latest-permits-none':
+      return 'No registry facet has a newer release than the one installed.'
+  }
+}

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -82,9 +82,12 @@ export interface InstallViewProps {
   /**
    * Header copy hint. `'add'` renders "Adding facets..."; `'install'`
    * renders "Installing facets..."; `'remove'` renders "Removing
-   * facets...". Functional behavior is identical.
+   * facets..."; `'update'` renders "Updating facets...". Functional
+   * behavior is identical — update in particular runs the same pipeline
+   * as every other operation, which is why it gets a word rather than a
+   * second progress renderer.
    */
-  mode: 'add' | 'install' | 'remove'
+  mode: 'add' | 'install' | 'remove' | 'update'
   /**
    * Fires once when the install completes, before Ink unmounts. Lets
    * the caller capture the result for exit-code mapping.
@@ -98,6 +101,14 @@ export interface InstallViewProps {
    */
   signal?: AbortSignal
 }
+
+/** What each mode calls the thing it is doing, in one table per surface. */
+const HEADER_LABELS = {
+  add: 'Adding facets:',
+  install: 'Installing facets:',
+  remove: 'Removing facets:',
+  update: 'Updating facets:',
+} as const satisfies Record<InstallViewProps['mode'], string>
 
 /** Type guard: a driver result that is an add prepare-phase failure. */
 function isPrepareFailure(r: InstallViewResult): r is { ok: false; prepareFailure: AddPrepareFailure } {
@@ -490,7 +501,7 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
     return () => signal.removeEventListener('abort', onAbort)
   }, [signal, phase])
 
-  const headerLabel = mode === 'add' ? 'Adding facets:' : mode === 'remove' ? 'Removing facets:' : 'Installing facets:'
+  const headerLabel = HEADER_LABELS[mode]
 
   // Compute live counters: [done, remaining, failed].
   let doneCount = 0
@@ -677,7 +688,7 @@ function SuccessSummary({
   elapsedMs,
 }: {
   result: RunInstallResult & { ok: true }
-  mode: 'add' | 'install' | 'remove'
+  mode: 'add' | 'install' | 'remove' | 'update'
   adapterCount: number
   elapsedMs: number
 }) {
@@ -728,18 +739,25 @@ function SuccessSummary({
   // still there because nothing proved this machine installed them.
   const untrackedNames = result.perFacet.filter((o) => o.kind === 'removed-untracked').map((o) => o.name)
 
+  // Every version this run moved, oldest fact first. `updated` is the
+  // only outcome that carries both halves, which is exactly why update
+  // mode names them: "1 updated" does not tell a user what they now have.
+  const transitions = result.perFacet.filter((outcome) => outcome.kind === 'updated')
+
   const actionLabel =
     mode === 'add'
       ? `${touched.join(', ')} installed.`
       : mode === 'remove'
         ? `${removedNames.join(', ')} removed.`
-        : 'Install complete.'
+        : mode === 'update'
+          ? 'Update complete.'
+          : 'Install complete.'
   const registrationSuffix =
     adapterCount > 0 ? ` Updated facets via ${adapterCount} adapter${adapterCount === 1 ? '' : 's'}` : ''
 
-  // Timer line: "Installed N facets" or "Removed N facets"
-  const timerVerb = mode === 'remove' ? 'Removed' : 'Installed'
-  const timerCount = mode === 'remove' ? removedNames.length : touched.length
+  // Timer line: "Installed N facets", "Removed N facets", "Updated N facets"
+  const timerVerb = mode === 'remove' ? 'Removed' : mode === 'update' ? 'Updated' : 'Installed'
+  const timerCount = mode === 'remove' ? removedNames.length : mode === 'update' ? transitions.length : touched.length
 
   return (
     <Box flexDirection="column">
@@ -758,6 +776,17 @@ function SuccessSummary({
       <Box flexDirection="column" marginLeft={2}>
         <Text color={THEME.hint}>{summaryLine(summary)}</Text>
         {bundleVizNode}
+        {/* The whole point of the command: which version each facet was
+            on, and which one it is on now. */}
+        {mode === 'update' &&
+          transitions.map((outcome) => (
+            <Text key={outcome.name}>
+              <Text color={THEME.hint}>{outcome.name} </Text>
+              <Text>{outcome.oldVersion}</Text>
+              <Text color={THEME.hint}> → </Text>
+              <Text color={THEME.success}>{outcome.newVersion}</Text>
+            </Text>
+          ))}
         {/* Aliases and omissions are the one thing a user cannot infer
             from the file tree: an asset is missing, or present under a
             name they did not publish. Naming both sides makes the

--- a/packages/cli/src/tui/views/update/plan-view.tsx
+++ b/packages/cli/src/tui/views/update/plan-view.tsx
@@ -1,0 +1,114 @@
+import type { UpdateChoice, UpdatePlanRow } from '@agent-facets/engine'
+import { Box, Text } from 'ink'
+import { THEME } from '../../theme.ts'
+
+/**
+ * What one facet would commit to `facets.json`, when that differs from
+ * what it already says.
+ *
+ * The value comes from the engine's selection validation, never from
+ * this file — the preview and the write have to be the same derivation
+ * or the preview is fiction.
+ */
+export interface ManifestRewrite {
+  from: string
+  to: string
+}
+
+export interface UpdatePlanViewProps {
+  plan: readonly UpdatePlanRow[]
+  /** Which version each selected facet takes. Absent names are not selected. */
+  selected: ReadonlyMap<string, UpdateChoice>
+  /** Manifest edits the selection would commit, keyed by facet name. */
+  rewrites: ReadonlyMap<string, ManifestRewrite>
+}
+
+/**
+ * The update plan as a table: every checkable facet's declared range,
+ * what is installed, and both versions it could move to.
+ *
+ * Current, Target, and Latest are shown together even when a facet is
+ * not selected. That is the point of the screen — "why is this one not
+ * moving?" is answered by seeing that its Target equals Current while
+ * Latest is ahead, which is exactly the case `--latest` exists for.
+ */
+export function UpdatePlanView({ plan, selected, rewrites }: UpdatePlanViewProps) {
+  const rows = plan.filter((row) => row.kind !== 'unsupported-source')
+  const unsupported = plan.filter((row) => row.kind === 'unsupported-source')
+
+  const nameWidth = width(rows.map((row) => row.facet.name))
+  const sourceWidth = width(rows.map((row) => row.facet.authored.source))
+  const currentWidth = width(rows.map((row) => describeExact(row.facet.current)))
+  const targetWidth = width(rows.map((row) => row.facet.target.metadata.version))
+
+  return (
+    <Box flexDirection="column">
+      {rows.length > 0 && (
+        <Text color={THEME.hint}>
+          {'  '}
+          {'facet'.padEnd(nameWidth)} {'declared'.padEnd(sourceWidth)} {'current'.padEnd(currentWidth)}{' '}
+          {'target'.padEnd(targetWidth)} latest
+        </Text>
+      )}
+      {rows.map((row) => {
+        const choice = selected.get(row.facet.name)
+        const rewrite = rewrites.get(row.facet.name)
+        return (
+          <Box key={row.facet.name} flexDirection="column">
+            <Text>
+              {/* The marker carries the same meaning as the picker's: this
+                  row is one of the ones about to move. */}
+              <Text color={choice === undefined ? THEME.hint : THEME.success}>
+                {choice === undefined ? '  ' : '▸ '}
+              </Text>
+              <Text bold color={THEME.brand}>
+                {row.facet.name.padEnd(nameWidth)}
+              </Text>{' '}
+              <Text color={THEME.hint}>{row.facet.authored.source.padEnd(sourceWidth)}</Text>{' '}
+              <Text>{describeExact(row.facet.current).padEnd(currentWidth)}</Text>{' '}
+              <Version version={row.facet.target.metadata.version} chosen={choice === 'range'} pad={targetWidth} />{' '}
+              <Version version={row.facet.latest.metadata.version} chosen={choice === 'latest'} />
+            </Text>
+            {rewrite !== undefined && (
+              <Text color={THEME.caution}>
+                {'    '}facets.json {rewrite.from} → {rewrite.to}
+              </Text>
+            )}
+          </Box>
+        )
+      })}
+      {/* Named, never counted as current: a git or local facet was not
+          checked at all, and reporting it as up to date would be a claim
+          nothing verified. */}
+      {unsupported.length > 0 && (
+        <Box flexDirection="column" marginTop={rows.length > 0 ? 1 : 0}>
+          {unsupported.map((row) => (
+            <Text key={row.name} color={THEME.hint}>
+              {'  '}
+              {row.name} — {row.sourceKind} source ({row.source}); not checked for updates
+            </Text>
+          ))}
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+function Version({ version, chosen, pad }: { version: string; chosen: boolean; pad?: number }) {
+  const text = pad === undefined ? version : version.padEnd(pad)
+  return chosen ? (
+    <Text color={THEME.success} bold>
+      {text}
+    </Text>
+  ) : (
+    <Text color={THEME.hint}>{text}</Text>
+  )
+}
+
+function describeExact(version: { major: number; minor: number; patch: number }): string {
+  return `${version.major}.${version.minor}.${version.patch}`
+}
+
+function width(values: readonly string[]): number {
+  return values.reduce((max, value) => Math.max(max, value.length), 0)
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -286,7 +286,11 @@ export type {
   UpdatePlanRow,
   UpdateSelectionFailure,
 } from './install/update/index.ts'
-export { prepareFacetUpdate, runPreparedFacetUpdate } from './install/update/index.ts'
+// `validateFacetUpdateSelections` is exported because a dry run has to
+// show the EXACT `facets.json` value an application would commit. That
+// value is derived here, once; recomputing it in the CLI would let a
+// preview describe a different edit than the one that runs.
+export { prepareFacetUpdate, runPreparedFacetUpdate, validateFacetUpdateSelections } from './install/update/index.ts'
 // loaders. Note: `ResolvedFacetManifest` and `FACET_MANIFEST_FILE` are
 // part of `@agent-facets/protocol`'s public surface, not engine's. CLI
 // imports them directly from protocol; we don't re-export them here to

--- a/packages/engine/src/install/update/apply.ts
+++ b/packages/engine/src/install/update/apply.ts
@@ -66,7 +66,7 @@ export async function runPreparedFacetUpdate(
 ): Promise<RunPreparedFacetUpdateResult> {
   const { prepared, adapters, selections, onStage, onLog, signal, ...interactions } = opts
 
-  const validated = validateSelections(prepared.plan, selections)
+  const validated = validateFacetUpdateSelections(prepared.plan, selections)
   if (!validated.ok) return { ok: false, phase: 'selection', failure: validated.failure }
 
   const install = await runInstall({
@@ -96,7 +96,7 @@ export async function runPreparedFacetUpdate(
  * computed its own manifest value would be describing a different
  * operation than the one that runs.
  */
-export function validateSelections(
+export function validateFacetUpdateSelections(
   plan: readonly UpdatePlanRow[],
   selections: ReadonlyArray<FacetUpdateSelection>,
 ):

--- a/packages/engine/src/install/update/index.ts
+++ b/packages/engine/src/install/update/index.ts
@@ -14,7 +14,7 @@ export type {
   RunPreparedFacetUpdateResult,
   UpdateSelectionFailure,
 } from './apply.ts'
-export { runPreparedFacetUpdate } from './apply.ts'
+export { runPreparedFacetUpdate, validateFacetUpdateSelections } from './apply.ts'
 export type { AuthoredSpecifier, UpdateChoice } from './manifest-source.ts'
 export { type PrepareFacetUpdateArgs, prepareFacetUpdate } from './prepare.ts'
 export type {


### PR DESCRIPTION
### Why

`facet upgrade` was an inert stub. Users running it got a "not yet implemented" message. This replaces the stub with a fully working `facet update` command (aliased as `upgrade`) that moves a project's registry-backed facets to newer releases.

### Details

The command is split into two engine phases: `prepareFacetUpdate` resolves each facet's range target and the registry's latest release without taking the project lock, and `runPreparedFacetUpdate` applies the reviewed choices through the ordinary install transaction. This ordering is deliberate — nothing that could install an adapter, acquire a lock, or write a file runs before the user has confirmed a selection they can still cancel.

`upgrade` is not a second entry in the command registry. It is an alias on `updateCommand`, so both names resolve to one object with one help page and one behavior. The old stub key is gone.

Key behaviors:

- **`--latest` / `-L`**: ignores the declared range and takes each facet's newest release, rewriting `facets.json` with the smallest specifier that admits it.
- **`--interactive` / `-i`**: opens a picker where each row shows both the range target and the latest release, with `l` to toggle between them. The picker is refused before any registry lookup when no TTY is available.
- **`--dry-run`**: renders the full plan — including any `facets.json` rewrites `--latest` would commit — and exits without touching any files or installing any adapter.
- **No-op classification**: four distinct outcomes (`no-registry-facets`, `all-current`, `ranges-permit-none`, `latest-permits-none`) each produce a different message, so the case where newer releases exist but the declared ranges forbid them is not silently collapsed into "nothing to update".
- **Positional arguments** are refused with a pointer to `--interactive`, since that is the mechanism for updating a subset of facets.
- **`InstallView`** gains an `'update'` mode that labels the operation correctly, counts only facets that actually moved in the timer line, and lists each version transition (`alpha 1.2.0 → 1.8.0`) in the success summary.
- **`UPDATE_PLAN_STALE`** is handled in the shared failure translator: the project moved between plan and application, so the remedy is to re-run rather than hunt for a broken file.
- `validateFacetUpdateSelections` is now exported from the engine so the CLI's dry-run preview derives `facets.json` values from the same derivation the write uses, making the preview and the application identical by construction.

### Verification

CI covers it. New test files added:

- `update.e2e.test.ts` — process-level tests covering help output, alias identity, refused invocations, no-op exits, and projects that cannot be checked.
- `commands/update/__tests__/registration.test.ts` — command registry, alias resolution, flag surface, and help rendering.
- `commands/update/__tests__/command.test.ts` — orchestration: refusals, preparation failures, no-ops, and dry-run output.
- `commands/update/__tests__/selection.test.ts` — `defaultSelections`, `classifyNoOp`, and `describeNoOp`.
- `commands/update/__tests__/picker.test.tsx` — `UpdatePicker` keyboard behavior, toggle logic, selection constraints, and cancellation.
- `commands/update/__tests__/plan-view.test.tsx` — `UpdatePlanView` table rendering and manifest rewrite display.
- `install-view.test.tsx` extended with an update-mode section covering the operation label, version transitions, timer count, and stale-plan failure rendering.