### PR TITLE
Add `--accept-mcp` flag to `facet install` in wt config

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -5,11 +5,11 @@
 # untrusted and every `mise exec` below fails until this runs.
 [[pre-start]]
 trust = "mise trust"
-
-[[pre-start]]
 # .env.local is gitignored, so it never arrives with the checkout, but
 # .mise.development.toml loads it for AWS_PROFILE. Tolerate its absence:
 # teammates without one should still get a worktree.
 env = "if [ -f \"{{ primary_worktree_path }}/.env.local\" ]; then cp \"{{ primary_worktree_path }}/.env.local\" .env.local; fi"
 deps = "mise exec -- bun nuke"
-facets = "facet install"
+
+[[post-start]]
+facets = "facet install --accept-mcp"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "docs:broken-links": "bun --cwd docs mint broken-links",
     "postinstall": "bun scripts/postinstall.ts",
     "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify",
-    "nuke": "bun run clean && bun install && bun check"
+    "nuke": "bun run clean && PUPPETEER_SKIP_DOWNLOAD=1 bun install && bun check"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",


### PR DESCRIPTION
### Why

The `facet install` command now requires explicit acceptance of MCP during worktree setup.

### Verification

CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation setup to automatically accept MCP server prompts during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->