### PR TITLE
Bump viper-plans to 1.3.1

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "facets": {
-    "viper-plans": "1.3.0",
+    "viper-plans": "1.3.1",
     "cowsay": "1.0.1",
     "@agentfacets/review-openspec-design": "latest",
     "@agentfacets/openspec-adversary": "3.2.2",

--- a/facets.lock
+++ b/facets.lock
@@ -668,8 +668,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.3.0",
-      "integrity": "sha256:be85be9bc09b87be4ffca314ec83cd317589a3da573ec73abc28e0cdda0e2ab2",
+      "version": "1.3.1",
+      "integrity": "sha256:fb53a7239e3bf13114ec8196231e3d11d9ae126aa1a55eaaa23a1848c8e80c94",
       "assets": [
         {
           "scope": "project",


### PR DESCRIPTION
### Why

Bumps `viper-plans` from version `1.3.0` to `1.3.1`.

### Verification

CI