### PR TITLE
Remove `bun check` from `nuke` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "docs:broken-links": "bun --cwd docs mint broken-links",
     "postinstall": "bun scripts/postinstall.ts",
     "clean": "rm -rf .turbo node_modules packages/**/node_modules packages/**/.turbo packages/**/dist packages/cli/bin/.facet test-results/*.xml tmp docs/.mintlify",
-    "nuke": "bun run clean && PUPPETEER_SKIP_DOWNLOAD=1 bun install && bun check"
+    "nuke": "bun run clean && PUPPETEER_SKIP_DOWNLOAD=1 bun install"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",


### PR DESCRIPTION
### Why

Running `bun check` as part of the `nuke` script causes the command to fail in environments where type errors or lint issues exist, making it harder to use `nuke` as a clean reset tool.

### Verification

CI