### PR TITLE
Overhaul interactive picker: three-column layout, arrow-key column navigation, discovery progress indicator, and latest-only candidate fix

### DIFF
--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -110,10 +110,20 @@ Selecting a Target never rewrites anything: the specifier already permits that v
 `--interactive` lists every facet with an advancing version and lets you pick both which facets move and which version each one takes:
 
 ```
-↑↓ move · Space toggle · l target/latest · Enter confirm · Esc cancel
+  facet        current  target  latest
+▸ ● viper-plans  1.2.0    1.8.0   2.0.0  (target)
+  ○ cowsay       2.1.3    2.1.3   3.0.0  (target)
 ```
 
-Each row starts on its Target, or on its Latest when `--latest` is also supplied. `l` toggles the focused row between the two. A row showing a version that is already installed cannot be selected until you toggle it — pressing `Space` there says so rather than silently doing nothing. Confirming requires at least one selected facet.
+```
+↑↓ move · ◀ ▶ target/latest · Space select · Enter confirm · Esc cancel
+```
+
+Every row shows all three versions at once, because the choice this screen exists for is a comparison. Only the digit that actually moves is coloured — green for a patch, amber for a minor, coral for a major — so the size of each jump is visible without reading the numbers twice. The column a row would install is named in words, so the screen still works with colour disabled.
+
+`↑↓` moves between facets and `◀ ▶` moves between the two columns, clamping at each end rather than wrapping. `l` also flips the focused row. Each row starts on its Target, or on its Latest when `--latest` is supplied.
+
+A row showing a version that is already installed cannot be selected until you move it — pressing `Space` there says so rather than silently doing nothing. That is the case `--latest` exists for, and it is reachable here without the flag. Confirming requires at least one selected facet.
 
 Selection happens **before** adapter selection and before anything is written, so `Esc` or `Ctrl-C` costs nothing: the command reports that nothing was applied and exits `1`.
 

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "1.3.0",
+    "viper-plans": "1.0.0",
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.2",

--- a/facets.lock
+++ b/facets.lock
@@ -668,8 +668,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.3.0",
-      "integrity": "sha256:be85be9bc09b87be4ffca314ec83cd317589a3da573ec73abc28e0cdda0e2ab2",
+      "version": "1.0.0",
+      "integrity": "sha256:d745129217896c754f60f62088a792042d9867151279d7b7fe55a7493cc73ebb",
       "assets": [
         {
           "scope": "project",
@@ -681,7 +681,7 @@
           "files": [
             {
               "path": "skills/viper-execution-rules/SKILL.md",
-              "integrity": "sha256:6b70bed17556faf5e131b2771c6475db23e93d26a39197ef21e143509545514f"
+              "integrity": "sha256:fc15fbdd4231e8e74a71ffb9b59b948e81c221442012970870dfed7b777c4b6b"
             }
           ]
         },
@@ -695,7 +695,7 @@
           "files": [
             {
               "path": "skills/viper-planning/SKILL.md",
-              "integrity": "sha256:cf326cb73bad44540fadd11f4c985b3f8634f734db7c8f87f9e8230bf895284c"
+              "integrity": "sha256:8360e3343f5e628e43c280da77591562035ebf82bb428a27f195150c829c39df"
             }
           ]
         },
@@ -709,7 +709,7 @@
           "files": [
             {
               "path": "commands/viper-continue.md",
-              "integrity": "sha256:80f8444039799ae1f06286994a2d420be97f1fe95c600f96b9cbc80516d29b79"
+              "integrity": "sha256:bffdb4ab2fa5a0d69a885aea589c79836e9ec94680e9cf4e7f7855d6d3bc0a75"
             }
           ]
         },
@@ -723,7 +723,7 @@
           "files": [
             {
               "path": "commands/viper-plan.md",
-              "integrity": "sha256:1faa52ff624a8fc997a4ce1a25857d9ce6d205c9e4d26015722dcd355272ed2d"
+              "integrity": "sha256:f5fa4ff8b4cbfecfed33cf54a234d2cfa7d2151b36adf36e82ce7ccc0e365988"
             }
           ]
         },
@@ -737,7 +737,7 @@
           "files": [
             {
               "path": "commands/viper-run.md",
-              "integrity": "sha256:ab4e2036931dc344424b52d0019e96853cf8e235e755a452e942953504000eee"
+              "integrity": "sha256:bfff09006b1e319e441ccc46c0b10d5079ee2c9e35231cf64e9931b606cde983"
             }
           ]
         }

--- a/openspec/changes/add-facet-update-command/design.md
+++ b/openspec/changes/add-facet-update-command/design.md
@@ -109,10 +109,13 @@ The CLI SHALL derive mode defaults from the prepared candidates:
 
 - Plain `facet update` SHALL select every candidate whose range Target is newer than Current.
 - `facet update --latest` SHALL select every candidate whose Latest is newer than Current.
-- `--interactive` SHALL show every candidate for which either choice is newer. Range SHALL be the initial choice unless `--latest` is present; `l` SHALL toggle the focused row between Range Target and Latest.
+- `--interactive` SHALL show every candidate for which either choice is newer. Range SHALL be the initial choice unless `--latest` is present. Left and right SHALL address the Target and Latest columns directly, clamping at each end rather than wrapping so a held key settles on a column instead of oscillating; `l` SHALL flip the focused row between them.
+- Interactive eligibility SHALL be derived from the presence of those candidate rows, not from whether the initial mode produced a non-empty default selection. In particular, plain `--interactive` SHALL open for a Latest-only candidate even though its initial Range Target is stationary. The range-specific “newer releases exist” no-op remains a non-interactive result; interactive selection is skipped only when neither choice advances for any facet.
 - A row whose displayed choice equals Current SHALL not be selectable until the user toggles to an advancing choice. Interactive row state SHALL be a tagged selected/unselected union so a selected no-op choice is not representable.
 - Confirm SHALL require at least one selected advancing target. Escape or Ctrl-C SHALL cancel before application.
 - `--dry-run` without `--interactive` SHALL render the complete prepared plan using the mode's default choices. With `--interactive`, it SHALL render the user's confirmed selection and then stop before adapter selection or application.
+
+The picker SHALL present candidate facets only and SHALL show aligned Current, Target, and Latest columns simultaneously. Each row SHALL state its chosen column as a visible word. Bold and underline MAY reinforce it but SHALL NOT carry it alone: those attributes are emitted only when the terminal advertises styling support, so under `NO_COLOR`, a pipe, or a screen reader they disappear entirely — and "which of these two similar numbers is selected" is not something a user can be left to infer. Advancing versions SHALL additionally expose the semantic size of the change by coloring only the changed suffix with existing theme roles: patch uses `THEME.success` (green), minor uses `THEME.caution` (amber), and major uses `THEME.warning` (coral). Current and stationary values remain dim. Colour is therefore never the sole carrier of any fact on this screen: the digits themselves say which component moved, and the chosen column is named in words. Reusing the existing three-rung semantic scale avoids introducing a second palette.
 
 Dry-run is a successful preview, not a drift-check contract. It SHALL exit `0` both when updates are available and when no update is selected, matching `self-update --dry-run`; real preparation failures SHALL exit non-zero. A future check mode MAY define a distinct updates-available exit contract, but is outside this change.
 
@@ -130,6 +133,10 @@ The update command SHALL define `--latest`/`-L`, `--interactive`/`-i`, `--dry-ru
 
 The command SHALL reject `--interactive` in a non-interactive terminal using `canPromptInteractively()` before starting discovery. The standalone update picker SHALL reuse the established `InstallPicker` keyboard conventions and the collision workspace's non-color focus markers and always-active interrupt handling. Installation progress and final per-facet outcomes SHALL reuse `InstallView` with an `update` mode rather than introducing a second progress renderer.
 
+After invocation and TTY validation, the CLI SHALL mount a lightweight discovery view before awaiting `prepareFacetUpdate`. While registry discovery is pending it SHALL state that it is checking the registry for facet updates and reuse the existing indeterminate `ProgressBar`; once preparation settles, that view SHALL be cleared and unmounted in a `finally` so the picker, static plan, no-op, or structured error renders onto a clean screen however discovery ended. The indicator SHALL remain indeterminate: discovery currently resolves concurrent groups without exposing per-request progress events, so a percentage or completed-count display would be invented rather than measured.
+
+The indicator SHALL be drawn only when stdout is a terminal. An animated frame is a terminal affordance; piped to a file or a CI log it becomes many frames per second in front of the output the caller wanted, and existing `--dry-run` output assertions depend on that stream staying clean. A non-terminal run performs identical discovery and emits nothing extra. This is a CLI presentation wrapper only and SHALL NOT add an engine progress API or alter metadata batching.
+
 Exit behavior SHALL remain:
 
 - `0` for applied updates, no-op, or successful dry-run;
@@ -138,7 +145,7 @@ Exit behavior SHALL remain:
 
 Errors SHALL use the existing three-line stderr format and registry/install failure translators. Help, tables, picker frames, progress, and summaries SHALL use stdout. Cancellation SHALL report that nothing was applied and SHALL not report success.
 
-**Alternatives considered:** Treating `-L` and `-i` as undeclared passthrough keys would leave aliases undocumented and force each handler to interpret two names. Registering `upgrade` as a second command object would duplicate help, tests, and behavior. A new update-specific progress pipeline would duplicate the install view. These alternatives are rejected.
+**Alternatives considered:** Treating `-L` and `-i` as undeclared passthrough keys would leave aliases undocumented and force each handler to interpret two names. Registering `upgrade` as a second command object would duplicate help, tests, and behavior. A new update-specific progress pipeline would duplicate the install view. Reporting discovery percentages without progress events would present synthetic precision; printing nothing until all registry calls settle leaves the user unable to distinguish work from a stalled command. Both are rejected in favor of the existing indeterminate progress component. These alternatives are rejected.
 
 ### D6. Reconcile documentation around one canonical update workflow
 

--- a/openspec/changes/add-facet-update-command/specs/cli/spec.md
+++ b/openspec/changes/add-facet-update-command/specs/cli/spec.md
@@ -41,7 +41,7 @@ The command SHALL accept `--latest` with short alias `-L`, `--interactive` with 
 
 ### Requirement: Update presentations distinguish Current Target and Latest
 
-Whenever the update command presents discovered choices, it SHALL identify each checkable registry facet's manifest specifier, locked Current version, range-respecting Target version, and registry Latest version. Git and local facets SHALL be named as unsupported sources rather than counted as current.
+Whenever the update command presents discovered choices, it SHALL identify each checkable registry facet's manifest specifier, locked Current version, range-respecting Target version, and registry Latest version. Interactive candidate rows SHALL show Current, Target, and Latest simultaneously in aligned columns. Each row SHALL name its chosen column in visible text, so the choice survives a terminal with no styling support. Styling MAY reinforce that cue but SHALL NOT be the only carrier of it. Advancing versions SHALL also color only the changed semantic-version suffix by change size using the existing semantic theme roles: patch as success/green, minor as caution/amber, and major as warning/coral. Current and stationary values SHALL remain dim. Git and local facets SHALL be named as unsupported sources rather than counted as current.
 
 #### Scenario: Preview shows all version choices
 
@@ -50,6 +50,13 @@ Whenever the update command presents discovered choices, it SHALL identify each 
 - **THEN** the output SHALL identify `1.2.0` as Current, `1.4.0` as Target, and `2.0.0` as Latest
 - **AND** the output SHALL include the authored specifier
 
+#### Scenario: Interactive rows show all choices and change size
+
+- **WHEN** interactive discovery finds candidate facets with patch, minor, or major Target or Latest advances
+- **THEN** each candidate row SHALL show Current, Target, and Latest simultaneously
+- **AND** each row SHALL name its chosen column in visible text, independent of any styling
+- **AND** the changed version suffix SHALL use the existing success, caution, or warning theme role for a patch, minor, or major advance respectively
+
 #### Scenario: Unsupported sources are named
 
 - **WHEN** a project contains git or local facets alongside registry facets
@@ -57,9 +64,31 @@ Whenever the update command presents discovered choices, it SHALL identify each 
 - **THEN** the output SHALL name each git or local facet as unsupported for update discovery
 - **AND** it SHALL NOT report those facets as current registry facets
 
+### Requirement: Update reports registry discovery progress
+
+When the output stream is a terminal, the update command SHALL provide immediate visible feedback while registry discovery is pending. It SHALL state that it is checking the registry for facet updates and SHALL reuse the CLI's existing indeterminate progress indicator. The indicator SHALL be removed before the command presents a picker, static plan, no-op, or structured error, however discovery ends. The command SHALL NOT present a percentage or completed count unless the discovery boundary exposes real progress events. When the output stream is not a terminal, the command SHALL perform the same discovery and SHALL NOT emit progress frames.
+
+#### Scenario: Pending discovery is visible in a terminal
+
+- **WHEN** registry discovery has started but has not settled in a terminal
+- **THEN** the command SHALL state that it is checking the registry for facet updates
+- **AND** it SHALL render the existing indeterminate progress indicator
+
+#### Scenario: Discovery feedback yields to the result
+
+- **WHEN** registry discovery succeeds or fails
+- **THEN** the pending indicator SHALL be removed
+- **AND** the command SHALL continue to the picker, plan, no-op, or structured error appropriate to the result
+
+#### Scenario: Non-terminal discovery emits no progress frames
+
+- **WHEN** registry discovery runs with a non-terminal output stream
+- **THEN** the command SHALL NOT write progress frames
+- **AND** the discovered result SHALL be unchanged
+
 ### Requirement: Users can select updates interactively
 
-The `--interactive` mode SHALL present every registry facet for which Target or Latest is newer than Current. Range Target SHALL be the initial choice unless `--latest` is also supplied, in which case Latest SHALL be initial. Users SHALL be able to navigate rows, select or deselect facets, and toggle the focused row between Target and Latest with `l`. A choice that does not advance Current SHALL NOT be selectable, and confirmation SHALL require at least one selected advancing choice.
+The `--interactive` mode SHALL present every registry facet for which Target or Latest is newer than Current. Whether the picker opens SHALL be determined from that candidate set, not from whether the initial mode has a non-empty default selection. Range Target SHALL be the initial choice unless `--latest` is also supplied, in which case Latest SHALL be initial. Users SHALL be able to navigate rows, select or deselect facets, and change the focused row's column between Target and Latest. Left and right SHALL address the Target and Latest columns directly and SHALL clamp at each end rather than wrap; `l` SHALL flip the focused row between them. A choice that does not advance Current SHALL NOT be selectable, and confirmation SHALL require at least one selected advancing choice.
 
 Interactive selection SHALL occur before adapter selection or update application. The command SHALL reject interactive mode before discovery when the terminal cannot prompt. Cancelling or interrupting the picker SHALL apply nothing, SHALL report that nothing was applied, and SHALL exit with code 1.
 
@@ -68,20 +97,34 @@ Interactive selection SHALL occur before adapter selection or update application
 - **WHEN** a user runs `facet update --interactive`
 - **AND** a facet has both an advancing Target and an advancing Latest
 - **THEN** the facet's initial choice SHALL be Target
-- **AND** pressing `l` on that row SHALL change its choice to Latest
+- **AND** pressing `l` or right on that row SHALL change its choice to Latest
+
+#### Scenario: Column keys clamp at each end
+
+- **WHEN** a row's choice is Target and the user presses left
+- **THEN** the choice SHALL remain Target
+- **AND** when a row's choice is Latest and the user presses right, the choice SHALL remain Latest
 
 #### Scenario: Latest interactive mode starts with latest targets
 
 - **WHEN** a user runs `facet update --interactive --latest`
 - **AND** a facet has both an advancing Target and an advancing Latest
 - **THEN** the facet's initial choice SHALL be Latest
-- **AND** pressing `l` on that row SHALL change its choice to Target
+- **AND** pressing `l` or left on that row SHALL change its choice to Target
 
 #### Scenario: Non-advancing choice cannot be selected
 
 - **WHEN** a facet's Target equals Current but its Latest is newer
 - **THEN** the Target choice SHALL NOT be selectable
 - **AND** the user SHALL be able to toggle to and select Latest
+
+#### Scenario: Latest-only candidate opens plain interactive mode
+
+- **WHEN** a facet's Target equals Current and its Latest is newer
+- **AND** the user runs `facet update --interactive` without `--latest`
+- **THEN** the command SHALL open the picker rather than report the range-specific no-op
+- **AND** the row SHALL start on its stationary Target, unselected
+- **AND** the user SHALL be able to toggle to Latest, select it, and confirm
 
 #### Scenario: Confirmation requires a selection
 

--- a/openspec/changes/add-facet-update-command/tasks.md
+++ b/openspec/changes/add-facet-update-command/tasks.md
@@ -100,7 +100,7 @@
 - [x] 9.3 Explore: Inspect `packages/cli/src/prompts/overview.txt`, `packages/cli/src/prompts/usage.txt`, prompt generation, and instruction-prompt unit/e2e tests so guidance is added without duplicating topic lists, adapter API support sets, or materialization schemas.
 - [x] 9.4 Explore: Inspect `docs/changelog/index.mdx`, its RSS rules, `.changeset/`, and contribution conventions for the required inert-stub-to-live-alias disclosure and package changeset.
 - [x] 9.5 Propose: Define the cohesive documentation, prompt, changelog, navigation, and validation approach while preserving historical changelog text and `facet list`'s offline contract.
-- [ ] 9.6 Pause: Model-switch boundary before documentation implementation.
+- [x] 9.6 Pause: Model-switch boundary before documentation implementation.
 
 ## 10. Documentation and Agent Guidance — Implementation
 
@@ -110,17 +110,29 @@
 - [x] 10.4 Implement: Update `packages/cli/src/prompts/overview.txt` and `usage.txt` with project update, alias, non-TTY, dry-run, `--accept-mcp`, and `facet install` recovery guidance, then add companion unit and end-to-end prompt assertions.
 - [x] 10.5 Implement: Leave `docs/changelog/index.mdx` untouched, ask the user to generate the `agent-facets` minor changeset manually, then replace only its placeholder body with the stub-to-live-alias warning without editing generated package changelogs.
 - [x] 10.6 Verify: Run prompt tests, Mintlify validation, and broken-link checks for all documentation and agent-guidance changes.
-- [ ] 10.7 Pause: Model-switch boundary before integrated acceptance research.
+- [x] 10.7 Pause: Model-switch boundary before integrated acceptance research.
 
-## 11. Integrated Acceptance — Research
+## 11. Interactive Update Corrections — Implementation
 
-- [ ] 11.1 Explore: Map every reconciled CLI and installation scenario to an automated test or explicit documentation check and identify any remaining coverage gaps across engine, CLI, transaction, prompts, and docs.
-- [ ] 11.2 Explore: Review the complete implementation for single-source-of-truth violations, representable illegal states, escaping expected errors, accidental registry-current checks, secondary metadata resolution, or dry-run side effects.
-- [ ] 11.3 Propose: Define the final acceptance pass and the smallest fixes needed to close all uncovered specification and regression gaps.
-- [ ] 11.4 Pause: Model-switch boundary before final acceptance implementation.
+The approach for this block was explored and approved during the block 10 review,
+so it opens on implementation rather than a second research pass.
 
-## 12. Integrated Acceptance — Implementation
+- [x] 11.1 Implement: Add a lightweight update-discovery view that starts before awaiting preparation, states that the registry is being checked, reuses the existing indeterminate `ProgressBar`, and yields cleanly to success, no-op, or structured failure without adding synthetic percentages or an engine progress API.
+- [x] 11.2 Implement: Correct interactive orchestration so the presence of any Target-or-Latest candidate opens the picker even when the initial Range selection is empty, while truly candidate-free plans retain their specific successful no-op and non-interactive range behavior remains unchanged.
+- [x] 11.3 Implement: Render candidate picker rows as aligned Current, Target, and Latest columns; preserve mode defaults and `l` toggling; emphasize the chosen cell without color alone; and color only the changed semantic-version suffix with existing success, caution, and warning theme roles for patch, minor, and major advances.
+- [x] 11.4 Implement: Add focused command, Ink, and pure presentation tests for pending/settled/failed discovery feedback, Latest-only plain interactive selection, truly empty no-ops, simultaneous version columns, and semantic change coloring, while preserving existing cancellation, dry-run, adapter-ordering, and side-effect coverage.
+- [x] 11.5 Verify: Run the targeted update command, picker, and Ink tests plus the CLI typecheck.
+- [ ] 11.6 Pause: Model-switch boundary before integrated acceptance research.
 
-- [ ] 12.1 Implement: Add or adjust the remaining focused tests and documentation checks identified by the acceptance matrix without duplicating coverage already owned by lower-level suites.
-- [ ] 12.2 Verify: Run `bun check`; if any test, type, lint, formatting, documentation, or end-to-end check fails, stop and report the failures.
-- [ ] 12.3 Verify: Validate the completed OpenSpec change against its schema and confirm every implementation task and reconciled scenario is accounted for before verification and archive.
+## 12. Integrated Acceptance — Research
+
+- [ ] 12.1 Explore: Map every reconciled CLI and installation scenario — including the corrected interactive and discovery-feedback behavior — to an automated test or explicit documentation check, and identify any remaining coverage gaps across engine, CLI, transaction, prompts, and docs.
+- [ ] 12.2 Explore: Review the complete implementation for single-source-of-truth violations, representable illegal states, escaping expected errors, accidental registry-current checks, secondary metadata resolution, or dry-run side effects.
+- [ ] 12.3 Propose: Define the final acceptance pass and the smallest fixes needed to close all uncovered specification and regression gaps.
+- [ ] 12.4 Pause: Model-switch boundary before final acceptance implementation.
+
+## 13. Integrated Acceptance — Implementation
+
+- [ ] 13.1 Implement: Add or adjust the remaining focused tests and documentation checks identified by the acceptance matrix without duplicating coverage already owned by lower-level suites.
+- [ ] 13.2 Verify: Run `bun check`; if any test, type, lint, formatting, documentation, or end-to-end check fails, stop and report the failures.
+- [ ] 13.3 Verify: Validate the completed OpenSpec change against its schema and confirm every implementation task and reconciled scenario is accounted for before verification and archive.

--- a/packages/cli/src/commands/update/__tests__/command.test.ts
+++ b/packages/cli/src/commands/update/__tests__/command.test.ts
@@ -4,22 +4,28 @@ import { captureStderr, captureStdout } from '../../../__tests__/helpers/capture
 import { withTTY } from '../../../__tests__/helpers/with-tty.ts'
 import * as adapterModule from '../../shared/ensure-adapters.ts'
 import { updateCommand } from '../index.ts'
+import * as pickerModule from '../run-picker.ts'
 import { candidate, current, unsupported } from './fixtures.ts'
 
 type Prepare = typeof engine.prepareFacetUpdate
 const prepareSpy = spyOn(engine, 'prepareFacetUpdate') as unknown as Mock<Prepare>
 const adaptersSpy = spyOn(adapterModule, 'ensureAdapters')
+// Stubbed rather than mounted: the real picker waits on keystrokes, so a
+// test that let it open would hang until the suite timed out.
+const pickerSpy = spyOn(pickerModule, 'runUpdatePicker')
 
 // Cleared, not restored: `mockRestore` retires the spy for good, and
 // every test after the first would then run against the real engine.
 afterEach(() => {
   prepareSpy.mockClear()
   adaptersSpy.mockClear()
+  pickerSpy.mockClear()
 })
 
 afterAll(() => {
   prepareSpy.mockRestore()
   adaptersSpy.mockRestore()
+  pickerSpy.mockRestore()
 })
 
 function preparing(plan: engine.UpdatePlanRow[]): void {
@@ -141,6 +147,81 @@ describe('facet update — successful runs that apply nothing', () => {
     expect(result).toBe(0)
     expect(stdout).toContain('facet update --latest')
     expect(stdout).not.toContain('are current')
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('facet update — opening the interactive picker', () => {
+  // The bug this guards: gating the picker on the mode's DEFAULT
+  // selection instead of on the candidate rows. An exact pin has a
+  // stationary target and an advancing latest, so plain `--interactive`
+  // produced an empty default selection, tripped the range no-op, and
+  // told the user to re-run with `--latest` -- the exact job the screen
+  // they asked for was there to do.
+  test('a latest-only candidate opens the picker instead of the range no-op', async () => {
+    preparing([PINNED])
+    pickerSpy.mockResolvedValue({ kind: 'cancelled' })
+    const { stdout, result } = await withTTY(true, () =>
+      captureStdout(() => updateCommand.run([], { interactive: true })),
+    )
+    expect(pickerSpy).toHaveBeenCalled()
+    expect(stdout).not.toContain('facet update --latest')
+    expect(result).toBe(1)
+  })
+
+  test('the picker starts on the mode the flags asked for', async () => {
+    preparing([BOUNDED])
+    pickerSpy.mockResolvedValue({ kind: 'cancelled' })
+    await withTTY(true, () => captureStdout(() => updateCommand.run([], { interactive: true })))
+    expect(pickerSpy.mock.calls[0]?.[1]).toBe('range')
+
+    pickerSpy.mockClear()
+    await withTTY(true, () => captureStdout(() => updateCommand.run([], { interactive: true, latest: true })))
+    expect(pickerSpy.mock.calls[0]?.[1]).toBe('latest')
+  })
+
+  // Interactive has a dead end, it is just a different one: a plan with
+  // no candidate row at all has nothing to put on screen.
+  test('a plan with no candidate at all still reports the specific no-op', async () => {
+    preparing([current({ name: 'gamma', source: '*', version: '4.0.0' })])
+    const { stdout, result } = await withTTY(true, () =>
+      captureStdout(() => updateCommand.run([], { interactive: true })),
+    )
+    expect(pickerSpy).not.toHaveBeenCalled()
+    expect(stdout).toContain('All registry facets are current')
+    expect(result).toBe(0)
+  })
+
+  test('a project with no registry facets never opens the picker', async () => {
+    preparing([unsupported('delta', 'github:a/b', 'git')])
+    const { stdout, result } = await withTTY(true, () =>
+      captureStdout(() => updateCommand.run([], { interactive: true })),
+    )
+    expect(pickerSpy).not.toHaveBeenCalled()
+    expect(stdout).toContain('No registry facets to update')
+    expect(result).toBe(0)
+  })
+
+  test('cancelling applies nothing, says so, and exits non-zero', async () => {
+    preparing([BOUNDED])
+    pickerSpy.mockResolvedValue({ kind: 'cancelled' })
+    const { stdout, result } = await withTTY(true, () =>
+      captureStdout(() => updateCommand.run([], { interactive: true })),
+    )
+    expect(result).toBe(1)
+    expect(stdout).toContain('Nothing was applied')
+    // Cancelling must not have cost an adapter install.
+    expect(adaptersSpy).not.toHaveBeenCalled()
+  })
+
+  test('a confirmed selection under --dry-run previews and stops', async () => {
+    preparing([PINNED])
+    pickerSpy.mockResolvedValue({ kind: 'confirmed', selections: [{ facetName: 'beta', choice: 'latest' }] })
+    const { stdout, result } = await withTTY(true, () =>
+      captureStdout(() => updateCommand.run([], { interactive: true, 'dry-run': true })),
+    )
+    expect(result).toBe(0)
+    expect(stdout).toContain('3.4.1')
     expect(adaptersSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/commands/update/__tests__/picker.test.tsx
+++ b/packages/cli/src/commands/update/__tests__/picker.test.tsx
@@ -10,6 +10,8 @@ import { candidate, current } from './fixtures.ts'
 const KEY = {
   up: '\u001B[A',
   down: '\u001B[B',
+  right: '\u001B[C',
+  left: '\u001B[D',
   enter: '\r',
   space: ' ',
   escape: '\u001B',
@@ -18,6 +20,19 @@ const KEY = {
 
 function nextTick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+/**
+ * Which column each row says it would install.
+ *
+ * Read from the visible text on purpose. Bold and underline carry the
+ * same meaning on a capable terminal, but they vanish under `NO_COLOR`,
+ * a pipe, or a screen reader — and this suite runs without colour
+ * support, which is exactly the environment that proves the word is
+ * load-bearing rather than decorative.
+ */
+function chosenLabels(frame: string): string[] {
+  return [...visibleTerminalText(frame).matchAll(/\((target|latest)\)/g)].map((match) => match[1] ?? '')
 }
 
 // Ink needs a grace period after a bare ESC byte to tell it apart from
@@ -80,32 +95,43 @@ describe('UpdatePicker — what it offers', () => {
     app.unmount()
   })
 
-  test('plain mode starts on the range target', async () => {
+  test('every row shows current, target, and latest together', async () => {
     const { app } = mount([BOUNDED])
     await nextTick()
     const frame = visibleTerminalText(app.lastFrame() ?? '')
-    expect(frame).toContain('1.2.0 → 1.8.0')
-    expect(frame).toContain('(target)')
-    expect(frame).toContain('1 of 1 selected')
+    expect(frame).toContain('facet current target latest')
+    // The comparison this screen exists for needs all three at once.
+    expect(frame).toContain('alpha 1.2.0 1.8.0 2.0.0')
+    app.unmount()
+  })
+
+  test('plain mode starts on the range target', async () => {
+    const { app, state } = mount([BOUNDED])
+    await nextTick()
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1 of 1 selected')
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['target'])
+    await press(app, KEY.enter)
+    expect(state.confirmed).toEqual([{ facetName: 'alpha', choice: 'range' }])
     app.unmount()
   })
 
   test('latest mode starts on the latest release', async () => {
-    const { app } = mount([BOUNDED], 'latest')
+    const { app, state } = mount([BOUNDED], 'latest')
     await nextTick()
-    const frame = visibleTerminalText(app.lastFrame() ?? '')
-    expect(frame).toContain('1.2.0 → 2.0.0')
-    expect(frame).toContain('(latest)')
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['latest'])
+    await press(app, KEY.enter)
+    expect(state.confirmed).toEqual([{ facetName: 'alpha', choice: 'latest' }])
     app.unmount()
   })
 
   // The row `--latest` exists for: its range cannot move, so plain mode
-  // shows it unselected and says why.
+  // shows it unselected with its target sitting on the installed version.
   test('a row whose displayed choice is already installed starts unselected', async () => {
     const { app } = mount([PINNED])
     await nextTick()
     const frame = visibleTerminalText(app.lastFrame() ?? '')
-    expect(frame).toContain('unchanged')
+    // Target equal to current is legible from the columns themselves.
+    expect(frame).toContain('beta 1.2.0 1.2.0 3.0.0')
     expect(frame).toContain('0 of 1 selected')
     app.unmount()
   })
@@ -116,9 +142,51 @@ describe('UpdatePicker — choosing', () => {
     const { app } = mount([BOUNDED])
     await nextTick()
     await press(app, 'l')
-    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1.2.0 → 2.0.0')
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['latest'])
     await press(app, 'l')
-    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1.2.0 → 1.8.0')
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['target'])
+    app.unmount()
+  })
+
+  test('right moves to latest, left moves back to target', async () => {
+    const { app } = mount([BOUNDED])
+    await nextTick()
+    await press(app, KEY.right)
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['latest'])
+    await press(app, KEY.left)
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['target'])
+    app.unmount()
+  })
+
+  // Clamping, not wrapping. Holding an arrow down should settle on a
+  // column rather than oscillate between the two.
+  test('the arrows clamp at each end instead of wrapping', async () => {
+    const { app } = mount([BOUNDED])
+    await nextTick()
+    await press(app, KEY.left, KEY.left)
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['target'])
+    await press(app, KEY.right, KEY.right, KEY.right)
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['latest'])
+    app.unmount()
+  })
+
+  test('the arrows carry selection the same way l does', async () => {
+    const { app, state } = mount([PINNED])
+    await nextTick()
+    // A stationary target cannot be selected; the advancing latest can.
+    await press(app, KEY.right, KEY.space, KEY.enter)
+    expect(state.confirmed).toEqual([{ facetName: 'beta', choice: 'latest' }])
+    app.unmount()
+  })
+
+  test('arrows move columns while up and down still move rows', async () => {
+    const { app, state } = mount([BOUNDED, PINNED])
+    await nextTick()
+    await press(app, KEY.down, KEY.right, KEY.space, KEY.enter)
+    expect(state.confirmed).toEqual([
+      { facetName: 'alpha', choice: 'range' },
+      { facetName: 'beta', choice: 'latest' },
+    ])
     app.unmount()
   })
 
@@ -160,9 +228,9 @@ describe('UpdatePicker — choosing', () => {
     await nextTick()
     expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('1 of 1 selected')
     await press(app, 'l')
-    const frame = visibleTerminalText(app.lastFrame() ?? '')
-    expect(frame).toContain('0 of 1 selected')
-    expect(frame).toContain('unchanged')
+    expect(visibleTerminalText(app.lastFrame() ?? '')).toContain('0 of 1 selected')
+    // Still shown as the row's choice, just not a selectable one.
+    expect(chosenLabels(app.lastFrame() ?? '')).toEqual(['target'])
     app.unmount()
   })
 

--- a/packages/cli/src/commands/update/__tests__/selection.test.ts
+++ b/packages/cli/src/commands/update/__tests__/selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { classifyNoOp, defaultSelections, describeNoOp } from '../selection.ts'
+import { classifyNoOp, defaultSelections, describeNoOp, hasSelectableCandidate } from '../selection.ts'
 import { candidate, current, unsupported } from './fixtures.ts'
 
 const BOUNDED = candidate({
@@ -37,6 +37,26 @@ describe('defaultSelections', () => {
     const plan = [current({ name: 'gamma', source: '*', version: '4.0.0' }), unsupported('delta', './local', 'local')]
     expect(defaultSelections(plan, 'range')).toEqual([])
     expect(defaultSelections(plan, 'latest')).toEqual([])
+  })
+})
+
+describe('hasSelectableCandidate', () => {
+  test('a candidate the mode would not select still counts', () => {
+    // The whole point: under plain update PINNED contributes no default
+    // selection, and it is still a row worth showing.
+    expect(defaultSelections([PINNED], 'range')).toEqual([])
+    expect(hasSelectableCandidate([PINNED])).toBe(true)
+  })
+
+  test('rows with nothing newer do not count', () => {
+    expect(hasSelectableCandidate([current({ name: 'gamma', source: '*', version: '4.0.0' })])).toBe(false)
+    expect(hasSelectableCandidate([unsupported('delta', './local', 'local')])).toBe(false)
+    expect(hasSelectableCandidate([])).toBe(false)
+  })
+
+  test('one candidate among unselectable rows is enough', () => {
+    const plan = [current({ name: 'gamma', source: '*', version: '4.0.0' }), PINNED]
+    expect(hasSelectableCandidate(plan)).toBe(true)
   })
 })
 

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -17,8 +17,16 @@ import { ACCEPT_MCP_FLAG, INSTALL_PIPELINE_FLAGS, mcpConsentPolicy } from '../sh
 import { installFailureDetail, installFailureFix } from '../shared/install-failure.ts'
 import { updatePrepareCliError, updateSelectionCliError } from './errors.ts'
 import { buildPreview } from './preview.ts'
+import { withUpdateDiscovery } from './run-discovery.ts'
 import { runUpdatePicker } from './run-picker.ts'
-import { classifyNoOp, defaultSelections, describeNoOp, type UpdateMode } from './selection.ts'
+import {
+  classifyNoOp,
+  defaultSelections,
+  describeNoOp,
+  hasSelectableCandidate,
+  type UpdateMode,
+  type UpdateNoOp,
+} from './selection.ts'
 
 /**
  * `facet update` (alias: `facet upgrade`) — move the project's
@@ -92,7 +100,10 @@ export const updateCommand: Command = {
     const dryRun = flags['dry-run'] === true
     const mode: UpdateMode = flags.latest === true ? 'latest' : 'range'
 
-    const prepared = await prepareFacetUpdate({ projectRoot: process.cwd() })
+    // Wrapped rather than awaited bare: discovery is the long, silent
+    // part of this command, and an empty screen while it runs is
+    // indistinguishable from a command that did nothing.
+    const prepared = await withUpdateDiscovery(() => prepareFacetUpdate({ projectRoot: process.cwd() }))
     if (!prepared.ok) {
       writeCliError(updatePrepareCliError(prepared.failure))
       return 1
@@ -108,9 +119,17 @@ export const updateCommand: Command = {
     // it is decides whether the user has anything to do about it, so the
     // message says which one rather than a single "nothing to update".
     //
-    // Checked before the picker for a reason: a screen with no selectable
-    // row is not a choice, it is a dead end with no explanation on it.
-    const noOp = classifyNoOp(plan, mode, defaults)
+    // What counts as nothing depends on the mode. A non-interactive run
+    // has only its mode's default selection to go on. An interactive run
+    // has the picker, which can reach a version those defaults did not
+    // select — so its only dead end is a plan with no candidate row to
+    // put on screen at all.
+    let noOp: UpdateNoOp | null
+    if (interactive) {
+      noOp = hasSelectableCandidate(plan) ? null : classifyNoOp(plan, mode, [])
+    } else {
+      noOp = classifyNoOp(plan, mode, defaults)
+    }
     if (noOp !== null) {
       process.stdout.write(`${describeNoOp(noOp)}\n`)
       return 0

--- a/packages/cli/src/commands/update/picker.tsx
+++ b/packages/cli/src/commands/update/picker.tsx
@@ -2,6 +2,13 @@ import type { FacetUpdateSelection, UpdateChoice, UpdatePlanRow } from '@agent-f
 import { Box, Text, useApp, useInput } from 'ink'
 import { useMemo, useState } from 'react'
 import { THEME } from '../../tui/theme.ts'
+import {
+  classifyVersionChange,
+  type ExactVersionParts,
+  formatExactVersion,
+  splitAtChange,
+  versionChangeColor,
+} from '../../tui/views/update/version-change.ts'
 import { choiceAdvances, type UpdateMode } from './selection.ts'
 
 type Candidate = Extract<UpdatePlanRow, { kind: 'candidate' }>
@@ -70,6 +77,23 @@ export function UpdatePicker({ plan, mode, onConfirm, onAbort }: UpdatePickerPro
     action()
   }
 
+  /**
+   * Put the focused row on a specific column.
+   *
+   * Absolute rather than relative, so left and right can clamp: asking for the
+   * column you are already on is a no-op instead of a bounce back to the
+   * other one. Selection is carried through `stateFor`, which drops it
+   * when the requested column is not an advancing one — a selected row
+   * showing the installed version is not a state this picker can hold.
+   */
+  const chooseColumn = (choice: UpdateChoice) => {
+    const row = rows[cursor]
+    const candidate = candidates[cursor]
+    if (row === undefined || candidate === undefined) return
+    if (row.displayed.choice === choice) return
+    setRows(replace(rows, cursor, stateFor(candidate, choice, row.kind === 'selected')))
+  }
+
   useInput((input, key) => {
     if (done) return
     if (hint !== null) setHint(null)
@@ -107,12 +131,24 @@ export function UpdatePicker({ plan, mode, onConfirm, onAbort }: UpdatePickerPro
       return
     }
 
+    // Left/right address the two columns directly: left is target,
+    // right is latest, and each is where it sits on screen. They clamp
+    // rather than wrap, so holding one down settles on a column instead
+    // of oscillating between them. `l` stays as the flip for anyone who
+    // learned it, and for a keyboard where the arrows are awkward.
+    if (key.leftArrow) {
+      chooseColumn('range')
+      return
+    }
+    if (key.rightArrow) {
+      chooseColumn('latest')
+      return
+    }
+
     if (input === 'l' || input === 'L') {
       const row = rows[cursor]
-      const candidate = candidates[cursor]
-      if (row === undefined || candidate === undefined) return
-      const flipped = other(row.displayed.choice)
-      setRows(replace(rows, cursor, stateFor(candidate, flipped, row.kind === 'selected')))
+      if (row === undefined) return
+      chooseColumn(other(row.displayed.choice))
       return
     }
 
@@ -131,12 +167,22 @@ export function UpdatePicker({ plan, mode, onConfirm, onAbort }: UpdatePickerPro
     }
   })
 
-  const nameWidth = candidates.reduce((max, row) => Math.max(max, row.facet.name.length), 0)
+  const widths = columnWidths(candidates)
 
   return (
     <Box flexDirection="column" paddingY={1}>
       <Text>Choose which facets to update.</Text>
       <Box height={1} />
+      <Text color={THEME.hint}>
+        {ROW_INDENT}
+        {'facet'.padEnd(widths.name)}
+        {COLUMN_GAP}
+        {'current'.padEnd(widths.current)}
+        {COLUMN_GAP}
+        {'target'.padEnd(widths.target)}
+        {COLUMN_GAP}
+        latest
+      </Text>
       {candidates.map((candidate, index) => {
         const row = rows[index]
         if (row === undefined) return null
@@ -146,12 +192,17 @@ export function UpdatePicker({ plan, mode, onConfirm, onAbort }: UpdatePickerPro
             candidate={candidate}
             state={row}
             focused={index === cursor}
-            nameWidth={nameWidth}
+            widths={widths}
           />
         )
       })}
       <Box height={1} />
-      <Text color={THEME.keyword}>↑↓ move · Space toggle · l target/latest · Enter confirm · Esc cancel</Text>
+      {/* Filled triangles rather than line arrows: `←→` jammed together
+          smears into one glyph in most terminal fonts, and these read
+          cleanly at any weight. They live on the legend line, never in a
+          column, so their ambiguous character width cannot pull the
+          version table out of alignment. */}
+      <Text color={THEME.keyword}>↑↓ move · ◀ ▶ target/latest · Space select · Enter confirm · Esc cancel</Text>
       <Text color={THEME.hint}>
         {selectedCount} of {candidates.length} selected
       </Text>
@@ -160,21 +211,57 @@ export function UpdatePicker({ plan, mode, onConfirm, onAbort }: UpdatePickerPro
   )
 }
 
+/**
+ * Two spaces between columns, not one.
+ *
+ * Every cell here is digits and dots, and a single space lets `1.2.0`
+ * and `1.8.0` read as one run of characters. Two is the smallest gutter
+ * that keeps the columns separable at a glance.
+ */
+const COLUMN_GAP = '  '
+
+/** Clears the focus marker and the selection dot, so the header lines up. */
+const ROW_INDENT = '    '
+
+interface ColumnWidths {
+  name: number
+  current: number
+  target: number
+}
+
+function columnWidths(candidates: readonly Candidate[]): ColumnWidths {
+  let name = 'facet'.length
+  let current = 'current'.length
+  let target = 'target'.length
+  for (const candidate of candidates) {
+    name = Math.max(name, candidate.facet.name.length)
+    current = Math.max(current, formatExactVersion(candidate.facet.current).length)
+    target = Math.max(target, candidate.facet.target.metadata.version.length)
+  }
+  return { name, current, target }
+}
+
+/**
+ * One facet's row: what is installed, and both versions it could take.
+ *
+ * Target and Latest are both always on screen. The choice this screen
+ * exists for cannot be made from one of them — "is the release my range
+ * forbids worth crossing the range for?" is a comparison, and hiding
+ * either side turns it into a guess.
+ */
 function PickerRow({
   candidate,
   state,
   focused,
-  nameWidth,
+  widths,
 }: {
   candidate: Candidate
   state: RowState
   focused: boolean
-  nameWidth: number
+  widths: ColumnWidths
 }) {
   const chosen = state.displayed.choice
-  const version = chosen === 'range' ? candidate.facet.target : candidate.facet.latest
-  const label = describeChoice(chosen)
-  const stationary = state.displayed.kind === 'stationary'
+  const current = candidate.facet.current
 
   return (
     <Box>
@@ -184,16 +271,82 @@ function PickerRow({
       </Text>
       <Text bold color={THEME.brand}>
         {' '}
-        {candidate.facet.name.padEnd(nameWidth)}
+        {candidate.facet.name.padEnd(widths.name)}
       </Text>
-      <Text color={THEME.hint}> {describeExact(candidate.facet.current)} → </Text>
-      <Text color={stationary ? THEME.hint : THEME.success}>{version.metadata.version}</Text>
       <Text color={THEME.hint}>
-        {' '}
-        ({label}
-        {stationary ? ', unchanged' : ''})
+        {COLUMN_GAP}
+        {formatExactVersion(current).padEnd(widths.current)}
+        {COLUMN_GAP}
+      </Text>
+      <VersionCell
+        current={current}
+        version={candidate.facet.target.metadata.version}
+        parts={candidate.facet.target.version}
+        chosen={chosen === 'range'}
+        pad={widths.target}
+      />
+      <Text>{COLUMN_GAP}</Text>
+      <VersionCell
+        current={current}
+        version={candidate.facet.latest.metadata.version}
+        parts={candidate.facet.latest.version}
+        chosen={chosen === 'latest'}
+      />
+      {/* The chosen column, in words. Bold and underline say the same
+          thing, but only where the terminal supports them — under
+          NO_COLOR, a dumb pipe, or a screen reader they are simply
+          absent, and "which of these two is selected" is not a question
+          the user can be left to infer from two similar numbers. */}
+      <Text color={THEME.hint}>
+        {COLUMN_GAP}({describeChoice(chosen)})
       </Text>
     </Box>
+  )
+}
+
+/**
+ * One of the two versions a row can take.
+ *
+ * Two independent things are encoded, and neither may depend on the
+ * other. Which cell the row would install is carried by underline —
+ * readable with no colour at all, which is what a colour-blind reader
+ * and a `NO_COLOR` terminal both get. How big the jump is, is carried by
+ * colour on only the digits that actually move.
+ */
+function VersionCell({
+  current,
+  version,
+  parts,
+  chosen,
+  pad,
+}: {
+  current: ExactVersionParts
+  version: string
+  parts: ExactVersionParts
+  chosen: boolean
+  pad?: number
+}) {
+  const change = classifyVersionChange(current, parts)
+  const { prefix, changed, rest } = splitAtChange(current, parts)
+  const padding = pad === undefined ? '' : ' '.repeat(Math.max(0, pad - version.length))
+
+  return (
+    <Text>
+      {/* The underline covers the version and nothing else. Column
+          padding inside it renders as underlined blanks — a stray
+          trailing underscore the user has to work out is not a
+          character. */}
+      <Text underline={chosen}>
+        <Text color={THEME.hint}>{prefix}</Text>
+        {changed.length > 0 && (
+          <Text bold={chosen} color={versionChangeColor(change)}>
+            {changed}
+          </Text>
+        )}
+        <Text color={THEME.hint}>{rest}</Text>
+      </Text>
+      {padding}
+    </Text>
   )
 }
 
@@ -223,6 +376,6 @@ function describeChoice(choice: UpdateChoice): string {
   return choice === 'range' ? 'target' : 'latest'
 }
 
-function describeExact(version: { major: number; minor: number; patch: number }): string {
+function _describeExact(version: { major: number; minor: number; patch: number }): string {
   return `${version.major}.${version.minor}.${version.patch}`
 }

--- a/packages/cli/src/commands/update/run-discovery.ts
+++ b/packages/cli/src/commands/update/run-discovery.ts
@@ -1,0 +1,42 @@
+import { render } from 'ink'
+import { createElement } from 'react'
+import { UpdateDiscoveryView } from '../../tui/views/update/discovery-view.tsx'
+
+export interface DiscoveryProgressOptions {
+  /**
+   * Whether to draw the indicator at all.
+   *
+   * Defaults to "stdout is a terminal". An animated frame is a terminal
+   * affordance: piped into a file or a CI log it becomes twenty lines a
+   * second of comet frames in front of the output someone actually
+   * wanted. A non-terminal run does the same work and prints nothing
+   * extra.
+   */
+  enabled?: boolean
+}
+
+/**
+ * Run `work` with the discovery indicator on screen, and take it back
+ * down however `work` ends.
+ *
+ * The indicator is torn down in a `finally`, so a rejected promise, a
+ * structured failure, and a successful plan all leave the same clean
+ * screen for whatever the command renders next. `clear()` precedes
+ * `unmount()` so the frame is erased rather than left sitting above the
+ * picker.
+ */
+export async function withUpdateDiscovery<T>(
+  work: () => Promise<T>,
+  options: DiscoveryProgressOptions = {},
+): Promise<T> {
+  const enabled = options.enabled ?? process.stdout.isTTY === true
+  if (!enabled) return work()
+
+  const instance = render(createElement(UpdateDiscoveryView), { exitOnCtrlC: false })
+  try {
+    return await work()
+  } finally {
+    instance.clear()
+    instance.unmount()
+  }
+}

--- a/packages/cli/src/commands/update/selection.ts
+++ b/packages/cli/src/commands/update/selection.ts
@@ -28,6 +28,22 @@ export function choiceAdvances(row: Extract<UpdatePlanRow, { kind: 'candidate' }
   }
 }
 
+/**
+ * Whether the interactive picker has anything to offer.
+ *
+ * Deliberately independent of the mode's default selections. A facet
+ * pinned to an exact version has a stationary Target and may still have
+ * an advancing Latest — under plain `--interactive` its default
+ * selection is empty while the row it would show is precisely the one
+ * the screen exists for. Gating the picker on the defaults instead sent
+ * that user to the "ranges permit none, pass --latest" message, telling
+ * them to re-run with a flag whose job the picker was already there to
+ * do interactively.
+ */
+export function hasSelectableCandidate(plan: readonly UpdatePlanRow[]): boolean {
+  return plan.some((row) => row.kind === 'candidate')
+}
+
 /** Every candidate whose chosen version advances, in project order. */
 export function defaultSelections(plan: readonly UpdatePlanRow[], mode: UpdateMode): FacetUpdateSelection[] {
   const selections: FacetUpdateSelection[] = []

--- a/packages/cli/src/tui/views/update/__tests__/discovery-view.test.tsx
+++ b/packages/cli/src/tui/views/update/__tests__/discovery-view.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import { render } from 'ink-testing-library'
+import { createElement } from 'react'
+import { visibleTerminalText } from '../../../../__tests__/helpers/terminal-output.ts'
+import { withUpdateDiscovery } from '../../../../commands/update/run-discovery.ts'
+import { UpdateDiscoveryView } from '../discovery-view.tsx'
+
+describe('UpdateDiscoveryView', () => {
+  test('says what it is waiting on', () => {
+    const app = render(createElement(UpdateDiscoveryView))
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).toContain('Checking the registry for facet updates')
+    app.unmount()
+  })
+
+  // No "3 of 12" and no percentage: discovery resolves its lookups in
+  // concurrent groups and reports nothing until the whole set settles,
+  // so any count rendered here would be invented rather than measured.
+  test('claims no measurable progress', () => {
+    const app = render(createElement(UpdateDiscoveryView))
+    const frame = visibleTerminalText(app.lastFrame() ?? '')
+    expect(frame).not.toMatch(/\d+%/)
+    expect(frame).not.toMatch(/\d+\s*(of|\/)\s*\d+/)
+    app.unmount()
+  })
+})
+
+describe('withUpdateDiscovery', () => {
+  test('returns the work result untouched', async () => {
+    const result = await withUpdateDiscovery(async () => ({ ok: true, value: 42 }), { enabled: false })
+    expect(result).toEqual({ ok: true, value: 42 })
+  })
+
+  test('a non-terminal run writes nothing', async () => {
+    const written: string[] = []
+    const original = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: unknown) => {
+      written.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    try {
+      await withUpdateDiscovery(async () => 'done', { enabled: false })
+    } finally {
+      process.stdout.write = original
+    }
+    expect(written).toEqual([])
+  })
+
+  test('a rejected promise still propagates', async () => {
+    await expect(
+      withUpdateDiscovery(
+        async () => {
+          throw new Error('registry exploded')
+        },
+        { enabled: false },
+      ),
+    ).rejects.toThrow('registry exploded')
+  })
+
+  // The indicator is a wrapper, not a gate: a structured failure is an
+  // ordinary return value and must reach the caller unchanged so the
+  // command can translate it into its own three-line stderr block.
+  test('a structured failure passes through as a value', async () => {
+    const failure = { ok: false as const, failure: { reason: 'manifest-read' as const, error: 'boom' } }
+    expect(await withUpdateDiscovery(async () => failure, { enabled: false })).toBe(failure)
+  })
+})

--- a/packages/cli/src/tui/views/update/__tests__/version-change.test.ts
+++ b/packages/cli/src/tui/views/update/__tests__/version-change.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test'
+import { THEME } from '../../../theme.ts'
+import { classifyVersionChange, formatExactVersion, splitAtChange, versionChangeColor } from '../version-change.ts'
+
+function v(version: string) {
+  const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number)
+  return { major, minor, patch }
+}
+
+describe('classifyVersionChange', () => {
+  test('names the largest component that moved', () => {
+    expect(classifyVersionChange(v('1.2.3'), v('2.0.0'))).toBe('major')
+    expect(classifyVersionChange(v('1.2.3'), v('1.3.0'))).toBe('minor')
+    expect(classifyVersionChange(v('1.2.3'), v('1.2.4'))).toBe('patch')
+    expect(classifyVersionChange(v('1.2.3'), v('1.2.3'))).toBe('none')
+  })
+
+  // A major bump is a major bump even when the lower components happen
+  // to match, and a minor bump is not downgraded to a patch because the
+  // patch also moved.
+  test('a larger change wins over a smaller one in the same jump', () => {
+    expect(classifyVersionChange(v('1.2.3'), v('2.2.3'))).toBe('major')
+    expect(classifyVersionChange(v('1.2.3'), v('1.9.9'))).toBe('minor')
+  })
+
+  // Nothing here assumes the second version is newer. The picker only
+  // ever shows advancing choices, but the classifier is asked about
+  // stationary rows too and must not invent a direction.
+  test('a lower version still reports which component differs', () => {
+    expect(classifyVersionChange(v('2.0.0'), v('1.0.0'))).toBe('major')
+  })
+})
+
+describe('splitAtChange', () => {
+  test('isolates only the component that moved', () => {
+    expect(splitAtChange(v('2.4.16'), v('2.5.10'))).toEqual({ prefix: '2.', changed: '5', rest: '.10' })
+    expect(splitAtChange(v('4.2.674'), v('4.2.825'))).toEqual({ prefix: '4.2.', changed: '825', rest: '' })
+    expect(splitAtChange(v('0.7.0'), v('1.0.0'))).toEqual({ prefix: '', changed: '1', rest: '.0.0' })
+  })
+
+  // The trailing components reset as a consequence of the bump rather
+  // than being part of it. Highlighting the `.0` in `1.2.3 -> 1.3.0`
+  // would claim the patch moved too.
+  test('components after the change are not part of the highlight', () => {
+    const { changed, rest } = splitAtChange(v('1.2.3'), v('1.3.0'))
+    expect(changed).toBe('3')
+    expect(rest).toBe('.0')
+  })
+
+  // An unchanged version is all prefix, so a caller renders it with no
+  // highlight at all rather than special-casing the equal row.
+  test('an unchanged version has nothing to highlight', () => {
+    expect(splitAtChange(v('1.2.0'), v('1.2.0'))).toEqual({ prefix: '1.2.0', changed: '', rest: '' })
+  })
+
+  test('the three parts always reassemble into the whole version', () => {
+    for (const [from, to] of [
+      ['1.2.3', '2.0.0'],
+      ['1.2.3', '1.3.0'],
+      ['1.2.3', '1.2.4'],
+      ['1.2.3', '1.2.3'],
+      ['2.4.16', '2.5.10'],
+    ] as const) {
+      const { prefix, changed, rest } = splitAtChange(v(from), v(to))
+      expect(prefix + changed + rest).toBe(formatExactVersion(v(to)))
+    }
+  })
+})
+
+describe('versionChangeColor', () => {
+  // Mapped onto the existing three-rung scale rather than a new palette:
+  // patch is the safe one, major is the one that can break you.
+  test('maps change size onto the semantic theme roles', () => {
+    expect(versionChangeColor('patch')).toBe(THEME.success)
+    expect(versionChangeColor('minor')).toBe(THEME.caution)
+    expect(versionChangeColor('major')).toBe(THEME.warning)
+  })
+
+  test('an unchanged version gets no colour of its own', () => {
+    expect(versionChangeColor('none')).toBeUndefined()
+  })
+
+  test('the three sizes are visually distinct from each other', () => {
+    const used = [versionChangeColor('patch'), versionChangeColor('minor'), versionChangeColor('major')]
+    expect(new Set(used).size).toBe(3)
+  })
+})

--- a/packages/cli/src/tui/views/update/discovery-view.tsx
+++ b/packages/cli/src/tui/views/update/discovery-view.tsx
@@ -1,0 +1,26 @@
+import { Box, Text } from 'ink'
+import { ProgressBar } from '../../components/progress-bar.tsx'
+import { THEME } from '../../theme.ts'
+
+/**
+ * What the terminal shows while update discovery is in flight.
+ *
+ * Discovery asks the registry for two versions per registry facet, which
+ * on a real project is the slowest thing `facet update` does and the
+ * only part of it that produces no output. Without this, a user who
+ * types the command sees an empty screen for several seconds and cannot
+ * tell a working command from a hung one.
+ *
+ * The indicator is deliberately indeterminate. Discovery resolves its
+ * lookups in concurrent groups and reports nothing until the whole set
+ * settles, so any "3 of 12" or percentage rendered here would be a
+ * number this view invented rather than one the work reported.
+ */
+export function UpdateDiscoveryView() {
+  return (
+    <Box flexDirection="column">
+      <Text color={THEME.hint}>Checking the registry for facet updates</Text>
+      <ProgressBar done={false} width={12} />
+    </Box>
+  )
+}

--- a/packages/cli/src/tui/views/update/version-change.ts
+++ b/packages/cli/src/tui/views/update/version-change.ts
@@ -1,0 +1,91 @@
+import { THEME } from '../../theme.ts'
+
+/** An exact release, as the update plan carries it. */
+export interface ExactVersionParts {
+  major: number
+  minor: number
+  patch: number
+}
+
+/**
+ * How far a candidate version moves from what is installed.
+ *
+ * `none` is its own arm rather than a null: a row showing the version
+ * already installed is a real, displayable state — it is what a pinned
+ * facet's Target looks like — and callers have to render it rather than
+ * treat it as missing data.
+ */
+export type VersionChange = 'none' | 'patch' | 'minor' | 'major'
+
+/**
+ * A version split into the one component that moved and everything else.
+ *
+ * Only `changed` is ever highlighted. Going from `1.2.3` to `1.3.0`, the
+ * digit that carries the news is the `3` in the minor position — the
+ * leading `1.` is shared, and the trailing `.0` is a consequence of the
+ * bump rather than part of it. Colouring from the first difference
+ * onward would light up that `.0` too and overstate how much moved.
+ */
+export interface SplitVersion {
+  /** Shared leading components, including their trailing dot. */
+  prefix: string
+  /** The single component that differs. Empty when nothing differs. */
+  changed: string
+  /** Components after the changed one, including their leading dot. */
+  rest: string
+}
+
+export function classifyVersionChange(current: ExactVersionParts, next: ExactVersionParts): VersionChange {
+  if (next.major !== current.major) return 'major'
+  if (next.minor !== current.minor) return 'minor'
+  if (next.patch !== current.patch) return 'patch'
+  return 'none'
+}
+
+export function formatExactVersion(version: ExactVersionParts): string {
+  return `${version.major}.${version.minor}.${version.patch}`
+}
+
+/**
+ * Split `next` around the single component that differs from `current`.
+ *
+ * A version that differs nowhere is all prefix, which is what lets a
+ * caller render an unchanged row with no highlight at all instead of
+ * special-casing it. The three parts always reassemble into the whole
+ * version, so a caller cannot render a version this function shortened.
+ */
+export function splitAtChange(current: ExactVersionParts, next: ExactVersionParts): SplitVersion {
+  switch (classifyVersionChange(current, next)) {
+    case 'major':
+      return { prefix: '', changed: `${next.major}`, rest: `.${next.minor}.${next.patch}` }
+    case 'minor':
+      return { prefix: `${next.major}.`, changed: `${next.minor}`, rest: `.${next.patch}` }
+    case 'patch':
+      return { prefix: `${next.major}.${next.minor}.`, changed: `${next.patch}`, rest: '' }
+    case 'none':
+      return { prefix: formatExactVersion(next), changed: '', rest: '' }
+  }
+}
+
+/**
+ * The theme role for a change of this size, or `undefined` for none.
+ *
+ * Mapped onto the existing three-rung semantic scale rather than a new
+ * palette: a patch is the safe one, a major is the one that can break
+ * you, and minor is the middle rung that scale already exists to
+ * express. Colour is never the only cue — the numbers themselves say
+ * which component moved, and the chosen cell carries separate non-colour
+ * emphasis.
+ */
+export function versionChangeColor(change: VersionChange): string | undefined {
+  switch (change) {
+    case 'patch':
+      return THEME.success
+    case 'minor':
+      return THEME.caution
+    case 'major':
+      return THEME.warning
+    case 'none':
+      return undefined
+  }
+}


### PR DESCRIPTION
### Why

The interactive update picker had two behavioral gaps that made it harder to use than it should be:

1. A facet pinned to an exact version has a stationary range Target and an advancing Latest. Plain `--interactive` was gating the picker on whether the mode's default selection was non-empty, so this case fell through to the "re-run with `--latest`" no-op message — telling the user to add a flag whose job the picker was already there to do.
2. The picker showed only the version a row would install, not all three versions at once. The choice the screen exists for — "is the release my range forbids worth crossing the range for?" — is a comparison, and hiding either side turned it into a guess.

### Details

**Picker layout.** Each candidate row now shows Current, Target, and Latest in aligned columns simultaneously. The chosen column is named in visible text (`(target)` or `(latest)`) so the selection survives a terminal with no styling support. On top of that, only the digit that actually moves is coloured — green for a patch, amber for a minor, coral for a major — using the existing three-rung semantic theme roles. Colour is never the sole carrier of any fact: the digits themselves say which component moved, and the chosen column is named in words.

**Column navigation.** Left and right arrow keys address the Target and Latest columns directly and clamp at each end rather than wrap, so holding an arrow key settles on a column instead of oscillating between the two. `l` remains as a flip key for anyone who learned it.

**Interactive eligibility.** The picker now opens whenever any candidate row exists, regardless of whether the mode's default selection is non-empty. The only dead end that skips the picker is a plan with no candidate rows at all.

**Discovery indicator.** A lightweight view is mounted before `prepareFacetUpdate` is awaited, showing an indeterminate progress bar and the message "Checking the registry for facet updates". It is torn down in a `finally` so the picker, static plan, no-op, or structured error always renders onto a clean screen. The indicator is suppressed when stdout is not a terminal, keeping piped and CI output clean. No synthetic percentages or completed counts are shown because discovery resolves its lookups in concurrent groups and reports nothing until the whole set settles.

**`hasSelectableCandidate`.** A new exported function in `selection.ts` answers whether the picker has anything to show, independently of what the mode's defaults would select. This is the predicate that replaced the old default-selection gate.

### Verification

Targeted tests cover: the discovery view rendering and non-terminal suppression, structured and rejected promise pass-through from `withUpdateDiscovery`, the Latest-only candidate opening the picker instead of the no-op, column clamping, left/right navigation carrying selection the same way `l` does, simultaneous version column rendering, semantic change coloring, and the `hasSelectableCandidate` logic. Existing cancellation, dry-run, adapter-ordering, and side-effect coverage is preserved.