### PR TITLE
Add background color configuration for light and dark themes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,12 @@
     "light": "#A78BFA",
     "dark": "#4C1D95"
   },
+  "background": {
+    "color": {
+      "light": "#f4f5f9",
+      "dark": "#0a0a12"
+    }
+  },
   "favicon": "/assets/favicon.ico",
   "redirects": [
     {


### PR DESCRIPTION
### Why

The documentation site lacked explicit background colors for light and dark modes, relying on defaults that may not align with the intended design.

### Details

Adds a light mode background color of `#f4f5f9` and a dark mode background color of `#0a0a12` to the docs configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation site with dedicated light and dark background colors for improved visual presentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->