### PR TITLE
Implement `facet update`, bound version components to 2^53 − 1, and move selection logic to the engine

### DIFF
--- a/.changeset/small-icons-write.md
+++ b/.changeset/small-icons-write.md
@@ -1,5 +1,6 @@
 ---
 "agent-facets": minor
+"@agent-facets/protocol": patch
 ---
 
 **New command: `facet update` (aliased `facet upgrade`)** — moves the registry-backed facets a project declares to newer releases. It reads `facets.json` and `facets.lock`, asks the registry for each facet's range-respecting target and its latest release, and shows both alongside what is installed, so "why is this one not moving?" is answerable from the plan itself. Plain `facet update` takes every target the declared specifier already permits. `--latest` (`-L`) crosses those specifiers and rewrites them by the smallest edit that admits the new version, preserving how the intent was written: a pin stays a pin, `1.*` becomes `2.*`, `1.2.*` becomes `2.4.*`, and `*` and `latest` are left exactly as authored.
@@ -11,3 +12,5 @@
 **Breaking: `facet upgrade` is no longer a placeholder.** It previously printed a not-yet-implemented notice and exited `0` without touching a single file. It is now an alias of `facet update` — one command, one help page, one behavior — so the same invocation contacts the registry, may install adapters, takes the project lock, and rewrites `facets.json`, `facets.lock`, the install receipt, and your materialized assets. `update` is the canonical spelling, and `facet upgrade --help` prints `Usage: facet update`. If something in your automation called `facet upgrade` expecting a no-op, drop the call or make it explicit with `facet update --dry-run`.
 
 Neither name touches the CLI binary. That remains `facet self-update`.
+
+**Protocol: version components are bounded by exact integer representation.** The published version grammar now rejects a specifier or locked version whose numeric component exceeds `2^53 - 1`, with an error that names the magnitude rather than the form. Above that bound two distinct releases are the same double — `9007199254740992` and `9007199254740993` compare equal — so a comparison that decides which release is newer, or whether a locked version still satisfies a manifest range, could answer for a version that was never published. `facet update` is the first command whose whole job is that comparison, which is why the bound lands now. No real version is anywhere near it.

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -138,6 +138,8 @@ Without a terminal that can prompt — CI, piped output — `--interactive` fail
 
 `--dry-run` prints the plan and modifies nothing: no manifest, no lockfile, no receipt, no assets, no cache, and no adapter installation. Combined with `--interactive`, it previews the selection you confirmed and stops there.
 
+A preview always prints the plan, including when nothing would move — with no row marked and no `facets.json` edit shown, followed by the reason. The plan is what the reason was read off: which facet is pinned, which is already current, which range is holding one back. A run without `--dry-run` prints the reason alone.
+
 <Note>
 A preview shows **versions**, not their downstream effects. Which assets a new release materializes, whether it collides with another facet, and what MCP configuration it declares are all determined during the install that a real run performs.
 </Note>
@@ -167,7 +169,7 @@ Recorded [materialization](/specification/materialization) choices — aliases a
 
 ## When nothing moves
 
-A run that applies nothing still succeeded, and exits `0`. Which kind of nothing it is decides whether you have anything to do about it:
+A run that applies nothing still succeeded, and exits `0`. Which kind of nothing it is decides whether you have anything to do about it. Under `--dry-run` the plan is printed first, so you can check the reason against the rows it came from:
 
 | Output | What it means |
 | ------ | ------------- |

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -1314,6 +1314,8 @@ Interactive selection SHALL occur before adapter selection or update application
 
 The `--dry-run` flag SHALL present the update choices that the selected mode would apply and SHALL NOT modify project or machine-local state. Without `--interactive`, it SHALL present the complete discovered plan using the default Target choices or the `--latest` choices. With `--interactive`, it SHALL present the user's confirmed selection and stop before adapter selection or application. A successful preview SHALL exit with code 0 whether updates are available or not.
 
+A preview that would apply nothing SHALL still present the complete discovered plan, with nothing selected and no manifest rewrite shown, before reporting the applicable no-op reason. The plan is the evidence the reason was derived from, and a preview that withholds it asks the user to accept a conclusion about their project without showing which facet is pinned, which is already current, or which range is holding one back. A run without `--dry-run` SHALL report the reason alone, because it was never going to present a plan.
+
 #### Scenario: Default dry run previews range targets
 
 - **WHEN** a user runs `facet update --dry-run`
@@ -1339,8 +1341,15 @@ The `--dry-run` flag SHALL present the update choices that the selected mode wou
 #### Scenario: Dry run with no available update succeeds
 
 - **WHEN** a user runs an update dry run and no selected mode permits an advancing choice
-- **THEN** the output SHALL report the applicable no-op reason
+- **THEN** the output SHALL present the complete discovered plan with nothing selected
+- **AND** the output SHALL report the applicable no-op reason
 - **AND** the process SHALL exit with code 0
+
+#### Scenario: A no-op outside a dry run reports the reason alone
+
+- **WHEN** a user runs `facet update` without `--dry-run` and no advancing choice is available
+- **THEN** the output SHALL report the applicable no-op reason
+- **AND** the output SHALL NOT present a plan
 
 ### Requirement: Update no-op outcomes are distinguishable
 

--- a/openspec/specs/installation/spec.md
+++ b/openspec/specs/installation/spec.md
@@ -668,6 +668,8 @@ Contention for the lock SHALL be the only failure the system can report before a
 
 Advisory reads performed outside the lock for presentation, such as validating that the project manifest can be read before adapters are discovered, SHALL NOT be reused as the basis of a commit. In particular, the set of facets a removal operates on SHALL be decided from state read under the lock, not from a pre-lock validation of the requested names. An advisory read SHALL NOT decide an operation's outcome even when that outcome commits nothing: a removal whose requested names all appear undeclared SHALL still proceed to the commit, where the manifest read under the lock decides whether anything is removed.
 
+A **snapshot-bound** operation is the single exception, and it does not weaken the rule above. Such an operation presents a plan derived from state read before the lock, and then refuses to commit unless that exact state is still on disk once the lock is held. It SHALL carry the exact observed states it read into the operation that applies them, SHALL acquire the project install lock before performing resolution, downloads, cache writes, or transaction creation, and SHALL compare the current states against the carried ones before any of that work begins. A mismatch SHALL fail the operation. It SHALL NOT merge the change into the reviewed plan, rebase the plan onto the new state, or silently re-derive it — the reviewed plan is what the user approved, and a re-derived one is a different plan wearing its approval. A snapshot-bound read therefore never decides a commit: under the lock it decides only whether the operation may proceed at all.
+
 #### Scenario: Lock contention is reported before project state is examined
 
 - **WHEN** an install runs against a project whose install lock is already held
@@ -693,6 +695,12 @@ Advisory reads performed outside the lock for presentation, such as validating t
 - **AND** one of those names is declared by a concurrent commit before the lock is acquired
 - **THEN** the system SHALL remove that facet
 - **AND** the operation SHALL NOT report a no-op decided before the lock was held
+
+#### Scenario: A snapshot-bound operation refuses rather than merges
+
+- **WHEN** a snapshot-bound operation acquires the lock and finds that the state it carried has changed
+- **THEN** it SHALL fail before performing resolution, downloads, cache writes, or transaction creation
+- **AND** it SHALL NOT merge the change into the reviewed plan or re-derive the plan from the new state
 
 ### Requirement: Resolved facet content is cached locally
 
@@ -2109,7 +2117,9 @@ Git and local facet sources SHALL be reported as unsupported for update discover
 
 ### Requirement: Update discovery is complete or fails without a partial plan
 
-The system SHALL complete every required Target and Latest lookup before presenting an actionable update plan. If any required lookup fails, the complete discovery SHALL fail and SHALL NOT present the successful subset as actionable. Discovery SHALL preserve project order when pairing results with facets and determining which lookup failure to report.
+The system SHALL complete every required Target and Latest lookup before presenting an actionable update plan. If any required lookup fails, the complete discovery SHALL fail with exactly one structured failure and SHALL NOT present the successful subset as actionable. Discovery SHALL preserve project order when pairing results with facets, so a returned plan lists facets in the order the manifest declares them.
+
+Which failure is reported when more than one lookup fails SHALL be unspecified. Every such failure ends the same run with no actionable plan and the same instruction to the user, so choosing among them is a distinction without a consequence — and pinning the choice would constrain how the lookups are batched, issued, and abandoned for no benefit the user can act on.
 
 #### Scenario: One lookup failure rejects the whole discovery
 
@@ -2124,34 +2134,34 @@ The system SHALL complete every required Target and Latest lookup before present
 - **THEN** discovery SHALL report it as a structured discovery failure
 - **AND** the error SHALL NOT escape update discovery
 
-#### Scenario: Concurrent failures have deterministic reporting order
+#### Scenario: Several concurrent failures still produce one failure
 
 - **WHEN** more than one required registry lookup fails
-- **THEN** the system SHALL report the first failure according to the original project lookup order
-- **AND** network completion order SHALL NOT change which failure is reported
+- **THEN** the system SHALL fail discovery with exactly one structured failure
+- **AND** it SHALL NOT present the facets that resolved as an actionable plan
 
 ### Requirement: Update modes select only advancing versions
 
-Plain update SHALL select Target for every registry facet whose Target is newer than Current. Latest mode SHALL select Latest for every registry facet whose Latest is newer than Current, regardless of whether the authored specifier permits Latest. No mode SHALL select a version equal to or older than Current.
+In non-interactive use, plain update SHALL select Target for every registry facet whose Target is newer than Current, and latest mode SHALL select Latest for every registry facet whose Latest is newer than Current, regardless of whether the authored specifier permits Latest. Interactive selection SHALL derive no selection from the mode at all: every choice is made on screen, and the mode's defaults SHALL NOT be applied there. No mode and no selection SHALL take a version equal to or older than Current.
 
 #### Scenario: Plain update respects a bounded range
 
 - **WHEN** Current is `1.2.0`, Target is `1.8.0`, and Latest is `2.0.0`
-- **AND** the user requests plain update
+- **AND** the user requests plain update without interactive selection
 - **THEN** the selected version SHALL be `1.8.0`
 
 #### Scenario: Latest mode crosses a bounded range
 
 - **WHEN** Current is `1.2.0`, Target is `1.8.0`, and Latest is `2.0.0`
-- **AND** the user requests latest mode
+- **AND** the user requests latest mode without interactive selection
 - **THEN** the selected version SHALL be `2.0.0`
 
 #### Scenario: Exact pin is unchanged by plain update
 
 - **WHEN** an exact manifest pin makes Target equal Current
 - **AND** Latest is newer than Current
-- **THEN** plain update SHALL leave that facet unselected
-- **AND** latest mode MAY select Latest
+- **THEN** non-interactive plain update SHALL leave that facet unselected
+- **AND** non-interactive latest mode SHALL select Latest
 
 #### Scenario: Older registry choices never downgrade Current
 
@@ -2259,7 +2269,9 @@ All selected facets SHALL pass the same cache audit, content download, integrity
 
 ### Requirement: Prepared updates reject stale project state
 
-Update discovery and selection SHALL remain read-only and SHALL capture the exact observed states of the project manifest and lockfile. Discovery SHALL re-check both files before returning a plan and SHALL reject the plan if either changed during discovery. Before application performs resolution, cache writes, downloads, or transaction creation, it SHALL acquire the project install lock and compare the current manifest and lockfile states with the reviewed states. Any mismatch SHALL fail as a stale plan, SHALL direct the user to rerun update, and SHALL leave project and machine-local state unchanged.
+Update discovery and selection SHALL remain read-only and SHALL capture the exact observed states of the project manifest and lockfile. Discovery SHALL re-check both files before returning a plan and SHALL reject the plan if either changed during discovery. Before application performs resolution, cache writes, downloads, or transaction creation, it SHALL acquire the project install lock and compare the current manifest and lockfile states with the reviewed states. Any mismatch SHALL fail as a stale plan, SHALL direct the user to rerun update, and SHALL leave the project manifest, lockfile, receipt, cache, materialized assets, and native configuration unchanged.
+
+Installing an adapter is a prerequisite of applying an update rather than a part of the update itself. A run that has a non-empty selection to apply MAY install adapter tooling before the stale check runs, and a stale-plan failure SHALL NOT be required to uninstall it: adapter tooling is machine-local tooling the user asked for and the rerun will need, and it records no facet, version, or project state that could later be mistaken for something this project installed. That permission extends no further — discovery, interactive selection, cancelled selection, and dry runs SHALL still install and select no adapter at all.
 
 #### Scenario: Manifest changes during discovery
 
@@ -2278,6 +2290,12 @@ Update discovery and selection SHALL remain read-only and SHALL capture the exac
 
 - **WHEN** the manifest and lockfile exactly match the states captured by discovery when application acquires the project lock
 - **THEN** application MAY proceed with the selected exact versions
+
+#### Scenario: A stale plan need not uninstall adapter tooling
+
+- **WHEN** an update with a non-empty selection installs adapter tooling and then fails the stale check under the project lock
+- **THEN** the project manifest, lockfile, receipt, cache, materialized assets, and native configuration SHALL remain unchanged
+- **AND** the adapter tooling installed for that run MAY remain installed
 
 ### Requirement: Discovery and preview are free of installation side effects
 

--- a/openspec/specs/protocol__version-spec/spec.md
+++ b/openspec/specs/protocol__version-spec/spec.md
@@ -26,6 +26,27 @@ A version specifier appearing inside a project manifest or a lockfile SHALL conf
 - **THEN** the system SHALL accept each specifier as valid
 - **AND** the system SHALL be able to determine whether a candidate version satisfies the specifier
 
+### Requirement: Version components are bounded by exact integer representation
+
+Every numeric component of a version specifier or a resolved version SHALL be an integer no greater than 2^53 − 1. A specifier or version whose shape conforms to the grammar but whose components exceed that bound SHALL be rejected as invalid, with a structured error distinguishing it from a malformed form. The bound exists because two versions differing above it are not reliably distinguishable once represented as double-precision numbers: they would compare equal, and a system would install one release believing it to be another. A system SHALL reject such a value rather than accept a version it cannot tell apart from a different one.
+
+#### Scenario: A component at the bound is accepted
+
+- **WHEN** a system reads a specifier whose components are all 2^53 − 1 or less
+- **THEN** the system SHALL accept the specifier as valid
+
+#### Scenario: A component above the bound is rejected
+
+- **WHEN** a system reads a conforming specifier form whose numeric component exceeds 2^53 − 1
+- **THEN** the system SHALL reject it as invalid
+- **AND** the error SHALL identify the component's magnitude as the cause rather than the specifier's form
+
+#### Scenario: An out-of-range locked version fails artifact validation
+
+- **WHEN** a lockfile records an exact version whose component exceeds 2^53 − 1
+- **THEN** the system SHALL reject the lockfile as invalid
+- **AND** it SHALL NOT compare that version against a manifest specifier
+
 ### Requirement: Version-specifier resolution semantics are deterministic
 
 For each conforming version-specifier form, the published grammar SHALL define which candidate versions satisfy the specifier. Different facet-compatible systems resolving the same specifier against the same set of candidate versions SHALL select the same version.

--- a/packages/cli/src/__tests__/install-view.test.tsx
+++ b/packages/cli/src/__tests__/install-view.test.tsx
@@ -2050,6 +2050,56 @@ describe('InstallView — update mode', () => {
     instance.unmount()
   })
 
+  // A selection refusal has no install result to draw, but it is still
+  // an outcome the driver RETURNED. It has to reach the command through
+  // the ordinary result channel; the alternative — throwing past a
+  // return type that cannot describe it — is what made every call site
+  // wrap its wait in a `catch` that then swallowed real crashes.
+  test('an update-selection refusal arrives as a result, not a crash', async () => {
+    const refusal: InstallViewResult = {
+      ok: false,
+      updateSelectionFailure: { reason: 'unknown-facet', facet: 'ghost' },
+    }
+    const seen: InstallViewResult[] = []
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        run: makeFakePrepareRun(refusal),
+        onComplete: (result) => {
+          seen.push(result)
+        },
+      }),
+    )
+    await settle()
+    expect(seen).toEqual([refusal])
+    // Nothing to report on screen: the remedy is a rerun, not a report
+    // about files. It must not be drawn as an install failure either.
+    const frame = visibleTerminalText(visibleContentFrame(instance.frames))
+    expect(frame).not.toContain('Update complete.')
+    expect(frame).not.toContain('Rollback')
+    instance.unmount()
+  })
+
+  test('a driver that throws is a crash, and completes nothing', async () => {
+    const seen: InstallViewResult[] = []
+    const instance = render(
+      createElement(InstallView, {
+        mode: 'update',
+        run: async () => {
+          throw new Error('the view driver fell over')
+        },
+        onComplete: (result) => {
+          seen.push(result)
+        },
+      }),
+    )
+    await settle()
+    // No result was produced, so nothing may be reported as one. The
+    // rejection channel is left carrying the only evidence there is.
+    expect(seen).toEqual([])
+    instance.unmount()
+  })
+
   test('a stale plan is reported as a failure, with the disk state', async () => {
     const stale: RunInstallResult = {
       ok: false,

--- a/packages/cli/src/__tests__/run-flags.test.ts
+++ b/packages/cli/src/__tests__/run-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import type { Command } from '../commands.ts'
+import { type Command, commands, findShortFlagCollisions } from '../commands.ts'
 import { run } from '../run.ts'
 
 /**
@@ -112,6 +112,82 @@ describe('run — declared short aliases', () => {
     })
     await run(['demo', '--skill', 'a', '-s', 'b'], registry)
     expect(captured()?.flags).toEqual({ skill: ['a', 'b'] })
+  })
+})
+
+describe('findShortFlagCollisions', () => {
+  test('accepts distinct short aliases', () => {
+    expect(
+      findShortFlagCollisions({
+        interactive: { type: 'boolean', short: 'i', description: 'interactive' },
+        latest: { type: 'boolean', short: 'L', description: 'latest' },
+        'dry-run': { type: 'boolean', description: 'dry run' },
+      }),
+    ).toEqual([])
+  })
+
+  test('distinguishes case, so -l and -L are different flags', () => {
+    expect(
+      findShortFlagCollisions({
+        list: { type: 'boolean', short: 'l', description: 'list' },
+        latest: { type: 'boolean', short: 'L', description: 'latest' },
+      }),
+    ).toEqual([])
+  })
+
+  test('reports two long flags claiming the same short alias', () => {
+    expect(
+      findShortFlagCollisions({
+        latest: { type: 'boolean', short: 'l', description: 'latest' },
+        list: { type: 'boolean', short: 'l', description: 'list' },
+      }),
+    ).toEqual([{ kind: 'duplicate-short', short: 'l', first: 'latest', second: 'list' }])
+  })
+
+  test('reports a short alias that shadows a long flag on the same command', () => {
+    expect(
+      findShortFlagCollisions({
+        i: { type: 'boolean', description: 'a one-letter long flag' },
+        interactive: { type: 'boolean', short: 'i', description: 'interactive' },
+      }),
+    ).toEqual([{ kind: 'short-shadows-long', short: 'i', declaredBy: 'interactive' }])
+  })
+
+  test('reports every collision rather than stopping at the first', () => {
+    const collisions = findShortFlagCollisions({
+      latest: { type: 'boolean', short: 'l', description: 'latest' },
+      list: { type: 'boolean', short: 'l', description: 'list' },
+      t: { type: 'boolean', description: 'a one-letter long flag' },
+      tag: { type: 'string', short: 't', description: 'tag' },
+    })
+    expect(collisions).toHaveLength(2)
+    expect(collisions.map((collision) => collision.kind).sort()).toEqual(['duplicate-short', 'short-shadows-long'])
+  })
+
+  // The validator only earns its place if the table it guards is clean.
+  test('the real command registry declares no ambiguous short flags', () => {
+    for (const [name, command] of Object.entries(commands)) {
+      if (command.flags === undefined) continue
+      expect([name, findShortFlagCollisions(command.flags)]).toEqual([name, []])
+    }
+  })
+})
+
+describe('run — ambiguous short aliases', () => {
+  test('a duplicate short alias fails instead of silently rebinding', async () => {
+    const { registry } = captureRegistry({
+      latest: { type: 'boolean', short: 'l', description: 'latest' },
+      list: { type: 'boolean', short: 'l', description: 'list' },
+    })
+    await expect(run(['demo', '-l'], registry)).rejects.toThrow('ambiguous short flags')
+  })
+
+  test('the failure names both claimants', async () => {
+    const { registry } = captureRegistry({
+      latest: { type: 'boolean', short: 'l', description: 'latest' },
+      list: { type: 'boolean', short: 'l', description: 'list' },
+    })
+    await expect(run(['demo'], registry)).rejects.toThrow('--latest and --list')
   })
 })
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -64,6 +64,69 @@ export type FlagDef = {
   description: string
 }
 
+/**
+ * A short-alias declaration that would make an invocation ambiguous.
+ *
+ * Both arms describe the same class of bug — two flags answering to one
+ * spelling — but they are reached differently and read differently in
+ * the message, so they stay separate rather than sharing an optional
+ * field that only one of them fills in.
+ */
+export type ShortFlagCollision =
+  /** Two long flags claim the same short alias. */
+  | { kind: 'duplicate-short'; short: ShortFlagName; first: string; second: string }
+  /** A short alias is spelled the same as a long flag on the same command. */
+  | { kind: 'short-shadows-long'; short: ShortFlagName; declaredBy: string }
+
+/**
+ * Every ambiguity in one command's short-alias declarations.
+ *
+ * The parser is configured from an alias map, and a map cannot hold two
+ * targets for one key: the second declaration silently replaces the
+ * first, so `-x` starts setting a flag its author never associated with
+ * it and the flag that declared `-x` stops responding to it. Nothing
+ * about that failure is visible at the call site — it looks exactly like
+ * a working command until someone uses the losing spelling.
+ *
+ * Returns every collision rather than the first, so a registry with more
+ * than one is repaired in a single pass.
+ *
+ * Pure: takes the declarations, returns data, decides nothing about what
+ * to do with them.
+ */
+export function findShortFlagCollisions(flags: Record<string, FlagDef>): ShortFlagCollision[] {
+  const collisions: ShortFlagCollision[] = []
+  const claimedBy = new Map<ShortFlagName, string>()
+  const longNames = new Set(Object.keys(flags))
+
+  for (const [name, def] of Object.entries(flags)) {
+    const short = def.short
+    if (short === undefined) continue
+
+    const first = claimedBy.get(short)
+    if (first === undefined) claimedBy.set(short, name)
+    else collisions.push({ kind: 'duplicate-short', short, first, second: name })
+
+    // A one-character long flag is legal on its own; it is only a problem
+    // when some other flag also claims that character as its short form,
+    // because the parser rewrites the short spelling to the long one and
+    // the two names are then the same token meaning two things.
+    if (longNames.has(short)) collisions.push({ kind: 'short-shadows-long', short, declaredBy: name })
+  }
+
+  return collisions
+}
+
+/** One collision, phrased for the invariant failure that reports it. */
+export function describeShortFlagCollision(collision: ShortFlagCollision): string {
+  switch (collision.kind) {
+    case 'duplicate-short':
+      return `-${collision.short} is claimed by both --${collision.first} and --${collision.second}`
+    case 'short-shadows-long':
+      return `-${collision.short} is claimed by --${collision.declaredBy} but --${collision.short} is also a flag`
+  }
+}
+
 export type Command = {
   name: string
   description: string

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -124,10 +124,11 @@ export const addCommand: Command = {
       { exitOnCtrlC: false },
     )
 
+    // See `install`: structured failures come back through `captured`,
+    // so a rejection here is an unmodelled view or driver failure and
+    // propagates to the CLI's top level rather than being swallowed.
     try {
       await instance.waitUntilExit()
-    } catch {
-      // Ink rejects on view-level failure; we have the captured result.
     } finally {
       process.off('SIGINT', sigintHandler)
     }

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -105,11 +105,13 @@ export const installCommand: Command = {
           return result
         },
         onComplete: (r) => {
-          // `install` never produces a prepare-phase failure (add/remove
-          // only); guard the wider InstallViewResult so the captured value
-          // stays a RunInstallResult. The `run` closure already set
+          // `install` produces none of the flow-specific failure arms —
+          // prepare belongs to add/remove, selection to update — so this
+          // narrows the wider InstallViewResult back to the only shape
+          // this command can receive. The `run` closure already set
           // `captured`.
-          if (!('prepareFailure' in r) && !('removePrepareFailure' in r)) captured = r
+          if ('prepareFailure' in r || 'removePrepareFailure' in r || 'updateSelectionFailure' in r) return
+          captured = r
         },
       }),
       // Ctrl-C must reach the collision workspace, which is the only
@@ -119,12 +121,13 @@ export const installCommand: Command = {
       { exitOnCtrlC: false },
     )
 
+    // Not wrapped in `catch`: a structured install failure unmounts the
+    // view cleanly and is read from `captured` below. A rejection here
+    // means the view or the driver failed in a way nothing modelled, and
+    // that belongs at the CLI's top level as an unexpected failure
+    // rather than being reshaped into an install error it is not.
     try {
       await instance.waitUntilExit()
-    } catch {
-      // Ink rejects on view-level errors (the view sets pendingExit).
-      // The result is already captured; we just need to fall through
-      // to the post-render error handling below.
     } finally {
       process.off('SIGINT', sigintHandler)
     }

--- a/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
+++ b/packages/cli/src/commands/instructions/__tests__/instructions.test.ts
@@ -253,6 +253,41 @@ describe('update guidance is present in the prompts', () => {
   })
 })
 
+/**
+ * The slice of a prompt between two anchors.
+ *
+ * Scoped rather than searched whole on purpose: both prompts mention
+ * `facet update` in several places, so a document-wide `toContain` would
+ * pass while the paragraph that actually tells an agent who owns
+ * `facets.json` still named only two of the three commands — which is
+ * exactly the state these tests were added to catch.
+ */
+function section(prompt: string, from: string, to: string): string {
+  const start = prompt.indexOf(from)
+  if (start === -1) expect.unreachable()
+  const end = prompt.indexOf(to, start)
+  if (end === -1) expect.unreachable()
+  return prompt.slice(start, end)
+}
+
+describe('project-file ownership guidance', () => {
+  // `facet update` rewrites a specifier only in latest mode; a plain
+  // update moves the lockfile and leaves the manifest alone. The prompt
+  // names the invocation rather than the command so an agent does not
+  // conclude that any update edits the file.
+  const MAINTAINERS = ['facet add', 'facet remove', 'facet update --latest']
+
+  test('usage names every command that maintains facets.json, where it describes the file', () => {
+    const block = section(TOPICS.usage.prompt, 'Your dependency list', 'facets.lock')
+    for (const command of MAINTAINERS) expect(block).toContain(command)
+  })
+
+  test('overview names every command that maintains facets.json, where it describes the file', () => {
+    const block = section(TOPICS.overview.prompt, 'A consuming project', 'facets.lock')
+    for (const command of MAINTAINERS) expect(block).toContain(command)
+  })
+})
+
 describe('manifest schema generation', () => {
   test('toJsonSchema with the predicate fallback does not throw and drops the predicate', () => {
     let schema: unknown

--- a/packages/cli/src/commands/remove/index.ts
+++ b/packages/cli/src/commands/remove/index.ts
@@ -119,10 +119,11 @@ export const removeCommand: Command = {
       { exitOnCtrlC: false },
     )
 
+    // See `install`: structured failures come back through `captured`,
+    // so a rejection here is an unmodelled view or driver failure and
+    // propagates to the CLI's top level rather than being swallowed.
     try {
       await instance.waitUntilExit()
-    } catch {
-      // Ink rejects on view-level failure; we have the captured result.
     } finally {
       process.off('SIGINT', sigintHandler)
     }

--- a/packages/cli/src/commands/update/__tests__/command.test.ts
+++ b/packages/cli/src/commands/update/__tests__/command.test.ts
@@ -284,6 +284,52 @@ describe('facet update — dry run', () => {
     expect(stdout).toContain('All registry facets are current')
     expect(adaptersSpy).not.toHaveBeenCalled()
   })
+
+  // ...and it has to show the rows that reason was read off. Printing
+  // the sentence alone asks the user to accept a claim about their
+  // project without any of the evidence for it.
+  test('a dry run with everything current still shows the plan', async () => {
+    preparing([current({ name: 'gamma', source: '*', version: '4.0.0' })])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], { 'dry-run': true }))
+    expect(result).toBe(0)
+    expect(stdout).toContain('gamma')
+    expect(stdout).toContain('4.0.0')
+    expect(stdout).toContain('All registry facets are current')
+  })
+
+  test('a dry run whose ranges block everything shows what is being held back', async () => {
+    preparing([PINNED])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], { 'dry-run': true }))
+    expect(result).toBe(0)
+    // The pin, what it holds, and the release it is holding back from.
+    expect(stdout).toContain('beta')
+    expect(stdout).toContain('1.2.0')
+    expect(stdout).toContain('3.4.1')
+    expect(stdout).toContain('facet update --latest')
+    // Nothing is selected, so no row is marked and no manifest edit is
+    // shown — both would describe a change this run is not making.
+    expect(stdout).not.toContain('▸')
+    expect(stdout).not.toContain('→')
+  })
+
+  test('a dry run of a project with only unsupported sources names them', async () => {
+    preparing([unsupported('delta', './local', 'local')])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], { 'dry-run': true }))
+    expect(result).toBe(0)
+    expect(stdout).toContain('delta')
+    expect(stdout).toContain('not checked for updates')
+    expect(stdout).toContain('No registry facets to update')
+  })
+
+  // The terse path: without `--dry-run` there was never a plan to
+  // review, so printing one would be answering a question nobody asked.
+  test('a no-op outside a dry run reports the reason alone', async () => {
+    preparing([PINNED])
+    const { stdout, result } = await captureStdout(() => updateCommand.run([], {}))
+    expect(result).toBe(0)
+    expect(stdout).toContain('facet update --latest')
+    expect(stdout).not.toContain('beta')
+  })
 })
 
 /**
@@ -338,6 +384,43 @@ describe('facet update — applying', () => {
     expect(stderr).toContain('update failed')
     // The stale-plan remedy, not a generic "fix the underlying issue".
     expect(stderr).toContain("Re-run 'facet update'")
+    runSpy.mockRestore()
+  })
+
+  // The engine refusing a selection is a documented outcome of this
+  // command, not an exception. It reaches the command as a returned
+  // value through the view's result channel, is reported on stderr with
+  // its own remedy, and exits 1 like every other expected failure.
+  test('a refused selection is reported on stderr and exits one', async () => {
+    preparing([BOUNDED])
+    const runSpy = applying({
+      ok: false,
+      phase: 'selection',
+      failure: { reason: 'unknown-facet', facet: 'ghost' },
+    })
+
+    const { stderr, result } = await withTTY(false, () =>
+      captureStderr(() => captureStdout(() => updateCommand.run([], {}))),
+    )
+
+    expect(result.result).toBe(1)
+    expect(stderr).toContain('ghost')
+    runSpy.mockRestore()
+  })
+
+  // The other half of the same contract: with expected failures off the
+  // rejection channel, a genuine crash is the only thing left on it and
+  // must not be quietly reshaped into "update failed". It escapes to the
+  // CLI's top level, which reports it as unexpected and exits 2.
+  test('an unexpected engine crash escapes rather than becoming an update error', async () => {
+    preparing([BOUNDED])
+    adaptersSpy.mockResolvedValue([])
+    const runSpy = spyOn(engine, 'runPreparedFacetUpdate').mockRejectedValue(new Error('engine fell over'))
+
+    await expect(
+      withTTY(false, () => captureStderr(() => captureStdout(() => updateCommand.run([], {})))),
+    ).rejects.toThrow('engine fell over')
+
     runSpy.mockRestore()
   })
 

--- a/packages/cli/src/commands/update/__tests__/selection.test.ts
+++ b/packages/cli/src/commands/update/__tests__/selection.test.ts
@@ -1,99 +1,23 @@
 import { describe, expect, test } from 'bun:test'
-import { candidateRows, classifyNoOp, defaultSelections, describeNoOp } from '../selection.ts'
-import { candidate, current, unsupported } from './fixtures.ts'
+import { describeNoOp } from '../selection.ts'
 
-const BOUNDED = candidate({
-  name: 'alpha',
-  source: '1.*',
-  current: '1.2.0',
-  target: '1.8.0',
-  latest: '2.0.0',
-})
-
-// An exact pin: the range cannot move, but a newer release exists.
-const PINNED = candidate({
-  name: 'beta',
-  source: '1.2.0',
-  current: '1.2.0',
-  target: '1.2.0',
-  latest: '3.0.0',
-})
-
-describe('defaultSelections', () => {
-  test('plain update takes the range target of every advancing candidate', () => {
-    expect(defaultSelections([BOUNDED, PINNED], 'range')).toEqual([{ facetName: 'alpha', choice: 'range' }])
-  })
-
-  test('latest mode takes the latest release, including across a bounded range', () => {
-    expect(defaultSelections([BOUNDED, PINNED], 'latest')).toEqual([
-      { facetName: 'alpha', choice: 'latest' },
-      { facetName: 'beta', choice: 'latest' },
-    ])
-  })
-
-  test('current and unsupported rows are never selected', () => {
-    const plan = [current({ name: 'gamma', source: '*', version: '4.0.0' }), unsupported('delta', './local', 'local')]
-    expect(defaultSelections(plan, 'range')).toEqual([])
-    expect(defaultSelections(plan, 'latest')).toEqual([])
-  })
-})
-
-describe('candidateRows', () => {
-  test('a candidate the mode would not select still counts', () => {
-    // The whole point: under plain update PINNED contributes no default
-    // selection, and it is still a row worth showing.
-    expect(defaultSelections([PINNED], 'range')).toEqual([])
-    expect(candidateRows([PINNED])).toEqual([PINNED])
-  })
-
-  test('rows with nothing newer do not count', () => {
-    expect(candidateRows([current({ name: 'gamma', source: '*', version: '4.0.0' })])).toEqual([])
-    expect(candidateRows([unsupported('delta', './local', 'local')])).toEqual([])
-    expect(candidateRows([])).toEqual([])
-  })
-
-  // The picker is handed exactly these rows, so the filter is what keeps
-  // a facet with nothing to offer off a screen that asks for a decision.
-  test('current and unsupported rows are dropped, in project order', () => {
-    const plan = [
-      current({ name: 'gamma', source: '*', version: '4.0.0' }),
-      PINNED,
-      unsupported('delta', './local', 'local'),
-      BOUNDED,
-    ]
-    expect(candidateRows(plan).map((row) => row.facet.name)).toEqual(['beta', 'alpha'])
-  })
-})
-
-describe('classifyNoOp', () => {
-  test('work to do is not a no-op', () => {
-    expect(classifyNoOp([BOUNDED], 'range', [{ facetName: 'alpha', choice: 'range' }])).toBeNull()
-  })
-
-  test('a project with only git and local facets has nothing to check', () => {
-    const noOp = classifyNoOp([unsupported('delta', 'github:a/b', 'git')], 'range', [])
-    expect(noOp).toEqual({ reason: 'no-registry-facets' })
+// Classification lives in the engine and is tested there. What is the
+// CLI's is the sentence each verdict becomes — in particular which of
+// them points at a flag, since a flag is a thing only a terminal has.
+describe('describeNoOp', () => {
+  test('a project with no registry facets says why nothing was checked', () => {
     expect(describeNoOp({ reason: 'no-registry-facets' })).toContain('No registry facets')
   })
 
-  test('every registry facet current is its own outcome', () => {
-    const noOp = classifyNoOp([current({ name: 'gamma', source: '*', version: '4.0.0' })], 'range', [])
-    expect(noOp).toEqual({ reason: 'all-current' })
+  test('everything current says so plainly', () => {
     expect(describeNoOp({ reason: 'all-current' })).toContain('current')
   })
 
-  // The case a single "nothing to update" would hide: there IS something
-  // newer, and the user has a flag that would take it.
   test('a blocked range names --latest as the way past it', () => {
-    const noOp = classifyNoOp([PINNED], 'range', [])
-    expect(noOp).toEqual({ reason: 'ranges-permit-none' })
-    const message = describeNoOp({ reason: 'ranges-permit-none' })
-    expect(message).toContain('facet update --latest')
+    expect(describeNoOp({ reason: 'ranges-permit-none' })).toContain('facet update --latest')
   })
 
   test('latest mode with nothing newer suggests nothing', () => {
-    const noOp = classifyNoOp([PINNED], 'latest', [])
-    expect(noOp).toEqual({ reason: 'latest-permits-none' })
     expect(describeNoOp({ reason: 'latest-permits-none' })).not.toContain('--latest')
   })
 })

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -126,6 +126,15 @@ export const updateCommand: Command = {
 
     const noOp = picking === null ? classifyNoOp(plan, mode, interactive ? [] : defaults) : null
     if (noOp !== null) {
+      // A dry run was asked for the plan, and "nothing to do" is a
+      // conclusion drawn FROM the plan. The reason alone asks the user to
+      // take that conclusion on faith; the rows it was drawn from let
+      // them check it — which facet is pinned, which is already current,
+      // which range is holding one back. Rendered with nothing selected
+      // and no rewrites, because that is precisely what this run would
+      // apply. An ordinary run stays terse: there is no plan to review
+      // when nothing was going to happen either way.
+      if (dryRun) renderPlan(plan, [], [])
       process.stdout.write(`${describeNoOp(noOp)}\n`)
       return 0
     }
@@ -206,9 +215,13 @@ export const updateCommand: Command = {
           captured = result
           if (result.ok) return result.install
           if (result.phase === 'install') return result.install
-          // A selection failure has no install result to render. It is
-          // reported on stderr after unmount, where its remedy lives.
-          throw new UpdateSelectionRejected()
+          // A selection failure has no install result to render, but it
+          // is still an outcome this driver produced. Returned rather
+          // than thrown: the engine refusing a selection is a documented
+          // way for this command to end, and the view's result type says
+          // so. It is reported on stderr after unmount, where its remedy
+          // lives.
+          return { ok: false, updateSelectionFailure: result.failure }
         },
         onComplete: () => {
           // `captured` is already the richer result, set inside `run`.
@@ -219,10 +232,13 @@ export const updateCommand: Command = {
       { exitOnCtrlC: false },
     )
 
+    // Not wrapped in `catch`: every outcome this command has is a value
+    // the driver returned, so a rejection here is the view or the driver
+    // failing in a way nothing modelled. It propagates, and the CLI's
+    // top level reports it as an unexpected failure instead of this
+    // command reporting a plausible-looking one it made up.
     try {
       await instance.waitUntilExit()
-    } catch {
-      // Ink rejects on view-level failure; we have the captured result.
     } finally {
       process.off('SIGINT', sigintHandler)
     }
@@ -252,15 +268,6 @@ export const updateCommand: Command = {
     return 1
   },
 }
-
-/**
- * Unmounts the view when the engine refuses the selection.
- *
- * The view renders `RunInstallResult`-shaped values and a selection
- * failure is not one. Throwing ends the mount; the structured failure is
- * already captured and is reported on stderr by the caller.
- */
-class UpdateSelectionRejected extends Error {}
 
 /** Draw the plan once and tear the mount down; nothing here is live. */
 function renderPlan(

--- a/packages/cli/src/commands/update/selection.ts
+++ b/packages/cli/src/commands/update/selection.ts
@@ -1,87 +1,19 @@
-import { advancingChoice, type FacetUpdateSelection, type UpdateChoice, type UpdatePlanRow } from '@agent-facets/engine'
+import type { UpdateNoOp } from '@agent-facets/engine'
+
+// Which rows are offerable, what a flagless run takes, and which kind of
+// no-op a project is in are engine decisions — re-exported here so the
+// command's own modules keep importing selection concepts from one
+// place, rather than restated as a second opinion.
+export type { UpdateCandidate, UpdateMode, UpdateNoOp } from '@agent-facets/engine'
+export { candidateRows, classifyNoOp, defaultSelections } from '@agent-facets/engine'
 
 /**
- * Which version a non-interactive run takes for each facet.
+ * The message for each no-op, including the one that has a next step.
  *
- * `range` respects what `facets.json` declares; `latest` ignores it. The
- * flag is the whole difference, so it is the whole type.
+ * The only part of this that is the CLI's: the classification is a fact
+ * about the project, the sentence is a choice about this terminal. It
+ * names flags because a terminal is where flags exist.
  */
-export type UpdateMode = UpdateChoice
-
-/** A plan row that has at least one version newer than what is installed. */
-export type UpdateCandidate = Extract<UpdatePlanRow, { kind: 'candidate' }>
-
-/**
- * The rows the interactive picker can offer, in project order.
- *
- * Deliberately independent of the mode's default selections. A facet
- * pinned to an exact version has a stationary Target and may still have
- * an advancing Latest — under plain `--interactive` its default
- * selection is empty while the row it would show is precisely the one
- * the screen exists for. Gating the picker on the defaults instead sent
- * that user to the "ranges permit none, pass --latest" message, telling
- * them to re-run with a flag whose job the picker was already there to
- * do interactively.
- */
-export function candidateRows(plan: readonly UpdatePlanRow[]): UpdateCandidate[] {
-  return plan.filter((row): row is UpdateCandidate => row.kind === 'candidate')
-}
-
-/**
- * Every candidate whose chosen version advances, in project order.
- *
- * `advancingChoice` is the engine's, not a comparison repeated here. It
- * is the same predicate the picker gates selection on and the same one
- * `validateFacetUpdateSelections` accepts by, so a default selection
- * cannot contain a row application would refuse.
- */
-export function defaultSelections(plan: readonly UpdatePlanRow[], mode: UpdateMode): FacetUpdateSelection[] {
-  const selections: FacetUpdateSelection[] = []
-  for (const row of candidateRows(plan)) {
-    if (advancingChoice(row.facet, mode) === undefined) continue
-    selections.push({ facetName: row.facet.name, choice: mode })
-  }
-  return selections
-}
-
-/**
- * Why a successful run is about to apply nothing.
- *
- * Four distinct facts, and a user acts on each of them differently: add
- * a facet, do nothing, pass `--latest`, or (the last one) nothing at
- * all. Collapsing them into "no updates available" is what makes the
- * third case — releases exist, the declared ranges just forbid them —
- * look like the second.
- */
-export type UpdateNoOp =
-  | { reason: 'no-registry-facets' }
-  | { reason: 'all-current' }
-  | { reason: 'ranges-permit-none' }
-  | { reason: 'latest-permits-none' }
-
-/**
- * Classify an empty selection. Returns `null` when there is work to do,
- * so the caller cannot reach a no-op message while holding selections.
- */
-export function classifyNoOp(
-  plan: readonly UpdatePlanRow[],
-  mode: UpdateMode,
-  selections: readonly FacetUpdateSelection[],
-): UpdateNoOp | null {
-  if (selections.length > 0) return null
-
-  const registryRows = plan.filter((row) => row.kind !== 'unsupported-source')
-  if (registryRows.length === 0) return { reason: 'no-registry-facets' }
-
-  if (candidateRows(plan).length === 0) return { reason: 'all-current' }
-
-  // Something newer exists and this mode cannot reach it. Under plain
-  // update that is the authored range's doing and `--latest` is the way
-  // past it; under `--latest` there is nothing left to suggest.
-  return mode === 'range' ? { reason: 'ranges-permit-none' } : { reason: 'latest-permits-none' }
-}
-
-/** The message for each no-op, including the one that has a next step. */
 export function describeNoOp(noOp: UpdateNoOp): string {
   switch (noOp.reason) {
     case 'no-registry-facets':

--- a/packages/cli/src/prompts/overview.txt
+++ b/packages/cli/src/prompts/overview.txt
@@ -28,8 +28,9 @@ The three artifact files
                and how it wants their assets and MCP servers named. Each entry
                is either a source string or an object carrying materialization
                choices, so read both forms. You touch this when USING facets
-               (via `facet add`, or by hand to resolve a name collision or
-               refuse an MCP server).
+               (via `facet add`, `facet remove`, or `facet update --latest`,
+               or by hand to resolve a name collision or refuse an MCP
+               server).
                See: facet instructions usage
   facets.lock  The install lockfile. Managed by the CLI; do not hand-edit.
 

--- a/packages/cli/src/prompts/usage.txt
+++ b/packages/cli/src/prompts/usage.txt
@@ -74,8 +74,9 @@ Move facets to newer releases — `facet update`
   in facets.json and running `facet install`.
 
 The project files
-  facets.json – Your dependency list. `facet add` and `facet remove` maintain
-                it; hand-edit it only to record materialization choices (below).
+  facets.json – Your dependency list. `facet add`, `facet remove`, and
+                `facet update --latest` maintain it; hand-edit it only to
+                record materialization choices (below).
                 It carries a "manifestVersion" the CLI stamps for you. The
                 current version is 0.2, which is what a "servers" override
                 group requires; 0.1 and unversioned documents are still read

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,5 +1,11 @@
 import { parse } from '@bomb.sh/args'
-import { allCommandNames, type Command, resolveCommand } from './commands.ts'
+import {
+  allCommandNames,
+  type Command,
+  describeShortFlagCollision,
+  findShortFlagCollisions,
+  resolveCommand,
+} from './commands.ts'
 import { printCommandHelp, printGlobalHelp } from './help.ts'
 import { findClosestCommand } from './suggest.ts'
 import { version } from './version.ts'
@@ -79,6 +85,21 @@ export async function run(argv: string[], commands: Record<string, Command>): Pr
   const alias: Record<string, string> = {}
 
   if (command.flags) {
+    // Before the alias map is built, not after: building it is what
+    // destroys the evidence. A second claim on the same short spelling
+    // overwrites the first, leaving a parser that quietly does the wrong
+    // thing with no trace of what it dropped. This is a declaration bug
+    // in this repository's own command table, so it fails loudly rather
+    // than becoming a user-facing error about an invocation that was
+    // fine.
+    const collisions = findShortFlagCollisions(command.flags)
+    if (collisions.length > 0) {
+      throw new Error(
+        `internal: command "${command.name}" declares ambiguous short flags: ` +
+          collisions.map(describeShortFlagCollision).join('; '),
+      )
+    }
+
     for (const [name, def] of Object.entries(command.flags)) {
       const bucket = def.type === 'boolean' ? booleanFlags : def.type === 'string' ? stringFlags : arrayFlags
       bucket.push(name)

--- a/packages/cli/src/tui/views/install/install-view.tsx
+++ b/packages/cli/src/tui/views/install/install-view.tsx
@@ -15,6 +15,7 @@ import type {
   RemovePrepareFailure,
   RunInstallResult,
   StageEvent,
+  UpdateSelectionFailure,
 } from '@agent-facets/engine'
 import { LOCKFILE_VERSION_0_3 } from '@agent-facets/protocol'
 import { Box, Text, useApp, useStderr } from 'ink'
@@ -35,13 +36,18 @@ import { AssetTakeoverScreen } from './takeover/screen.tsx'
  * `add` and `remove` flows may instead fail in a pre-install (prepare)
  * phase — `add`: name resolution / manifest read; `remove`: manifest read
  * / undeclared facet — which has no `RunInstallResult` shape, so it
- * surfaces as a distinct `prepare-failure` arm. The arm is tagged by which
- * flow produced it so the view renders the matching block.
+ * surfaces as a distinct `prepare-failure` arm. `update` adds a third:
+ * the engine can refuse the selection before installing anything, which
+ * likewise has no `RunInstallResult` to render. The arm is tagged by
+ * which flow produced it so the view renders the matching block — and so
+ * a driver can report any of them by returning, rather than by throwing
+ * past a return type that could not describe them.
  */
 export type InstallViewResult =
   | RunInstallResult
   | { ok: false; prepareFailure: AddPrepareFailure }
   | { ok: false; removePrepareFailure: RemovePrepareFailure }
+  | { ok: false; updateSelectionFailure: UpdateSelectionFailure }
 
 /**
  * Everything the view can lend a driver for one run.
@@ -121,12 +127,24 @@ function isRemovePrepareFailure(r: InstallViewResult): r is { ok: false; removeP
 }
 
 /**
+ * Type guard: a driver result that is an update-selection refusal. The
+ * view has nothing to draw for it — the remedy is a flag or a rerun, not
+ * a report about files — so it exists to be excluded from the arms that
+ * do render, and to be reported on stderr by the command afterwards.
+ */
+function isUpdateSelectionFailure(
+  r: InstallViewResult,
+): r is { ok: false; updateSelectionFailure: UpdateSelectionFailure } {
+  return !r.ok && 'updateSelectionFailure' in r
+}
+
+/**
  * Type guard: a driver result that is an install-pipeline failure (a
  * `RunInstallResult` with `ok: false`), as opposed to a prepare-phase
  * failure. Narrows so `.failure` and `.rollback` are accessible.
  */
 function isInstallFailure(r: InstallViewResult): r is Extract<RunInstallResult, { ok: false }> {
-  return !r.ok && !isPrepareFailure(r) && !isRemovePrepareFailure(r)
+  return !r.ok && !isPrepareFailure(r) && !isRemovePrepareFailure(r) && !isUpdateSelectionFailure(r)
 }
 
 /** A materialization choice dropped because its contribution no longer exists. */
@@ -472,11 +490,20 @@ export function InstallView({ run, mode, onComplete, signal }: InstallViewProps)
 
   useEffect(() => {
     if (phase.kind === 'result') {
-      if (phase.result.ok) exit()
-      else exit(new Error('Install failed'))
+      // A structured result — success or failure — is the view doing its
+      // job. It unmounts cleanly, and the command reads the outcome from
+      // the value it captured. Rejecting `waitUntilExit()` for an
+      // ordinary failure is what forced every call site to wrap the wait
+      // in a `catch {}`, and that `catch` then swallowed the crashes the
+      // rejection channel exists for.
+      exit()
       return
     }
     if (phase.kind === 'crashed') {
+      // The driver threw instead of returning. Nothing captured a
+      // result, so the rejection is the only remaining evidence — it
+      // propagates to the command, which has no handling for it, and
+      // out to the top-level as an unexpected failure.
       exit(phase.error)
       return
     }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -282,7 +282,10 @@ export type {
   TargetVersion,
   UnusableFacetState,
   UnusableStateReason,
+  UpdateCandidate,
   UpdateChoice,
+  UpdateMode,
+  UpdateNoOp,
   UpdatePlanRow,
   UpdateSelectionFailure,
 } from './install/update/index.ts'
@@ -296,8 +299,16 @@ export type {
 // identical predicate application enforces, and the plan view must
 // render the identical version. Both are one function here rather than
 // a rule the CLI reimplements.
+//
+// `candidateRows`, `defaultSelections`, and `classifyNoOp` are the same
+// argument once more: which rows are offerable, what a flagless run
+// takes, and which kind of nothing a project is in are decided from the
+// plan, not from the terminal. Only the wording of a no-op is the CLI's.
 export {
   advancingChoice,
+  candidateRows,
+  classifyNoOp,
+  defaultSelections,
   displayedVersion,
   prepareFacetUpdate,
   runPreparedFacetUpdate,

--- a/packages/engine/src/install/__tests__/parse-locked-version.test.ts
+++ b/packages/engine/src/install/__tests__/parse-locked-version.test.ts
@@ -14,11 +14,26 @@ describe('parseLockedVersion', () => {
     expect(parseLockedVersion('0.0.0')).toEqual({ kind: 'exact', major: 0, minor: 0, patch: 0 })
   })
 
+  test('parses the largest representable components', () => {
+    expect(parseLockedVersion('9007199254740991.0.0')).toEqual({
+      kind: 'exact',
+      major: Number.MAX_SAFE_INTEGER,
+      minor: 0,
+      patch: 0,
+    })
+  })
+
   test('throws on a non-M.N.P string (schema/parser drift is a programmer bug)', () => {
     // Lockfile schema narrows `version` to M.N.P, so this is unreachable on
     // validated input — the throw guards against schema/parser drift.
     expect(() => parseLockedVersion('1.2')).toThrow('parseLockedVersion regex rejected it')
     expect(() => parseLockedVersion('1.2.3-rc.1')).toThrow()
     expect(() => parseLockedVersion('latest')).toThrow()
+  })
+
+  test('throws on an unrepresentable component (schema/parser drift is a programmer bug)', () => {
+    // Same contract as above on the other half of the schema's narrow:
+    // returning a number here would name a release this value is not.
+    expect(() => parseLockedVersion('9007199254740992.0.0')).toThrow('exceed the version grammar')
   })
 })

--- a/packages/engine/src/install/parse-locked-version.ts
+++ b/packages/engine/src/install/parse-locked-version.ts
@@ -1,3 +1,4 @@
+import { isSafeVersionComponent } from '@agent-facets/protocol'
 import { regex } from 'arkregex'
 
 /**
@@ -48,6 +49,14 @@ export function parseLockedVersion(version: string): {
     throw new Error(`internal: lockfile schema accepted "${version}" but parseLockedVersion regex rejected it`)
   }
   const [, major, minor, patch] = match
+  // The same narrow also bounds each component's magnitude, so a value
+  // that would not survive the conversion below cannot reach a validated
+  // lockfile. Checked here for the same reason as the shape: if the two
+  // ever drift, this fails loudly instead of returning a number that
+  // compares equal to a different release.
+  if (![major, minor, patch].every((component) => isSafeVersionComponent(component))) {
+    throw new Error(`internal: lockfile schema accepted "${version}" but its components exceed the version grammar`)
+  }
   return {
     kind: 'exact',
     major: Number(major),

--- a/packages/engine/src/install/update/__tests__/discover.test.ts
+++ b/packages/engine/src/install/update/__tests__/discover.test.ts
@@ -436,7 +436,7 @@ describe('discoverUpdates — unusable local state', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Grouping and failure ordering
+// Grouping and failure propagation
 // ---------------------------------------------------------------------------
 
 describe('discoverUpdates — batching', () => {
@@ -550,15 +550,16 @@ describe('discoverUpdates — batching', () => {
     expect(result.failure.reason).toBe('discovery-failed')
   })
 
-  test('the reported failure follows project order, not completion order', async () => {
+  test('a failure in any group fails the whole discovery', async () => {
     const names = Array.from({ length: 60 }, (_, index) => `facet-${String(index).padStart(3, '0')}`)
     const versions: Record<string, string> = {}
     for (const name of names) {
       versions[`${name}@1.*`] = '1.8.0'
       versions[`${name}@latest`] = '2.0.0'
     }
-    // Fail one facet in each group; the earlier one must win even though
-    // the later group is made to settle first.
+    // One failure in each group, with the later group made to settle
+    // first. Which of the two is reported is deliberately not promised;
+    // what is promised is that neither leaves a partial plan behind.
     delete versions['facet-005@1.*']
     delete versions['facet-055@1.*']
 
@@ -576,9 +577,7 @@ describe('discoverUpdates — batching', () => {
     })
 
     if (result.ok) expect.unreachable()
-    if (result.failure.reason !== 'discovery-failed') expect.unreachable()
-    if (result.failure.error.code !== 'NOT_FOUND') expect.unreachable()
-    expect(result.failure.error.name).toBe('facet-005')
+    expect(result.failure.reason).toBe('discovery-failed')
   })
 })
 

--- a/packages/engine/src/install/update/__tests__/plan-fixtures.ts
+++ b/packages/engine/src/install/update/__tests__/plan-fixtures.ts
@@ -1,0 +1,93 @@
+import { parseVersionSpec } from '../../../sources/facet/parse-version.ts'
+import type { AuthoredSpecifier } from '../manifest-source.ts'
+import type { TargetVersion, UpdatePlanRow } from '../types.ts'
+import type { ExactVersion } from '../version-order.ts'
+
+/**
+ * Hand-built plan rows for tests about what happens *after* discovery.
+ *
+ * Discovery's own tests drive the real resolver; selection's do not care
+ * how a row was produced, only what it says. Every version and specifier
+ * still goes through the real grammar so a malformed fixture is a thrown
+ * setup error rather than a silent `0.0.0`.
+ *
+ * Which columns advance is deliberately NOT a parameter. It is derived
+ * from the versions by the same predicate selection and application use,
+ * so a fixture cannot describe a row discovery could not produce.
+ */
+export function exact(version: string): ExactVersion {
+  const spec = parseVersionSpec(version)
+  if (!spec.ok || spec.value.kind !== 'exact') {
+    throw new Error(`test fixture declares an invalid exact version: ${version}`)
+  }
+  return spec.value
+}
+
+function choice(name: string, version: string) {
+  return {
+    version: exact(version),
+    metadata: {
+      name,
+      version,
+      transportHash: `transport-${name}-${version}`,
+      contentFingerprint: `content-${name}-${version}`,
+    },
+  }
+}
+
+function authored(source: string): AuthoredSpecifier {
+  const spec = parseVersionSpec(source)
+  if (!spec.ok) throw new Error(`test fixture declares an invalid specifier: ${source}`)
+  return { source, spec: spec.value }
+}
+
+/**
+ * An exact specifier's Target is the pin itself, and discovery never
+ * asks the registry for it — so the fixture carries no metadata either.
+ */
+function target(name: string, declared: AuthoredSpecifier, version: string): TargetVersion {
+  if (declared.spec.kind === 'exact') return { kind: 'pinned', version: exact(version) }
+  return { kind: 'resolved', ...choice(name, version) }
+}
+
+export function candidate(args: {
+  name: string
+  source: string
+  current: string
+  target: string
+  latest: string
+}): Extract<UpdatePlanRow, { kind: 'candidate' }> {
+  const declared = authored(args.source)
+  return {
+    kind: 'candidate',
+    facet: {
+      name: args.name,
+      authored: declared,
+      current: exact(args.current),
+      target: target(args.name, declared, args.target),
+      latest: choice(args.name, args.latest),
+    },
+  }
+}
+
+export function current(args: {
+  name: string
+  source: string
+  version: string
+}): Extract<UpdatePlanRow, { kind: 'current' }> {
+  const declared = authored(args.source)
+  return {
+    kind: 'current',
+    facet: {
+      name: args.name,
+      authored: declared,
+      current: exact(args.version),
+      target: target(args.name, declared, args.version),
+      latest: choice(args.name, args.version),
+    },
+  }
+}
+
+export function unsupported(name: string, source: string, sourceKind: 'git' | 'local'): UpdatePlanRow {
+  return { kind: 'unsupported-source', name, source, sourceKind }
+}

--- a/packages/engine/src/install/update/__tests__/selection.test.ts
+++ b/packages/engine/src/install/update/__tests__/selection.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+import { candidateRows, classifyNoOp, defaultSelections } from '../selection.ts'
+import { candidate, current, unsupported } from './plan-fixtures.ts'
+
+const BOUNDED = candidate({
+  name: 'alpha',
+  source: '1.*',
+  current: '1.2.0',
+  target: '1.8.0',
+  latest: '2.0.0',
+})
+
+// An exact pin: the range cannot move, but a newer release exists.
+const PINNED = candidate({
+  name: 'beta',
+  source: '1.2.0',
+  current: '1.2.0',
+  target: '1.2.0',
+  latest: '3.0.0',
+})
+
+describe('defaultSelections', () => {
+  test('a plain run takes the range target of every advancing candidate', () => {
+    expect(defaultSelections([BOUNDED, PINNED], 'range')).toEqual([{ facetName: 'alpha', choice: 'range' }])
+  })
+
+  test('latest mode takes the latest release, including across a bounded range', () => {
+    expect(defaultSelections([BOUNDED, PINNED], 'latest')).toEqual([
+      { facetName: 'alpha', choice: 'latest' },
+      { facetName: 'beta', choice: 'latest' },
+    ])
+  })
+
+  test('current and unsupported rows are never selected', () => {
+    const plan = [current({ name: 'gamma', source: '*', version: '4.0.0' }), unsupported('delta', './local', 'local')]
+    expect(defaultSelections(plan, 'range')).toEqual([])
+    expect(defaultSelections(plan, 'latest')).toEqual([])
+  })
+})
+
+describe('candidateRows', () => {
+  test('a candidate the mode would not select still counts', () => {
+    // The whole point: under a plain run PINNED contributes no default
+    // selection, and it is still a row worth offering.
+    expect(defaultSelections([PINNED], 'range')).toEqual([])
+    expect(candidateRows([PINNED])).toEqual([PINNED])
+  })
+
+  test('rows with nothing newer do not count', () => {
+    expect(candidateRows([current({ name: 'gamma', source: '*', version: '4.0.0' })])).toEqual([])
+    expect(candidateRows([unsupported('delta', './local', 'local')])).toEqual([])
+    expect(candidateRows([])).toEqual([])
+  })
+
+  // A chooser is handed exactly these rows, so the filter is what keeps
+  // a facet with nothing to offer off a screen that asks for a decision.
+  test('current and unsupported rows are dropped, in project order', () => {
+    const plan = [
+      current({ name: 'gamma', source: '*', version: '4.0.0' }),
+      PINNED,
+      unsupported('delta', './local', 'local'),
+      BOUNDED,
+    ]
+    expect(candidateRows(plan).map((row) => row.facet.name)).toEqual(['beta', 'alpha'])
+  })
+})
+
+describe('classifyNoOp', () => {
+  test('work to do is not a no-op', () => {
+    expect(classifyNoOp([BOUNDED], 'range', [{ facetName: 'alpha', choice: 'range' }])).toBeNull()
+  })
+
+  test('a project with only git and local facets has nothing to check', () => {
+    expect(classifyNoOp([unsupported('delta', 'github:a/b', 'git')], 'range', [])).toEqual({
+      reason: 'no-registry-facets',
+    })
+  })
+
+  test('every registry facet current is its own outcome', () => {
+    expect(classifyNoOp([current({ name: 'gamma', source: '*', version: '4.0.0' })], 'range', [])).toEqual({
+      reason: 'all-current',
+    })
+  })
+
+  // The case a single "nothing to update" would hide: there IS something
+  // newer, and latest mode would take it.
+  test('a blocked range is distinct from having nothing newer', () => {
+    expect(classifyNoOp([PINNED], 'range', [])).toEqual({ reason: 'ranges-permit-none' })
+  })
+
+  test('latest mode with nothing newer has no remaining suggestion', () => {
+    expect(classifyNoOp([PINNED], 'latest', [])).toEqual({ reason: 'latest-permits-none' })
+  })
+})

--- a/packages/engine/src/install/update/__tests__/version-order.test.ts
+++ b/packages/engine/src/install/update/__tests__/version-order.test.ts
@@ -24,6 +24,21 @@ describe('parseExactVersion', () => {
     expect(parseExactVersion(value)).toBeUndefined()
   })
 
+  test('accepts a component at the representable bound', () => {
+    expect(parseExactVersion('9007199254740991.0.0')).toEqual(at(Number.MAX_SAFE_INTEGER, 0, 0))
+  })
+
+  test.each([
+    '9007199254740992.0.0',
+    '1.9007199254740992.0',
+    '1.0.9007199254740992',
+  ])('rejects the unrepresentable version %p', (value) => {
+    // Ordering is this module's whole job, and past the bound two
+    // distinct releases compare equal. A version it cannot order is a
+    // version it must not return.
+    expect(parseExactVersion(value)).toBeUndefined()
+  })
+
   test('never throws on hand-edited lockfile text', () => {
     // The point of this parser existing alongside `parseLockedVersion`:
     // that one throws, because the lockfile schema promised it wouldn't

--- a/packages/engine/src/install/update/discover.ts
+++ b/packages/engine/src/install/update/discover.ts
@@ -172,9 +172,11 @@ type PendingLookup =
  * already known to be the installed version, and asking for it would
  * turn a yanked release into a project-wide discovery failure.
  *
- * Groups are issued concurrently but inspected in order, which is what
- * makes the reported failure the same on every run no matter which
- * request happened to lose the race.
+ * Groups are issued concurrently. When more than one of them fails,
+ * which failure comes back is deliberately not pinned down: every one of
+ * them ends the run with no plan and the same instruction to the user, so
+ * promising a particular one would constrain how these lookups are
+ * batched and issued to buy a distinction nobody can act on.
  */
 async function resolvePendingFacets(
   pending: readonly PendingFacet[],

--- a/packages/engine/src/install/update/index.ts
+++ b/packages/engine/src/install/update/index.ts
@@ -18,6 +18,8 @@ export type {
 export { runPreparedFacetUpdate, validateFacetUpdateSelections } from './apply.ts'
 export type { AuthoredSpecifier, UpdateChoice } from './manifest-source.ts'
 export { type PrepareFacetUpdateArgs, prepareFacetUpdate } from './prepare.ts'
+export type { UpdateCandidate, UpdateMode, UpdateNoOp } from './selection.ts'
+export { candidateRows, classifyNoOp, defaultSelections } from './selection.ts'
 export type {
   CheckableRegistryFacet,
   PreparedFacetUpdate,

--- a/packages/engine/src/install/update/selection.ts
+++ b/packages/engine/src/install/update/selection.ts
@@ -1,0 +1,103 @@
+/**
+ * What an update run selects, and why a run selects nothing.
+ *
+ * These are update-domain decisions, not presentation ones. Which rows a
+ * chooser may offer, what a flagless run takes, and which kind of
+ * "nothing to do" a project is in are all answered from the plan and the
+ * mode alone — no terminal, no rendering, no user in the loop. A GUI or
+ * an RPC server driving the same engine would need every one of these
+ * answers and would have to reach the same verdicts, which is what makes
+ * this the wrong knowledge for a display layer to hold.
+ *
+ * The one thing deliberately left out is the wording. Turning a
+ * `UpdateNoOp` into a sentence is presentation, and it lives with the
+ * surface that prints it.
+ */
+
+import { advancingChoice } from './advancing.ts'
+import type { FacetUpdateSelection } from './apply.ts'
+import type { UpdateChoice } from './manifest-source.ts'
+import type { UpdatePlanRow } from './types.ts'
+
+/**
+ * Which version a non-interactive run takes for each facet.
+ *
+ * `range` respects what `facets.json` declares; `latest` ignores it. The
+ * flag is the whole difference, so it is the whole type.
+ */
+export type UpdateMode = UpdateChoice
+
+/** A plan row that has at least one version newer than what is installed. */
+export type UpdateCandidate = Extract<UpdatePlanRow, { kind: 'candidate' }>
+
+/**
+ * The rows a chooser can offer, in project order.
+ *
+ * Deliberately independent of the mode's default selections. A facet
+ * pinned to an exact version has a stationary Target and may still have
+ * an advancing Latest — under a plain interactive run its default
+ * selection is empty while the row it would show is precisely the one
+ * the chooser exists for. Gating on the defaults instead sent that user
+ * to the "ranges permit none, pass --latest" message, telling them to
+ * re-run with a flag whose job the chooser was already there to do.
+ */
+export function candidateRows(plan: readonly UpdatePlanRow[]): UpdateCandidate[] {
+  return plan.filter((row): row is UpdateCandidate => row.kind === 'candidate')
+}
+
+/**
+ * Every candidate whose chosen version advances, in project order.
+ *
+ * This is what a run with no user in it takes. Interactive selection
+ * never uses it: every choice is made on screen, so the mode has nothing
+ * left to say there.
+ *
+ * `advancingChoice` is the same predicate a chooser gates selection on
+ * and the same one `validateFacetUpdateSelections` accepts by, so a
+ * default selection cannot contain a row application would refuse.
+ */
+export function defaultSelections(plan: readonly UpdatePlanRow[], mode: UpdateMode): FacetUpdateSelection[] {
+  const selections: FacetUpdateSelection[] = []
+  for (const row of candidateRows(plan)) {
+    if (advancingChoice(row.facet, mode) === undefined) continue
+    selections.push({ facetName: row.facet.name, choice: mode })
+  }
+  return selections
+}
+
+/**
+ * Why a successful run is about to apply nothing.
+ *
+ * Four distinct facts, and a user acts on each of them differently: add
+ * a facet, do nothing, ask for latest, or (the last one) nothing at all.
+ * Collapsing them into "no updates available" is what makes the third
+ * case — releases exist, the declared ranges just forbid them — look
+ * like the second.
+ */
+export type UpdateNoOp =
+  | { reason: 'no-registry-facets' }
+  | { reason: 'all-current' }
+  | { reason: 'ranges-permit-none' }
+  | { reason: 'latest-permits-none' }
+
+/**
+ * Classify an empty selection. Returns `null` when there is work to do,
+ * so a caller cannot reach a no-op verdict while holding selections.
+ */
+export function classifyNoOp(
+  plan: readonly UpdatePlanRow[],
+  mode: UpdateMode,
+  selections: readonly FacetUpdateSelection[],
+): UpdateNoOp | null {
+  if (selections.length > 0) return null
+
+  const registryRows = plan.filter((row) => row.kind !== 'unsupported-source')
+  if (registryRows.length === 0) return { reason: 'no-registry-facets' }
+
+  if (candidateRows(plan).length === 0) return { reason: 'all-current' }
+
+  // Something newer exists and this mode cannot reach it. Under a plain
+  // run that is the authored range's doing and latest mode is the way
+  // past it; under latest mode there is nothing left to suggest.
+  return mode === 'range' ? { reason: 'ranges-permit-none' } : { reason: 'latest-permits-none' }
+}

--- a/packages/engine/src/install/update/types.ts
+++ b/packages/engine/src/install/update/types.ts
@@ -111,12 +111,12 @@ export interface UnusableFacetState {
  * first one, so a single run tells the user the whole repair list.
  *
  * `discovery-failed` names no facet on purpose. The batch resolver
- * reports the first failure in input order — which is what makes the
- * reported error stable across runs — but it does not say which
- * specifier produced it, and a `NETWORK_ERROR` genuinely belongs to no
- * single facet. Inventing an attribution here would be a guess the user
- * could act on wrongly; the registry's own error already names the facet
- * whenever the registry knew one.
+ * returns one failure without saying which specifier produced it, and a
+ * `NETWORK_ERROR` genuinely belongs to no single facet. Inventing an
+ * attribution here would be a guess the user could act on wrongly; the
+ * registry's own error already names the facet whenever the registry
+ * knew one. When several lookups fail, which one is reported is not
+ * promised — each ends the run identically.
  *
  * `invalid-resolved-version` and `target-outside-range` are the registry
  * answering incoherently rather than failing: a version that is not an

--- a/packages/engine/src/registry/resolve-metadata.ts
+++ b/packages/engine/src/registry/resolve-metadata.ts
@@ -26,12 +26,12 @@ export const MAX_REGISTRY_METADATA_SPECIFIERS = 100
 /**
  * Resolve registry metadata for a batch of `(name, version)` pairs.
  *
- * Returns one `RegistryMetadata` per input spec, in input order, or the
- * first failure in that same order. All-or-nothing: a caller never gets
- * a partially resolved set it could mistake for a complete answer.
- * Because the failure is chosen by input position rather than by which
- * request happened to settle first, the reported error is the same on
- * every run regardless of network timing.
+ * Returns one `RegistryMetadata` per input spec, in input order, or a
+ * single failure. All-or-nothing: a caller never gets a partially
+ * resolved set it could mistake for a complete answer. When several
+ * specifiers fail, which failure is returned is not part of the
+ * contract — every one of them denies the caller the same complete
+ * answer, and callers are required to treat any of them the same way.
  *
  * Empty input returns `{ ok: true, value: [] }` without resolving a
  * credential or touching the network. More than
@@ -88,10 +88,10 @@ export async function resolveRegistryMetadataBatch(
   }
   const results = await Promise.all(specs.map((spec) => fetchOne(client, spec)))
 
-  // One pass in input order: the first failure wins, and the success
-  // list is built from the same narrowing that proved it. Scanning for
-  // failures and then re-narrowing in a second pass would leave a
-  // branch the compiler can't discharge and that can't happen.
+  // One pass, building the success list from the same narrowing that
+  // proved each entry resolved. Scanning for failures and then
+  // re-narrowing in a second pass would leave a branch the compiler
+  // can't discharge and that can't happen.
   const resolved: RegistryMetadata[] = []
   for (const result of results) {
     if (!result.ok) return result

--- a/packages/engine/src/sources/adapter/__tests__/specifier.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/specifier.test.ts
@@ -181,6 +181,17 @@ describe('parseAdapterSpecifier — rejected npm selectors', () => {
     expect(result.error.fix).toMatch(/1\.\*|1\.2\.\*/)
   })
 
+  test('an unrepresentable version component is rejected as a magnitude problem', () => {
+    // The adapter selector shares the facet version grammar, so the
+    // bound it enforces has to reach here too rather than stopping at
+    // the manifest.
+    const result = parseAdapterSpecifier('some-adapter@9007199254740992.0.0')
+    if (result.ok) expect.unreachable()
+    if (result.reason !== 'invalid-npm-selector') expect.unreachable()
+    expect(result.error.code).toBe('VERSION_COMPONENT_TOO_LARGE')
+    expect(result.specifier).toBe('some-adapter@9007199254740992.0.0')
+  })
+
   test('rejected selector reports the alias-resolved package name', () => {
     const result = parseAdapterSpecifier('opencode@^1.0.0')
     if (result.ok) expect.unreachable()

--- a/packages/engine/src/sources/facet/__tests__/parse-source.test.ts
+++ b/packages/engine/src/sources/facet/__tests__/parse-source.test.ts
@@ -306,4 +306,14 @@ describe('parseSource — rejected forms', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error.code).toBe('CARET_RANGE')
   })
+
+  test.each([
+    'cowsay@9007199254740992.0.0',
+    '@julian/cowsay@9007199254740992.0.0',
+    'cowsay@9007199254740992.*',
+  ])('an unrepresentable version component in %p is rejected', (input) => {
+    const result = parseSource(input)
+    if (result.ok) expect.unreachable()
+    expect(result.error.code).toBe('VERSION_COMPONENT_TOO_LARGE')
+  })
 })

--- a/packages/engine/src/sources/facet/__tests__/parse-version.test.ts
+++ b/packages/engine/src/sources/facet/__tests__/parse-version.test.ts
@@ -38,6 +38,43 @@ describe('parseVersionSpec — accepted forms', () => {
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.value).toEqual({ kind: 'latest' })
   })
+
+  test('components at the representable bound', () => {
+    const result = parseVersionSpec('9007199254740991.9007199254740991.9007199254740991')
+    if (!result.ok) expect.unreachable()
+    expect(result.value).toEqual({
+      kind: 'exact',
+      major: Number.MAX_SAFE_INTEGER,
+      minor: Number.MAX_SAFE_INTEGER,
+      patch: Number.MAX_SAFE_INTEGER,
+    })
+  })
+})
+
+describe('parseVersionSpec — oversized components', () => {
+  // Every arm that converts digits to numbers has to refuse the same
+  // magnitudes, otherwise a wildcard would admit a major an exact pin
+  // rejects and the two would disagree about the same project.
+  test.each([
+    '9007199254740992.0.0',
+    '1.9007199254740992.0',
+    '1.0.9007199254740992',
+    '9007199254740992.*',
+    '9007199254740992.0.*',
+    '1.9007199254740992.*',
+    '99999999999999999999.0.0',
+  ])('rejects %p', (input) => {
+    const result = parseVersionSpec(input)
+    if (result.ok) expect.unreachable()
+    expect(result.error.code).toBe('VERSION_COMPONENT_TOO_LARGE')
+  })
+
+  test('reports magnitude rather than form', () => {
+    const result = parseVersionSpec('9007199254740992.0.0')
+    if (result.ok) expect.unreachable()
+    expect(result.error.what).toContain('9007199254740991')
+    expect(result.error.code).not.toBe('INVALID_VERSION')
+  })
 })
 
 describe('parseVersionSpec — rejected forms', () => {

--- a/packages/engine/src/sources/facet/parse-version.ts
+++ b/packages/engine/src/sources/facet/parse-version.ts
@@ -1,5 +1,5 @@
-import type { VersionSpec } from '@agent-facets/protocol'
-import type { ParseResult } from './types.ts'
+import { isSafeVersionComponent, MAX_VERSION_COMPONENT, type VersionSpec } from '@agent-facets/protocol'
+import type { ParseErrorCode, ParseResult } from './types.ts'
 
 /**
  * Parse a version specifier string into a `VersionSpec`.
@@ -81,6 +81,8 @@ export function parseVersionSpec(input: string): ParseResult<VersionSpec> {
   // Major-wildcard: `<major>.*`
   const majorWildcardMatch = /^(\d+)\.\*$/.exec(input)
   if (majorWildcardMatch && majorWildcardMatch[1] !== undefined) {
+    const oversized = rejectOversized(input, [majorWildcardMatch[1]])
+    if (oversized) return oversized
     const major = Number.parseInt(majorWildcardMatch[1], 10)
     return ok({ kind: 'majorWildcard', major })
   }
@@ -88,6 +90,8 @@ export function parseVersionSpec(input: string): ParseResult<VersionSpec> {
   // Minor-wildcard: `<major>.<minor>.*`
   const minorWildcardMatch = /^(\d+)\.(\d+)\.\*$/.exec(input)
   if (minorWildcardMatch && minorWildcardMatch[1] !== undefined && minorWildcardMatch[2] !== undefined) {
+    const oversized = rejectOversized(input, [minorWildcardMatch[1], minorWildcardMatch[2]])
+    if (oversized) return oversized
     const major = Number.parseInt(minorWildcardMatch[1], 10)
     const minor = Number.parseInt(minorWildcardMatch[2], 10)
     return ok({ kind: 'minorWildcard', major, minor })
@@ -98,6 +102,8 @@ export function parseVersionSpec(input: string): ParseResult<VersionSpec> {
   // if/when needed, that's a follow-up change.
   const exactMatch = /^(\d+)\.(\d+)\.(\d+)$/.exec(input)
   if (exactMatch && exactMatch[1] !== undefined && exactMatch[2] !== undefined && exactMatch[3] !== undefined) {
+    const oversized = rejectOversized(input, [exactMatch[1], exactMatch[2], exactMatch[3]])
+    if (oversized) return oversized
     const major = Number.parseInt(exactMatch[1], 10)
     const minor = Number.parseInt(exactMatch[2], 10)
     const patch = Number.parseInt(exactMatch[3], 10)
@@ -107,14 +113,29 @@ export function parseVersionSpec(input: string): ParseResult<VersionSpec> {
   return err('INVALID_VERSION', `invalid version specifier "${input}"`, 'use 1.2.3, 1.*, 1.2.*, *, or latest')
 }
 
+/**
+ * Refuse a specifier whose shape is right but whose magnitude is not,
+ * before any component reaches `Number.parseInt`.
+ *
+ * The conversion is the lossy step: past `MAX_VERSION_COMPONENT` two
+ * different releases land on the same double and compare equal, so a
+ * specifier that got this far would resolve, order, and install as if it
+ * named a version it does not. Rejecting is the only honest answer —
+ * the parser cannot represent what it was asked to parse.
+ */
+function rejectOversized(input: string, components: readonly string[]): ParseResult<VersionSpec> | undefined {
+  if (components.every((component) => isSafeVersionComponent(component))) return undefined
+  return err(
+    'VERSION_COMPONENT_TOO_LARGE',
+    `version specifier "${input}" has a component larger than ${MAX_VERSION_COMPONENT}`,
+    `use version components no larger than ${MAX_VERSION_COMPONENT}`,
+  )
+}
+
 function ok(value: VersionSpec): ParseResult<VersionSpec> {
   return { ok: true, value }
 }
 
-function err(
-  code: 'EMPTY' | 'CARET_RANGE' | 'TILDE_RANGE' | 'COMPARATOR_RANGE' | 'OR_RANGE' | 'X_RANGE' | 'INVALID_VERSION',
-  what: string,
-  fix: string,
-): ParseResult<VersionSpec> {
+function err(code: ParseErrorCode, what: string, fix: string): ParseResult<VersionSpec> {
   return { ok: false, error: { code, what, fix } }
 }

--- a/packages/engine/src/sources/facet/types.ts
+++ b/packages/engine/src/sources/facet/types.ts
@@ -42,6 +42,13 @@ export type ParseErrorCode =
   | 'OR_RANGE'
   | 'X_RANGE'
   | 'INVALID_VERSION'
+  /**
+   * The specifier has a conforming shape but names a component the
+   * grammar cannot carry — see protocol's `MAX_VERSION_COMPONENT`.
+   * Distinct from `INVALID_VERSION` because the fix is different: the
+   * form was right, the number was too big.
+   */
+  | 'VERSION_COMPONENT_TOO_LARGE'
   | 'INVALID_REGISTRY_NAME'
   | 'UNKNOWN_SCHEME'
 

--- a/packages/protocol/src/__tests__/lockfile.test.ts
+++ b/packages/protocol/src/__tests__/lockfile.test.ts
@@ -252,6 +252,12 @@ describe('Lockfile02Schema — invalid lockfiles', () => {
     'v1.2.3',
     '1.2.3 ',
     ' 1.2.3',
+    // Conforming shape, unrepresentable magnitude: past 2^53 - 1 this
+    // version and the next one are the same double, so accepting it
+    // would let the installer confuse two distinct releases.
+    '9007199254740992.0.0',
+    '1.9007199254740992.0',
+    '1.0.9007199254740992',
   ])('version %p is rejected', (version) => {
     const input = {
       lockfileVersion: LOCKFILE_VERSION_0_2,
@@ -266,6 +272,25 @@ describe('Lockfile02Schema — invalid lockfiles', () => {
     }
     const result = Lockfile02Schema(input)
     expect(result).toBeInstanceOf(type.errors)
+  })
+
+  // The bound is inclusive: the largest exactly-representable component
+  // is a legal version, so the rejection above is about magnitude rather
+  // than about long version numbers in general.
+  test('version at the representable bound is accepted', () => {
+    const input = {
+      lockfileVersion: LOCKFILE_VERSION_0_2,
+      facets: {
+        'huge-version': {
+          source: { kind: 'git', url: 'github:a/b', commit: 'abcabcabcabcabcabcabcabcabcabcabcabcabca' },
+          version: '9007199254740991.0.0',
+          integrity: 'sha256:x',
+          assets: [],
+        },
+      },
+    }
+    const result = Lockfile02Schema(input)
+    expect(result).not.toBeInstanceOf(type.errors)
   })
 
   // A git source's commit is a REQUIRED field — a git entry without one

--- a/packages/protocol/src/__tests__/version-spec.test.ts
+++ b/packages/protocol/src/__tests__/version-spec.test.ts
@@ -1,7 +1,57 @@
 import { describe, expect, test } from 'bun:test'
-import { resolvesToLatest, satisfies, type VersionSpec } from '@agent-facets/protocol'
+import {
+  isSafeVersionComponent,
+  MAX_VERSION_COMPONENT,
+  resolvesToLatest,
+  satisfies,
+  type VersionSpec,
+} from '@agent-facets/protocol'
 
 const v = (major: number, minor: number, patch: number) => ({ major, minor, patch })
+
+describe('isSafeVersionComponent', () => {
+  test('accepts ordinary components', () => {
+    expect(isSafeVersionComponent('0')).toBe(true)
+    expect(isSafeVersionComponent('1')).toBe(true)
+    expect(isSafeVersionComponent('4294967296')).toBe(true)
+  })
+
+  test('accepts the largest representable component', () => {
+    expect(MAX_VERSION_COMPONENT).toBe(Number.MAX_SAFE_INTEGER)
+    expect(isSafeVersionComponent('9007199254740991')).toBe(true)
+  })
+
+  test('rejects the first component that cannot be told apart from its successor', () => {
+    // The bound is not arbitrary: these two distinct releases are the
+    // same double, which is precisely what the predicate exists to stop.
+    expect(Number('9007199254740992')).toBe(Number('9007199254740993'))
+    expect(isSafeVersionComponent('9007199254740992')).toBe(false)
+    expect(isSafeVersionComponent('9007199254740993')).toBe(false)
+  })
+
+  test('rejects components far above the bound', () => {
+    expect(isSafeVersionComponent('99999999999999999999')).toBe(false)
+  })
+
+  test('compares magnitude rather than digits', () => {
+    // Same length as the bound, lexically larger only in a later digit.
+    expect(isSafeVersionComponent('9007199254740990')).toBe(true)
+    expect(isSafeVersionComponent('9999999999999999')).toBe(false)
+  })
+
+  test('ignores leading zeros when judging magnitude', () => {
+    expect(isSafeVersionComponent('0000000000000000001')).toBe(true)
+    expect(isSafeVersionComponent('09007199254740992')).toBe(false)
+  })
+
+  test('rejects anything that is not a bare run of decimal digits', () => {
+    expect(isSafeVersionComponent('')).toBe(false)
+    expect(isSafeVersionComponent('1.2')).toBe(false)
+    expect(isSafeVersionComponent('-1')).toBe(false)
+    expect(isSafeVersionComponent('1e3')).toBe(false)
+    expect(isSafeVersionComponent(' 1')).toBe(false)
+  })
+})
 
 describe('satisfies — exact specifier', () => {
   const spec: VersionSpec = { kind: 'exact', major: 1, minor: 2, patch: 3 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -326,4 +326,4 @@ export {
 } from './schemas/project-manifest.ts'
 // version-spec grammar (versions as they appear inside artifacts)
 export type { VersionSpec } from './sources/version-spec.ts'
-export { resolvesToLatest, satisfies } from './sources/version-spec.ts'
+export { isSafeVersionComponent, MAX_VERSION_COMPONENT, resolvesToLatest, satisfies } from './sources/version-spec.ts'

--- a/packages/protocol/src/schemas/lockfile.ts
+++ b/packages/protocol/src/schemas/lockfile.ts
@@ -1,6 +1,7 @@
 import { type AssetType, validateAssetName } from '@agent-facets/common'
 import { type } from 'arktype'
 import { canonicalPrimaryPath, skillRootPath } from '../materialization/identity.ts'
+import { isSafeVersionComponent } from '../sources/version-spec.ts'
 import { MaterializationDispositionSchema } from './materialization.ts'
 
 /*
@@ -64,11 +65,23 @@ export const SUPPORTED_LOCKFILE_VERSIONS: readonly number[] = [LOCKFILE_VERSION_
  * returns) only models `M.N.P`. Aligning the schema with the parser
  * keeps both shapes in sync. Adding prerelease support means widening
  * both — see the open question in the engine-side parser.
+ *
+ * Each component is additionally required to be one the grammar can
+ * carry (see `isSafeVersionComponent`). The shape check alone would
+ * admit a digit run too large to survive the conversion to a number,
+ * and a lockfile is exactly where such a value would be read back and
+ * compared against a manifest specifier as if it were exact.
  */
-const LOCKED_VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+$/
+const LOCKED_VERSION_RE = /^([0-9]+)\.([0-9]+)\.([0-9]+)$/
 const LockedVersion = type('string').narrow(
-  (s, ctx) => LOCKED_VERSION_RE.test(s) || ctx.mustBe('an exact M.N.P version string'),
+  (s, ctx) => isExactLockedVersion(s) || ctx.mustBe('an exact M.N.P version string with components below 2^53'),
 )
+
+function isExactLockedVersion(value: string): boolean {
+  const match = LOCKED_VERSION_RE.exec(value)
+  if (match === null) return false
+  return match.slice(1).every((component) => isSafeVersionComponent(component))
+}
 
 /**
  * A locked git commit SHA. Narrowed so a commitless or non-SHA git source

--- a/packages/protocol/src/sources/version-spec.ts
+++ b/packages/protocol/src/sources/version-spec.ts
@@ -26,6 +26,49 @@ export type VersionSpec =
   | { kind: 'latest' }
 
 /**
+ * The largest value a single version component may take.
+ *
+ * `VersionSpec` carries components as JavaScript numbers, and every
+ * consumer of this grammar compares and displays them as numbers. Above
+ * `Number.MAX_SAFE_INTEGER` that representation stops being faithful:
+ * `9007199254740992` and `9007199254740993` are the same double, so two
+ * distinct releases would compare equal and one would silently install
+ * in place of the other. The grammar therefore refuses those components
+ * rather than admitting values it cannot tell apart.
+ *
+ * This is a bound on what the *grammar* accepts, not a limit any real
+ * release approaches — a project would have to publish a major version
+ * of nine quadrillion to reach it.
+ */
+export const MAX_VERSION_COMPONENT = Number.MAX_SAFE_INTEGER
+
+/** `MAX_VERSION_COMPONENT` as digits, for magnitude comparison. */
+const MAX_VERSION_COMPONENT_DIGITS = String(MAX_VERSION_COMPONENT)
+
+/**
+ * True when a run of decimal digits names a version component this
+ * grammar can carry.
+ *
+ * Takes the digits rather than a number on purpose: converting first is
+ * exactly the lossy step this guards against, so the comparison is done
+ * on the string. Equal-length digit runs compare identically whether
+ * read lexicographically or numerically, which is what makes the
+ * length-then-lexical test below a faithful magnitude check.
+ *
+ * Input that is not a bare run of decimal digits is not a component of
+ * this grammar at all and is rejected here too, so a caller cannot use
+ * this as a "safe" verdict on something it never validated.
+ */
+export function isSafeVersionComponent(digits: string): boolean {
+  if (!/^[0-9]+$/.test(digits)) return false
+  const significant = digits.replace(/^0+(?=[0-9])/, '')
+  if (significant.length !== MAX_VERSION_COMPONENT_DIGITS.length) {
+    return significant.length < MAX_VERSION_COMPONENT_DIGITS.length
+  }
+  return significant <= MAX_VERSION_COMPONENT_DIGITS
+}
+
+/**
  * True when a `VersionSpec` resolves to "the highest published version"
  * (no constraint). Used by resolvers to collapse `*`, `latest`, and the
  * implicit bare-name spec into a single registry-resolution branch.


### PR DESCRIPTION
### Why

`facet update` is the first command whose entire job is comparing versions — deciding which release is newer and whether a locked version still satisfies a manifest range. That comparison breaks silently above `2^53 − 1`: `9007199254740992` and `9007199254740993` are the same double, so the installer could act on a version it never actually resolved. The bound lands now because the command that depends on it does.

Separately, dry-run no-ops were reporting only the reason a run applied nothing, without showing the plan that reason was derived from. A user told "all facets are current" or "ranges permit none" had no way to check which facet was pinned, which was already current, or which range was holding one back without re-running without `--dry-run`.

### Details

**Version component bound (`@agent-facets/protocol`, engine, lockfile schema)**

`isSafeVersionComponent` and `MAX_VERSION_COMPONENT` are added to the protocol package and exported from its public surface. The check is done on the raw digit string rather than after conversion — converting first is the lossy step being guarded against. Equal-length digit runs compare identically lexicographically and numerically, so a length-then-lexical comparison is a faithful magnitude check without touching `Number`.

The lockfile schema's `LockedVersion` pattern is widened to capture groups so each component can be passed to `isSafeVersionComponent` before the schema accepts the value. `parseLockedVersion` and `parseExactVersion` in the engine apply the same guard. Every specifier arm in `parseVersionSpec` (exact, major-wildcard, minor-wildcard) calls `rejectOversized` before converting digits to numbers. The error code is `VERSION_COMPONENT_TOO_LARGE`, distinct from `INVALID_VERSION`, because the form was right and the fix is different.

**Dry-run plan display**

`facet update --dry-run` now always renders the full plan before printing the no-op reason, even when nothing would move. A run without `--dry-run` continues to print the reason alone — there was never a plan to review. The spec and docs are updated to match: the dry-run no-op scenario now requires the plan to be shown first, and a new scenario covers the terse non-dry-run path.

**Selection logic moved to the engine**

`candidateRows`, `defaultSelections`, `classifyNoOp`, `UpdateCandidate`, `UpdateMode`, and `UpdateNoOp` have moved from the CLI's `selection.ts` into a new `packages/engine/src/install/update/selection.ts` and are re-exported through the engine's public index. The CLI's `selection.ts` now re-exports them from the engine rather than restating them. Plan fixtures used by selection tests are extracted into a shared `plan-fixtures.ts` in the engine, and the selection tests themselves move there too.

**Update selection refusal as a returned value, not a thrown one**

`UpdateSelectionFailure` is added as a new arm of `InstallViewResult`. The update command's view driver now returns `{ ok: false, updateSelectionFailure: result.failure }` instead of throwing `UpdateSelectionRejected`. The `InstallView` exits cleanly for any structured result — success or failure — and only rejects `waitUntilExit()` when the driver throws. The `catch {}` blocks that were swallowing genuine crashes in `install`, `add`, `remove`, and `update` are removed; unmodelled failures now propagate to the CLI's top level as unexpected errors.

**Short-flag collision detection**

`findShortFlagCollisions` and `describeShortFlagCollision` are added to `commands.ts`. `run.ts` calls the validator before building the alias map, because building the map is what destroys the evidence — a duplicate short alias silently overwrites the first claimant. A collision in the command table throws an internal error rather than producing a user-facing parse failure.

**Discovery failure ordering relaxed**

The requirement that concurrent lookup failures be reported in project order is dropped. Every failure ends the run identically with no actionable plan, so pinning the choice would constrain how lookups are batched for no benefit the user can act on. The spec scenario is renamed and the test updated to assert only that discovery fails with one structured failure, not which one.

**Prompt and documentation updates**

`facets.json` ownership descriptions in `usage.txt`, `overview.txt`, and the instructions tests are updated to include `facet update --latest` alongside `facet add` and `facet remove`, since `--latest` is the only update invocation that rewrites the manifest.

### Verification

CI — new and updated unit tests cover the version bound at every layer (protocol predicate, version spec parser, lockfile schema, locked-version parser, exact-version parser, adapter specifier parser, source parser), the dry-run plan display for each no-op reason, the selection refusal result path, the crash propagation path, and the short-flag collision detector against the real command registry.