### PR TITLE
Fix cold-cache git install crash caused by `assets` vs `files` manifest shape mismatch

### DIFF
--- a/.changeset/wet-cases-wear.md
+++ b/.changeset/wet-cases-wear.md
@@ -1,0 +1,28 @@
+---
+"agent-facets": patch
+---
+
+Fix the crash when installing a facet from a git source for the first time.
+
+Installing a git-sourced facet on a cold cache aborted with
+`TypeError: Object.entries requires that input parameter not be null or
+undefined` instead of installing anything. The clone succeeded and the build
+succeeded; the run died on the step that commits the built content to the
+cache.
+
+The build pipeline emits the current `0.2` archive format, which records one
+hash per archive entry under `files`. The git install path re-read that
+output as the legacy `0.1` shape, whose map is named `assets` — a member the
+current format does not have — and handed the resulting `undefined` to the
+cache write, which audits every entry it is given.
+
+The cache write now takes the integrity and the complete per-entry hash map
+straight from the build result rather than re-deriving them by re-parsing the
+build manifest, so this call site is no longer coupled to one archive-format
+shape. Nothing about which files are audited or what is written changed: the
+same entries are verified, and the cache sidecar records the full set,
+including supplementary files that no asset owns.
+
+Only fresh clones were affected — a first install, or one whose cache slot
+was cold or evicted. Installs served by an audited cache hit, and facets from
+the registry or a local path, never took this path.

--- a/packages/engine/src/__tests__/cache.test.ts
+++ b/packages/engine/src/__tests__/cache.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { BuildManifest } from '@agent-facets/protocol'
+import type { LegacyBuildManifest } from '@agent-facets/protocol'
 import { assembleTar, computeContentHash } from '@agent-facets/protocol'
 import {
   auditCacheSlot,
@@ -264,7 +264,10 @@ describe('cacheSlotIsDir', () => {
 })
 
 /**
- * Build a real `BuildManifest` for the given files. Per-asset hashes
+ * Build a real legacy (`0.1`) build manifest for the given files. The
+ * version is deliberate: `cachePutVerified` is format-neutral — it takes a
+ * `{ integrity, fileHashes }` pair, not a manifest — so these tests pin the
+ * legacy `assets` map to prove the older shape still feeds it. Per-asset hashes
  * are computed honestly via `computeContentHash`. The top-level
  * `integrity` is a stable opaque value derived from the file set —
  * `cachePutVerified` does not recompute it; it only string-compares
@@ -272,7 +275,7 @@ describe('cacheSlotIsDir', () => {
  * same value as `computedIntegrity` for the success case, or a
  * different value to exercise the facet-level mismatch arm.
  */
-function buildManifestFor(staging: string, files: Record<string, string>): BuildManifest {
+function buildManifestFor(staging: string, files: Record<string, string>): LegacyBuildManifest {
   const assets: Record<string, string> = {}
   for (const [path, content] of Object.entries(files)) {
     const fullPath = join(staging, path)
@@ -650,7 +653,7 @@ describe('cachePutVerified path traversal defense', () => {
     const id: CacheIdentity = { kind: 'registry', name: 'traversal', version: '1.0.0' }
     const staging = cacheStagingDir()
     writeFileSync(join(staging, 'facet.json'), '{"name":"traversal","version":"1.0.0"}')
-    const manifest: BuildManifest = {
+    const manifest: LegacyBuildManifest = {
       facetVersion: 0.1,
       archive: 'archive.tar.gz',
       integrity: 'sha256:fake',
@@ -685,7 +688,7 @@ describe('cachePutVerified path traversal defense', () => {
     const id: CacheIdentity = { kind: 'registry', name: 'abs-path', version: '1.0.0' }
     const staging = cacheStagingDir()
     writeFileSync(join(staging, 'facet.json'), '{"name":"abs-path","version":"1.0.0"}')
-    const manifest: BuildManifest = {
+    const manifest: LegacyBuildManifest = {
       facetVersion: 0.1,
       archive: 'archive.tar.gz',
       integrity: 'sha256:fake',

--- a/packages/engine/src/__tests__/run-install.test.ts
+++ b/packages/engine/src/__tests__/run-install.test.ts
@@ -10,7 +10,7 @@ import {
   planSkillBundleInstall,
   planSkillBundleRemoval,
 } from '@agent-facets/adapter'
-import type { BuildManifest, Lockfile02 } from '@agent-facets/protocol'
+import type { LegacyBuildManifest, Lockfile02 } from '@agent-facets/protocol'
 import {
   CURRENT_LOCKFILE_VERSION,
   CurrentLockfileSchema,
@@ -936,7 +936,7 @@ function seedCacheSlotForGit(
   const computed = computeDirIntegrity(staging, ['facet.json', 'skills/planning/SKILL.md'])
   if (!computed.ok) throw new Error('test bug: staged fixture unreadable')
   const integrity = computed.integrity
-  const manifest: BuildManifest = {
+  const manifest: LegacyBuildManifest = {
     facetVersion: 0.1,
     archive: 'archive.tar.gz',
     integrity,

--- a/packages/engine/src/install/__tests__/materialize-version.test.ts
+++ b/packages/engine/src/install/__tests__/materialize-version.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { BuildManifest } from '@agent-facets/protocol'
+import type { LegacyBuildManifest } from '@agent-facets/protocol'
 import type { CacheIdentity } from '../../cache/types.ts'
 import type { RegistryMetadata, RegistryResult } from '../../registry/types.ts'
 
@@ -48,7 +48,7 @@ const { cachePath, cachePutVerified, cacheStagingDir, computeDirIntegrity, readC
 
 interface Content {
   dir: string
-  manifest: BuildManifest
+  manifest: LegacyBuildManifest
   integrity: string
 }
 
@@ -61,7 +61,7 @@ function makeContent(parent: string, name: string, version: string, skillBody?: 
   writeFileSync(join(dir, 'skills/planning/SKILL.md'), skillBody ?? `# planning ${version}\n`)
   const computed = computeDirIntegrity(dir, ['facet.json', 'skills/planning/SKILL.md'])
   if (!computed.ok) throw new Error('test bug: fixture content unreadable')
-  const manifest: BuildManifest = {
+  const manifest: LegacyBuildManifest = {
     facetVersion: 0.1,
     archive: 'archive.tar.gz',
     integrity: computed.integrity,
@@ -307,7 +307,7 @@ describe('materializeVersion — confirming-miss', () => {
 
   test('a manifest listing an asset the download did not deliver fails as an asset integrity failure', async () => {
     const content = makeContent(fakeHome, 'cowsay', '0.2.0')
-    const manifestWithGhost: BuildManifest = {
+    const manifestWithGhost: LegacyBuildManifest = {
       ...content.manifest,
       assets: {
         ...content.manifest.assets,

--- a/packages/engine/src/install/__tests__/run-install.chain.test.ts
+++ b/packages/engine/src/install/__tests__/run-install.chain.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ADAPTER_API_VERSION } from '@agent-facets/adapter/api-version'
 import { isNonEmpty } from '@agent-facets/common'
-import type { BuildManifest, CurrentBuildManifest, Lockfile02Facet, ProjectFacetEntry } from '@agent-facets/protocol'
+import type {
+  CurrentBuildManifest,
+  LegacyBuildManifest,
+  Lockfile02Facet,
+  ProjectFacetEntry,
+} from '@agent-facets/protocol'
 import { LOCKFILE_VERSION_0_2 } from '@agent-facets/protocol'
 import type { Addition, InstallOperation } from '../types.ts'
 
@@ -130,7 +135,7 @@ function seedRegistrySlot(
   if (!computed.ok) throw new Error('test bug: staged fixture unreadable')
   const skillIntegrity = computed.assetHashes['skills/planning/SKILL.md']
   if (skillIntegrity === undefined) throw new Error('test bug: fixture has no planning skill')
-  const manifest: BuildManifest = {
+  const manifest: LegacyBuildManifest = {
     facetVersion: 0.1,
     archive: 'archive.tar.gz',
     integrity: computed.integrity,

--- a/packages/engine/src/install/commit/__tests__/resolve-git.test.ts
+++ b/packages/engine/src/install/commit/__tests__/resolve-git.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { cachePath, cacheSlotIsDir, readCachedIntegrity } from '../../../cache/index.ts'
+import { resolveGitFacet } from '../resolve-git.ts'
+
+/**
+ * Cold-cache git resolution against a real local repository.
+ *
+ * The whole point of this suite is that NOTHING is stubbed on the path
+ * under test: a genuine `git clone` (over `file://`, so it runs offline
+ * with no network or auth), a genuine build, and a genuine verified cache
+ * put. That combination is what a user's first install of a git facet
+ * does, and it is the one path where a build-manifest-shape mismatch
+ * between the producer and the cache write surfaces.
+ */
+
+const FACET_NAME = 'viper-plans'
+const FACET_VERSION = '0.1.0'
+const SKILL_BODY = '# planning\n'
+const README_BODY = '# viper-plans\n'
+
+let fixtureRepo: string
+let initialCommit: string
+let facetDir: string
+let originalFacetDir: string | undefined
+
+function git(args: string[], cwd?: string): { stdout: string; ok: boolean } {
+  const result = Bun.spawnSync(['git', ...args], {
+    cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' } as Record<string, string>,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return { stdout: result.stdout.toString().trim(), ok: result.exitCode === 0 }
+}
+
+beforeAll(() => {
+  fixtureRepo = realpathSync(mkdtempSync(join(tmpdir(), 'resolve-git-commit-fixture-')))
+  // A README declared in `files` makes the fixture exercise the COMPLETE
+  // `0.2` hash map: an archive-only supplementary entry that no asset owns,
+  // so a primary-asset-only subset would be visibly short in the sidecar.
+  writeFileSync(
+    join(fixtureRepo, 'facet.json'),
+    JSON.stringify({
+      name: FACET_NAME,
+      version: FACET_VERSION,
+      files: ['README.md'],
+      skills: { planning: { description: 'planning skill' } },
+    }),
+  )
+  writeFileSync(join(fixtureRepo, 'README.md'), README_BODY)
+  mkdirSync(join(fixtureRepo, 'skills/planning'), { recursive: true })
+  writeFileSync(join(fixtureRepo, 'skills/planning/SKILL.md'), SKILL_BODY)
+
+  git(['init', '-q', '-b', 'main'], fixtureRepo)
+  git(['config', 'user.email', 'test@example.com'], fixtureRepo)
+  git(['config', 'user.name', 'Test'], fixtureRepo)
+  git(['add', '.'], fixtureRepo)
+  git(['commit', '-q', '-m', 'initial'], fixtureRepo)
+  initialCommit = git(['rev-parse', 'HEAD'], fixtureRepo).stdout
+})
+
+afterAll(() => {
+  rmSync(fixtureRepo, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  // A fresh, EMPTY facet dir per test: the cache slot this suite asserts on
+  // can only exist because the resolver created it during the run.
+  facetDir = realpathSync(mkdtempSync(join(tmpdir(), 'resolve-git-commit-facetdir-')))
+  originalFacetDir = process.env.FACET_DIR
+  process.env.FACET_DIR = facetDir
+})
+
+afterEach(() => {
+  if (originalFacetDir === undefined) {
+    delete process.env.FACET_DIR
+  } else {
+    process.env.FACET_DIR = originalFacetDir
+  }
+  rmSync(facetDir, { recursive: true, force: true })
+})
+
+async function resolveFixture() {
+  return resolveGitFacet({
+    facetName: FACET_NAME,
+    // `file://` keeps the clone offline. `parseFacetSource` would read a
+    // bare path as a local source, so the git arm is constructed from the
+    // URL form the parser does classify as git.
+    source: { kind: 'git', url: `file://${fixtureRepo}` },
+    adapters: [],
+    effectiveLocked: undefined,
+    onStage: () => {},
+    onLog: () => {},
+  })
+}
+
+describe('resolveGitFacet — cold cache, current-format build', () => {
+  test('clones, builds, and commits a fresh git facet to the cache', async () => {
+    const result = await resolveFixture()
+
+    if (!result.ok) expect.unreachable()
+    expect(result.value.version).toBe(FACET_VERSION)
+    expect(result.value.integrity).toMatch(/^sha256:[a-f0-9]{64}$/)
+    // Provenance for a fresh clone is the URL plus the commit git resolved.
+    expect(result.value.source).toEqual({
+      kind: 'git',
+      url: `file://${fixtureRepo}`,
+      commit: initialCommit,
+    })
+  })
+
+  test('derives the asset plan from the cached content', async () => {
+    const result = await resolveFixture()
+
+    if (!result.ok) expect.unreachable()
+    expect(result.value.plan.assets).toEqual([
+      {
+        scope: 'project',
+        type: 'skill',
+        name: 'planning',
+        files: [{ path: 'skills/planning/SKILL.md', integrity: expect.stringMatching(/^sha256:[a-f0-9]{64}$/) }],
+      },
+    ])
+    expect(result.value.plan.archiveOnly.map((entry) => entry.path)).toEqual(['README.md'])
+  })
+
+  test('writes the durable cache slot and a sidecar covering every archive entry', async () => {
+    const result = await resolveFixture()
+
+    if (!result.ok) expect.unreachable()
+    const slotPath = cachePath({ kind: 'git', name: FACET_NAME, version: FACET_VERSION })
+    expect(cacheSlotIsDir({ kind: 'git', name: FACET_NAME, version: FACET_VERSION })).toBe(true)
+
+    const sidecar = readCachedIntegrity(slotPath)
+    if (sidecar === null) expect.unreachable()
+    // The sidecar's top-level hash is the integrity the resolution is
+    // anchored to — the same value a later audited hit compares against.
+    expect(sidecar.integrity).toBe(result.value.integrity)
+    // Every inner-archive entry is audited and recorded, not just the
+    // primary asset: the embedded manifest and the archive-only README too.
+    expect(Object.keys(sidecar.assets).sort()).toEqual(['README.md', 'facet.json', 'skills/planning/SKILL.md'])
+  })
+})

--- a/packages/engine/src/install/commit/resolve-git.ts
+++ b/packages/engine/src/install/commit/resolve-git.ts
@@ -1,6 +1,6 @@
 import { rm } from 'node:fs/promises'
 import type { Adapter } from '@agent-facets/adapter'
-import type { BuildManifest, LockfileSource, SupportedLockfileFacet } from '@agent-facets/protocol'
+import type { LockfileSource, SupportedLockfileFacet } from '@agent-facets/protocol'
 import { verifyGitOneCheck } from '@agent-facets/protocol'
 import { runBuildPipeline } from '../../build/pipeline.ts'
 import { type CacheIdentity, cachePutVerified } from '../../cache/index.ts'
@@ -143,14 +143,17 @@ export async function resolveGitFacet(args: ResolveGitFacetArgs): Promise<Resolv
 
       // Fresh clone → audit-then-write to cache; disarm cleanup once the
       // content lives in a durable slot.
-      const buildManifest = JSON.parse(buildResult.manifestJson) as BuildManifest
+      //
+      // The build result carries the canonical integrity and the complete
+      // per-entry hash map directly, so the cache put consumes them as-is.
+      // Re-deriving them by parsing `manifestJson` would couple this call
+      // site to one archive-format shape; `cachePutVerified` is
+      // version-neutral by contract and only wants `{ integrity, fileHashes }`.
       const cacheId: CacheIdentity = { kind: 'git', name: facetName, version: buildResult.data.version }
       const putResult = cachePutVerified(
         cacheId,
         sourceDir,
-        // The producer still emits legacy 0.1 manifests during the
-        // consumer bridge, so the per-entry hash map is `assets`.
-        { integrity: buildManifest.integrity, fileHashes: buildManifest.assets },
+        { integrity: buildResult.integrity, fileHashes: buildResult.fileHashes },
         buildResult.integrity,
         facetName,
       )


### PR DESCRIPTION
### Why

Installing a git-sourced facet on a cold cache crashed with `TypeError: Object.entries requires that input parameter not be null or undefined` instead of completing the install. The clone and build succeeded, but the step that commits built content to the cache failed because the git install path was re-reading the build output as the legacy `0.1` manifest shape (whose per-entry hash map is named `assets`), while the build pipeline now emits the `0.2` format (which uses `files`). Passing `undefined` to the cache write — which audits every entry it receives — caused the crash.

Only first installs or cold/evicted cache slots were affected. Installs served from an audited cache hit, and facets from the registry or a local path, never took this code path.

### Details

Rather than re-parsing `manifestJson` and coupling the call site to a specific archive format shape, the cache put now consumes `integrity` and `fileHashes` directly from the `buildResult` object, which already carries both in a format-neutral form. `cachePutVerified` only needs `{ integrity, fileHashes }` and is version-neutral by contract, so nothing about which files are audited or what is written to the cache sidecar changed.

The `BuildManifest` type references in tests have been updated to `LegacyBuildManifest` where the `0.1` shape (with `assets`) is intentionally used, making the format distinction explicit at each call site.

### Verification

A new integration test suite (`resolve-git.test.ts`) covers the exact failure path end-to-end with no stubs: a real `git clone` over `file://`, a real build, and a real verified cache put. It asserts that the resolved version, integrity, and source provenance are correct, that the asset plan is derived properly from cached content, and that the cache sidecar covers every archive entry including supplementary files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed first-time installation of facets from Git sources.
  - Improved cache handling to preserve file integrity, audited entries, and sidecar contents.
  - Registry, local-path, and existing audited-cache installations remain unaffected.

- **Tests**
  - Added coverage for Git-based facet resolution, integrity verification, asset planning, and durable caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->