### PR TITLE
Implement `facet update` (aliased `facet upgrade`) with docs, spec, and prompts

### DIFF
--- a/.changeset/small-icons-write.md
+++ b/.changeset/small-icons-write.md
@@ -1,0 +1,13 @@
+---
+"agent-facets": minor
+---
+
+**New command: `facet update` (aliased `facet upgrade`)** — moves the registry-backed facets a project declares to newer releases. It reads `facets.json` and `facets.lock`, asks the registry for each facet's range-respecting target and its latest release, and shows both alongside what is installed, so "why is this one not moving?" is answerable from the plan itself. Plain `facet update` takes every target the declared specifier already permits. `--latest` (`-L`) crosses those specifiers and rewrites them by the smallest edit that admits the new version, preserving how the intent was written: a pin stays a pin, `1.*` becomes `2.*`, `1.2.*` becomes `2.4.*`, and `*` and `latest` are left exactly as authored.
+
+**Previews and per-facet selection.** `--dry-run` prints the plan and writes nothing — no manifest, no lockfile, no receipt, no assets, no cache, and no adapter installation, which makes it safe on a machine with no adapter connected. `--interactive` (`-i`) opens a picker for choosing which facets move and which version each takes; it requires a real terminal and fails immediately without one, before any registry lookup. Git and local facets are named as unsupported rather than counted as current — reporting them as up to date would claim something nothing verified.
+
+**Applying an update is an install.** Discovery runs read-only and takes no project lock, so reading a plan never blocks another facet operation. Application re-checks under the lock that the project has not moved since the plan was reviewed, then runs the ordinary install pipeline: the same verification, collision handling, MCP approval, rollback, and atomic manifest/lockfile/receipt write. The version you reviewed is the version installed — a release published in between does not silently change it. Recorded materialization choices survive a version change. There is no `--frozen-lockfile`: reproducing what the lockfile already records is the opposite of what this command does.
+
+**Breaking: `facet upgrade` is no longer a placeholder.** It previously printed a not-yet-implemented notice and exited `0` without touching a single file. It is now an alias of `facet update` — one command, one help page, one behavior — so the same invocation contacts the registry, may install adapters, takes the project lock, and rewrites `facets.json`, `facets.lock`, the install receipt, and your materialized assets. `update` is the canonical spelling, and `facet upgrade --help` prints `Usage: facet update`. If something in your automation called `facet upgrade` expecting a no-op, drop the call or make it explicit with `facet update --dry-run`.
+
+Neither name touches the CLI binary. That remains `facet self-update`.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Please see https://docs.agentfacets.io/cli for a detailed reference for the `fac
 ### Other Commands
 
 ```shell
-
-
 # Reapply an existing project's facets after a fresh clone or after
 # pulling teammate changes:
 facet install
@@ -40,7 +38,13 @@ facet install
 # up front — otherwise a facet that declares servers fails before writing.
 facet install --accept-mcp
 
-# Update the CLI later
+# Move this project's facets to newer releases (alias: facet upgrade).
+# Respects the ranges in facets.json; --latest crosses them.
+facet update
+facet update --latest
+facet update --dry-run
+
+# Update the CLI binary itself — a different thing from the line above.
 facet self-update
 ```
 

--- a/docs/cli/add.mdx
+++ b/docs/cli/add.mdx
@@ -148,6 +148,8 @@ facet add viper-plans@1.x            # x-style placeholders — use 1.* or 1.2.*
 
 ## Re-adding a facet
 
+Re-adding is how you pin **one** facet to a version you name. To move every declared facet to whatever newer releases exist, use [`facet update`](/cli/update) instead — it checks the registry for you rather than making you supply the version.
+
 Running `facet add` against a facet that's already in `facets.json` is supported:
 
 - Same source as before → no-op (lockfile may report `unchanged` or `repaired`). If you have since aliased or omitted one of its assets or servers, it reports `updated` instead — the version did not move, but its materialization did.
@@ -162,4 +164,5 @@ What gets written per specifier shape is defined by the [manifest-write policy](
 ## See also
 
 - [`facet install`](/cli/install)  -- re-runs the install pipeline against the current `facets.json` and lockfile, useful after a fresh `git clone` or to reapply assets after manual edits.
+- [`facet update`](/cli/update)  -- move declared facets to newer releases without naming versions yourself.
 - [`facet adapter add`](/cli/adapters/add)  -- install adapters into your machine.

--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -32,6 +32,9 @@ The following are the most common `facet` commands. See the [roadmap](/roadmap) 
   <Card title={<Badge>facet add</Badge>} href="/cli/add">
     Add a **facet** to the project  -- resolve from a source, download, and install in one step
   </Card>
+  <Card title={<Badge>facet update</Badge>} href="/cli/update">
+    Move the project's **facets** to newer releases (alias: `facet upgrade`)
+  </Card>
   <Card title={<Badge>facet publish</Badge>} href="/cli/authoring/publish">
     Publish a built **facet** to the registry
   </Card>

--- a/docs/cli/list.mdx
+++ b/docs/cli/list.mdx
@@ -40,3 +40,4 @@ Shows all facets declared in `facets.json` for the current project. No network c
 
 - [`facet add`](/cli/add) -- add a facet to the project.
 - [`facet install`](/cli/install) -- install all declared facets.
+- [`facet update`](/cli/update) -- ask the registry whether newer releases exist, which `facet list` never does.

--- a/docs/cli/self-update.mdx
+++ b/docs/cli/self-update.mdx
@@ -11,6 +11,8 @@ facet self-update
 
 `facet self-upgrade` is an alias of the same command.
 
+This updates the `facet` **binary**. To move the facets a project declares to newer releases, use [`facet update`](/cli/update).
+
 ## Examples
 
 ```sh
@@ -43,7 +45,9 @@ re-ran without `--dry-run`.
 
 ## What it does
 
-Updates the running `facet` binary in place. Detects how the binary was
+Updates the running `facet` binary in place. It never reads or writes
+`facets.json`, `facets.lock`, or any materialized asset  -- that is
+[`facet update`](/cli/update)'s job. Detects how the binary was
 installed  -- the curl installer, an `npm` / `yarn` / `pnpm` / `bun` global
 install, dev mode, or an unclassified location  -- and dispatches to the
 matching update mechanism for that path. Existing trust roots (the
@@ -81,6 +85,9 @@ has no business writing over the path you pointed it at. Unset
 
 Three variables affect self-update — `FACET_CLI_REGISTRY` (npm registry for version lookup), `FACET_DIR` (where the curl-installed binary lives), and `FACET_BIN_OVERRIDE` (triggers the dev-mode refusal above). See the [environment variables reference](/cli/env) for details.
 
+`FACET_CLI_REGISTRY` is the **npm** registry the CLI is published to. It is not the facet registry facets come from — that one is `FACET_REGISTRY_URL`, and it has no effect here.
+
 ## See also
 
+- [`facet update`](/cli/update) -- update the project's facets, not the CLI binary.
 - [Environment variables](/cli/env) -- `FACET_CLI_REGISTRY`, `FACET_DIR`, and `FACET_BIN_OVERRIDE` in full.

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -1,0 +1,206 @@
+---
+title: facet update
+description: Move declared facets to newer releases
+---
+
+## Usage
+
+```sh
+facet update
+```
+
+Checks every registry-backed facet in `facets.json` for a newer release and installs the ones that move. `facet upgrade` is an alias of the same command — same flags, same output, same exit codes.
+
+This updates the **facets your project declares**. To update the `facet` binary itself, use [`facet self-update`](/cli/self-update).
+
+`facet update` does not accept positional arguments. To update some facets but not others, use [`--interactive`](#param-interactive).
+
+## Examples
+
+```sh
+facet update                    # take the newest release each range allows
+facet update --latest           # take the newest release, ignoring ranges
+facet update --dry-run          # print the plan; change nothing
+facet update --interactive      # choose per facet, and which version each takes
+facet update -L -i              # same, starting from each facet's latest
+```
+
+## Flags
+
+<ResponseField name="--latest" type="boolean">
+  Update to each facet's latest release, ignoring the range in `facets.json`. Short form: `-L`.
+
+  Because the selected version may fall outside what the project declares, this is the only mode that rewrites the specifier — see [Crossing the declared range](#crossing-the-declared-range).
+</ResponseField>
+
+<ResponseField name="--interactive" type="boolean">
+  Choose which facets to update, and which version each one takes. Short form: `-i`.
+
+  Requires a terminal that can prompt. Without one, the command fails **before** contacting the registry rather than after — see [Choosing interactively](#choosing-interactively).
+</ResponseField>
+
+<ResponseField name="--dry-run" type="boolean">
+  Print the plan; do not modify any files. Exits `0` whether or not updates are available.
+</ResponseField>
+
+<ResponseField name="--verbose" type="boolean">
+  Show detailed step output on stderr. Verbose output never reproduces an MCP server declaration — see [Where declarations appear](/cli/install#where-declarations-appear).
+</ResponseField>
+
+<ResponseField name="--accept-mcp" type="boolean">
+  Approve the MCP server configuration this update would write, without prompting.
+
+  An update is an install, so it collects the same approval on the same terms as [`facet install`](/cli/install#param-accept-mcp). It does **not** authorize an [asset takeover](/cli/install#taking-over-an-existing-file) or resolve an asset [name collision](/cli/install#name-collisions).
+</ResponseField>
+
+<Note>
+There is no `--frozen-lockfile`. Frozen mode reproduces what the lockfile already records, which is the opposite of what this command does. It belongs to [`facet install`](/cli/install#param-frozen-lockfile).
+</Note>
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0`  | Updates applied, a successful [no-op](#when-nothing-moves), or a completed `--dry-run`. |
+| `1`  | Positional arguments, `--interactive` without a terminal, a cancelled picker, a project that [cannot be checked](#when-the-project-cannot-be-checked), a failed registry lookup, a [stale plan](#when-the-project-moves-mid-run), or a failed install. |
+| `2`  | An unexpected error escaped command handling. |
+
+## Current, Target, and Latest
+
+Every checkable facet has three versions, and the plan shows all three:
+
+<ResponseField name="current" type="installed">
+  The exact version `facets.lock` records as installed.
+</ResponseField>
+
+<ResponseField name="target" type="range-respecting">
+  The newest release the specifier in `facets.json` already permits. Selecting it never changes what the project declares.
+</ResponseField>
+
+<ResponseField name="latest" type="newest published">
+  The registry's newest release, regardless of the declared specifier.
+</ResponseField>
+
+All three are shown even for a facet that is not moving, because that is what answers "why is this one staying put?":
+
+```
+  facet       declared  current  target  latest
+▸ viper-plans 1.*       1.2.0    1.4.0   2.0.0
+  cowsay      2.1.*     2.1.3    2.1.3   3.0.0
+```
+
+Here `viper-plans` moves to `1.4.0` under a plain `facet update`. `cowsay` does not move at all: its range allows nothing newer than what is installed, and reaching `3.0.0` requires `--latest`.
+
+Plain `facet update` takes every Target that advances. `--latest` takes every Latest that advances.
+
+## Crossing the declared range
+
+`--latest` may select a version the declared specifier forbids, so it rewrites that specifier — by the smallest edit that admits the new version while preserving how you chose to express intent:
+
+```
+    facets.json 1.* → 2.*
+```
+
+A pin stays a pin, a major wildcard stays a major wildcard, and a specifier that already floats is left exactly as written. The complete table lives in the [manifest-write policy](/specification/commit#manifest-write-policy).
+
+Selecting a Target never rewrites anything: the specifier already permits that version, so the declared intent has not changed.
+
+## Choosing interactively
+
+`--interactive` lists every facet with an advancing version and lets you pick both which facets move and which version each one takes:
+
+```
+↑↓ move · Space toggle · l target/latest · Enter confirm · Esc cancel
+```
+
+Each row starts on its Target, or on its Latest when `--latest` is also supplied. `l` toggles the focused row between the two. A row showing a version that is already installed cannot be selected until you toggle it — pressing `Space` there says so rather than silently doing nothing. Confirming requires at least one selected facet.
+
+Selection happens **before** adapter selection and before anything is written, so `Esc` or `Ctrl-C` costs nothing: the command reports that nothing was applied and exits `1`.
+
+Without a terminal that can prompt — CI, piped output — `--interactive` fails immediately, before any registry lookup, and points at plain `facet update` or `facet update --latest`.
+
+## Previewing
+
+`--dry-run` prints the plan and modifies nothing: no manifest, no lockfile, no receipt, no assets, no cache, and no adapter installation. Combined with `--interactive`, it previews the selection you confirmed and stops there.
+
+<Note>
+A preview shows **versions**, not their downstream effects. Which assets a new release materializes, whether it collides with another facet, and what MCP configuration it declares are all determined during the install that a real run performs.
+</Note>
+
+## What it does
+
+<Steps>
+  <Step title="Discover, without taking the project lock">
+    Reads `facets.json` and `facets.lock`, then asks the registry for each facet's range Target and its Latest. This phase writes nothing and takes no lock, so reading a plan never blocks another facet operation on the machine. A single failed lookup rejects the whole discovery rather than presenting a partial answer.
+  </Step>
+  <Step title="Select">
+    Applies the mode's default choices, or the ones you confirmed in the picker. A `--dry-run` stops here.
+  </Step>
+  <Step title="Apply through the install pipeline">
+    Confirms the project has not changed since the plan was reviewed, then runs the ordinary [install pipeline](/specification/install) for the selected facets — the same verification, collision detection, [MCP approval](/cli/install#mcp-servers), materialization, rollback, and atomic [tri-write](/specification/commit#transactional-tri-write) as every other install. The reviewed version is installed as chosen; a release published between review and application does not change it.
+  </Step>
+</Steps>
+
+The summary reports each facet's move:
+
+```
+  1 updated · 2 assets written
+  viper-plans 1.2.0 → 1.4.0
+```
+
+Recorded [materialization](/specification/materialization) choices — aliases and omissions — survive a version change. Outcomes, counts, and collision behavior are identical to [`facet install`](/cli/install#outcomes).
+
+## When nothing moves
+
+A run that applies nothing still succeeded, and exits `0`. Which kind of nothing it is decides whether you have anything to do about it:
+
+| Output | What it means |
+| ------ | ------------- |
+| `No registry facets to update.` | Nothing in the project is registry-backed. Only registry facets can be checked. |
+| `All registry facets are current.` | Every facet is already at the newest release that exists. |
+| `Newer releases exist, but the ranges in facets.json permit none of them.` | Something newer was published, and your specifiers forbid it. The message names `facet update --latest` as the way to take it. |
+| `No registry facet has a newer release than the one installed.` | Under `--latest`, with nothing left to suggest. |
+
+## Sources that cannot be checked
+
+Only registry facets have releases to compare. Git and local facets are **named** in the plan rather than counted as current:
+
+```
+  scratch — local source (./packages/scratch); not checked for updates
+```
+
+Reporting them as up to date would claim something nothing verified. Move one by editing its source in `facets.json` and running [`facet install`](/cli/install).
+
+## When the project cannot be checked
+
+If a declared registry facet is missing from `facets.lock`, locked to a different kind of source, locked at something that is not an exact release, or locked at a version its specifier no longer permits, update refuses to guess and exits `1`. It names **every** affected facet, because one [`facet install`](/cli/install) covers all of them:
+
+```
+error: this project cannot be checked for updates yet
+fix: run 'facet install' to bring facets.lock in line with facets.json, then update again
+```
+
+Repairing lockfile drift is `facet install`'s job, not this command's.
+
+## When the project moves mid-run
+
+If `facets.json` or `facets.lock` changes between reading the plan and applying it, the update is withdrawn before anything is written and exits `1`. Nothing is broken and nothing needs repairing — the plan simply described a project that no longer exists. Re-run `facet update` to plan against the current state.
+
+## Project facets vs. the CLI binary
+
+Four command names sit one keystroke apart. The `self-` prefix is what separates them:
+
+| Command | Acts on |
+| ------- | ------- |
+| `facet update`, `facet upgrade` | The facets declared in this project's `facets.json`. |
+| `facet self-update`, `facet self-upgrade` | The `facet` CLI binary itself. |
+
+Neither touches the other.
+
+## See also
+
+- [`facet install`](/cli/install) — the pipeline an update runs, and every outcome it reports.
+- [`facet add`](/cli/add) — add a facet, or pin an existing one to an exact version.
+- [`facet self-update`](/cli/self-update) — update the CLI binary.
+- [`facet upgrade`](/cli/upgrade) — the alias.
+- [Commit specification](/specification/commit#resolve) — how a reviewed version is resolved and written.

--- a/docs/cli/upgrade.mdx
+++ b/docs/cli/upgrade.mdx
@@ -1,6 +1,6 @@
 ---
 title: facet upgrade
-description: Upgrade installed facets to newer versions
+description: Alias of facet update
 ---
 
 ## Usage
@@ -9,32 +9,13 @@ description: Upgrade installed facets to newer versions
 facet upgrade
 ```
 
+`facet upgrade` is an alias of [`facet update`](/cli/update). One command, one help page, one behavior — the same flags, the same output, and the same exit codes. `facet upgrade --help` prints `Usage: facet update`.
+
 <Warning>
-This command is not yet implemented. Running it prints a notice and exits. It is on the roadmap for a future release.
+Older releases treated this name as a placeholder: it printed a not-yet-implemented notice, exited `0`, and changed nothing. It now applies real updates to `facets.json`, `facets.lock`, the install receipt, and your materialized assets. If something in your automation called `facet upgrade` expecting a no-op, drop the call or make it a preview with `facet update --dry-run`.
 </Warning>
-
-## Exit codes
-
-| Code | Meaning |
-| ---- | ------- |
-| `0`  | Always -- the command prints its not-yet-implemented notice and exits |
-
-## Planned behavior
-
-`facet upgrade` will re-resolve version specifiers in `facets.json` against the registry and update `facets.lock` to the newest versions that satisfy each specifier ([resolution semantics](/specification/commit#resolve)). It is the complement to `facet install`, which honors existing lockfile pins.
-
-Until `facet upgrade` ships, you can upgrade a specific facet manually:
-
-```sh
-# Re-add at a new version (updates both facets.json and facets.lock).
-facet add viper-plans@2.0.0
-
-# Or widen the specifier and reinstall.
-# Edit facets.json to change "1.2.3" to "2.*", then:
-facet install
-```
 
 ## See also
 
-- [`facet install`](/cli/install) -- install from the current lockfile.
-- [`facet add`](/cli/add) -- add or re-add a facet at a specific version.
+- [`facet update`](/cli/update) — the canonical command, with the full flag and behavior reference.
+- [`facet self-update`](/cli/self-update) — update the `facet` CLI binary instead.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,7 +97,7 @@
           {
             "group": "Facet Management",
             "icon": "box",
-            "pages": ["cli/install", "cli/add", "cli/remove", "cli/upgrade", "cli/search", "cli/list"]
+            "pages": ["cli/install", "cli/add", "cli/remove", "cli/update", "cli/search", "cli/list"]
           },
           {
             "group": "Adapters",

--- a/docs/guides/install-facets.mdx
+++ b/docs/guides/install-facets.mdx
@@ -3,7 +3,7 @@ title: Install Facets in Your Project
 description: Add, pin, reinstall, and remove facets
 ---
 
-Bring facets into a project in two moves: connect an adapter for your AI tool, then add the facets you want. This guide walks the whole loop  -- add, list, reinstall, and remove.
+Bring facets into a project in two moves: connect an adapter for your AI tool, then add the facets you want. This guide walks the whole loop  -- add, list, reinstall, update, and remove.
 
 <Visibility for="agents">
 
@@ -20,8 +20,16 @@ Bring facets into a project in two moves: connect an adapter for your AI tool, t
 > facet add viper-plans               # registry-first: a bare name is a registry facet
 > facet add viper-plans@1.2.3         # or pin a version
 > facet install                       # after a git clone: materialize from the lockfile
+> facet update                        # move declared facets to newer releases
+> facet update --latest               # ...even past the ranges facets.json declares
+> facet update --dry-run              # print the plan; write nothing, install no adapter
 > facet remove viper-plans            # take a facet back out
 > ```
+>
+> `facet upgrade` is an alias of `facet update`. Neither touches the CLI binary --
+> that is `facet self-update`. Do not pass `--interactive` without a TTY: it fails
+> immediately. If update reports the project cannot be checked, run `facet install`
+> first, then update again.
 >
 > A facet may declare MCP servers. Without a TTY those need explicit approval,
 > or the command fails before writing anything:
@@ -29,6 +37,7 @@ Bring facets into a project in two moves: connect an adapter for your AI tool, t
 > ```sh
 > facet add viper-plans --accept-mcp  # approve the MCP config this would write
 > facet install --accept-mcp
+> facet update --accept-mcp
 > facet remove viper-plans --accept-mcp
 > ```
 >
@@ -42,7 +51,8 @@ Bring facets into a project in two moves: connect an adapter for your AI tool, t
 > Approval is per machine, so a teammate's approval never covers yours.
 >
 > See [`facet add`](/cli/add), [`facet install`](/cli/install),
-> [`facet remove`](/cli/remove), and [`facet adapter add`](/cli/adapters/add).
+> [`facet update`](/cli/update), [`facet remove`](/cli/remove), and
+> [`facet adapter add`](/cli/adapters/add).
 
 </Visibility>
 
@@ -171,7 +181,7 @@ Note this facet ships an agent `cowsay` **and** a command `cowsay`. That is lega
 </Note>
 
 <Note>
-  The lockfile honors the manifest. A pinned entry is reused as long as it still satisfies `facets.json`; when you bump a version or widen a wildcard, `facet install` [re-resolves](/specification/commit#resolve) and updates the lock.
+  The lockfile honors the manifest. A pinned entry is reused as long as it still satisfies `facets.json`; when you bump a version or widen a wildcard, `facet install` [re-resolves](/specification/commit#resolve) and updates the lock. To move to a newer release without editing the manifest yourself, use [`facet update`](/cli/update).
 </Note>
 
 ## Where assets land
@@ -317,13 +327,24 @@ facet list
 
 [`facet list`](/cli/list) shows every facet in `facets.json` with its resolved version (from the lockfile), or its source specifier if it hasn't been installed yet.
 
-**Move to a newer version:**
+**Move to newer versions:**
 
 ```sh
-facet add viper-plans@2.0.0    # re-add at the new version
+facet update                   # newest release each declared range allows
+facet update --latest          # newest release, even outside those ranges
+facet update --dry-run         # print the plan; change nothing
+facet update --interactive     # choose per facet, and which version each takes
 ```
 
-Re-adding at a new version updates both `facets.json` and the lockfile. A dedicated [`facet upgrade`](/cli/upgrade) command is on the roadmap; its page documents the manual paths until it ships.
+[`facet update`](/cli/update) checks every registry facet for a newer release and installs the ones that move, showing what is installed alongside both versions it could move to. Plain `update` respects the specifier in `facets.json`; `--latest` crosses it and rewrites that specifier in place, preserving how you wrote it (`1.*` becomes `2.*`, a pin becomes the new pin). `facet upgrade` is an alias of the same command.
+
+A dry run installs no adapter and writes nothing, so it is safe in CI. Git and local facets are named as unsupported rather than counted as current — only registry facets have releases to compare.
+
+To pin one facet to an exact version instead, re-add it:
+
+```sh
+facet add viper-plans@2.0.0    # re-add at an exact version
+```
 
 **Remove a facet:**
 

--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -15,16 +15,86 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
     facet self-update
     facet --version
     ```
+
+    [`facet update`](/cli/update) is newer still. An older CLI does not recognize `facet update` at all, and recognizes `facet upgrade` only as a placeholder that prints a not-yet-implemented notice and exits `0` without changing anything. If you see that notice, the CLI is the thing to update first.
   </Accordion>
 
   <Accordion title='"could not reach the registry"'>
-    **Cause:** `facet search`, a registry `facet add`, and `facet publish` need network access to the registry. Offline, they [**fail closed**](/specification/commit#verify) rather than write an unconfirmed entry.
+    **Cause:** `facet search`, a registry `facet add`, [`facet update`](/cli/update), and `facet publish` need network access to the registry. Offline, they [**fail closed**](/specification/commit#verify) rather than write an unconfirmed entry.
 
     **Fix:** check your connection and retry. Note that **local paths** (`./my-facet`) and **git sources** (`github:owner/repo`) resolve without the registry, so you do not need registry access to install/add from these sources.
+
+    `facet update` fails closed for the whole project, not per facet: one failed lookup rejects the entire plan rather than presenting the facets that did resolve. A partial plan would look like a complete answer. Git and local facets are not checked at all, so they are named as unsupported rather than reported as current.
   </Accordion>
 
-  <Accordion title='"no adapters installed" when running facet add (non-interactive)'>
-    **Cause:** a facet has to be materialized into at least one adapter, but none is connected. In a real terminal `facet add` shows a picker; in a non-interactive shell (CI, piped stdin) it exits with an error instead.
+  <Accordion title='"this project cannot be checked for updates yet"'>
+    **Cause:** [`facet update`](/cli/update) compares what `facets.json` declares against what `facets.lock` records, and something in that pairing does not line up — a declared facet is missing from the lockfile, the lockfile records a different kind of source, the locked version is not an exact release, or the locked version no longer satisfies the declared specifier. Update refuses to guess what is installed rather than checking a version it cannot vouch for. Nothing was written.
+
+    The message names **every** affected facet, because one install covers all of them.
+
+    **Fix:** repair the lockfile first, then update:
+
+    ```sh
+    facet install
+    facet update
+    ```
+
+    Repairing drift is [`facet install`](/cli/install)'s job. `facet update` is not a second drift-repairer, and it will keep refusing until install has run.
+  </Accordion>
+
+  <Accordion title='"the project changed while this update was being reviewed"'>
+    **Cause:** `facets.json` or `facets.lock` changed between the moment the update plan was read and the moment it would have been applied — a concurrent `facet add`, a `git pull`, an editor save. Applying the plan would install versions chosen against a project that no longer exists.
+
+    A closely related message, *"facets.json changed while update was checking versions"*, is the same situation caught earlier, during discovery.
+
+    **Fix:** re-run `facet update`. **Nothing is broken and nothing needs repairing** — no file was written in either case. The second run plans against the project as it now stands.
+  </Accordion>
+
+  <Accordion title='"facet update --interactive needs an interactive terminal"'>
+    **Cause:** `--interactive` opens a selection screen, and this environment cannot prompt — CI, piped output, or a closed stdin. The check runs **before** any registry lookup, so the run fails immediately rather than after resolving every facet.
+
+    **Fix:** pick a non-interactive mode:
+
+    ```sh
+    facet update            # every range-respecting target
+    facet update --latest   # every latest release
+    facet update --dry-run  # print the plan; change nothing
+    ```
+  </Accordion>
+
+  <Accordion title='"facet update does not accept positional arguments"'>
+    **Cause:** unlike [`facet add`](/cli/add) and [`facet remove`](/cli/remove), `facet update` takes no facet names. It considers everything declared in `facets.json`.
+
+    **Fix:** to update some facets but not others, choose them from the picker:
+
+    ```sh
+    facet update --interactive
+    ```
+
+    Per-facet filtering on the command line is deliberately deferred, not missing by oversight.
+  </Accordion>
+
+  <Accordion title='facet update says nothing to do, but a newer release exists'>
+    **Cause:** an update that applies nothing still succeeded and exits `0`. There are four such outcomes and they are not interchangeable — the message says which one you got. The one that usually surprises people is the third:
+
+    ```
+    Newer releases exist, but the ranges in facets.json permit none of them.
+    Run `facet update --latest` to take them anyway.
+    ```
+
+    Your specifiers are doing exactly what they were written to do. `1.*` will never accept `2.0.0`.
+
+    **Fix:** take the newer releases with `facet update --latest`, which crosses the declared ranges and [rewrites the specifiers](/cli/update#crossing-the-declared-range) to match. Preview it first with `--dry-run` if you want to see the rewrites before committing to them.
+  </Accordion>
+
+  <Accordion title='"the registry returned an unusable version" during update'>
+    **Cause:** the registry answered an update lookup with something that is not an exact `MAJOR.MINOR.PATCH` release, or resolved a facet's declared range to a version that range does not permit. Neither is something your project can cause.
+
+    **Fix:** retry in a moment. If it persists, report it with the facet name from the message — this one is on the registry, not on you.
+  </Accordion>
+
+  <Accordion title='"no adapters installed" when running facet add or facet update (non-interactive)'>
+    **Cause:** a facet has to be materialized into at least one adapter, but none is connected. In a real terminal `facet add` and [`facet update`](/cli/update) show a picker; in a non-interactive shell (CI, piped stdin) they exit with an error instead.
 
     **Fix:** install an adapter first with [`facet adapter add`](/cli/adapters/add):
 
@@ -32,10 +102,14 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
     facet adapter add claude-code
     facet adapter list
     ```
+
+    <Note>
+    `facet update --dry-run` returns **before** adapters are checked, so a preview never needs one. That makes it safe to run on a machine that has no adapter connected at all.
+    </Note>
   </Accordion>
 
   <Accordion title='"adapter incompatible" / "unsupported adapter API" (build, add, remove, install fail before writing)' id='adapter-incompatible'>
-    **Cause:** every installed adapter declares the adapter API contract it was built against, and each CLI release supports an exact set — currently just `0.3` (the read-only planning contract). Bundles declaring `0.0`, `0.1`, or `0.2` wrote files themselves and owned their own rollback, so this CLI cannot offer them the guarantees it now makes about exact restoration and concurrency; they are unsupported. A bundle installed before API versioning has **no** declaration; others can carry a malformed declaration or disagree with the npm metadata they were selected by. All these cases fail closed: `facet build`, `facet add`, `facet remove`, and `facet install` stop **before** invoking any adapter method or writing project files.
+    **Cause:** every installed adapter declares the adapter API contract it was built against, and each CLI release supports an exact set — currently just `0.3` (the read-only planning contract). Bundles declaring `0.0`, `0.1`, or `0.2` wrote files themselves and owned their own rollback, so this CLI cannot offer them the guarantees it now makes about exact restoration and concurrency; they are unsupported. A bundle installed before API versioning has **no** declaration; others can carry a malformed declaration or disagree with the npm metadata they were selected by. All these cases fail closed: `facet build`, `facet add`, `facet remove`, `facet install`, and `facet update` stop **before** invoking any adapter method or writing project files.
 
     Upgrading the CLI across this boundary makes every previously installed adapter unsupported at once, including the first-party ones. Reinstall each — the listing prints the exact command.
 
@@ -115,9 +189,11 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
   </Accordion>
 
   <Accordion title='A materialization choice was dropped, or is rejected in CI'>
-    **Cause:** an override names an asset or MCP server the resolved facet version no longer contains — usually the publisher renamed or removed it in an upgrade. A normal install prunes the stale override and tells you which one; a frozen install treats it as blocking drift, because it has no transaction in which to prune.
+    **Cause:** an override names an asset or MCP server the resolved facet version no longer contains — usually the publisher renamed or removed it in a newer release, which makes [`facet update`](/cli/update) the operation that most often surfaces it. A normal install prunes the stale override and tells you which one; a frozen install treats it as blocking drift, because it has no transaction in which to prune.
 
     **Fix:** nothing, if you saw the pruning notice — it is already resolved and `facets.json` was updated. In CI, run `facet install` locally without `--frozen-lockfile` and commit the pruned manifest.
+
+    Overrides that still name something the new version contains are carried across a version change untouched: updating a facet does not cost you your aliases and omissions.
   </Accordion>
 
   <Accordion title='"facets.json declares an unsupported manifestVersion"'>
@@ -144,7 +220,7 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
     }
     ```
 
-    The same flag works on [`facet add`](/cli/add) and [`facet remove`](/cli/remove).
+    The same flag works on [`facet add`](/cli/add), [`facet update`](/cli/update), and [`facet remove`](/cli/remove) — pass it to whichever command reported the failure.
   </Accordion>
 
   <Accordion title='Approval keeps being requested for a server you already approved'>
@@ -202,7 +278,7 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
     - **"changed by something else … left as it is"** — nothing is wrong with your file. Your editor, another agent, or a concurrent command wrote it after this run did, so the rollback declined to overwrite that work. Their content is intact.
     - **"could not be restored: …"** — the restore itself failed, usually a permissions or disk problem. This one needs you.
 
-    **Fix:** for a preserved edit, nothing — decide whether you still want the change and re-run `facet install` when you do. For a genuine restore failure, resolve the named cause and re-run; install reconciles each file against its recorded integrity and repairs what it owns without touching files you added yourself.
+    **Fix:** for a preserved edit, nothing — decide whether you still want the change and re-run the command that failed when you do. For a genuine restore failure, resolve the named cause and re-run; the `fix:` line names the right command for the operation you ran, and installing reconciles each file against its recorded integrity and repairs what it owns without touching files you added yourself.
 
     <Note>
     Facets never prompts to force-overwrite a contested file, in a terminal or in CI. Being asked to choose between two versions of a file during a failure — before you can compare them — is not a decision anyone can make well.
@@ -210,7 +286,7 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
   </Accordion>
 
   <Accordion title='A takeover prompt appeared, or an install was cancelled at one'>
-    **Cause:** something already occupies a name your project wants, and this machine's receipt does not record putting it there. For an MCP server this is disclosed up front on the [approval screen](/cli/install#taking-over-an-existing-entry); for a file it is a separate mid-write prompt with **Continue** selected by default.
+    **Cause:** something already occupies a name your project wants, and this machine's receipt does not record putting it there. Any operation that materializes assets can hit this — `facet add`, `facet install`, or [`facet update`](/cli/update). For an MCP server it is disclosed up front on the [approval screen](/cli/install#taking-over-an-existing-entry); for a file it is a separate mid-write prompt with **Continue** selected by default.
 
     **Fix:** continue to take ownership, or cancel. Cancelling an asset takeover rolls back everything the command has done so far and exits non-zero — nothing is left half-applied. Non-interactive runs never see the asset prompt; they continue automatically, which is the behavior that predates the prompt.
   </Accordion>
@@ -225,6 +301,23 @@ Common errors, what causes them, and how to fix them. Each entry mirrors the CLI
     **Cause:** Facets writes configuration; it does not run servers. A successful install proves the entry is in your tool's config file — not that the server starts, is reachable, or is authenticated.
 
     **Fix:** check the file the adapter wrote, then take it up in the tool. Many servers need a sign-in step the tool provides; Facets deliberately stores no credentials and performs no OAuth.
+  </Accordion>
+
+  <Accordion title='facet update ran but the CLI version did not change (or vice versa)'>
+    **Cause:** four command names sit one keystroke apart and they do two different jobs. The `self-` prefix is the whole distinction:
+
+    | Command | Acts on |
+    | ------- | ------- |
+    | `facet update`, `facet upgrade` | The facets declared in this project's `facets.json`. |
+    | `facet self-update`, `facet self-upgrade` | The `facet` CLI binary itself. |
+
+    Neither touches the other. [`facet update`](/cli/update) never rewrites your binary, and [`facet self-update`](/cli/self-update) never reads `facets.json`.
+
+    **Fix:** run the one that matches what you meant to move.
+
+    <Warning>
+    `facet upgrade` used to be a placeholder that printed a notice and exited `0` without changing anything. It is now a live alias of `facet update` and applies real changes. If a script called it expecting a no-op, drop the call or make it `facet update --dry-run`.
+    </Warning>
   </Accordion>
 
   <Accordion title='"not signed in — no registry credential found"'>

--- a/docs/roadmap/alpha.mdx
+++ b/docs/roadmap/alpha.mdx
@@ -25,6 +25,7 @@ The alpha is the **current phase**. The core loop  -- author, publish, discover,
 
 - [`facet add`](/cli/add)  -- add and install in one step, registry-first source grammar
 - [`facet install`](/cli/install)  -- lockfile-driven reproducible installs, `--frozen-lockfile` for CI
+- [`facet update`](/cli/update)  -- move declared facets to newer releases (aliased `upgrade`)
 - [`facet remove`](/cli/remove)  -- transactional removal (aliased `rm`)
 - [`facet list`](/cli/list)  -- see what's declared and resolved
 
@@ -32,7 +33,7 @@ The alpha is the **current phase**. The core loop  -- author, publish, discover,
 
 - [`facet adapter`](/cli/adapters/add)  -- add/list/remove adapters; first-party adapters for Claude Code, OpenCode, and Codex; a public [adapter SDK](/guides/custom-adapters) for building your own
 - [`facet instructions`](/cli/instructions)  -- built-in usage guidance for AI agents
-- [`facet self-update`](/cli/self-update)  -- update the CLI in place
+- [`facet self-update`](/cli/self-update)  -- update the CLI binary in place (not the project's facets  -- that is [`facet update`](/cli/update))
 
 ## Alpha caveats
 

--- a/docs/roadmap/beta.mdx
+++ b/docs/roadmap/beta.mdx
@@ -4,13 +4,9 @@ sidebarTitle: Beta
 description: Goals for the public beta
 ---
 
-The open beta begins when the features below ship. The [alpha](/roadmap/alpha) already covers the full author → publish → install loop, plus MCP server configuration; the beta rounds out the ecosystem with an upgrade flow, registry introspection, and composition.
+The open beta begins when the features below ship. The [alpha](/roadmap/alpha) already covers the full author → publish → install loop, the update flow, and MCP server configuration; the beta rounds out the ecosystem with registry introspection and composition.
 
 ## Planned
-
-<ResponseField name="facet upgrade" type="command">
-  Check installed facets for newer versions, surface what changed, and let you choose which updates to apply. Today, re-run `facet add <name>` to move a facet to a new version.
-</ResponseField>
 
 <ResponseField name="facet info" type="command">
   Show a published facet's metadata, versions, and assets straight from the registry, without installing it.
@@ -19,6 +15,10 @@ The open beta begins when the features below ship. The [alpha](/roadmap/alpha) a
 <ResponseField name="Facet composition" type="format">
   A facet that declares `facets: [...]` composes text from other published facets. The manifest format reserves the field today; installs reject it until server-side composition ships.
 </ResponseField>
+
+<Note>
+  **The update flow has shipped.** [`facet update`](/cli/update) checks every registry facet for a newer release and moves the ones you choose, respecting the ranges in `facets.json` or crossing them with `--latest`. `facet upgrade` is its alias.
+</Note>
 
 <Note>
   **MCP server support has shipped.** A facet can declare concrete [MCP servers](/specification/manifest#mcp-server-declarations), and installing one configures them in every connected tool after you approve them. See [`facet install`](/cli/install#mcp-servers).

--- a/docs/roadmap/stable.mdx
+++ b/docs/roadmap/stable.mdx
@@ -8,7 +8,7 @@ The stable release will be announced as **v1.0.0** and flags general availabilit
 
 ## GA criteria
 
-- **Everything in the [beta](/roadmap/beta) is shipped and stable**  -- upgrade flow, `facet info`, and composition.
+- **Everything in the [beta](/roadmap/beta) is shipped and stable**  -- `facet info` and composition, alongside the already-shipped [update flow](/cli/update).
 - **Format stability**  -- the `facet.json` manifest, `facets.json`, `facets.lock`, the `.facet` archive format, the machine-local install receipt, and the adapter API contract are frozen under semver guarantees; breaking format changes require a major version. These are [independent version axes](/specification/project-manifest#fields) and each carries its own migration obligations.
 - **CLI surface stability**  -- commands and flags stop churning; deprecations get a documented migration window.
 - **Specification completeness**  -- the [specification](/specification) fully describes the shipped behavior, suitable for independent implementations.

--- a/docs/specification/commit.mdx
+++ b/docs/specification/commit.mdx
@@ -25,9 +25,13 @@ It is never partial. Commit runs in three phases, and the boundary between the s
 
 <Steps>
   <Step title="Load state and gate">
-    The manifest is read and the **install lock** — a per-project advisory lock ensuring only one install operates on a project at a time — is acquired. A frozen operation carrying a non-empty delta is rejected here, before the lockfile is even read, so `facet add --frozen-lockfile` against a corrupt lockfile reports the operation it cannot perform rather than a file it never needed to open.
+    The manifest is read and the **install lock** — a per-project advisory lock ensuring only one install operates on a project at a time — is acquired.
 
-    The lockfile and receipt are then loaded (a receipt that is absent, corrupt, or path-mismatched witnesses nothing and is never projected from the lockfile; the two readable failures are reported; individual receipt asset entries that fail validation are reported and skipped, leaving the files they covered in place). A delta naming the same facet in both additions and removals MUST be rejected, and the adapters selected for this operation MUST pass the adapter API compatibility preflight — a defense-in-depth re-check behind the command-level gate that already rejected any incompatible installed adapter before planning. Every incompatible adapter is collected, not just the first. A selected adapter whose declared adapter API the CLI does not support MUST fail the commit here, before any Git or local facet build can invoke adapter metadata methods. Failures here touch nothing — no rollback is needed.
+    An operation is one of a fixed set of mutually exclusive kinds — reproduce, add, remove, or update — and each carries only the data that kind can use. Frozen mode is a property of *reproduce* alone, so a frozen add, remove, or update is not something the commit rejects at runtime: it cannot be described in the first place. An operation naming the same facet as both an addition and a removal is likewise unconstructable rather than checked for.
+
+    An **update** operation is additionally gated here, under the lock and before anything else: the manifest and lockfile as they now stand MUST match the exact state the update plan was reviewed against. If either moved, the operation is rejected as a stale plan. This is placed ahead of resolution, cache writes, downloads, and transaction creation so a withdrawn update has nothing to undo. See [Applying a reviewed update](#applying-a-reviewed-update).
+
+    The lockfile and receipt are then loaded (a receipt that is absent, corrupt, or path-mismatched witnesses nothing and is never projected from the lockfile; the two readable failures are reported; individual receipt asset entries that fail validation are reported and skipped, leaving the files they covered in place). The adapters selected for this operation MUST pass the adapter API compatibility preflight — a defense-in-depth re-check behind the command-level gate that already rejected any incompatible installed adapter before planning. Every incompatible adapter is collected, not just the first. A selected adapter whose declared adapter API the CLI does not support MUST fail the commit here, before any Git or local facet build can invoke adapter metadata methods. Failures here touch nothing — no rollback is needed.
   </Step>
   <Step title="Merge delta in memory">
     Additions are upserted, removals are deleted — all in memory. The on-disk `facets.json` MUST NOT be written ahead of the install. Re-adding a facet preserves any materialization overrides already recorded for it: changing where a facet comes from is not a statement about how its assets should be named.
@@ -133,13 +137,17 @@ Whether the lockfile is trusted for version resolution depends on **how an entry
 
 **Explicit version request** — the lockfile **IS trusted** when satisfying a version (`foo-facet@2.0.1`). A satisfying recorded version needs no version resolution; only an absent or stale entry triggers it. The facet was already declared — the locked state is reproduced.
 
-The **exact-version gate** then decides whether the network fires at all: a satisfying lockfile entry supplies the exact version (no resolution), an exact specifier supplies it directly, and only a non-exact, unlocked specifier resolves fresh against the registry.
+**Prepared version** — a facet being updated brings its exact version with it. The registry was asked during the update's read-only discovery phase and the user approved *that* answer, so the question is not asked again here. See [Applying a reviewed update](#applying-a-reviewed-update).
+
+The **exact-version gate** then decides whether the network fires at all: a satisfying lockfile entry supplies the exact version (no resolution), an exact specifier supplies it directly, a reviewed update supplies the version chosen during discovery, and only a non-exact, unlocked specifier resolves fresh against the registry.
 
 ```mermaid
 flowchart TD
     A["Facet (specifier)"] --> K{Specifier shape}
     K -->|"exact 1.2.3"| EX["No resolution needed"]
     EX --> CACHE
+    K -->|"reviewed update"| PREP["Version already chosen"]
+    PREP --> CACHE
     K -->|"bare name"| BARE["Resolve NEWEST"]
     BARE --> CACHE
     K -->|"@latest or *"| LATEST["Resolve NEWEST"]
@@ -148,6 +156,17 @@ flowchart TD
     WILD --> CACHE
     CACHE["Verify + materialize"]
 ```
+
+#### Applying a reviewed update
+
+An update is planned in one phase and applied in another, and the exact version travels between them:
+
+- The version was resolved during **read-only discovery**, which takes no install lock and writes nothing. What the user reviewed is what gets installed.
+- Resolution is **not repeated** at commit time. A release published between review and application does not silently change the selected version.
+- This skips the *question*, not the *verification*. The cache is still self-audited, a miss still downloads, and the content MUST still reproduce the fingerprint discovery recorded before any lockfile entry is written.
+- The prior lockfile entry is bypassed **as a version anchor only**. It is still read, because it is what identifies the assets and MCP entries the old version owned and what makes the `(was X → Y)` outcome possible.
+
+Because the entry is being replaced, [integrity confirmation](#verify) applies rather than lockfile comparison — and it is satisfied by the published fingerprint obtained during discovery, not by a second metadata request.
 
 ### Verify
 
@@ -386,6 +405,26 @@ The manifest value written for an addition depends on the specifier shape. The p
 | Explicit (`1.2.3`, `0.*`, `0.1.*`, `*`, `latest`) | Written verbatim                   | Resolved exact + integrity |
 | Reproduction (not an addition)           | Unchanged                          | Unchanged or re-resolved   |
 
+### Updates
+
+An update's manifest value is decided **before** resolution rather than after it, because the choice the user reviewed — take the range's target, or take the latest release — is itself what determines both the version to install and the specifier to keep. It is carried through the same in-memory merge and written by the same tri-write.
+
+Selecting a facet's **range target** never rewrites anything: the declared specifier already permits that version, so the intent has not changed and the authored string is preserved byte-for-byte. Re-rendering it from its parsed form would be a silent reformat of something the user typed.
+
+Selecting **latest** may cross the declared range, so the specifier is widened by the smallest edit that admits the selected version while preserving how the intent was expressed:
+
+| Declared | Selected | Manifest value | Why                              |
+|----------|----------|----------------|----------------------------------|
+| `1.2.0`  | `2.4.1`  | `2.4.1`        | a pin stays a pin                |
+| `1.*`    | `2.4.1`  | `2.*`          | major-pinned stays major-pinned  |
+| `1.2.*`  | `2.4.1`  | `2.4.*`        | minor-pinned stays minor-pinned  |
+| `*`      | `2.4.1`  | `*`            | already floats; nothing to widen |
+| `latest` | `2.4.1`  | `latest`       | likewise, and the spelling is kept |
+
+The two floating forms are written back as authored rather than re-rendered, so `*` and `latest` each survive as the one the user chose. The lockfile records the selected exact version and its integrity in every row.
+
+Materialization overrides are carried across a version change untouched — moving a facet to a newer release is not a statement about how its assets and servers should be named. An override naming something the new version no longer contains is [pruned and reported](/specification/materialization#recording-intent), exactly as on a re-add.
+
 ## Transactional tri-write
 
 On success, three files MUST be written together: the project manifest, the lockfile, and the receipt. A failure anywhere MUST leave all three exactly as they were — and MUST also restore every materialized asset and every native MCP document the operation touched, replaying configuration byte restores and asset inverses in reverse order.
@@ -424,7 +463,7 @@ sequenceDiagram
 Frozen mode (the [`--frozen-lockfile`](/cli/install#param-frozen-lockfile) flag) treats the lockfile as the complete, authoritative source of truth **for what to reproduce**. It is not authority to delete — that stays with the receipt in frozen mode exactly as it does everywhere else.
 
 <Warning>
-A frozen commit with a non-empty delta (any addition or removal) MUST be rejected immediately. Only a plain `facet install` can run frozen.
+Only a reproduce operation can run frozen. This is not a runtime rejection but a structural one: frozen mode is a property of the reproduce arm alone, so a frozen addition, removal, or update has no representation to reject. `facet update` accordingly exposes no `--frozen-lockfile` flag — reproducing what the lockfile records is the opposite of what it does.
 </Warning>
 
 Frozen mode never prompts — for a collision or for MCP approval — but it MAY use approval supplied ahead of time on the command line.
@@ -457,7 +496,7 @@ Unlike the asset-disposition gates, the MCP checks may need to fetch locked cont
 
 | Behavior                         | Frozen mode                                          |
 |----------------------------------|------------------------------------------------------|
-| Additions or removals            | Rejected                                             |
+| Additions, removals, or updates  | Unrepresentable — frozen belongs to reproduce alone  |
 | Version resolution               | Forbidden — absent/stale entry fails immediately     |
 | Integrity confirmation           | Never fires (no entry creation)                      |
 | Archive resolution               | Allowed (downloading locked content is reproduction) |

--- a/docs/specification/materialization.mdx
+++ b/docs/specification/materialization.mdx
@@ -89,7 +89,7 @@ Dispositions live in [`facets.json`](/specification/project-manifest) as durable
 
 Overrides are keyed by authored name because that is the only stable identifier — an alias is the thing being declared, so it cannot also be the key.
 
-Intent is durable. It survives a failed install, a re-add, and a change of source: changing *where* a facet comes from is not a statement about *how* its assets and servers should be named. It is discarded only when the facet is removed, or when the contribution it names disappears (see [Stale overrides](#stale-overrides)).
+Intent is durable. It survives a failed install, a re-add, a version update, and a change of source: changing *which release* a facet is at, or *where* it comes from, is not a statement about *how* its assets and servers should be named. It is discarded only when the facet is removed, or when the contribution it names disappears (see [Stale overrides](#stale-overrides)).
 
 One server disposition applies to **every** selected adapter. There is no per-adapter aliasing or omission: a project decides once what a server is called, and each adapter writes that same effective name into its own document.
 

--- a/openspec/changes/add-facet-update-command/tasks.md
+++ b/openspec/changes/add-facet-update-command/tasks.md
@@ -91,25 +91,25 @@
 - [x] 8.6 Implement: Add registration, help, command, static-view, picker, and install-view unit tests covering canonical/alias identity, mode defaults, cancellation, no-op output, output streams, and `--accept-mcp` boundaries.
 - [x] 8.7 Implement: Add CLI end-to-end tests for global and per-command help, `upgrade` alias behavior, positional and non-TTY failures, dry-run without adapters, interactive cancellation before adapter installation, applied old-to-new summaries, stale plans, and expected exit codes.
 - [x] 8.8 Verify: Run targeted CLI command, Ink, and end-to-end tests and typecheck the CLI package.
-- [ ] 8.9 Pause: Model-switch boundary before documentation research.
+- [x] 8.9 Pause: Model-switch boundary before documentation research.
 
 ## 9. Documentation and Agent Guidance — Research
 
-- [ ] 9.1 Explore: Inspect `docs/cli/update.mdx` requirements and reference-page conventions together with existing `docs/cli/upgrade.mdx`, `docs/cli/self-update.mdx`, `docs/cli/index.mdx`, `docs/cli/add.mdx`, `docs/cli/list.mdx`, and `docs/docs.json`; verify whether retaining the upgrade alias page outside primary navigation passes Mintlify validation.
-- [ ] 9.2 Explore: Inspect `docs/guides/install-facets.mdx`, `docs/guides/troubleshooting.mdx`, `docs/roadmap/alpha.mdx`, `docs/roadmap/beta.mdx`, `docs/roadmap/stable.mdx`, `docs/specification/commit.mdx`, `docs/specification/materialization.mdx`, and root `README.md` for stale promises, update remedies, and package-versus-binary ambiguity.
-- [ ] 9.3 Explore: Inspect `packages/cli/src/prompts/overview.txt`, `packages/cli/src/prompts/usage.txt`, prompt generation, and instruction-prompt unit/e2e tests so guidance is added without duplicating topic lists, adapter API support sets, or materialization schemas.
-- [ ] 9.4 Explore: Inspect `docs/changelog/index.mdx`, its RSS rules, `.changeset/`, and contribution conventions for the required inert-stub-to-live-alias disclosure and package changeset.
-- [ ] 9.5 Propose: Define the cohesive documentation, prompt, changelog, navigation, and validation approach while preserving historical changelog text and `facet list`'s offline contract.
+- [x] 9.1 Explore: Inspect `docs/cli/update.mdx` requirements and reference-page conventions together with existing `docs/cli/upgrade.mdx`, `docs/cli/self-update.mdx`, `docs/cli/index.mdx`, `docs/cli/add.mdx`, `docs/cli/list.mdx`, and `docs/docs.json`; verify whether retaining the upgrade alias page outside primary navigation passes Mintlify validation.
+- [x] 9.2 Explore: Inspect `docs/guides/install-facets.mdx`, `docs/guides/troubleshooting.mdx`, `docs/roadmap/alpha.mdx`, `docs/roadmap/beta.mdx`, `docs/roadmap/stable.mdx`, `docs/specification/commit.mdx`, `docs/specification/materialization.mdx`, and root `README.md` for stale promises, update remedies, and package-versus-binary ambiguity.
+- [x] 9.3 Explore: Inspect `packages/cli/src/prompts/overview.txt`, `packages/cli/src/prompts/usage.txt`, prompt generation, and instruction-prompt unit/e2e tests so guidance is added without duplicating topic lists, adapter API support sets, or materialization schemas.
+- [x] 9.4 Explore: Inspect `docs/changelog/index.mdx`, its RSS rules, `.changeset/`, and contribution conventions for the required inert-stub-to-live-alias disclosure and package changeset.
+- [x] 9.5 Propose: Define the cohesive documentation, prompt, changelog, navigation, and validation approach while preserving historical changelog text and `facet list`'s offline contract.
 - [ ] 9.6 Pause: Model-switch boundary before documentation implementation.
 
 ## 10. Documentation and Agent Guidance — Implementation
 
-- [ ] 10.1 Implement: Create `docs/cli/update.mdx`, convert `docs/cli/upgrade.mdx` into a concise alias page, update `docs/cli/self-update.mdx` and `docs/cli/index.mdx`, and revise `docs/docs.json` so canonical behavior, flags, TTY rules, preview scope, no-op/failure outcomes, and package-versus-binary distinctions have one source of truth.
-- [ ] 10.2 Implement: Update both audiences in `docs/guides/install-facets.mdx`, add remedies to `docs/guides/troubleshooting.mdx`, update `docs/roadmap/alpha.mdx`, `beta.mdx`, and `stable.mdx`, update root `README.md`, and add cross-links from `docs/cli/add.mdx` and `docs/cli/list.mdx` while retaining list's offline contract and narrowing the beta promise.
-- [ ] 10.3 Implement: Update `docs/specification/commit.mdx` for prepared exact resolution and style-preserving Latest selection, and verify `docs/specification/materialization.mdx` remains accurate without duplicating override rules.
-- [ ] 10.4 Implement: Update `packages/cli/src/prompts/overview.txt` and `usage.txt` with project update, alias, non-TTY, dry-run, `--accept-mcp`, and `facet install` recovery guidance, then add companion unit and end-to-end prompt assertions.
-- [ ] 10.5 Implement: Add the newest `docs/changelog/index.mdx` entry with the stub-to-live-alias warning while preserving historical entries, and add the appropriate `agent-facets` changeset without editing generated package changelogs.
-- [ ] 10.6 Verify: Run prompt tests, Mintlify validation, and broken-link checks for all documentation and agent-guidance changes.
+- [x] 10.1 Implement: Create `docs/cli/update.mdx`, convert `docs/cli/upgrade.mdx` into a concise alias page, update `docs/cli/self-update.mdx` and `docs/cli/index.mdx`, and revise `docs/docs.json` so canonical behavior, flags, TTY rules, preview scope, no-op/failure outcomes, and package-versus-binary distinctions have one source of truth.
+- [x] 10.2 Implement: Update both audiences in `docs/guides/install-facets.mdx`, add remedies to `docs/guides/troubleshooting.mdx`, update `docs/roadmap/alpha.mdx`, `beta.mdx`, and `stable.mdx`, update root `README.md`, and add cross-links from `docs/cli/add.mdx` and `docs/cli/list.mdx` while retaining list's offline contract and narrowing the beta promise.
+- [x] 10.3 Implement: Update `docs/specification/commit.mdx` for prepared exact resolution and style-preserving Latest selection, and verify `docs/specification/materialization.mdx` remains accurate without duplicating override rules.
+- [x] 10.4 Implement: Update `packages/cli/src/prompts/overview.txt` and `usage.txt` with project update, alias, non-TTY, dry-run, `--accept-mcp`, and `facet install` recovery guidance, then add companion unit and end-to-end prompt assertions.
+- [x] 10.5 Implement: Leave `docs/changelog/index.mdx` untouched, ask the user to generate the `agent-facets` minor changeset manually, then replace only its placeholder body with the stub-to-live-alias warning without editing generated package changelogs.
+- [x] 10.6 Verify: Run prompt tests, Mintlify validation, and broken-link checks for all documentation and agent-guidance changes.
 - [ ] 10.7 Pause: Model-switch boundary before integrated acceptance research.
 
 ## 11. Integrated Acceptance — Research

--- a/packages/cli/src/__tests__/instructions.e2e.test.ts
+++ b/packages/cli/src/__tests__/instructions.e2e.test.ts
@@ -24,6 +24,10 @@ describe('facet instructions', () => {
     expect(indexAt).toBeLessThan(result.stdout.indexOf('AUTHORING a facet'))
     // The injection marker must never leak into the printed output.
     expect(result.stdout).not.toContain('{{TOPIC_INDEX}}')
+    // Prompts are inlined into the binary at compile time, so this is the
+    // only level that proves the shipped bytes carry the guidance.
+    expect(result.stdout).toContain('facet update')
+    expect(result.stdout).toContain('facet upgrade')
   })
 
   test('authoring topic covers README and supplementary-file authoring', async () => {
@@ -41,6 +45,8 @@ describe('facet instructions', () => {
     expect(result.stdout).toContain('facet add viper-plans')
     expect(result.stdout).toContain(`adapter API ${renderAdapterApiSupportSet()}`)
     expect(result.stdout).toContain('facet adapter list')
+    expect(result.stdout).toContain('facet update --latest')
+    expect(result.stdout).toContain('facet update --dry-run')
   })
 
   test('manifest topic documents supplementary files and appends the generated JSON Schema', async () => {

--- a/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
+++ b/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { SUPPORTED_ADAPTER_APIS } from '@agent-facets/engine'
 import { FacetManifestSchema } from '@agent-facets/protocol'
+import { commands } from '../../../commands.ts'
 import {
   DEFAULT_TOPIC,
   INSTRUCTION_TOPICS,
@@ -10,6 +11,8 @@ import {
   renderTopicIndex,
   TOPICS,
 } from '../../../prompts/index.ts'
+import { ACCEPT_MCP_FLAG } from '../../shared/flags.ts'
+import { updateCommand } from '../../update/index.ts'
 import { instructionsCommand } from '../index.ts'
 
 describe('instruction topics', () => {
@@ -171,9 +174,82 @@ describe('materialization guidance is present in the prompts', () => {
 
   test('overview command index covers the project-management commands', () => {
     const overview = TOPICS.overview.prompt
-    for (const command of ['facet install', 'facet remove', 'facet list', 'facet publish']) {
+    for (const command of ['facet install', 'facet update', 'facet remove', 'facet list', 'facet publish']) {
       expect(overview).toContain(command)
     }
+  })
+
+  // The index is hand-written on purpose: its descriptions are aimed at an
+  // agent and differ from the registry's own `description`. What is NOT
+  // deliberate is a command shipping without ever reaching this list --
+  // which is exactly how `facet update` was missing from it. Derive the
+  // expectation from the registry so the next one cannot repeat it.
+  test('every implemented command reaches the overview index', () => {
+    // Covered inline on the `facet login` line rather than by their own
+    // entries, because they are one authentication story.
+    const coveredInline = new Set(['logout', 'whoami'])
+    const overview = TOPICS.overview.prompt
+    for (const [name, command] of Object.entries(commands)) {
+      if (command.implemented !== true) continue
+      if (coveredInline.has(name)) {
+        expect(overview).toContain(name)
+        continue
+      }
+      expect(overview).toContain(`facet ${name}`)
+    }
+  })
+})
+
+describe('update guidance is present in the prompts', () => {
+  test('overview names update, its alias, and what it is not', () => {
+    const overview = TOPICS.overview.prompt
+    expect(overview).toContain('facet update')
+    expect(overview).toContain('facet upgrade')
+    // The whole point of the pairing: one moves facets, the other moves
+    // the binary, and an agent that confuses them does the wrong thing.
+    expect(overview).toContain('facet self-update')
+    expect(overview).toContain('CLI binary')
+  })
+
+  test('overview names the alias from the command declaration, not a guess', () => {
+    for (const alias of updateCommand.aliases ?? []) {
+      expect(TOPICS.overview.prompt).toContain(`facet ${alias}`)
+    }
+  })
+
+  test('usage covers both modes, the preview, and the TTY refusal', () => {
+    const usage = TOPICS.usage.prompt
+    expect(usage).toContain('facet update --latest')
+    expect(usage).toContain('facet update --dry-run')
+    expect(usage).toContain('--interactive')
+    // An agent must be told not to reach for the screen it cannot use.
+    expect(usage).toContain('REQUIRES a real terminal')
+  })
+
+  test('usage gives the recovery path for a project that cannot be checked', () => {
+    const usage = TOPICS.usage.prompt
+    expect(usage).toContain('cannot be checked for updates yet')
+    expect(usage).toContain('facet install')
+    // A stale plan is not damage, and an agent that treats it as damage
+    // will go looking for a file to repair.
+    expect(usage).toContain('Nothing is broken')
+  })
+
+  test('usage names the one no-op that has a next step', () => {
+    expect(TOPICS.usage.prompt).toContain('ranges in facets.json permit none of them')
+  })
+
+  test('usage lists update among the commands that accept the MCP flag', () => {
+    // Sourced from the flag constant: the prompt and the remedy the CLI
+    // prints on failure have to be the same string.
+    expect(TOPICS.usage.prompt).toContain(`facet update --${ACCEPT_MCP_FLAG}`)
+  })
+
+  test('usage does not restate the version specifier grammar a second time', () => {
+    // The forms are taught once, under `facet add`. A second copy is a
+    // second thing to keep correct.
+    const usage = TOPICS.usage.prompt
+    expect(usage.match(/Latest 1\.2\.x\./g)?.length ?? 0).toBe(1)
   })
 })
 

--- a/packages/cli/src/prompts/overview.txt
+++ b/packages/cli/src/prompts/overview.txt
@@ -40,13 +40,15 @@ Command index
   facet edit           Interactive editing wizard (TTY only — prefer `modify`).
   facet add            Add a facet to a project and install it.
   facet install        Install every facet declared in facets.json.
+  facet update         Move the project's registry facets to newer releases
+                       (alias: facet upgrade). Not the CLI binary.
   facet remove         Remove a facet from the project (alias: facet rm).
   facet list           List declared facets and their resolved versions.
   facet search         Search the registry.
   facet adapter        Add / list / remove adapter tooling.
   facet publish        Publish a built facet to the registry.
   facet login          Authenticate with the registry (also: logout, whoami).
-  facet self-update    Update the CLI itself.
+  facet self-update    Update the CLI binary itself, never project facets.
   facet instructions   Print these instructions (see the topic index above).
 
 Machine-readable output

--- a/packages/cli/src/prompts/usage.txt
+++ b/packages/cli/src/prompts/usage.txt
@@ -12,8 +12,8 @@ Add a facet to a project — `facet add`
   rolled back automatically.
 
   Use --accept-mcp when a facet declares MCP servers and you have no TTY (see
-  "MCP servers" below). It is also accepted by `facet install` and
-  `facet remove`.
+  "MCP servers" below). It is also accepted by `facet install`,
+  `facet update`, and `facet remove`.
 
   PREFERRED: the facet registry (agentfacets.io)
   The registry is the default, first-choice source. A bare name resolves to a
@@ -32,6 +32,46 @@ Add a facet to a project — `facet add`
     facet add https://host/repo.git#ref  Any git URL at a ref.
     facet add git@host:owner/repo#ref    SSH git URL at a ref.
     facet add ./path/to/facet            A local facet directory in the project.
+
+Move facets to newer releases — `facet update`
+  Checks every registry-backed facet in facets.json for a newer release and
+  installs the ones that move. `facet upgrade` is an alias of the same command.
+  NEITHER touches the CLI binary — that is `facet self-update`.
+    facet update              Newest release each declared specifier allows.
+    facet update --latest     Newest release, ignoring those specifiers. (-L)
+    facet update --dry-run    Print the plan; write nothing, install no adapter.
+  Takes NO positional arguments; it always considers every declared facet.
+
+  --latest may select a version the declared specifier forbids, so it rewrites
+  that specifier, preserving the form you wrote (1.* becomes 2.*, an exact pin
+  becomes the new pin, `*` and `latest` are left alone). Plain update never
+  rewrites anything. The specifier forms are the same ones listed under
+  `facet add` above.
+
+  --interactive (-i) opens a selection screen and REQUIRES a real terminal; it
+  fails immediately without one. As an agent, use plain update, --latest, or
+  --dry-run instead. Cancelling the screen applies nothing and exits non-zero.
+
+  Applying an update is an install: name collisions, MCP approval, takeover,
+  and rollback all behave exactly as described in the sections below, and
+  recorded materialization choices are preserved across a version change.
+
+  A run that applies nothing still SUCCEEDS (exit 0), and the message says
+  which kind of nothing it is. The one that is actionable:
+    "Newer releases exist, but the ranges in facets.json permit none of them."
+  That means the declared specifiers are doing their job; `facet update
+  --latest` is how to take those releases anyway.
+
+  Two refusals worth recognizing, both exit 1 with nothing written:
+    - "this project cannot be checked for updates yet" — facets.json and
+      facets.lock disagree about some facet. Run `facet install` first, then
+      update again. Update is not a drift-repairer and will keep refusing.
+    - "the project changed while this update was being reviewed" — a stale
+      plan. Nothing is broken; just re-run `facet update`.
+
+  Git and local facets have no releases to compare, so they are NAMED as
+  unsupported rather than reported as current. Move one by editing its source
+  in facets.json and running `facet install`.
 
 The project files
   facets.json – Your dependency list. `facet add` and `facet remove` maintain
@@ -111,9 +151,10 @@ MCP servers — when a facet configures a server
   prints every server with its full declaration. You have exactly two ways
   forward:
 
-    1. Approve everything reported:
+    1. Approve everything reported (pass it to whichever command failed):
          facet add <source> --accept-mcp
          facet install --accept-mcp
+         facet update --accept-mcp
          facet remove <name> --accept-mcp
 
     2. Refuse specific servers by recording an omission (requires


### PR DESCRIPTION
### Why

`facet upgrade` was a placeholder that printed a not-yet-implemented notice and exited `0` without touching any files. This ships the real implementation as `facet update` (with `facet upgrade` as an alias), closing the gap between what the roadmap promised and what the CLI delivered.

### Details

**Command behavior.** `facet update` reads `facets.json` and `facets.lock`, queries the registry for each registry-backed facet's range-respecting target and its absolute latest, and installs the versions that advance. Plain `facet update` stays within declared specifiers; `--latest` (`-L`) crosses them and rewrites the specifier by the smallest edit that admits the new version while preserving its form (`1.*` → `2.*`, a pin → the new pin, `*` and `latest` left as authored). `--dry-run` prints the plan and writes nothing — no manifest, no lockfile, no receipt, no assets, no adapter installation. `--interactive` (`-i`) opens a per-facet picker but requires a real terminal and fails immediately without one, before any registry lookup.

**Discovery is read-only.** The plan phase takes no project lock, so reading a plan never blocks another facet operation. Application re-checks under the lock that the project has not moved since the plan was reviewed, then runs the ordinary install pipeline. A release published between review and application does not silently change the selected version. Recorded materialization choices (aliases, omissions) survive a version change.

**Git and local facets** are named as unsupported rather than counted as current — reporting them as up to date would claim something nothing verified.

**Specification updates.** The commit spec now describes the "prepared version" resolution path (version chosen during read-only discovery, not re-resolved at commit time), the stale-plan gate that fires under the install lock before anything is written, the style-preserving specifier rewrite table for `--latest`, and the structural reason `--frozen-lockfile` has no place here. The materialization spec notes that intent survives a version change, not just a re-add or source change.

**Breaking change for `facet upgrade`.** It previously exited `0` and changed nothing. It now applies real updates. Automation that called it expecting a no-op should drop the call or replace it with `facet update --dry-run`. The changeset documents this explicitly.

**Documentation.** A new `docs/cli/update.mdx` is the single source of truth for flags, exit codes, the current/target/latest model, no-op outcomes, and the project-vs-binary distinction. `docs/cli/upgrade.mdx` becomes a concise alias page. Cross-links added to `facet add`, `facet list`, `facet self-update`, the install guide, troubleshooting, and the roadmap. The beta roadmap removes `facet upgrade` from the planned list and notes the update flow has shipped.

**Agent guidance.** `overview.txt` adds `facet update` to the command index and clarifies that `facet self-update` never touches project facets. `usage.txt` adds a full `facet update` section covering both modes, the TTY refusal, the two actionable refusals (`cannot be checked` → run `facet install` first; stale plan → nothing is broken, re-run), and the `--accept-mcp` pairing. Tests assert every implemented command reaches the overview index, preventing a recurrence of the omission this fixes.

### Verification

Targeted CLI command, Ink component, and end-to-end tests cover canonical/alias identity, mode defaults, dry-run without adapters, interactive cancellation before adapter installation, stale-plan detection, applied update summaries, and all expected exit codes. Prompt unit tests assert the new guidance is present and that the specifier grammar is not duplicated. Mintlify validation and broken-link checks pass across all documentation changes.