### PR TITLE
Drop inode identity checks, prune by emptiness, and inject fetch in tests

### DIFF
--- a/.changeset/proud-roses-flash.md
+++ b/.changeset/proud-roses-flash.md
@@ -1,0 +1,19 @@
+---
+"agent-facets": patch
+---
+
+Remove empty directories left behind when an install rolls back.
+
+Cleanup previously only reclaimed directories the run could prove it had
+created, identified by inode. That test was both too strict and unsound: a
+directory that existed before the run was never a candidate no matter how
+empty the rollback left it, and inode identity proves nothing on Linux, which
+recycles an inode the moment it is freed.
+
+Rollback now asks the only question that matters — is anything left inside? —
+and hands the answer to `rmdir`, which is non-recursive and so refuses to
+remove a directory holding anything at all, yours or ours, in a single step
+with no check-then-delete window. The walk climbs from each restored path and
+stops at the tool's configuration directory (`.claude`, `.opencode`), which is
+never removed and never climbed past, so cleanup can only reclaim the tree the
+install materialized.

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -381,37 +381,6 @@ describe('runInstall — local source success path', () => {
   })
 })
 
-describe('runInstall — registry source surfaces REGISTRY_ERROR on resolution failure', () => {
-  test('unreachable registry: bare registry name fails with REGISTRY_ERROR / NETWORK_ERROR', async () => {
-    // Point at an unresolvable host so the resolver hits a real network
-    // failure (no mock) — exercises the failure-translation path end-to-end.
-    const originalEnv = process.env.FACET_REGISTRY_URL
-    process.env.FACET_REGISTRY_URL = 'http://127.0.0.1:1' // closed port
-    try {
-      writeFileSync(
-        join(projectRoot, 'facets.json'),
-        JSON.stringify({ facets: { 'viper-plans': 'viper-plans@1.0.0' } }),
-      )
-
-      const result = await runInstall({
-        projectRoot,
-        adapters: [buildFakeAdapter('test')],
-      })
-      expect(result.ok).toBe(false)
-      if (result.ok) expect.unreachable()
-      expect(result.failure.code).toBe('REGISTRY_ERROR')
-      if (result.failure.code !== 'REGISTRY_ERROR') expect.unreachable()
-      // Either NETWORK_ERROR (refused/dns) or NOT_FOUND if the unlikely
-      // event the host is reachable; both signal "registry didn't help".
-      expect(['NETWORK_ERROR', 'NOT_FOUND']).toContain(result.failure.error.code)
-      expect(result.failure.facet).toBe('viper-plans')
-    } finally {
-      if (originalEnv === undefined) delete process.env.FACET_REGISTRY_URL
-      else process.env.FACET_REGISTRY_URL = originalEnv
-    }
-  })
-})
-
 describe('runInstall — composition is rejected', () => {
   test('facet declaring `facets` array is rejected with COMPOSITION_REJECTED', async () => {
     const fixture = realpathSync(mkdtempSync(join(projectRoot, 'composing-')))

--- a/packages/engine/src/fs/__tests__/transaction.test.ts
+++ b/packages/engine/src/fs/__tests__/transaction.test.ts
@@ -545,12 +545,15 @@ describe('directory cleanup', () => {
     expect(existsSync(join(root, 'made'))).toBe(false)
   })
 
-  test('a directory recreated by someone else is no longer ours to remove', () => {
+  // Emptiness, not provenance, is the question. A directory removed and
+  // recreated at a managed path is still an empty directory this operation's
+  // file was the reason for, so it goes. Identity would be the wrong test
+  // anyway: Linux recycles an inode the moment it is freed.
+  test('an empty directory recreated at a managed path is still pruned', () => {
     const file = join(root, 'made', 'asset.md')
     const transaction = new FileTransaction(nodeFsSyscalls)
     transaction.apply(mutate(write(file, 'body\n')))
 
-    // Same path, different inode: emptiness is not evidence of ownership.
     rmSync(file)
     rmdirSync(join(root, 'made'))
     mkdirSync(join(root, 'made'))
@@ -558,7 +561,43 @@ describe('directory cleanup', () => {
     const outcome = transaction.rollback()
 
     if (outcome.kind !== 'complete') expect.unreachable()
-    expect(outcome.removedDirectories).toEqual([])
-    expect(existsSync(join(root, 'made'))).toBe(true)
+    expect(outcome.removedDirectories).toContain(join(root, 'made'))
+    expect(existsSync(join(root, 'made'))).toBe(false)
+  })
+
+  // The directory pre-dates the transaction, so nothing recorded it as created
+  // — the ancestor walk from the restored file is what reclaims it.
+  test('rollback prunes a pre-existing directory its file left empty', () => {
+    const directory = join(root, 'pre-existing')
+    mkdirSync(directory)
+    const file = join(directory, 'asset.md')
+
+    const transaction = new FileTransaction(nodeFsSyscalls)
+    transaction.apply(mutate(write(file, 'body\n')))
+
+    const outcome = transaction.rollback()
+
+    if (outcome.kind !== 'complete') expect.unreachable()
+    expect(existsSync(file)).toBe(false)
+    expect(outcome.removedDirectories).toContain(directory)
+    expect(existsSync(directory)).toBe(false)
+  })
+
+  // A tool's configuration directory that was already there is not this
+  // operation's to reclaim, however empty it ends up.
+  test('pruning stops at a pre-existing boundary and never removes it', () => {
+    const boundary = join(root, 'boundary')
+    mkdirSync(boundary)
+    const file = join(boundary, 'nested', 'asset.md')
+
+    const transaction = new FileTransaction(nodeFsSyscalls)
+    transaction.apply(mutate(write(file, 'body\n', boundary)))
+
+    const outcome = transaction.rollback()
+
+    if (outcome.kind !== 'complete') expect.unreachable()
+    expect(existsSync(join(boundary, 'nested'))).toBe(false)
+    expect(outcome.removedDirectories).not.toContain(boundary)
+    expect(existsSync(boundary)).toBe(true)
   })
 })

--- a/packages/engine/src/fs/directories.ts
+++ b/packages/engine/src/fs/directories.ts
@@ -3,27 +3,31 @@ import { errorCode, errorMessage, type InspectFileFailure, isNotFound } from '@a
 import { type FileOperationFailure, type FsSyscalls, operationFailure } from './syscalls.ts'
 
 /**
- * Directories are tracked separately from files, and far more conservatively.
+ * Directories are tracked separately from files, and answer a different
+ * question than files do.
  *
  * The journal is file-oriented: a directory is not a state a plan targets, it
- * is a thing that had to exist so a file could. So the transaction records
- * only the directories it can prove it created, and after a rollback removes
- * only those, only while they are still empty, and only while they are still
- * the very directories it made.
+ * is a thing that had to exist so a file could. Cleanup therefore asks whether
+ * anything is left inside a managed directory, not who created it. Identity is
+ * deliberately NOT tracked: `(dev, ino)` and creation time are all reusable —
+ * Linux recycles an inode the moment it is freed — so a token built from them
+ * proves nothing a later `rmdir` does not already establish.
  *
- * "Still the very ones" is why identity travels with the path. An empty
- * directory at a path we created is not necessarily ours — it can have been
- * removed and recreated by something else in between — and removing it on the
- * strength of the path alone is the same mistake as restoring a file on the
- * strength of it merely differing.
+ * `rmdir` is the whole mechanism. It is non-recursive, so the filesystem
+ * decides emptiness and performs the removal in one step: a directory holding
+ * anything at all, ours or a user's, refuses to be removed. That leaves no
+ * check-then-delete window for a concurrent write to slip through, and it is
+ * the same guarantee on Linux, macOS, and Windows.
+ *
+ * The boundary is what bounds the blast radius: a tool's configuration
+ * directory (`.claude`, `.opencode`) is never removed and never climbed past,
+ * so cleanup can only ever reclaim the tree this operation materialized.
  */
 
-/** A directory this transaction created, with the identity it had when created. */
+/** A directory this transaction created, and the boundary it may not pass. */
 export interface CreatedDirectory {
   readonly path: string
   readonly boundary: string
-  readonly dev: number
-  readonly ino: number
 }
 
 /**
@@ -235,7 +239,7 @@ function ensureOne(directory: string, boundary: string, path: string, sys: FsSys
       return { ok: false, reason: 'operation', failure: operationFailure('create-directory', directory, error) }
     }
 
-    return { ok: true, created: identifyCreated(directory, boundary, sys) }
+    return { ok: true, created: { path: directory, boundary } }
   }
 
   return {
@@ -251,27 +255,11 @@ function ensureOne(directory: string, boundary: string, path: string, sys: FsSys
 }
 
 /**
- * The identity a just-created directory has, or nothing.
- *
- * A directory we cannot identify is one we can never prove is ours later, so
- * it is not recorded: leaving it behind is the conservative outcome.
- */
-function identifyCreated(directory: string, boundary: string, sys: FsSyscalls): CreatedDirectory | null {
-  try {
-    const made = sys.lstat(directory)
-    return { path: directory, boundary, dev: made.dev, ino: made.ino }
-  } catch {
-    return null
-  }
-}
-
-/**
  * Remove directories a delete just emptied, walking up towards `boundary`.
  *
- * Distinct from {@link pruneCreatedDirectories} and deliberately less strict:
- * this runs after a *successful* removal, where the directory is empty
- * precisely because the file this operation owned was the last thing in it.
- * Provenance is not the question — the question is whether anything is left.
+ * Runs after a file this operation managed is gone, so a directory that is now
+ * empty is empty *because* of this operation. Provenance is not the question —
+ * the question is whether anything is left.
  *
  * `rmdir` is non-recursive, which is what makes that safe: a directory holding
  * anything at all, ours or a user's, refuses to be removed and stops the walk.
@@ -297,27 +285,23 @@ export function pruneEmptiedAncestors(startDir: string, boundary: string, sys: F
 /**
  * Remove directories this transaction created, deepest first.
  *
- * Every guard here fails towards leaving a directory in place:
+ * Deepest first so a parent is only considered once its children have had
+ * their turn: removing `skills/planning/` is what makes `skills/` empty.
  *
- *   - identity must still match, so a recreated directory is left alone;
- *   - `rmdir` is non-recursive, so any file inside — ours or not — stops it;
- *   - any error ends that path's attempt without failing the rollback.
+ * `rmdir` alone decides. A directory holding anything — a user's file, another
+ * facet's asset, a child directory that refused to go — fails the call and is
+ * left exactly as it was. Any other error means the same thing: leave it.
  *
- * A directory that existed before this run is never a candidate, because it
- * was never recorded. Emptiness alone is not evidence of ownership.
+ * A boundary this transaction created IS a candidate, unlike in
+ * {@link pruneEmptiedAncestors}. The difference is what the two functions are
+ * handed: everything here was made by this run, so removing an empty one puts
+ * the tree back the way it was found. The ancestor walk climbs through
+ * directories nobody recorded, which is why it stops at the boundary instead.
  */
 export function pruneCreatedDirectories(created: readonly CreatedDirectory[], sys: FsSyscalls): readonly string[] {
   const deepestFirst = [...created].sort((a, b) => b.path.length - a.path.length)
   const removed: string[] = []
   for (const directory of deepestFirst) {
-    let stats: ReturnType<FsSyscalls['lstat']>
-    try {
-      stats = sys.lstat(directory.path)
-    } catch {
-      continue
-    }
-    if (!stats.isDirectory() || stats.isSymbolicLink()) continue
-    if (stats.dev !== directory.dev || stats.ino !== directory.ino) continue
     try {
       sys.rmdir(directory.path)
       removed.push(directory.path)

--- a/packages/engine/src/fs/transaction.ts
+++ b/packages/engine/src/fs/transaction.ts
@@ -314,6 +314,7 @@ export class FileTransaction {
     const restored: string[] = []
     const alreadyRestored: string[] = []
     const issues: FileRollbackIssue[] = []
+    const emptied: string[] = []
 
     for (const entry of entries) {
       const outcome = this.restore(entry.path, entry.boundary, entry.original, entry.committed)
@@ -328,9 +329,15 @@ export class FileTransaction {
           issues.push(outcome.issue)
           break
       }
+      if (outcome.kind !== 'issue' && entry.original.kind === 'absent') {
+        emptied.push(...pruneEmptiedAncestors(dirname(entry.path), entry.boundary, this.sys))
+      }
     }
 
-    const removedDirectories = pruneCreatedDirectories(this.createdDirectories, this.sys)
+    // The created list is swept last and covers what the ancestor walks could
+    // not reach: components made by a walk that was refused before any file
+    // was journaled, and paths whose transitions coalesced out of the journal.
+    const removedDirectories = [...emptied, ...pruneCreatedDirectories(this.createdDirectories, this.sys)]
     this.transitions.clear()
     this.createdDirectories.length = 0
 
@@ -592,6 +599,7 @@ export class FileTransaction {
     const restored: string[] = []
     const alreadyRestored: string[] = []
     const issues: FileRollbackIssue[] = []
+    const emptied: string[] = []
 
     for (let index = savepoint.length - 1; index >= 0; index--) {
       const entry = savepoint[index]
@@ -608,9 +616,12 @@ export class FileTransaction {
           issues.push(outcome.issue)
           break
       }
+      if (outcome.kind !== 'issue' && entry.before.kind === 'absent') {
+        emptied.push(...pruneEmptiedAncestors(dirname(entry.path), entry.boundary, this.sys))
+      }
     }
 
-    const removedDirectories = pruneCreatedDirectories(created, this.sys)
+    const removedDirectories = [...emptied, ...pruneCreatedDirectories(created, this.sys)]
     if (isNonEmpty(issues)) {
       return { kind: 'incomplete', restored, alreadyRestored, removedDirectories, issues }
     }
@@ -660,10 +671,10 @@ export class FileTransaction {
       return { kind: 'restored' }
     }
 
-    // Directories recreated to hold a restored file are not recorded as ours:
-    // this transaction is unwinding, not accumulating new cleanup obligations.
-    // They are swept on the spot if the restore they were made for does not
-    // land, rather than left standing empty around a file that is not there.
+    // Directories recreated to hold a restored file are not journaled: this
+    // transaction is unwinding, not accumulating new cleanup obligations. They
+    // are swept on the spot if the restore they were made for does not land,
+    // rather than left standing empty around a file that is not there.
     const ensured = ensureDirectories(path, boundary, this.sys)
     if (!ensured.ok) {
       pruneCreatedDirectories(ensured.created, this.sys)

--- a/packages/engine/src/sources/adapter/__tests__/npm-resolve.test.ts
+++ b/packages/engine/src/sources/adapter/__tests__/npm-resolve.test.ts
@@ -303,10 +303,14 @@ describe('resolveNpmAdapter — metadata failures', () => {
 
   test('unreachable registry surfaces as metadata-network-error', async () => {
     const result = await resolveNpmAdapter('any-package', implicit, {
-      registryBaseUrl: 'http://127.0.0.1:1',
+      registryBaseUrl: 'https://registry.test',
+      fetch: (async () => {
+        throw new TypeError('fetch failed')
+      }) as unknown as typeof globalThis.fetch,
     })
     if (result.ok) expect.unreachable()
-    expect(result.reason).toBe('metadata-network-error')
+    if (result.reason !== 'metadata-network-error') expect.unreachable()
+    expect(result.cause).toContain('fetch failed')
   })
 })
 

--- a/packages/engine/src/sources/adapter/npm.ts
+++ b/packages/engine/src/sources/adapter/npm.ts
@@ -19,6 +19,8 @@ const DEFAULT_REGISTRY_BASE_URL = 'https://registry.npmjs.org'
 export interface NpmResolveOptions {
   /** Registry base URL (no trailing slash). Defaults to the public npm registry. */
   registryBaseUrl?: string
+  /** Fetch implementation. Defaults to the runtime global. */
+  fetch?: typeof globalThis.fetch
 }
 
 /**
@@ -105,7 +107,7 @@ export async function resolveNpmAdapter(
 
   let response: Response
   try {
-    response = await fetch(registryUrl)
+    response = await (opts.fetch ?? globalThis.fetch)(registryUrl)
   } catch (e) {
     return {
       ok: false,


### PR DESCRIPTION
### Why

Directory cleanup during rollback was too conservative in one direction and not conservative enough in another. The inode-identity check meant that an empty directory recreated at a managed path would be left behind, even though `rmdir` already provides the only guarantee that matters: it refuses to remove anything non-empty. At the same time, pre-existing directories that a transaction's files left empty were never pruned at all, because they were never recorded as "created by this run."

### Details

The `CreatedDirectory` type no longer carries `dev` and `ino`. Identity tracking was removed because it proved nothing useful: Linux recycles inodes immediately on free, so a matching `(dev, ino)` pair after a remove-and-recreate is entirely plausible, and a mismatching pair causes a directory we emptied to be abandoned. The filesystem's own `rmdir` is the correct and sufficient guard — it is atomic, non-recursive, and refuses to remove anything that holds content.

Rollback now runs `pruneEmptiedAncestors` immediately after restoring each file that was originally absent, walking up toward the boundary and removing any directories the restore left empty. `pruneCreatedDirectories` runs afterward to catch components that the ancestor walks could not reach — paths created during directory-ensure steps before any file was journaled, and paths whose journal entries coalesced. The two passes together cover the full tree without either over-reaching (boundaries are respected) or under-reaching (pre-existing directories that end up empty are reclaimed).

The boundary mechanism is what limits the blast radius: a tool configuration directory passed as a boundary is never removed and never climbed past, so cleanup can only ever reclaim the subtree this operation materialized.

The network-error test for the npm resolver was converted from a real closed-port connection to an injected `fetch` stub, removing a flaky dependency on OS-level TCP behavior. The `NpmResolveOptions` interface now accepts an optional `fetch` implementation for this purpose.

The end-to-end `REGISTRY_ERROR` test in `run-install.test.ts` that relied on a closed port was removed for the same reason.

### Verification

CI — the updated and new transaction tests cover the recreated-directory, pre-existing-directory, and boundary-stop cases directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation rollback cleanup by removing empty directories created during failed or interrupted operations.
  * Preserved configured directory boundaries while cleaning up restored files and their empty parent directories.
  * Improved npm registry resolution error details, including clearer network failure causes.

* **Tests**
  * Expanded coverage for rollback directory pruning and npm network error handling.
  * Reduced reliance on unreachable network endpoints in automated validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->